### PR TITLE
chore(release): prepare v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-07-03
+
+The first release of atago: an end-to-end test runner for command-line tools
+driven by plain-YAML specs, with HTTP, DB, SSH, gRPC, and headless-browser
+peers, snapshot testing, and Markdown doc generation.
+
 ### Added
 
 - Scenario `teardown:` steps — cleanup that always runs after the steps (pass,


### PR DESCRIPTION
## Summary

Cut the changelog for **v0.1.0** — the first release of atago.

- Stamp `[0.1.0] - 2026-07-03` in CHANGELOG.md with a short release headline; keep an empty `[Unreleased]` section on top.

## Release flow

Per [doc/RELEASE.md](doc/RELEASE.md), releases are tag-driven: after this PR merges, pushing the `v0.1.0` tag triggers GoReleaser (archives for Linux/macOS/Windows, cosign-signed checksums, SBOMs, SLSA provenance, Homebrew cask).

## Verification

- Full unit suite, golangci-lint, and the self-hosted E2E suite (134 scenarios) are green on `main` at the base commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new release entry for version 0.1.0.
  * Included a brief project description and release date in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->