### PR TITLE
feat(cli): add --verbose scenario tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `atago run --verbose` (#6): trace every scenario as it finishes — the
+  expanded command, exit code / HTTP status, captured stdout/stderr (excerpted
+  at the same limit as failure output), skip reasons, teardown steps, and each
+  assertion's one-line verdict — for passing scenarios too, so authoring a
+  spec no longer requires breaking an assertion to see what a command printed.
+  Secrets stay masked; with a machine report (`--report json|junit|gha|tap`)
+  the trace goes to stderr so stdout stays machine-readable; failing checks
+  appear as one-line verdicts only (the full FAILED block is still rendered
+  exactly once by the report).
+
 ## [0.1.0] - 2026-07-03
 
 The first release of atago: an end-to-end test runner for command-line tools

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Every feature has a commented, runnable spec under [examples/](examples/). The e
 | [grpc](examples/grpc.atago.yaml) | unary gRPC calls via server reflection |
 | [browser](examples/browser.atago.yaml) | headless-Chrome flows and screenshots |
 
-Selection flags compose with any spec: `--filter NAME`, `--tag T`, `--skip-tag T`, `--parallel N` (default: the number of CPUs — scenarios are isolated, so runs are concurrent out of the box), `--fail-fast`, and `--rerun-failed` (rerun only what failed last time).
+Selection flags compose with any spec: `--filter NAME`, `--tag T`, `--skip-tag T`, `--parallel N` (default: the number of CPUs — scenarios are isolated, so runs are concurrent out of the box), `--fail-fast`, and `--rerun-failed` (rerun only what failed last time). While authoring a spec, `--verbose` traces every scenario — the expanded command, exit code, captured stdout/stderr, and each assertion's verdict — for passing scenarios too, so you never have to break an assertion just to see what a command printed.
 
 ## Use it in CI
 

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -209,7 +209,7 @@ Source: `test/e2e/atago/cdp.atago.yaml`
 - Fixture file `badcdp.atago.yaml` is created.
 #### Inputs
 _Fixture `badcdp.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: browser
@@ -235,7 +235,7 @@ ${atago} run badcdp.atago.yaml
 - Fixture file `norunner.atago.yaml` is created.
 #### Inputs
 _Fixture `norunner.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: browser
@@ -259,7 +259,7 @@ ${atago} run norunner.atago.yaml
 - Fixture file `noshotpath.atago.yaml` is created.
 #### Inputs
 _Fixture `noshotpath.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: browser
@@ -288,7 +288,7 @@ ${atago} run noshotpath.atago.yaml
 - Fixture file `actions.atago.yaml` is created.
 #### Inputs
 _Fixture `actions.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: browser
@@ -322,7 +322,7 @@ ${atago} explain actions.atago.yaml
 - Fixture file `crosstype.atago.yaml` is created.
 #### Inputs
 _Fixture `crosstype.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: browser
@@ -348,7 +348,7 @@ ${atago} run crosstype.atago.yaml
 - Fixture file `cfg.atago.yaml` is created.
 #### Inputs
 _Fixture `cfg.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: browser
@@ -380,7 +380,7 @@ ${atago} manifest cfg.atago.yaml
 - Fixture file `badupload.atago.yaml` is created.
 #### Inputs
 _Fixture `badupload.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: browser
@@ -407,7 +407,7 @@ ${atago} run badupload.atago.yaml
 - Fixture file `baddownload.atago.yaml` is created.
 #### Inputs
 _Fixture `baddownload.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: browser
@@ -478,7 +478,7 @@ Source: `test/e2e/atago/db.atago.yaml`
 - Fixture file `db.atago.yaml` is created.
 #### Inputs
 _Fixture `db.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: inner-db
@@ -513,7 +513,7 @@ ${atago} run db.atago.yaml
 - Fixture file `norunner.atago.yaml` is created.
 #### Inputs
 _Fixture `norunner.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: inner-db
@@ -538,7 +538,7 @@ Source: `test/e2e/atago/defaults.atago.yaml`
 - Fixture file `shell.atago.yaml` is created.
 #### Inputs
 _Fixture `shell.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: shelled
@@ -568,7 +568,7 @@ ${atago} run shell.atago.yaml
 - Fixture file `env.atago.yaml` is created.
 #### Inputs
 _Fixture `env.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: enved
@@ -602,7 +602,7 @@ ${atago} run env.atago.yaml
 - Fixture file `bad.atago.yaml` is created.
 #### Inputs
 _Fixture `bad.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: bad
@@ -643,7 +643,7 @@ Source: `test/e2e/atago/doc.atago.yaml`
 - Fixture file `target.atago.yaml` is created.
 #### Inputs
 _Fixture `target.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: sample
@@ -669,7 +669,7 @@ ${atago} doc --out specs.md target.atago.yaml
 - Fixture file `t2.atago.yaml` is created.
 #### Inputs
 _Fixture `t2.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: sample2
@@ -693,7 +693,7 @@ ${atago} doc t2.atago.yaml
 - Fixture file `rich.atago.yaml` is created.
 #### Inputs
 _Fixture `rich.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: rich
@@ -722,7 +722,7 @@ ${atago} doc rich.atago.yaml
 - Fixture file `two.atago.yaml` is created.
 #### Inputs
 _Fixture `one.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: suite-one
@@ -733,7 +733,7 @@ scenarios:
       - assert: {exit_code: 0}
 ```
 _Fixture `two.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: suite-two
@@ -761,7 +761,7 @@ ${atago} doc --split-by-spec --out-dir generated one.atago.yaml two.atago.yaml
 - Fixture file `solo.atago.yaml` is created.
 #### Inputs
 _Fixture `solo.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: solo
@@ -785,7 +785,7 @@ Source: `test/e2e/atago/edge.atago.yaml`
 - Fixture file `empty.atago.yaml` is created.
 #### Inputs
 _Fixture `empty.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: inner
@@ -813,7 +813,7 @@ ${atago} run empty.atago.yaml
 - Fixture file `bad.atago.yaml` is created.
 #### Inputs
 _Fixture `bad.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: inner
@@ -872,7 +872,7 @@ printf '%s\n' "$ISO_HOME"
 - Fixture file `data.txt` is created.
 #### Inputs
 _Fixture `data.txt`:_
-```
+```text
 alpha
 beta
 ```
@@ -883,7 +883,7 @@ beta
 - Fixture file `inner.atago.yaml` is created.
 #### Inputs
 _Fixture `inner.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: inner
@@ -908,7 +908,7 @@ ${atago} run inner.atago.yaml
 - Fixture file `bad.atago.yaml` is created.
 #### Inputs
 _Fixture `bad.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: bad
@@ -932,7 +932,7 @@ Source: `test/e2e/atago/explain.atago.yaml`
 - Fixture file `target.atago.yaml` is created.
 #### Inputs
 _Fixture `target.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: sample
@@ -971,7 +971,7 @@ wc -c < copied.bin
 - Fixture file `copied.bin` is created.
 #### Inputs
 _Fixture `copied.bin`:_
-```
+```text
 version: "1"
 suite:
   name: inner
@@ -999,7 +999,7 @@ Source: `test/e2e/atago/fixture_modes.atago.yaml`
 - Fixture file `alias.txt` is created.
 #### Inputs
 _Fixture `target.txt`:_
-```
+```text
 payload
 ```
 #### When
@@ -1014,11 +1014,11 @@ cat alias.txt
 - Fixture file `data.txt` is created.
 #### Inputs
 _Fixture `run.sh`:_
-```
+```text
 echo hi
 ```
 _Fixture `data.txt`:_
-```
+```text
 plain
 ```
 #### Then
@@ -1029,7 +1029,7 @@ plain
 - Fixture file `stamped.txt` is created.
 #### Inputs
 _Fixture `stamped.txt`:_
-```
+```text
 x
 ```
 #### When
@@ -1057,7 +1057,7 @@ Source: `test/e2e/atago/grpc.atago.yaml`
 - Fixture file `badgrpc.atago.yaml` is created.
 #### Inputs
 _Fixture `badgrpc.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: grpc
@@ -1083,7 +1083,7 @@ ${atago} run badgrpc.atago.yaml
 - Fixture file `norunner.atago.yaml` is created.
 #### Inputs
 _Fixture `norunner.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: grpc
@@ -1108,7 +1108,7 @@ Source: `test/e2e/atago/http.atago.yaml`
 - Fixture file `denied.atago.yaml` is created.
 #### Inputs
 _Fixture `denied.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: api
@@ -1140,7 +1140,7 @@ ${atago} run denied.atago.yaml
 - Fixture file `norunner.atago.yaml` is created.
 #### Inputs
 _Fixture `norunner.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: api
@@ -1166,7 +1166,7 @@ Source: `test/e2e/atago/image.atago.yaml`
 - Fixture file `img.atago.yaml` is created.
 #### Inputs
 _Fixture `img.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: sample
@@ -1201,7 +1201,7 @@ ${atago} run img.atago.yaml
 - Fixture file `sim.atago.yaml` is created.
 #### Inputs
 _Fixture `sim.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: sample
@@ -1228,7 +1228,7 @@ ${atago} run sim.atago.yaml
 - Fixture file `bad.atago.yaml` is created.
 #### Inputs
 _Fixture `bad.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: sample
@@ -1256,7 +1256,7 @@ ${atago} run bad.atago.yaml
 - Fixture file `diff.atago.yaml` is created.
 #### Inputs
 _Fixture `diff.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: sample
@@ -1312,7 +1312,7 @@ ${atago} run starter.atago.yaml
 - Fixture file `taken.atago.yaml` is created.
 #### Inputs
 _Fixture `taken.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: keep
@@ -1511,7 +1511,7 @@ echo '{"n":"7"}'
 - Fixture file `metrics.json` is created.
 #### Inputs
 _Fixture `metrics.json`:_
-```
+```text
 {"processed": 1200, "errors": 0}
 ```
 #### Then
@@ -1522,7 +1522,7 @@ _Fixture `metrics.json`:_
 - Fixture file `cmp.atago.yaml` is created.
 #### Inputs
 _Fixture `cmp.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: inner
@@ -1550,7 +1550,7 @@ ${atago} run cmp.atago.yaml
 - Fixture file `cmp.atago.yaml` is created.
 #### Inputs
 _Fixture `cmp.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: inner
@@ -1596,7 +1596,7 @@ printf 'only-line\n'
 - Fixture file `oor.atago.yaml` is created.
 #### Inputs
 _Fixture `oor.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: inner
@@ -1624,7 +1624,7 @@ Source: `test/e2e/atago/list.atago.yaml`
 - Fixture file `sample.atago.yaml` is created.
 #### Inputs
 _Fixture `sample.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: demo
@@ -1652,7 +1652,7 @@ ${atago} list sample.atago.yaml
 - Fixture file `sample.atago.yaml` is created.
 #### Inputs
 _Fixture `sample.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: demo
@@ -1677,7 +1677,7 @@ Source: `test/e2e/atago/manifest.atago.yaml`
 - Fixture file `sample.atago.yaml` is created.
 #### Inputs
 _Fixture `sample.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: demo
@@ -1720,7 +1720,7 @@ ${atago} manifest sample.atago.yaml
 - Fixture file `side_effect.atago.yaml` is created.
 #### Inputs
 _Fixture `side_effect.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: side
@@ -1747,7 +1747,7 @@ Source: `test/e2e/atago/matrix.atago.yaml`
 - Fixture file `matrix.atago.yaml` is created.
 #### Inputs
 _Fixture `matrix.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: greetings
@@ -1776,7 +1776,7 @@ ${atago} run --report junit matrix.atago.yaml
 - Fixture file `suffix.atago.yaml` is created.
 #### Inputs
 _Fixture `suffix.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: suffixed
@@ -1828,7 +1828,7 @@ printf 'first\nsecond\n'
 - Fixture file `ne.atago.yaml` is created.
 #### Inputs
 _Fixture `ne.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: inner
@@ -1855,7 +1855,7 @@ Source: `test/e2e/atago/parallel.atago.yaml`
 - Fixture file `many.atago.yaml` is created.
 #### Inputs
 _Fixture `many.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: many
@@ -1879,7 +1879,7 @@ ${atago} run --parallel 3 many.atago.yaml
 - Fixture file `ff.atago.yaml` is created.
 #### Inputs
 _Fixture `ff.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: ff
@@ -1903,7 +1903,7 @@ Source: `test/e2e/atago/pdf.atago.yaml`
 - Fixture file `report.pdf` is created.
 #### Inputs
 _Fixture `report.pdf`:_
-```
+```text
 %PDF-1.4
 1 0 obj
 << /Type /Catalog /Pages 2 0 R >>
@@ -1933,7 +1933,7 @@ trailer
 - Fixture file `notpdf.txt` is created.
 #### Inputs
 _Fixture `notpdf.txt`:_
-```
+```text
 just text
 ```
 #### When
@@ -1949,7 +1949,7 @@ Source: `test/e2e/atago/reports.atago.yaml`
 - Fixture file `ok.atago.yaml` is created.
 #### Inputs
 _Fixture `ok.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: sample
@@ -1974,7 +1974,7 @@ ${atago} run --report junit ok.atago.yaml
 - Fixture file `bad.atago.yaml` is created.
 #### Inputs
 _Fixture `bad.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: sample
@@ -1999,7 +1999,7 @@ ${atago} run --report gha bad.atago.yaml
 - Fixture file `mixed.atago.yaml` is created.
 #### Inputs
 _Fixture `mixed.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: sample
@@ -2033,7 +2033,7 @@ ${atago} run --report tap mixed.atago.yaml
 - Fixture file `bad.atago.yaml` is created.
 #### Inputs
 _Fixture `bad.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: sample
@@ -2065,7 +2065,7 @@ Source: `test/e2e/atago/rerun.atago.yaml`
 - Fixture file `inner.atago.yaml` is created.
 #### Inputs
 _Fixture `inner.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: inner
@@ -2099,7 +2099,7 @@ ${atago} run --rerun-failed inner.atago.yaml
 - Fixture file `green.atago.yaml` is created.
 #### Inputs
 _Fixture `green.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: green
@@ -2123,7 +2123,7 @@ Source: `test/e2e/atago/retry.atago.yaml`
 - Fixture file `ready.atago.yaml` is created.
 #### Inputs
 _Fixture `ready.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: inner
@@ -2155,7 +2155,7 @@ ${atago} run ready.atago.yaml
 - Fixture file `never.atago.yaml` is created.
 #### Inputs
 _Fixture `never.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: inner
@@ -2184,7 +2184,7 @@ Source: `test/e2e/atago/run.atago.yaml`
 - Fixture file `passing.atago.yaml` is created.
 #### Inputs
 _Fixture `passing.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: sample
@@ -2212,7 +2212,7 @@ ${atago} run passing.atago.yaml
 - Fixture file `failing.atago.yaml` is created.
 #### Inputs
 _Fixture `failing.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: sample
@@ -2237,7 +2237,7 @@ ${atago} run failing.atago.yaml
 - Fixture file `broken.atago.yaml` is created.
 #### Inputs
 _Fixture `broken.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   : not valid yaml
@@ -2253,7 +2253,7 @@ ${atago} run broken.atago.yaml
 - Fixture file `ok.atago.yaml` is created.
 #### Inputs
 _Fixture `ok.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: sample
@@ -2284,7 +2284,7 @@ Source: `test/e2e/atago/security.atago.yaml`
 - Environment variables are set: DEMO_TOKEN.
 #### Inputs
 _Fixture `sec.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: inner
@@ -2312,7 +2312,7 @@ ${atago} run sec.atago.yaml
 - Fixture file `escape.atago.yaml` is created.
 #### Inputs
 _Fixture `escape.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: inner
@@ -2339,7 +2339,7 @@ ${atago} run escape.atago.yaml
 - Fixture file `snap_escape.atago.yaml` is created.
 #### Inputs
 _Fixture `snap_escape.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: inner
@@ -2367,7 +2367,7 @@ Source: `test/e2e/atago/select.atago.yaml`
 - Fixture file `many.atago.yaml` is created.
 #### Inputs
 _Fixture `many.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: many
@@ -2389,7 +2389,7 @@ ${atago} run --filter keep many.atago.yaml
 - Fixture file `tagged.atago.yaml` is created.
 #### Inputs
 _Fixture `tagged.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: tagged
@@ -2452,7 +2452,7 @@ echo ${a}-${b}
 - Fixture file `notready.atago.yaml` is created.
 #### Inputs
 _Fixture `notready.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: sample
@@ -2485,7 +2485,7 @@ cat arts/*/*/service-chatty.log
 - Fixture file `readythenfail.atago.yaml` is created.
 #### Inputs
 _Fixture `readythenfail.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: sample
@@ -2522,7 +2522,7 @@ cat arts/*/*/service-peer.log
 - Fixture file `healthy.atago.yaml` is created.
 #### Inputs
 _Fixture `healthy.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: sample
@@ -2559,7 +2559,7 @@ Source: `test/e2e/atago/shell_path.atago.yaml`
 - Fixture file `sh` is created.
 #### Inputs
 _Fixture `sh`:_
-```
+```text
 #!/bin/sh
 echo HIJACKED
 exit 0
@@ -2586,7 +2586,7 @@ Source: `test/e2e/atago/skip_command.atago.yaml`
 - Fixture file `skip.atago.yaml` is created.
 #### Inputs
 _Fixture `skip.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: inner
@@ -2614,7 +2614,7 @@ ${atago} run skip.atago.yaml
 - Fixture file `only.atago.yaml` is created.
 #### Inputs
 _Fixture `only.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: inner
@@ -2642,7 +2642,7 @@ ${atago} run only.atago.yaml
 - Fixture file `run.atago.yaml` is created.
 #### Inputs
 _Fixture `run.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: inner
@@ -2673,7 +2673,7 @@ Source: `test/e2e/atago/snapshot.atago.yaml`
 - Fixture file `out.snap` is created.
 #### Inputs
 _Fixture `snap.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: sample
@@ -2687,7 +2687,7 @@ scenarios:
             snapshot: out.snap
 ```
 _Fixture `out.snap`:_
-```
+```text
 stable
 ```
 #### When
@@ -2702,7 +2702,7 @@ ${atago} run snap.atago.yaml
 - Fixture file `gen.atago.yaml` is created.
 #### Inputs
 _Fixture `gen.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: sample
@@ -2728,7 +2728,7 @@ ${atago} snapshot update gen.atago.yaml
 - Fixture file `committed.snap` is created.
 #### Inputs
 _Fixture `drift.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: sample
@@ -2742,7 +2742,7 @@ scenarios:
             snapshot: committed.snap
 ```
 _Fixture `committed.snap`:_
-```
+```text
 original
 ```
 #### When
@@ -2764,7 +2764,7 @@ Source: `test/e2e/atago/ssh.atago.yaml`
 - Fixture file `badssh.atago.yaml` is created.
 #### Inputs
 _Fixture `badssh.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: ssh
@@ -2790,7 +2790,7 @@ ${atago} run badssh.atago.yaml
 - Fixture file `norunner.atago.yaml` is created.
 #### Inputs
 _Fixture `norunner.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: ssh
@@ -2815,7 +2815,7 @@ Source: `test/e2e/atago/store.atago.yaml`
 - Fixture file `store.atago.yaml` is created.
 #### Inputs
 _Fixture `store.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: inner
@@ -2850,7 +2850,7 @@ ${atago} run store.atago.yaml
 - Fixture file `bad-store.atago.yaml` is created.
 #### Inputs
 _Fixture `bad-store.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: inner
@@ -2883,7 +2883,7 @@ Source: `test/e2e/atago/verbose.atago.yaml`
 - Fixture file `ok.atago.yaml` is created.
 #### Inputs
 _Fixture `ok.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: sample
@@ -2910,7 +2910,7 @@ ${atago} run --verbose ok.atago.yaml
 - Fixture file `ok.atago.yaml` is created.
 #### Inputs
 _Fixture `ok.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: sample
@@ -2935,7 +2935,7 @@ ${atago} run ok.atago.yaml
 - Fixture file `ok.atago.yaml` is created.
 #### Inputs
 _Fixture `ok.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: sample
@@ -2961,7 +2961,7 @@ ${atago} run --verbose --report json ok.atago.yaml
 - Fixture file `bad.atago.yaml` is created.
 #### Inputs
 _Fixture `bad.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: sample
@@ -3009,7 +3009,7 @@ Source: `test/e2e/atago/yaml.atago.yaml`
 - Fixture file `yaml_ok.atago.yaml` is created.
 #### Inputs
 _Fixture `yaml_ok.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: yaml-matcher
@@ -3045,7 +3045,7 @@ ${atago} run yaml_ok.atago.yaml
 - Fixture file `yaml_fail.atago.yaml` is created.
 #### Inputs
 _Fixture `yaml_fail.atago.yaml`:_
-```
+```text
 version: "1"
 suite:
   name: yaml-matcher-fail

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-39 suites · 129 scenarios
+40 suites · 133 scenarios
 ## Contents
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 3 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
@@ -164,6 +164,11 @@
 - [atago self-hosting / store](#atago-self-hosting--store) — 2 scenarios
   - [a stored JSON value is reusable in later commands](#scenario-a-stored-json-value-is-reusable-in-later-commands)
   - [storing from a missing JSON path is an execution error](#scenario-storing-from-a-missing-json-path-is-an-execution-error)
+- [atago self-hosting / verbose](#atago-self-hosting--verbose) — 4 scenarios
+  - [verbose shows a passing scenario's command, output, and verdicts](#scenario-verbose-shows-a-passing-scenarios-command-output-and-verdicts)
+  - [without --verbose the trace is absent](#scenario-without---verbose-the-trace-is-absent)
+  - [verbose with a JSON report keeps stdout pure and traces to stderr](#scenario-verbose-with-a-json-report-keeps-stdout-pure-and-traces-to-stderr)
+  - [a failing run under --verbose renders the FAILED block exactly once](#scenario-a-failing-run-under---verbose-renders-the-failed-block-exactly-once)
 - [atago self-hosting / version](#atago-self-hosting--version) — 2 scenarios
   - [version command prints the binary name](#scenario-version-command-prints-the-binary-name)
   - [unknown command is a configuration error](#scenario-unknown-command-is-a-configuration-error)
@@ -2871,6 +2876,113 @@ ${atago} run bad-store.atago.yaml
 #### Then
 - exit code is `4`
 - stdout contains `ERROR`
+## atago self-hosting / verbose
+Source: `test/e2e/atago/verbose.atago.yaml`
+### Scenario: verbose shows a passing scenario's command, output, and verdicts
+#### Given
+- Fixture file `ok.atago.yaml` is created.
+#### Inputs
+_Fixture `ok.atago.yaml`:_
+```
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: greets
+    steps:
+      - run:
+          shell: true
+          command: echo hello-trace
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: hello-trace
+```
+#### When
+```shell
+${atago} run --verbose ok.atago.yaml
+```
+#### Then
+- exit code is `0`
+- stdout contains `sample / greets`, `echo hello-trace`, `exit 0`, `ok   assert`
+### Scenario: without --verbose the trace is absent
+#### Given
+- Fixture file `ok.atago.yaml` is created.
+#### Inputs
+_Fixture `ok.atago.yaml`:_
+```
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: greets
+    steps:
+      - run:
+          shell: true
+          command: echo hello-trace
+      - assert:
+          exit_code: 0
+```
+#### When
+```shell
+${atago} run ok.atago.yaml
+```
+#### Then
+- exit code is `0`
+- stdout does not contain `echo hello-trace`
+### Scenario: verbose with a JSON report keeps stdout pure and traces to stderr
+#### Given
+- Fixture file `ok.atago.yaml` is created.
+#### Inputs
+_Fixture `ok.atago.yaml`:_
+```
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: greets
+    steps:
+      - run:
+          shell: true
+          command: echo hello-trace
+      - assert:
+          exit_code: 0
+```
+#### When
+```shell
+${atago} run --verbose --report json ok.atago.yaml
+```
+#### Then
+- exit code is `0`
+- stdout at `$.schema_version` equals `1`
+- stderr contains `exit 0`
+### Scenario: a failing run under --verbose renders the FAILED block exactly once
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: mismatch
+    steps:
+      - run:
+          shell: true
+          command: echo hello
+      - assert:
+          stdout:
+            contains: goodbye
+```
+#### When
+```shell
+${atago} run --verbose bad.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `FAIL assert`, `FAILED:`
+- stdout does not match `/(?s)FAILED:.*FAILED:/`
 ## atago self-hosting / version
 Source: `test/e2e/atago/version.atago.yaml`
 ### Scenario: version command prints the binary name

--- a/doc/e2e/caddy.md
+++ b/doc/e2e/caddy.md
@@ -24,7 +24,7 @@ caddy list-modules
 - Fixture file `Caddyfile` is created.
 #### Inputs
 _Fixture `Caddyfile`:_
-```
+```text
 :18080
 respond "hello from caddy"
 ```
@@ -40,7 +40,7 @@ caddy adapt --config Caddyfile
 - Fixture file `Caddyfile` is created.
 #### Inputs
 _Fixture `Caddyfile`:_
-```
+```text
 :18080   {
         respond    "ok"
   }
@@ -57,7 +57,7 @@ caddy fmt --overwrite Caddyfile
 - Fixture file `Caddyfile` is created.
 #### Inputs
 _Fixture `Caddyfile`:_
-```
+```text
 :18080
 no_such_directive_xyz
 ```
@@ -74,7 +74,7 @@ caddy validate --config Caddyfile --adapter caddyfile
 - Fixture file `Caddyfile` is created.
 #### Inputs
 _Fixture `Caddyfile`:_
-```
+```text
 {
 	admin off
 }
@@ -96,11 +96,11 @@ respond "configured response" 200
 - Fixture file `site/api/status.json` is created.
 #### Inputs
 _Fixture `site/index.html`:_
-```
+```text
 <html><body>hello from caddy</body></html>
 ```
 _Fixture `site/api/status.json`:_
-```
+```text
 {"status":"ok","service":"caddy"}
 ```
 #### When

--- a/doc/e2e/coredns.md
+++ b/doc/e2e/coredns.md
@@ -25,14 +25,14 @@ coredns -version
 - Fixture file `zones/example.test.zone` is created.
 #### Inputs
 _Fixture `Corefile`:_
-```
+```text
 example.test:18150 {
     bind 127.0.0.1
     file zones/example.test.zone
 }
 ```
 _Fixture `zones/example.test.zone`:_
-```
+```text
 $ORIGIN example.test.
 @   3600 IN SOA ns.example.test. admin.example.test. (2026070201 7200 3600 1209600 3600)
 @   3600 IN NS  ns.example.test.
@@ -66,14 +66,14 @@ dig @127.0.0.1 -p 18150 alias.example.test A +short
 - Fixture file `zones/example.test.zone` is created.
 #### Inputs
 _Fixture `Corefile`:_
-```
+```text
 example.test:18151 {
     bind 127.0.0.1
     file zones/example.test.zone
 }
 ```
 _Fixture `zones/example.test.zone`:_
-```
+```text
 $ORIGIN example.test.
 @   3600 IN SOA ns.example.test. admin.example.test. (2026070201 7200 3600 1209600 3600)
 @   3600 IN NS  ns.example.test.
@@ -99,7 +99,7 @@ dig @127.0.0.1 -p 18151 www.example.com A +noall +comments
 - Fixture file `zones/example.test.zone` is created.
 #### Inputs
 _Fixture `Corefile`:_
-```
+```text
 example.test:18152 {
     bind 127.0.0.1
     file zones/example.test.zone
@@ -107,7 +107,7 @@ example.test:18152 {
 }
 ```
 _Fixture `zones/example.test.zone`:_
-```
+```text
 $ORIGIN example.test.
 @   3600 IN SOA ns.example.test. admin.example.test. (2026070201 7200 3600 1209600 3600)
 @   3600 IN NS  ns.example.test.
@@ -131,7 +131,7 @@ dig @127.0.0.1 -p 18152 www.example.test A +short
 - Fixture file `Corefile` is created.
 #### Inputs
 _Fixture `Corefile`:_
-```
+```text
 example.test:18159 {
     no_such_plugin_xyz
 }

--- a/doc/e2e/git.md
+++ b/doc/e2e/git.md
@@ -27,7 +27,7 @@ git -C repo rev-parse HEAD
 - Fixture file `repo-src/hello.txt` is created.
 #### Inputs
 _Fixture `repo-src/hello.txt`:_
-```
+```text
 hello from atago
 ```
 #### When
@@ -51,7 +51,7 @@ git -C repo-src log --oneline
 - Fixture file `r/f.txt` is created.
 #### Inputs
 _Fixture `r/f.txt`:_
-```
+```text
 v1
 ```
 #### When

--- a/doc/e2e/gitea.md
+++ b/doc/e2e/gitea.md
@@ -22,7 +22,7 @@ gitea --version
 - Fixture file `app.ini` is created.
 #### Inputs
 _Fixture `app.ini`:_
-```
+```text
 [server]
 HTTP_ADDR = 127.0.0.1
 HTTP_PORT = 18140
@@ -62,7 +62,7 @@ ROOT = data/repos
 - Fixture file `app.ini` is created.
 #### Inputs
 _Fixture `app.ini`:_
-```
+```text
 [server]
 HTTP_ADDR = 127.0.0.1
 HTTP_PORT = 18141

--- a/doc/e2e/iso8583tool.md
+++ b/doc/e2e/iso8583tool.md
@@ -329,7 +329,7 @@ Source: `test/e2e/tools/iso8583tool/bcd_starter.atago.yaml`
 - Fixture file `emv.json` is created.
 #### Inputs
 _Fixture `emv.json`:_
-```
+```text
 {"mti":"0100","fields":{"2":"4019249999999999","3":"000000","4":"000000001000","7":"0605123456","11":"123456","41":"TERMID01"},"binary_fields":{"55.9F02":"000000001000"}}
 ```
 #### When
@@ -346,7 +346,7 @@ iso8583tool view emv.hex --encoding hex --spec spec87bcd-starter --format json
 - Fixture file `pin.json` is created.
 #### Inputs
 _Fixture `pin.json`:_
-```
+```text
 {"mti":"0100","fields":{"2":"4019249999999999","3":"000000","4":"000000001000","7":"0605123456","11":"123456","41":"TERMID01"},"binary_fields":{"52":"A1B2C3D4E5F60708"}}
 ```
 #### When
@@ -361,7 +361,7 @@ iso8583tool convert pin.json --to hex --encoding hex --spec spec87bcd-starter
 - Fixture file `mac.json` is created.
 #### Inputs
 _Fixture `mac.json`:_
-```
+```text
 {"mti":"0100","fields":{"2":"4019249999999999","3":"000000","4":"000000001000","7":"0605123456","11":"123456","41":"TERMID01"},"binary_fields":{"64":"A1B2C3D4E5F60708"}}
 ```
 #### When
@@ -378,7 +378,7 @@ iso8583tool view mac.hex --encoding hex --spec spec87bcd-starter --unsafe --form
 - Fixture file `f32.json` is created.
 #### Inputs
 _Fixture `f32.json`:_
-```
+```text
 {"mti":"0100","fields":{"2":"4019249999999999","3":"000000","4":"000000001000","7":"0605123456","11":"123456","32":"123456","41":"TERMID01"}}
 ```
 #### When
@@ -395,7 +395,7 @@ iso8583tool view f32.hex --encoding hex --spec spec87bcd-starter --format json
 - Fixture file `f71.json` is created.
 #### Inputs
 _Fixture `f71.json`:_
-```
+```text
 {"mti":"0800","fields":{"11":"123456","70":"301","71":"1234"}}
 ```
 #### When
@@ -411,7 +411,7 @@ iso8583tool convert f71.json --to hex --spec spec87bcd-starter
 - Fixture file `sec.json` is created.
 #### Inputs
 _Fixture `sec.json`:_
-```
+```text
 {"mti":"0800","fields":{"11":"123456","70":"301","74":"0000000001","99":"12345678901","100":"98765432109"}}
 ```
 #### When
@@ -621,7 +621,7 @@ iso8583tool convert $ISO_EXAMPLES/basei/0100-auth-request.json --to sideways
 ### Scenario: rejects a path present in both fields and binary_fields
 #### Inputs
 _stdin for `iso8583tool`:_
-```
+```text
 {"mti":"0100","fields":{"55.8A":"00"},"binary_fields":{"55.8A":"3035"}}
 ```
 #### When
@@ -634,7 +634,7 @@ iso8583tool convert --to hex
 ### Scenario: rejects a parent path that also has nested children
 #### Inputs
 _stdin for `iso8583tool`:_
-```
+```text
 {"mti":"0100","binary_fields":{"55":"9F0206000000005000","55.9F02":"000000009999"}}
 ```
 #### When
@@ -647,7 +647,7 @@ iso8583tool convert --to hex
 ### Scenario: rejects field id 0 (reserved for the MTI)
 #### Inputs
 _stdin for `iso8583tool`:_
-```
+```text
 {"mti":"0100","fields":{"0":"9999"}}
 ```
 #### When
@@ -660,7 +660,7 @@ iso8583tool convert --to hex
 ### Scenario: rejects field id 1 (the bitmap)
 #### Inputs
 _stdin for `iso8583tool`:_
-```
+```text
 {"mti":"0100","fields":{"1":"1234"}}
 ```
 #### When
@@ -673,7 +673,7 @@ iso8583tool convert --to hex
 ### Scenario: rejects field id 0 set through binary_fields
 #### Inputs
 _stdin for `iso8583tool`:_
-```
+```text
 {"mti":"0100","binary_fields":{"0":"31323334"}}
 ```
 #### When
@@ -686,7 +686,7 @@ iso8583tool convert --to hex
 ### Scenario: rejects an out-of-range field id
 #### Inputs
 _stdin for `iso8583tool`:_
-```
+```text
 {"mti":"0100","fields":{"129":"x"}}
 ```
 #### When
@@ -699,7 +699,7 @@ iso8583tool convert --to hex
 ### Scenario: rejects a non-numeric field id
 #### Inputs
 _stdin for `iso8583tool`:_
-```
+```text
 {"mti":"0100","fields":{"A.1":"x"}}
 ```
 #### When
@@ -712,7 +712,7 @@ iso8583tool convert --to hex
 ### Scenario: rejects a malformed dotted path
 #### Inputs
 _stdin for `iso8583tool`:_
-```
+```text
 {"mti":"0100","binary_fields":{"55..9F02":"00"}}
 ```
 #### When
@@ -725,7 +725,7 @@ iso8583tool convert --to hex
 ### Scenario: rejects leading whitespace in a path key
 #### Inputs
 _stdin for `iso8583tool`:_
-```
+```text
 {"mti":"0100","fields":{" 2":"4111111111111111"}}
 ```
 #### When
@@ -738,7 +738,7 @@ iso8583tool convert --to hex
 ### Scenario: rejects a leading-zero duplicate alias (02 vs 2)
 #### Inputs
 _stdin for `iso8583tool`:_
-```
+```text
 {"mti":"0100","fields":{"02":"4111111111111111","2":"4222222222222222"}}
 ```
 #### When
@@ -751,7 +751,7 @@ iso8583tool convert --to hex
 ### Scenario: rejects a case-different duplicate TLV alias (9f02 vs 9F02)
 #### Inputs
 _stdin for `iso8583tool`:_
-```
+```text
 {"mti":"0100","binary_fields":{"55.9f02":"000000001000","55.9F02":"000000005000"}}
 ```
 #### When
@@ -764,7 +764,7 @@ iso8583tool convert --to hex
 ### Scenario: rejects raw bytes routed to a text field via binary_fields
 #### Inputs
 _stdin for `iso8583tool`:_
-```
+```text
 {"mti":"0100","binary_fields":{"11":"000102030405"}}
 ```
 #### When
@@ -835,11 +835,11 @@ Source: `test/e2e/tools/iso8583tool/custom_spec.atago.yaml`
 - Fixture file `doc.json` is created.
 #### Inputs
 _Fixture `hex-top.json`:_
-```
+```text
 {"name":"Hex top","fields":{"0":{"type":"String","length":4,"description":"MTI","enc":"ASCII","prefix":"ASCII.Fixed"},"1":{"type":"Bitmap","length":16,"description":"Bitmap","enc":"HexToASCII","prefix":"Hex.Fixed"},"52":{"type":"Hex","length":8,"description":"PIN Data","enc":"Binary","prefix":"Binary.Fixed"}}}
 ```
 _Fixture `doc.json`:_
-```
+```text
 {"mti":"0100","binary_fields":{"52":"A1B2C3D4E5F60708"}}
 ```
 #### When
@@ -854,7 +854,7 @@ iso8583tool convert doc.json --to hex --spec hex-top.json
 - Fixture file `hex-sub.json` is created.
 #### Inputs
 _Fixture `hex-sub.json`:_
-```
+```text
 {"name":"TLV Hex","fields":{"0":{"type":"String","length":4,"description":"MTI","enc":"ASCII","prefix":"ASCII.Fixed"},"1":{"type":"Bitmap","length":16,"description":"Bitmap","enc":"HexToASCII","prefix":"Hex.Fixed"},"55":{"type":"Composite","length":999,"description":"ICC","prefix":"ASCII.LLL","tag":{"enc":"BerTLVTag","sort":"StringsByHex","skipUnknownTLVTags":true,"storeUnknownTLVTags":true},"subfields":{"9F02":{"type":"Hex","length":6,"description":"Amount","enc":"Binary","prefix":"BerTLV"}}}}}
 ```
 #### When
@@ -869,7 +869,7 @@ iso8583tool view $ISO_EXAMPLES/basei/0100-auth-request.hex --spec hex-sub.json
 - Fixture file `track1.json` is created.
 #### Inputs
 _Fixture `track1.json`:_
-```
+```text
 {"name":"Track1","fields":{"0":{"type":"String","length":4,"description":"MTI","enc":"ASCII","prefix":"ASCII.Fixed"},"1":{"type":"Bitmap","length":16,"description":"Bitmap","enc":"HexToASCII","prefix":"Hex.Fixed"},"45":{"type":"Track1","length":76,"description":"Track 1","enc":"ASCII","prefix":"ASCII.LL"}}}
 ```
 #### When
@@ -884,7 +884,7 @@ iso8583tool view $ISO_EXAMPLES/basei/0100-auth-request.hex --spec track1.json
 - Fixture file `track3.json` is created.
 #### Inputs
 _Fixture `track3.json`:_
-```
+```text
 {"name":"Track3","fields":{"0":{"type":"String","length":4,"description":"MTI","enc":"ASCII","prefix":"ASCII.Fixed"},"1":{"type":"Bitmap","length":16,"description":"Bitmap","enc":"HexToASCII","prefix":"Hex.Fixed"},"36":{"type":"Track3","length":104,"description":"Track 3","enc":"ASCII","prefix":"ASCII.LLL"}}}
 ```
 #### When
@@ -899,7 +899,7 @@ iso8583tool view $ISO_EXAMPLES/basei/0100-auth-request.hex --spec track3.json
 - Fixture file `indextag.json` is created.
 #### Inputs
 _Fixture `indextag.json`:_
-```
+```text
 {"name":"IndexTag","fields":{"0":{"type":"String","length":4,"description":"MTI","enc":"ASCII","prefix":"ASCII.Fixed"},"1":{"type":"Bitmap","length":16,"description":"Bitmap","enc":"HexToASCII","prefix":"Hex.Fixed"},"48":{"type":"Composite","length":999,"description":"IndexTag Composite","prefix":"ASCII.LLL","tag":{"sort":"StringsByInt","length":2,"enc":"ASCII"},"subfields":{"1":{"type":"IndexTag","length":2,"description":"Tag index","enc":"ASCII","prefix":"ASCII.Fixed"}}}}}
 ```
 #### When
@@ -914,7 +914,7 @@ iso8583tool view $ISO_EXAMPLES/basei/0100-auth-request.hex --spec indextag.json
 - Fixture file `nosort.json` is created.
 #### Inputs
 _Fixture `nosort.json`:_
-```
+```text
 {"name":"No sort","fields":{"0":{"type":"String","length":4,"description":"MTI","enc":"ASCII","prefix":"ASCII.Fixed"},"1":{"type":"Bitmap","length":16,"description":"Bitmap","enc":"HexToASCII","prefix":"Hex.Fixed"},"55":{"type":"Composite","length":999,"description":"ICC","prefix":"ASCII.LLL","tag":{"enc":"BerTLVTag","skipUnknownTLVTags":true,"storeUnknownTLVTags":true},"subfields":{"9F02":{"type":"Binary","length":6,"description":"Amount","enc":"Binary","prefix":"BerTLV"}}}}}
 ```
 #### When
@@ -1154,11 +1154,11 @@ iso8583tool doctor "with space.hex" --no-color
 - Fixture file `other.json` is created.
 #### Inputs
 _Fixture `spec.json`:_
-```
+```text
 {"name":"F48 positional","fields":{"0":{"type":"String","length":4,"description":"MTI","enc":"ASCII","prefix":"ASCII.Fixed"},"1":{"type":"Bitmap","length":16,"description":"Bitmap","enc":"HexToASCII","prefix":"Hex.Fixed"},"11":{"type":"String","length":6,"description":"STAN","enc":"ASCII","prefix":"ASCII.Fixed"},"48":{"type":"Composite","length":999,"description":"Private Data","prefix":"ASCII.LLL","tag":{"sort":"StringsByInt"},"subfields":{"1":{"type":"String","length":3,"description":"A","enc":"ASCII","prefix":"ASCII.Fixed"},"2":{"type":"String","length":2,"description":"B","enc":"ASCII","prefix":"ASCII.Fixed"}}}}}
 ```
 _Fixture `other.json`:_
-```
+```text
 {"name":"F127 bitmap","fields":{"0":{"type":"String","length":4,"description":"MTI","enc":"ASCII","prefix":"ASCII.Fixed"},"1":{"type":"Bitmap","length":16,"description":"Bitmap","enc":"HexToASCII","prefix":"Hex.Fixed"},"11":{"type":"String","length":6,"description":"STAN","enc":"ASCII","prefix":"ASCII.Fixed"},"127":{"type":"Composite","length":255,"description":"Private use field","prefix":"ASCII.LL","bitmap":{"type":"Bitmap","length":8,"description":"Bitmap","enc":"HexToASCII","prefix":"Hex.Fixed","disableAutoExpand":true},"subfields":{"1":{"type":"String","length":2,"description":"A","enc":"ASCII","prefix":"ASCII.Fixed"},"2":{"type":"String","length":2,"description":"B","enc":"ASCII","prefix":"ASCII.Fixed"}}}}}
 ```
 #### When
@@ -1353,7 +1353,7 @@ iso8583tool view -- -response.hex
 - Fixture file `cfg.json` is created.
 #### Inputs
 _Fixture `cfg.json`:_
-```
+```text
 {"spec":"basei-starter","extensions":[{"id":63,"name":"Acme Blob","strategy":"opaque"}]}
 ```
 #### When
@@ -1368,7 +1368,7 @@ iso8583tool validate $ISO_EXAMPLES/basei/0110-auth-response.hex --config cfg.jso
 - Fixture file `bad.json` is created.
 #### Inputs
 _Fixture `bad.json`:_
-```
+```text
 {"extensions":[{"id":1,"strategy":"nope"}]}
 ```
 #### When
@@ -1386,7 +1386,7 @@ Source: `test/e2e/tools/iso8583tool/extension_strategy.atago.yaml`
 - Fixture file `msg.json` is created.
 #### Inputs
 _Fixture `spec.json`:_
-```
+```text
 {
   "name": "F48 positional",
   "fields": {
@@ -1405,7 +1405,7 @@ _Fixture `spec.json`:_
 }
 ```
 _Fixture `msg.json`:_
-```
+```text
 {"mti":"0100","fields":{"11":"123456","48.1":"ABC","48.2":"DE"}}
 ```
 #### When
@@ -1422,7 +1422,7 @@ iso8583tool view msg.hex --spec spec.json --encoding hex --no-color
 - Fixture file `msg.json` is created.
 #### Inputs
 _Fixture `msg.json`:_
-```
+```text
 {"mti":"0100","fields":{"11":"123456","127":"EEE"}}
 ```
 #### When
@@ -1602,7 +1602,7 @@ printf '%s' '{"mti":"0110","fields":{"11":"123456","39":"00","63":"card number=4
 - Fixture file `msg.json` is created.
 #### Inputs
 _Fixture `spec.json`:_
-```
+```text
 {
   "name": "F48 positional",
   "fields": {
@@ -1621,7 +1621,7 @@ _Fixture `spec.json`:_
 }
 ```
 _Fixture `msg.json`:_
-```
+```text
 {"mti":"0100","fields":{"11":"123456","48.1":"ABC","48.2":"DE"}}
 ```
 #### When
@@ -1641,11 +1641,11 @@ Source: `test/e2e/tools/iso8583tool/masking_custom.atago.yaml`
 - Fixture file `doc.json` is created.
 #### Inputs
 _Fixture `spec.json`:_
-```
+```text
 {"name":"B63","fields":{"0":{"type":"String","length":4,"description":"MTI","enc":"ASCII","prefix":"ASCII.Fixed"},"1":{"type":"Bitmap","length":16,"description":"Bitmap","enc":"HexToASCII","prefix":"Hex.Fixed"},"11":{"type":"String","length":6,"description":"STAN","enc":"ASCII","prefix":"ASCII.Fixed"},"63":{"type":"Binary","length":999,"description":"Private","enc":"Binary","prefix":"ASCII.LLL"}}}
 ```
 _Fixture `doc.json`:_
-```
+```text
 {"mti":"0110","fields":{"11":"123456"},"binary_fields":{"63":"50414E3D34313131313131313131313131313131"}}
 ```
 #### When
@@ -1663,11 +1663,11 @@ iso8583tool view m.hex --spec spec.json --format json
 - Fixture file `doc.json` is created.
 #### Inputs
 _Fixture `spec.json`:_
-```
+```text
 {"name":"9F6B","fields":{"0":{"type":"String","length":4,"description":"MTI","enc":"ASCII","prefix":"ASCII.Fixed"},"1":{"type":"Bitmap","length":16,"description":"Bitmap","enc":"HexToASCII","prefix":"Hex.Fixed"},"11":{"type":"String","length":6,"description":"STAN","enc":"ASCII","prefix":"ASCII.Fixed"},"55":{"type":"Composite","length":999,"description":"ICC","prefix":"ASCII.LLL","tag":{"enc":"BerTLVTag","sort":"StringsByHex","skipUnknownTLVTags":true,"storeUnknownTLVTags":true},"subfields":{"9F6B":{"type":"Binary","length":19,"description":"Track 2 Equivalent","enc":"Binary","prefix":"BerTLV"}}}}}
 ```
 _Fixture `doc.json`:_
-```
+```text
 {"mti":"0110","fields":{"11":"123456"},"binary_fields":{"55.9F6B":"4111111111111111D29122011234567890"}}
 ```
 #### When
@@ -1685,11 +1685,11 @@ iso8583tool view m.hex --spec spec.json --format json
 - Fixture file `doc.json` is created.
 #### Inputs
 _Fixture `spec.json`:_
-```
+```text
 {"name":"9F6B","fields":{"0":{"type":"String","length":4,"description":"MTI","enc":"ASCII","prefix":"ASCII.Fixed"},"1":{"type":"Bitmap","length":16,"description":"Bitmap","enc":"HexToASCII","prefix":"Hex.Fixed"},"11":{"type":"String","length":6,"description":"STAN","enc":"ASCII","prefix":"ASCII.Fixed"},"55":{"type":"Composite","length":999,"description":"ICC","prefix":"ASCII.LLL","tag":{"enc":"BerTLVTag","sort":"StringsByHex","skipUnknownTLVTags":true,"storeUnknownTLVTags":true},"subfields":{"9F6B":{"type":"Binary","length":19,"description":"Track 2 Equivalent","enc":"Binary","prefix":"BerTLV"}}}}}
 ```
 _Fixture `doc.json`:_
-```
+```text
 {"mti":"0110","fields":{"11":"123456"},"binary_fields":{"55.9F6B":"4111111111111111D29122011234567890"}}
 ```
 #### When
@@ -1707,11 +1707,11 @@ iso8583tool redact m.hex --spec spec.json --format json
 - Fixture file `doc.json` is created.
 #### Inputs
 _Fixture `spec.json`:_
-```
+```text
 {"name":"T127","fields":{"0":{"type":"String","length":4,"description":"MTI","enc":"ASCII","prefix":"ASCII.Fixed"},"1":{"type":"Bitmap","length":16,"description":"Bitmap","enc":"HexToASCII","prefix":"Hex.Fixed"},"11":{"type":"String","length":6,"description":"STAN","enc":"ASCII","prefix":"ASCII.Fixed"},"127":{"type":"Composite","length":999,"description":"Private TLV","prefix":"ASCII.LLL","tag":{"enc":"BerTLVTag","sort":"StringsByHex","skipUnknownTLVTags":true,"storeUnknownTLVTags":true},"subfields":{"57":{"type":"Binary","length":18,"description":"Track2Eq","enc":"Binary","prefix":"BerTLV"}}}}}
 ```
 _Fixture `doc.json`:_
-```
+```text
 {"mti":"0110","fields":{"11":"123456"},"binary_fields":{"127.57":"4111111111111111D29122011234567890"}}
 ```
 #### When
@@ -1729,11 +1729,11 @@ iso8583tool view m.hex --spec spec.json --format json
 - Fixture file `doc.json` is created.
 #### Inputs
 _Fixture `spec.json`:_
-```
+```text
 {"name":"C57","fields":{"0":{"type":"String","length":4,"description":"MTI","enc":"ASCII","prefix":"ASCII.Fixed"},"1":{"type":"Bitmap","length":16,"description":"Bitmap","enc":"HexToASCII","prefix":"Hex.Fixed"},"11":{"type":"String","length":6,"description":"STAN","enc":"ASCII","prefix":"ASCII.Fixed"},"55":{"type":"Composite","length":999,"description":"ICC","prefix":"ASCII.LLL","tag":{"enc":"BerTLVTag","sort":"StringsByHex","skipUnknownTLVTags":true,"storeUnknownTLVTags":true},"subfields":{"70":{"type":"Composite","length":255,"description":"Template","prefix":"BerTLV","tag":{"enc":"BerTLVTag","sort":"StringsByHex","skipUnknownTLVTags":true,"storeUnknownTLVTags":true},"subfields":{"57":{"type":"Binary","length":18,"description":"Track2Eq","enc":"Binary","prefix":"BerTLV"}}}}}}}
 ```
 _Fixture `doc.json`:_
-```
+```text
 {"mti":"0110","fields":{"11":"123456"},"binary_fields":{"55.70.57":"4111111111111111D29122011234567890"}}
 ```
 #### When
@@ -1751,11 +1751,11 @@ iso8583tool redact m.hex --spec spec.json --format json
 - Fixture file `doc.json` is created.
 #### Inputs
 _Fixture `spec.json`:_
-```
+```text
 {"name":"F35","fields":{"0":{"type":"String","length":4,"description":"MTI","enc":"ASCII","prefix":"ASCII.Fixed"},"1":{"type":"Bitmap","length":16,"description":"Bitmap","enc":"HexToASCII","prefix":"Hex.Fixed"},"11":{"type":"String","length":6,"description":"STAN","enc":"ASCII","prefix":"ASCII.Fixed"},"35":{"type":"String","length":37,"description":"Partner Reference","enc":"ASCII","prefix":"ASCII.LL"}}}
 ```
 _Fixture `doc.json`:_
-```
+```text
 {"mti":"0110","fields":{"11":"123456","35":"REF-ORDER-ABC-0001"}}
 ```
 #### When
@@ -1773,11 +1773,11 @@ iso8583tool view m.hex --spec spec.json --format json
 - Fixture file `doc.json` is created.
 #### Inputs
 _Fixture `spec.json`:_
-```
+```text
 {"name":"F52","fields":{"0":{"type":"String","length":4,"description":"MTI","enc":"ASCII","prefix":"ASCII.Fixed"},"1":{"type":"Bitmap","length":16,"description":"Bitmap","enc":"HexToASCII","prefix":"Hex.Fixed"},"11":{"type":"String","length":6,"description":"STAN","enc":"ASCII","prefix":"ASCII.Fixed"},"52":{"type":"String","length":8,"description":"Partner Status","enc":"ASCII","prefix":"ASCII.Fixed"}}}
 ```
 _Fixture `doc.json`:_
-```
+```text
 {"mti":"0110","fields":{"11":"123456","52":"ABCDEFGH"}}
 ```
 #### When
@@ -1795,11 +1795,11 @@ iso8583tool view m.hex --spec spec.json --format json
 - Fixture file `doc.json` is created.
 #### Inputs
 _Fixture `spec.json`:_
-```
+```text
 {"name":"F2","fields":{"0":{"type":"String","length":4,"description":"MTI","enc":"ASCII","prefix":"ASCII.Fixed"},"1":{"type":"Bitmap","length":16,"description":"Bitmap","enc":"HexToASCII","prefix":"Hex.Fixed"},"2":{"type":"String","length":19,"description":"Account","enc":"ASCII","prefix":"ASCII.LL"},"11":{"type":"String","length":6,"description":"STAN","enc":"ASCII","prefix":"ASCII.Fixed"}}}
 ```
 _Fixture `doc.json`:_
-```
+```text
 {"mti":"0110","fields":{"2":"4111111111111111","11":"123456"}}
 ```
 #### When
@@ -1819,7 +1819,7 @@ Source: `test/e2e/tools/iso8583tool/nested_describe.atago.yaml`
 - Fixture file `msg.json` is created.
 #### Inputs
 _Fixture `spec.json`:_
-```
+```text
 {
   "name": "F48 nested positional",
   "fields": {
@@ -1838,7 +1838,7 @@ _Fixture `spec.json`:_
 … (truncated)
 ```
 _Fixture `msg.json`:_
-```
+```text
 {"mti":"0100","fields":{"11":"123456","48.1":"AB","48.2.1":"260604"}}
 ```
 #### When
@@ -1856,7 +1856,7 @@ iso8583tool view msg.hex --spec spec.json --encoding hex --no-color
 - Fixture file `msg.json` is created.
 #### Inputs
 _Fixture `spec.json`:_
-```
+```text
 {
   "name": "Constructed TLV 8A",
   "fields": {
@@ -1874,7 +1874,7 @@ _Fixture `spec.json`:_
 … (truncated, 2 more lines)
 ```
 _Fixture `msg.json`:_
-```
+```text
 {"mti":"0110","fields":{"11":"123456"},"binary_fields":{"55.70.8A":"3030","55.70.9A":"260605"}}
 ```
 #### When
@@ -1892,7 +1892,7 @@ iso8583tool view msg.hex --spec spec.json --encoding hex --no-color
 - Fixture file `msg.json` is created.
 #### Inputs
 _Fixture `spec.json`:_
-```
+```text
 {
   "name": "Constructed TLV 8A",
   "fields": {
@@ -1910,7 +1910,7 @@ _Fixture `spec.json`:_
 … (truncated, 2 more lines)
 ```
 _Fixture `msg.json`:_
-```
+```text
 {"mti":"0110","fields":{"11":"123456"},"binary_fields":{"55.70.8A":"3030","55.70.9A":"260605"}}
 ```
 #### When
@@ -1930,7 +1930,7 @@ Source: `test/e2e/tools/iso8583tool/nested_tlv.atago.yaml`
 - Fixture file `a.json` is created.
 #### Inputs
 _Fixture `spec.json`:_
-```
+```text
 {
   "name": "Constructed TLV",
   "fields": {
@@ -1948,7 +1948,7 @@ _Fixture `spec.json`:_
 … (truncated)
 ```
 _Fixture `a.json`:_
-```
+```text
 {"mti":"0110","fields":{"11":"123456"},"binary_fields":{"55.70.9F02":"000000005000"}}
 ```
 #### When
@@ -1967,7 +1967,7 @@ iso8583tool convert a.hex --spec spec.json
 - Fixture file `a.json` is created.
 #### Inputs
 _Fixture `spec.json`:_
-```
+```text
 {
   "name": "Constructed TLV",
   "fields": {
@@ -1985,7 +1985,7 @@ _Fixture `spec.json`:_
 … (truncated)
 ```
 _Fixture `a.json`:_
-```
+```text
 {"mti":"0110","fields":{"11":"123456"},"binary_fields":{"55.70.9F02":"000000005000"}}
 ```
 #### When
@@ -2005,7 +2005,7 @@ iso8583tool view a.hex --spec spec.json --filter 55.70.9F02 --no-color
 - Fixture file `b.json` is created.
 #### Inputs
 _Fixture `spec.json`:_
-```
+```text
 {
   "name": "Constructed TLV",
   "fields": {
@@ -2023,11 +2023,11 @@ _Fixture `spec.json`:_
 … (truncated)
 ```
 _Fixture `a.json`:_
-```
+```text
 {"mti":"0110","fields":{"11":"123456"},"binary_fields":{"55.70.9F02":"000000005000"}}
 ```
 _Fixture `b.json`:_
-```
+```text
 {"mti":"0110","fields":{"11":"123456"},"binary_fields":{"55.70.9F02":"000000009999"}}
 ```
 #### When
@@ -2045,7 +2045,7 @@ iso8583tool diff a.hex b.hex --spec spec.json --no-color
 - Fixture file `spec.json` is created.
 #### Inputs
 _Fixture `spec.json`:_
-```
+```text
 {
   "name": "Constructed TLV",
   "fields": {
@@ -2078,7 +2078,7 @@ iso8583tool convert mix.hex --spec spec.json
 - Fixture file `a.json` is created.
 #### Inputs
 _Fixture `spec.json`:_
-```
+```text
 {
   "name": "Constructed TLV",
   "fields": {
@@ -2096,7 +2096,7 @@ _Fixture `spec.json`:_
 … (truncated)
 ```
 _Fixture `a.json`:_
-```
+```text
 {"mti":"0110","fields":{"11":"123456"},"binary_fields":{"55.70.9F02":"000000005000"}}
 ```
 #### When
@@ -2515,7 +2515,7 @@ Source: `test/e2e/tools/iso8583tool/sanitize_output.atago.yaml`
 - Fixture file `bin41.json` is created.
 #### Inputs
 _Fixture `bin41.json`:_
-```
+```text
 {"name":"Bin41","fields":{"0":{"type":"String","length":4,"description":"MTI","enc":"ASCII","prefix":"ASCII.Fixed"},"1":{"type":"Bitmap","length":16,"description":"Bitmap","enc":"HexToASCII","prefix":"Hex.Fixed"},"41":{"type":"Binary","length":8,"description":"Terminal","enc":"Binary","prefix":"Binary.Fixed"}}}
 ```
 #### When
@@ -2533,7 +2533,7 @@ iso8583tool view a.hex --no-color
 - Fixture file `bin41.json` is created.
 #### Inputs
 _Fixture `bin41.json`:_
-```
+```text
 {"name":"Bin41","fields":{"0":{"type":"String","length":4,"description":"MTI","enc":"ASCII","prefix":"ASCII.Fixed"},"1":{"type":"Bitmap","length":16,"description":"Bitmap","enc":"HexToASCII","prefix":"Hex.Fixed"},"41":{"type":"Binary","length":8,"description":"Terminal","enc":"Binary","prefix":"Binary.Fixed"}}}
 ```
 #### When
@@ -2550,7 +2550,7 @@ iso8583tool validate a.hex --no-color
 - Fixture file `bin41.json` is created.
 #### Inputs
 _Fixture `bin41.json`:_
-```
+```text
 {"name":"Bin41","fields":{"0":{"type":"String","length":4,"description":"MTI","enc":"ASCII","prefix":"ASCII.Fixed"},"1":{"type":"Bitmap","length":16,"description":"Bitmap","enc":"HexToASCII","prefix":"Hex.Fixed"},"41":{"type":"Binary","length":8,"description":"Terminal","enc":"Binary","prefix":"Binary.Fixed"}}}
 ```
 #### When
@@ -2569,7 +2569,7 @@ iso8583tool diff a.hex b.hex --no-color
 - Fixture file `bin41.json` is created.
 #### Inputs
 _Fixture `bin41.json`:_
-```
+```text
 {"name":"Bin41","fields":{"0":{"type":"String","length":4,"description":"MTI","enc":"ASCII","prefix":"ASCII.Fixed"},"1":{"type":"Bitmap","length":16,"description":"Bitmap","enc":"HexToASCII","prefix":"Hex.Fixed"},"41":{"type":"Binary","length":8,"description":"Terminal","enc":"Binary","prefix":"Binary.Fixed"}}}
 ```
 #### When
@@ -2827,7 +2827,7 @@ Source: `test/e2e/tools/iso8583tool/standard_fields.atago.yaml`
 - Fixture file `hi.json` is created.
 #### Inputs
 _Fixture `hi.json`:_
-```
+```text
 {"mti":"0200","fields":{"11":"123456","95":"000000000000000000000000000000000000000000","100":"12345678901","102":"1234567890123456789012345678","103":"8765432109876543210987654321","104":"DESCRIPTION"},"binary_fields":{"96":"A1B2C3D4E5F60708"}}
 ```
 #### When
@@ -2844,7 +2844,7 @@ iso8583tool view hi.hex --format json
 - Fixture file `r.json` is created.
 #### Inputs
 _Fixture `r.json`:_
-```
+```text
 {"mti":"0100","fields":{"11":"123456","123":"AAA","124":"BBB","125":"CCC","126":"DDD","127":"EEE"}}
 ```
 #### When
@@ -2859,7 +2859,7 @@ iso8583tool convert r.json --to hex
 - Fixture file `m.json` is created.
 #### Inputs
 _Fixture `m.json`:_
-```
+```text
 {"mti":"0100","binary_fields":{"128":"A1B2C3D4E5F60708"}}
 ```
 #### When
@@ -2878,7 +2878,7 @@ Source: `test/e2e/tools/iso8583tool/strict_validate.atago.yaml`
 - Fixture file `h0120.json` is created.
 #### Inputs
 _Fixture `h0120.json`:_
-```
+```text
 {"mti":"0120","fields":{"11":"123456"}}
 ```
 #### When
@@ -2895,7 +2895,7 @@ iso8583tool validate h0120.hex --strict
 - Fixture file `h0220.json` is created.
 #### Inputs
 _Fixture `h0220.json`:_
-```
+```text
 {"mti":"0220","fields":{"11":"123456"}}
 ```
 #### When
@@ -2912,7 +2912,7 @@ iso8583tool validate h0220.hex --strict
 - Fixture file `h0820.json` is created.
 #### Inputs
 _Fixture `h0820.json`:_
-```
+```text
 {"mti":"0820","fields":{"11":"123456"}}
 ```
 #### When
@@ -2929,7 +2929,7 @@ iso8583tool validate h0820.hex --strict
 - Fixture file `h0810.json` is created.
 #### Inputs
 _Fixture `h0810.json`:_
-```
+```text
 {"mti":"0810","fields":{"11":"123456","39":"00"}}
 ```
 #### When
@@ -2946,7 +2946,7 @@ iso8583tool validate h0810.hex --strict
 - Fixture file `h0830.json` is created.
 #### Inputs
 _Fixture `h0830.json`:_
-```
+```text
 {"mti":"0830","fields":{"11":"123456","39":"00"}}
 ```
 #### When
@@ -2971,7 +2971,7 @@ iso8583tool validate $ISO_EXAMPLES/basei/0800-network-echo.hex --strict
 - Fixture file `h0140.json` is created.
 #### Inputs
 _Fixture `h0140.json`:_
-```
+```text
 {"mti":"0140","fields":{"11":"123456"}}
 ```
 #### When
@@ -2988,7 +2988,7 @@ iso8583tool validate h0140.hex --strict
 - Fixture file `h0270.json` is created.
 #### Inputs
 _Fixture `h0270.json`:_
-```
+```text
 {"mti":"0270","fields":{"11":"123456"}}
 ```
 #### When
@@ -3005,7 +3005,7 @@ iso8583tool validate h0270.hex --strict
 - Fixture file `h0300.json` is created.
 #### Inputs
 _Fixture `h0300.json`:_
-```
+```text
 {"mti":"0300","fields":{"11":"123456"}}
 ```
 #### When
@@ -3022,7 +3022,7 @@ iso8583tool validate h0300.hex --strict
 - Fixture file `h0400.json` is created.
 #### Inputs
 _Fixture `h0400.json`:_
-```
+```text
 {"mti":"0400","fields":{"4":"000000001000","7":"0605123456","11":"123456","90":"020022334406041301050000000000000000000000"}}
 ```
 #### When
@@ -3039,7 +3039,7 @@ iso8583tool validate h0400.hex --strict
 - Fixture file `h0500.json` is created.
 #### Inputs
 _Fixture `h0500.json`:_
-```
+```text
 {"mti":"0500","fields":{"11":"123456"}}
 ```
 #### When
@@ -3056,7 +3056,7 @@ iso8583tool validate h0500.hex --strict
 - Fixture file `hc0800.json` is created.
 #### Inputs
 _Fixture `hc0800.json`:_
-```
+```text
 {"mti":"0800","fields":{"11":"123456","70":"ABC"}}
 ```
 #### When

--- a/doc/e2e/mailpit.md
+++ b/doc/e2e/mailpit.md
@@ -24,7 +24,7 @@ mailpit version
 - Fixture file `mail.txt` is created.
 #### Inputs
 _Fixture `mail.txt`:_
-```
+```text
 From: Alice <alice@example.test>
 To: Bob <bob@example.test>
 Subject: Deploy finished
@@ -55,7 +55,7 @@ curl -s --url smtp://127.0.0.1:18170 --mail-from alice@example.test --mail-rcpt 
 - Fixture file `mail2.txt` is created.
 #### Inputs
 _Fixture `mail1.txt`:_
-```
+```text
 From: ci@example.test
 To: team@example.test
 Subject: nightly build report
@@ -63,7 +63,7 @@ Subject: nightly build report
 All tests were green tonight.
 ```
 _Fixture `mail2.txt`:_
-```
+```text
 From: ci@example.test
 To: team@example.test
 Subject: invoice reminder
@@ -88,7 +88,7 @@ curl -s --url smtp://127.0.0.1:18172 --mail-from ci@example.test --mail-rcpt tea
 - Fixture file `mail.txt` is created.
 #### Inputs
 _Fixture `mail.txt`:_
-```
+```text
 From: reports@example.test
 To: audit@example.test
 Subject: weekly numbers
@@ -125,7 +125,7 @@ curl -s --url smtp://127.0.0.1:18174 --mail-from reports@example.test --mail-rcp
 - Fixture file `mail.txt` is created.
 #### Inputs
 _Fixture `mail.txt`:_
-```
+```text
 From: temp@example.test
 To: trash@example.test
 Subject: ephemeral

--- a/doc/e2e/mimixbox.md
+++ b/doc/e2e/mimixbox.md
@@ -2072,11 +2072,11 @@ Source: `test/e2e/tools/mimixbox/archival/ar.atago.yaml`
 - Fixture file `b.txt` is created.
 #### Inputs
 _Fixture `a.txt`:_
-```
+```text
 alpha
 ```
 _Fixture `b.txt`:_
-```
+```text
 beta
 ```
 #### When
@@ -2092,7 +2092,7 @@ ar rc lib.a a.txt b.txt && ar t lib.a
 - Fixture file `a.txt` is created.
 #### Inputs
 _Fixture `a.txt`:_
-```
+```text
 alpha
 ```
 #### When
@@ -2141,7 +2141,7 @@ Source: `test/e2e/tools/mimixbox/archival/compress.atago.yaml`
 - Fixture file `data.txt` is created.
 #### Inputs
 _Fixture `data.txt`:_
-```
+```text
 compress me compress me compress me
 ```
 #### When
@@ -2158,7 +2158,7 @@ Source: `test/e2e/tools/mimixbox/archival/cpio.atago.yaml`
 - Fixture file `in/file.txt` is created.
 #### Inputs
 _Fixture `in/file.txt`:_
-```
+```text
 payload
 ```
 #### When
@@ -2179,7 +2179,7 @@ cat file.txt
 - Fixture file `in/file.txt` is created.
 #### Inputs
 _Fixture `in/file.txt`:_
-```
+```text
 payload
 ```
 #### When
@@ -2487,7 +2487,7 @@ Source: `test/e2e/tools/mimixbox/archival/tar.atago.yaml`
 - Fixture file `src/a.txt` is created.
 #### Inputs
 _Fixture `src/a.txt`:_
-```
+```text
 alpha
 ```
 #### When
@@ -2506,7 +2506,7 @@ cat dest/src/a.txt
 - Fixture file `src/a.txt` is created.
 #### Inputs
 _Fixture `src/a.txt`:_
-```
+```text
 alpha
 ```
 #### When
@@ -2647,7 +2647,7 @@ Source: `test/e2e/tools/mimixbox/archival/zip.atago.yaml`
 - Fixture file `a.txt` is created.
 #### Inputs
 _Fixture `a.txt`:_
-```
+```text
 zipped
 ```
 #### When
@@ -2662,7 +2662,7 @@ zip out.zip a.txt >/dev/null && unzip -l out.zip
 - Fixture file `a.txt` is created.
 #### Inputs
 _Fixture `a.txt`:_
-```
+```text
 zipped
 ```
 #### When
@@ -2793,7 +2793,7 @@ mimixbox '[' -f /no/such/mimixbox/file ']' && echo yes || echo no
 - Fixture file `f` is created.
 #### Inputs
 _Fixture `f`:_
-```
+```text
 hello
 ```
 #### When
@@ -3058,7 +3058,7 @@ chat
 ### Scenario: fails when an expected string never arrives
 #### Inputs
 _stdin for `chat`:_
-```
+```text
 nope
 ```
 #### When
@@ -3356,7 +3356,7 @@ printf 'a\nb\nc\n' | more
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 a
 b
 c
@@ -3371,7 +3371,7 @@ printf 'x\ny\nz\n' | less
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 x
 y
 z
@@ -3381,7 +3381,7 @@ z
 - Fixture file `f` is created.
 #### Inputs
 _Fixture `f`:_
-```
+```text
 one
 two
 ```
@@ -3394,7 +3394,7 @@ more f
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 one
 two
 ```
@@ -3551,7 +3551,7 @@ Source: `test/e2e/tools/mimixbox/console-tools/stty.atago.yaml`
 ### Scenario: reports when standard input is not a terminal
 #### Inputs
 _stdin for `stty`:_
-```
+```text
 x
 ```
 #### When
@@ -3609,7 +3609,7 @@ printf 'a b\nb c\n' | tsort
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 a
 b
 c
@@ -3624,7 +3624,7 @@ printf 'foo\nbar\nbaz\n' | egrep 'ba(r|z)'
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 bar
 baz
 ```
@@ -3732,7 +3732,7 @@ valid-shell --help
 - Fixture file `shells.txt` is created.
 #### Inputs
 _Fixture `shells.txt`:_
-```
+```text
 /bin/sh
 /bin/bash
 ```
@@ -3785,13 +3785,13 @@ Source: `test/e2e/tools/mimixbox/editors/diff.atago.yaml`
 - Fixture file `b` is created.
 #### Inputs
 _Fixture `a`:_
-```
+```text
 one
 two
 three
 ```
 _Fixture `b`:_
-```
+```text
 one
 2
 three
@@ -3809,13 +3809,13 @@ diff a b
 - Fixture file `c` is created.
 #### Inputs
 _Fixture `a`:_
-```
+```text
 one
 two
 three
 ```
 _Fixture `c`:_
-```
+```text
 one
 two
 three
@@ -3833,13 +3833,13 @@ diff a c
 - Fixture file `b` is created.
 #### Inputs
 _Fixture `a`:_
-```
+```text
 one
 two
 three
 ```
 _Fixture `b`:_
-```
+```text
 one
 2
 three
@@ -3858,13 +3858,13 @@ Source: `test/e2e/tools/mimixbox/editors/ed.atago.yaml`
 - Fixture file `buf.txt` is created.
 #### Inputs
 _Fixture `buf.txt`:_
-```
+```text
 one
 two
 three
 ```
 _stdin for `ed`:_
-```
+```text
 1,$p
 q
 ```
@@ -3877,7 +3877,7 @@ ed buf.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 14
 one
 two
@@ -3888,7 +3888,7 @@ three
 - Fixture file `buf.txt` is created.
 #### Inputs
 _Fixture `buf.txt`:_
-```
+```text
 one
 two
 three
@@ -3904,7 +3904,7 @@ cat buf.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 one
 two
 INSERTED
@@ -3915,7 +3915,7 @@ three
 - Fixture file `buf.txt` is created.
 #### Inputs
 _Fixture `buf.txt`:_
-```
+```text
 one
 two
 three
@@ -3931,7 +3931,7 @@ cat buf.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 one
 TWO
 three
@@ -3944,13 +3944,13 @@ Source: `test/e2e/tools/mimixbox/editors/patch.atago.yaml`
 - Fixture file `p.diff` is created.
 #### Inputs
 _Fixture `f.txt`:_
-```
+```text
 one
 two
 three
 ```
 _Fixture `p.diff`:_
-```
+```text
 --- ${workdir}/f.txt
 +++ ${workdir}/f.txt
 @@ -1,3 +1,3 @@
@@ -3972,7 +3972,7 @@ cat f.txt
   - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 one
 2
 three
@@ -4019,7 +4019,7 @@ Source: `test/e2e/tools/mimixbox/editors/vi.atago.yaml`
 - Fixture file `a.txt` is created.
 #### Inputs
 _Fixture `a.txt`:_
-```
+```text
 hello
 world
 ```
@@ -4034,7 +4034,7 @@ cat a.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 ello
 world
 ```
@@ -4043,7 +4043,7 @@ world
 - Fixture file `b.txt` is created.
 #### Inputs
 _Fixture `b.txt`:_
-```
+```text
 bar
 ```
 #### When
@@ -4070,7 +4070,7 @@ cat new.txt
 - Fixture file `a.txt` is created.
 #### Inputs
 _Fixture `a.txt`:_
-```
+```text
 hello
 world
 ```
@@ -4085,7 +4085,7 @@ cat a.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 hello
 world
 ```
@@ -4094,7 +4094,7 @@ world
 - Fixture file `yp.txt` is created.
 #### Inputs
 _Fixture `yp.txt`:_
-```
+```text
 one
 two
 ```
@@ -4109,7 +4109,7 @@ cat yp.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 one
 one
 two
@@ -4119,7 +4119,7 @@ two
 - Fixture file `cd.txt` is created.
 #### Inputs
 _Fixture `cd.txt`:_
-```
+```text
 abcdef
 ```
 #### When
@@ -4136,7 +4136,7 @@ cat cd.txt
 - Fixture file `u.txt` is created.
 #### Inputs
 _Fixture `u.txt`:_
-```
+```text
 keepme
 ```
 #### When
@@ -4153,7 +4153,7 @@ cat u.txt
 - Fixture file `sn.txt` is created.
 #### Inputs
 _Fixture `sn.txt`:_
-```
+```text
 x
 foo
 y
@@ -4171,7 +4171,7 @@ cat sn.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 x
 foo
 y
@@ -6546,7 +6546,7 @@ lpq -S spool
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 page content
 no entries
 ```
@@ -6632,7 +6632,7 @@ Source: `test/e2e/tools/mimixbox/embedded/makedevs.atago.yaml`
 - Fixture file `table.txt` is created.
 #### Inputs
 _Fixture `table.txt`:_
-```
+```text
 # device table
 /dev d 755 0 0 0 0 0 0 0
 /etc/hostname f 644 0 0 0 0 0 0 0
@@ -7062,7 +7062,7 @@ cp -r ${workdir}/cp ${workdir}/cp2 && ls ${workdir}/cp2 && ls ${workdir}/cp2/cp
   - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 cp
 1.txt
 2.txt
@@ -7081,7 +7081,7 @@ cp -r ${workdir}/cp ${workdir}/cp; ls ${workdir}/cp
   - stderr equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 1.txt
 2.txt
 3.txt
@@ -7109,7 +7109,7 @@ cp ${workdir}/cp/1.txt ${workdir}/cp/2.txt ${workdir}/cp/3.txt ${workdir}/cp2 &&
   - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 1.txt
 2.txt
 3.txt
@@ -7126,7 +7126,7 @@ cp ${workdir}/cp ${workdir}/cp2
   - stderr equals an exact value
 #### Expected output
 _expected stderr:_
-```
+```text
 cp: --recursive is not specified: omitting directory: ${workdir}/cp
 ```
 ### Scenario: can not copy a directory to root without authority
@@ -7150,7 +7150,7 @@ printf 'A\n' > a.txt && printf 'B\n' > b.txt && mkdir dst_t dst_plain && cp --ta
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 A
 B
 ```
@@ -7182,7 +7182,7 @@ printf 'new\n' > src.txt && printf 'old\n' > dst.txt && cp --backup=simple src.t
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 new
 old
 ```
@@ -7215,7 +7215,7 @@ mkdir -p src dst/src && printf 'new\n' > src/f.txt && printf 'old\n' > dst/src/f
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 new
 old
 ```
@@ -7283,7 +7283,7 @@ Source: `test/e2e/tools/mimixbox/fileutils/link.atago.yaml`
 - Fixture file `link_src` is created.
 #### Inputs
 _Fixture `link_src`:_
-```
+```text
 data
 ```
 #### When
@@ -7300,7 +7300,7 @@ Source: `test/e2e/tools/mimixbox/fileutils/ln.atago.yaml`
 - Fixture file `ln/target.txt` is created.
 #### Inputs
 _Fixture `ln/target.txt`:_
-```
+```text
 content
 ```
 #### When
@@ -7315,7 +7315,7 @@ ln ${workdir}/ln/target.txt ${workdir}/ln/hardlink.txt && cat ${workdir}/ln/hard
 - Fixture file `ln/target.txt` is created.
 #### Inputs
 _Fixture `ln/target.txt`:_
-```
+```text
 content
 ```
 #### When
@@ -7362,7 +7362,7 @@ ln --target-directory ${workdir}/ln_gnu/dst ${workdir}/ln_gnu/a.txt ${workdir}/l
   - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 a.txt
 b.txt
 ```
@@ -7380,7 +7380,7 @@ ls ${workdir}/ls
   - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 a.txt
 b.txt
 sub
@@ -7634,7 +7634,7 @@ mkdir -p mkdir && mkdir ${workdir}/mkdir/1 ${workdir}/mkdir/2 ${workdir}/mkdir/3
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 1
 2
 3
@@ -7681,7 +7681,7 @@ mkdir -p mkdir && mkdir ${workdir}/mkdir/1 /mkdir/2 ${workdir}/mkdir/3; ls ${wor
 - stderr equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 1
 3
 ```
@@ -7710,7 +7710,7 @@ ls -al ${workdir}/mkfifo/3 | cut -f 1 -d " "
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 prw-r--r--
 prw-r--r--
 prw-r--r--
@@ -7746,7 +7746,7 @@ ls ${workdir}/mkfifo
 - stderr equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 1
 3
 ```
@@ -7784,7 +7784,7 @@ mv ${workdir}/mv/1.txt ${workdir}/mv/inner && ls ${workdir}/mv/inner
   - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 1.txt
 inner.txt
 ```
@@ -7800,7 +7800,7 @@ mv ${workdir}/mv/1.txt ${workdir}/mv/2.txt ${workdir}/mv/3.txt ${workdir}/mv/inn
   - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 1.txt
 2.txt
 3.txt
@@ -7818,7 +7818,7 @@ mv ${workdir}/mv/1.txt ${workdir}/mv/no_exist_file ${workdir}/mv/3.txt ${workdir
   - stderr equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 1.txt
 3.txt
 inner.txt
@@ -7835,7 +7835,7 @@ mv ${workdir}/mv2 ${workdir}/mv && ls ${workdir}/mv
   - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 1.txt
 2.txt
 3.txt
@@ -7854,7 +7854,7 @@ mv ${workdir}/mv2 ${workdir}/mv3 ${workdir}/mv4 ${workdir}/mv && ls ${workdir}/m
   - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 1.txt
 2.txt
 3.txt
@@ -7875,7 +7875,7 @@ mv ${workdir}/mv2 ${workdir}/mv/no_exist_dir ${workdir}/mv4 ${workdir}/mv/inner;
   - stderr equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 inner.txt
 mv2
 mv4
@@ -7892,7 +7892,7 @@ mv ${workdir}/mv/1.txt ${workdir}/mv/1.txt
   - stderr equals an exact value
 #### Expected output
 _expected stderr:_
-```
+```text
 mv: source '${workdir}/mv/1.txt' and destination '${workdir}/mv/1.txt' is same
 ```
 ### Scenario: overwrite a file with the same destination name
@@ -7907,7 +7907,7 @@ touch ${workdir}/mv/inner.txt && mv ${workdir}/mv/inner.txt ${workdir}/mv/inner/
   - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 1.txt
 2.txt
 3.txt
@@ -7926,7 +7926,7 @@ touch ${workdir}/mv/inner.txt && mv -b ${workdir}/mv/inner.txt ${workdir}/mv/inn
   - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 inner.txt
 inner.txt~
 ```
@@ -7947,7 +7947,7 @@ mv --target-directory ${workdir}/mv_gnu/dst ${workdir}/mv_gnu/a.txt ${workdir}/m
   - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 a.txt
 b.txt
 ```
@@ -8037,7 +8037,7 @@ rm ${workdir}/rm/1.txt && ls ${workdir}/rm
   - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 2.txt
 3.txt
 inner
@@ -8074,12 +8074,12 @@ rm ${workdir}/rm/1.txt ${workdir}/rm/no_exist_file.txt ${workdir}/rm/3.txt; ls $
   - stderr equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 2.txt
 inner
 ```
 _expected stderr:_
-```
+```text
 rm: can't remove ${workdir}/rm/no_exist_file.txt: No such file or directory exists
 ```
 ### Scenario: can not remove a directory without the recursive option
@@ -8094,7 +8094,7 @@ rm ${workdir}/rm; ls ${workdir}/rm
   - stderr equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 1.txt
 2.txt
 3.txt
@@ -8165,7 +8165,7 @@ rmdir ${workdir}/rmdir/full
   - stderr equals an exact value
 #### Expected output
 _expected stderr:_
-```
+```text
 rmdir: failed to remove '${workdir}/rmdir/full': Directory not empty
 ```
 ### Scenario: rmdir -p removes nested empty directories
@@ -8202,7 +8202,7 @@ serial ${workdir}/serial > /dev/null && ls ${workdir}/serial
   - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 0_apple.txt
 1_banana.txt
 2_cherry.txt
@@ -8219,7 +8219,7 @@ serial -d ${workdir}/serial > /dev/null && ls ${workdir}/serial
   - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 apple.txt
 banana.txt
 cherry.txt
@@ -8239,7 +8239,7 @@ Source: `test/e2e/tools/mimixbox/fileutils/shred.atago.yaml`
 - Fixture file `shred_file` is created.
 #### Inputs
 _Fixture `shred_file`:_
-```
+```text
 secret
 ```
 #### When
@@ -8256,7 +8256,7 @@ Source: `test/e2e/tools/mimixbox/fileutils/stat.atago.yaml`
 - Fixture file `stat_file` is created.
 #### Inputs
 _Fixture `stat_file`:_
-```
+```text
 hello
 ```
 #### When
@@ -8273,7 +8273,7 @@ Source: `test/e2e/tools/mimixbox/fileutils/stat_gnu.atago.yaml`
 - Fixture file `stat_file` is created.
 #### Inputs
 _Fixture `stat_file`:_
-```
+```text
 hello
 ```
 #### When
@@ -8288,7 +8288,7 @@ stat --printf '%n=%s' ${workdir}/stat_file
 - Fixture file `stat_file` is created.
 #### Inputs
 _Fixture `stat_file`:_
-```
+```text
 hello
 ```
 #### When
@@ -8303,7 +8303,7 @@ stat --printf '%n %s\n' ${workdir}/stat_file
 - Fixture file `stat_file` is created.
 #### Inputs
 _Fixture `stat_file`:_
-```
+```text
 hello
 ```
 #### When
@@ -8318,7 +8318,7 @@ stat --format '%s' ${workdir}/stat_file | wc -l | tr -d ' '
 - Fixture file `stat_file` is created.
 #### Inputs
 _Fixture `stat_file`:_
-```
+```text
 hello
 ```
 #### When
@@ -8333,7 +8333,7 @@ stat --terse ${workdir}/stat_file | awk '{print NF}'
 - Fixture file `stat_file` is created.
 #### Inputs
 _Fixture `stat_file`:_
-```
+```text
 hello
 ```
 #### When
@@ -8368,7 +8368,7 @@ ls ${workdir}/touch/3.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 ${workdir}/touch/1.txt
 ${workdir}/touch/2.txt
 ${workdir}/touch/3.txt
@@ -8387,7 +8387,7 @@ ls ${workdir}/touch/3.txt
 - stderr equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 ${workdir}/touch/1.txt
 ${workdir}/touch/3.txt
 ```
@@ -8452,7 +8452,7 @@ Source: `test/e2e/tools/mimixbox/fileutils/unlink.atago.yaml`
 - Fixture file `unlink.txt` is created.
 #### Inputs
 _Fixture `unlink.txt`:_
-```
+```text
 x
 ```
 #### When
@@ -8469,7 +8469,7 @@ Source: `test/e2e/tools/mimixbox/findutils/alias_parity.atago.yaml`
 - Fixture file `fixture.txt` is created.
 #### Inputs
 _Fixture `fixture.txt`:_
-```
+```text
 apple
 banana
 a.b
@@ -8484,7 +8484,7 @@ egrep 'a(p|x)' fixture.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 apple
 axb
 ```
@@ -8493,7 +8493,7 @@ axb
 - Fixture file `fixture.txt` is created.
 #### Inputs
 _Fixture `fixture.txt`:_
-```
+```text
 apple
 banana
 a.b
@@ -8625,7 +8625,7 @@ printf 'one\ntwo\nthree\n' | grep two
 - Fixture file `fruits.txt` is created.
 #### Inputs
 _Fixture `fruits.txt`:_
-```
+```text
 apple
 banana
 cherry
@@ -8642,7 +8642,7 @@ grep an ${workdir}/fruits.txt
 - Fixture file `fruits.txt` is created.
 #### Inputs
 _Fixture `fruits.txt`:_
-```
+```text
 apple
 banana
 cherry
@@ -8668,7 +8668,7 @@ Source: `test/e2e/tools/mimixbox/findutils/grep_gnu.atago.yaml`
 - Fixture file `grep_gnu/ctx.txt` is created.
 #### Inputs
 _Fixture `grep_gnu/ctx.txt`:_
-```
+```text
 1
 2
 MATCH
@@ -8684,7 +8684,7 @@ grep -A1 MATCH ${workdir}/grep_gnu/ctx.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 MATCH
 b
 ```
@@ -8693,7 +8693,7 @@ b
 - Fixture file `grep_gnu/ctx2.txt` is created.
 #### Inputs
 _Fixture `grep_gnu/ctx2.txt`:_
-```
+```text
 a
 MATCH
 b
@@ -8707,7 +8707,7 @@ grep -B1 MATCH ${workdir}/grep_gnu/ctx2.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 a
 MATCH
 ```
@@ -8716,7 +8716,7 @@ MATCH
 - Fixture file `grep_gnu/ctx2.txt` is created.
 #### Inputs
 _Fixture `grep_gnu/ctx2.txt`:_
-```
+```text
 a
 MATCH
 b
@@ -8730,7 +8730,7 @@ grep -C1 MATCH ${workdir}/grep_gnu/ctx2.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 a
 MATCH
 b
@@ -8740,7 +8740,7 @@ b
 - Fixture file `grep_gnu/groups.txt` is created.
 #### Inputs
 _Fixture `grep_gnu/groups.txt`:_
-```
+```text
 MATCH
 b
 c
@@ -8809,7 +8809,7 @@ printf 'hello world\n' | grep --color=always world
 - Fixture file `grep_gnu/off.txt` is created.
 #### Inputs
 _Fixture `grep_gnu/off.txt`:_
-```
+```text
 aaa
 bbb
 ccc
@@ -9110,7 +9110,7 @@ Source: `test/e2e/tools/mimixbox/loginutils/chpasswd.atago.yaml`
 ### Scenario: rejects an unknown method
 #### Inputs
 _stdin for `chpasswd`:_
-```
+```text
 alice:secret
 ```
 #### When
@@ -9197,7 +9197,7 @@ Source: `test/e2e/tools/mimixbox/loginutils/cryptpw.atago.yaml`
 ### Scenario: hashes a stdin password with sha-512
 #### Inputs
 _stdin for `cryptpw`:_
-```
+```text
 secret
 ```
 #### When
@@ -9209,13 +9209,13 @@ cryptpw -S abcdefgh
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 $6$abcdefgh$ltjgWl6579NluT/Vi1nwEvcil.G5Nbc4NiXZaNGStk8PSwGfQv72N2CKPPrVACtLtip/cZ/1GM/O6IND4WQhG.
 ```
 ### Scenario: supports the md5 method
 #### Inputs
 _stdin for `cryptpw`:_
-```
+```text
 secret
 ```
 #### When
@@ -9267,7 +9267,7 @@ printf '\n' | getty tty1 2>/dev/null | grep -c 'login: '
 ### Scenario: requires a TTY argument
 #### Inputs
 _stdin for `getty`:_
-```
+```text
 alice
 ```
 #### When
@@ -9349,7 +9349,7 @@ Source: `test/e2e/tools/mimixbox/loginutils/init.atago.yaml`
 - Fixture file `inittab` is created.
 #### Inputs
 _Fixture `inittab`:_
-```
+```text
 si::sysinit:echo SYSINIT
 l::wait:echo WAIT
 ```
@@ -9373,7 +9373,7 @@ Source: `test/e2e/tools/mimixbox/loginutils/login.atago.yaml`
 ### Scenario: fails for an unknown user
 #### Inputs
 _stdin for `login`:_
-```
+```text
 nope
 ```
 #### When
@@ -9402,13 +9402,13 @@ mkpasswd -m sha-512 -S abcdefgh secret
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 $6$abcdefgh$ltjgWl6579NluT/Vi1nwEvcil.G5Nbc4NiXZaNGStk8PSwGfQv72N2CKPPrVACtLtip/cZ/1GM/O6IND4WQhG.
 ```
 ### Scenario: reads the password from stdin
 #### Inputs
 _stdin for `mkpasswd`:_
-```
+```text
 frompipe
 ```
 #### When
@@ -9499,12 +9499,12 @@ Source: `test/e2e/tools/mimixbox/loginutils/run_parts.atago.yaml`
 - Fixture file `parts/10-a` is created.
 #### Inputs
 _Fixture `parts/20-b`:_
-```
+```text
 #!/bin/sh
 echo B
 ```
 _Fixture `parts/10-a`:_
-```
+```text
 #!/bin/sh
 echo A
 ```
@@ -9594,7 +9594,7 @@ Source: `test/e2e/tools/mimixbox/loginutils/sulogin.atago.yaml`
 ### Scenario: rejects a wrong root password
 #### Inputs
 _stdin for `sulogin`:_
-```
+```text
 definitely_wrong_password
 ```
 #### When
@@ -9616,7 +9616,7 @@ Source: `test/e2e/tools/mimixbox/loginutils/vlock.atago.yaml`
 ### Scenario: fails on a wrong password
 #### Inputs
 _stdin for `vlock`:_
-```
+```text
 definitely_wrong_xyz
 ```
 #### When
@@ -10964,7 +10964,7 @@ Source: `test/e2e/tools/mimixbox/procps/logread.atago.yaml`
 - Fixture file `sys.log` is created.
 #### Inputs
 _Fixture `sys.log`:_
-```
+```text
 msg one
 msg two
 ```
@@ -11297,7 +11297,7 @@ Source: `test/e2e/tools/mimixbox/runit/chpst.atago.yaml`
 - Fixture file `env/HELLO` is created.
 #### Inputs
 _Fixture `env/HELLO`:_
-```
+```text
 world
 ```
 #### When
@@ -11321,7 +11321,7 @@ Source: `test/e2e/tools/mimixbox/runit/envdir.atago.yaml`
 - Fixture file `env/GREETING` is created.
 #### Inputs
 _Fixture `env/GREETING`:_
-```
+```text
 hello
 ```
 #### When
@@ -11440,7 +11440,7 @@ sv up svc && cat svc/supervise/control
 - Fixture file `svc2/supervise/pid` is created.
 #### Inputs
 _Fixture `svc2/supervise/pid`:_
-```
+```text
 99
 ```
 #### When
@@ -11487,7 +11487,7 @@ cat log/current
 ### Scenario: requires a directory
 #### Inputs
 _stdin for `svlogd`:_
-```
+```text
 x
 ```
 #### When
@@ -11662,7 +11662,7 @@ Source: `test/e2e/tools/mimixbox/securityutils/pwcrack.atago.yaml`
 - Fixture file `words.txt` is created.
 #### Inputs
 _Fixture `words.txt`:_
-```
+```text
 alpha
 secret
 beta
@@ -11768,11 +11768,11 @@ Source: `test/e2e/tools/mimixbox/securityutils/unshadow.atago.yaml`
 - Fixture file `shadow` is created.
 #### Inputs
 _Fixture `passwd`:_
-```
+```text
 alice:x:1000:1000:Alice:/home/alice:/bin/sh
 ```
 _Fixture `shadow`:_
-```
+```text
 alice:$6$abc$HASH:19000:0:99999:7:::
 ```
 #### When
@@ -11801,7 +11801,7 @@ Source: `test/e2e/tools/mimixbox/securityutils/zippwcrack.atago.yaml`
 - Fixture file `enc.zip` is created.
 #### Inputs
 _Fixture `words.txt`:_
-```
+```text
 alpha
 hunter2
 beta
@@ -11838,7 +11838,7 @@ printf 'hello\n' | base64
 - Fixture file `base64.txt` is created.
 #### Inputs
 _Fixture `base64.txt`:_
-```
+```text
 hello
 ```
 #### When
@@ -11948,7 +11948,7 @@ basename -a /bin/basename /home/nao /home
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 basename
 nao
 home
@@ -12023,7 +12023,7 @@ cal 11 2023
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
    November 2023
 Su Mo Tu We Th Fr Sa
           1  2  3  4
@@ -12060,7 +12060,7 @@ chmod 644 /no_such_file
 - stderr equals an exact value
 #### Expected output
 _expected stderr:_
-```
+```text
 chmod: cannot access '/no_such_file': no such file or directory
 ```
 ## mimixbox chroot
@@ -12097,11 +12097,11 @@ Source: `test/e2e/tools/mimixbox/shellutils/cmp.atago.yaml`
 - Fixture file `cmp/same.txt` is created.
 #### Inputs
 _Fixture `cmp/a.txt`:_
-```
+```text
 abc
 ```
 _Fixture `cmp/same.txt`:_
-```
+```text
 abc
 ```
 #### When
@@ -12117,11 +12117,11 @@ cmp cmp/a.txt cmp/same.txt; echo "rc=$?"
 - Fixture file `cmp/diff.txt` is created.
 #### Inputs
 _Fixture `cmp/a.txt`:_
-```
+```text
 abc
 ```
 _Fixture `cmp/diff.txt`:_
-```
+```text
 abd
 ```
 #### When
@@ -12133,7 +12133,7 @@ cmp ${workdir}/cmp/a.txt ${workdir}/cmp/diff.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 ${workdir}/cmp/a.txt ${workdir}/cmp/diff.txt differ: byte 3, line 1
 ```
 ### Scenario: cmp -s prints nothing but exits non-zero
@@ -12142,11 +12142,11 @@ ${workdir}/cmp/a.txt ${workdir}/cmp/diff.txt differ: byte 3, line 1
 - Fixture file `cmp/diff.txt` is created.
 #### Inputs
 _Fixture `cmp/a.txt`:_
-```
+```text
 abc
 ```
 _Fixture `cmp/diff.txt`:_
-```
+```text
 abd
 ```
 #### When
@@ -12164,11 +12164,11 @@ Source: `test/e2e/tools/mimixbox/shellutils/cmp_gnu.atago.yaml`
 - Fixture file `cmp_gnu/b.txt` is created.
 #### Inputs
 _Fixture `cmp_gnu/a.txt`:_
-```
+```text
 abcXdef
 ```
 _Fixture `cmp_gnu/b.txt`:_
-```
+```text
 abcYdef
 ```
 #### When
@@ -12184,11 +12184,11 @@ cmp -n 3 cmp_gnu/a.txt cmp_gnu/b.txt; echo "rc=$?"
 - Fixture file `cmp_gnu/b.txt` is created.
 #### Inputs
 _Fixture `cmp_gnu/a.txt`:_
-```
+```text
 abcXdef
 ```
 _Fixture `cmp_gnu/b.txt`:_
-```
+```text
 abcYdef
 ```
 #### When
@@ -12204,11 +12204,11 @@ cmp --bytes=4 ${workdir}/cmp_gnu/a.txt ${workdir}/cmp_gnu/b.txt
 - Fixture file `cmp_gnu/skip_b.txt` is created.
 #### Inputs
 _Fixture `cmp_gnu/skip_a.txt`:_
-```
+```text
 XXXcommon
 ```
 _Fixture `cmp_gnu/skip_b.txt`:_
-```
+```text
 YYYcommon
 ```
 #### When
@@ -12224,11 +12224,11 @@ cmp -i 3 cmp_gnu/skip_a.txt cmp_gnu/skip_b.txt; echo "rc=$?"
 - Fixture file `cmp_gnu/pair_b.txt` is created.
 #### Inputs
 _Fixture `cmp_gnu/pair_a.txt`:_
-```
+```text
 _abZ
 ```
 _Fixture `cmp_gnu/pair_b.txt`:_
-```
+```text
 ___abQ
 ```
 #### When
@@ -12244,12 +12244,12 @@ cmp -i 1:3 ${workdir}/cmp_gnu/pair_a.txt ${workdir}/cmp_gnu/pair_b.txt
 - Fixture file `cmp_gnu/pb_b.txt` is created.
 #### Inputs
 _Fixture `cmp_gnu/pb_a.txt`:_
-```
+```text
 first
 second
 ```
 _Fixture `cmp_gnu/pb_b.txt`:_
-```
+```text
 first
 SECOND
 ```
@@ -12621,7 +12621,7 @@ dirname /bin/dirname /home/nao /home
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 /bin
 /home
 /
@@ -13036,7 +13036,7 @@ Source: `test/e2e/tools/mimixbox/shellutils/gzip.atago.yaml`
 - Fixture file `g.txt` is created.
 #### Inputs
 _Fixture `g.txt`:_
-```
+```text
 hello gzip roundtrip
 ```
 #### When
@@ -13168,7 +13168,7 @@ Source: `test/e2e/tools/mimixbox/shellutils/install.atago.yaml`
 - Fixture file `install/src` is created.
 #### Inputs
 _Fixture `install/src`:_
-```
+```text
 hello
 ```
 #### When
@@ -13183,7 +13183,7 @@ install -m 640 install/src install/dst && printf '%s' "$(cat install/dst)"
 - Fixture file `install/src` is created.
 #### Inputs
 _Fixture `install/src`:_
-```
+```text
 hello
 ```
 #### When
@@ -13225,7 +13225,7 @@ cat dst dst~
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 new
 old
 ```
@@ -13257,7 +13257,7 @@ cat dst dst.~1~ dst.~2~
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 v2
 orig
 v1
@@ -13421,7 +13421,7 @@ Source: `test/e2e/tools/mimixbox/shellutils/logcollect.atago.yaml`
 - Fixture file `src/a.log` is created.
 #### Inputs
 _Fixture `src/a.log`:_
-```
+```text
 log
 ```
 #### When
@@ -13531,7 +13531,7 @@ rm -rf "$d"
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 one
 two
 ```
@@ -13673,7 +13673,7 @@ printf 'ABC\n' | od -c
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 0000000   A   B   C  \n
 0000004
 ```
@@ -13687,7 +13687,7 @@ printf 'AB' | od -A x -t x1
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 000000 41 42
 000002
 ```
@@ -13967,7 +13967,7 @@ seq 3
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 1
 2
 3
@@ -13982,7 +13982,7 @@ seq 2 5
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 2
 3
 4
@@ -13998,7 +13998,7 @@ seq 1 2 9
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 1
 3
 5
@@ -14023,7 +14023,7 @@ seq -w 8 10
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 08
 09
 10
@@ -14058,7 +14058,7 @@ printf 'banana\napple\ncherry\n' | sort
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 apple
 banana
 cherry
@@ -14073,7 +14073,7 @@ printf '10\n2\n1\n' | sort -n
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 1
 2
 10
@@ -14088,7 +14088,7 @@ printf 'a\nb\nc\n' | sort -r
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 c
 b
 a
@@ -14103,7 +14103,7 @@ printf 'a\na\nb\n' | sort -u
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 a
 b
 ```
@@ -14119,7 +14119,7 @@ printf '1.10\n1.2\n1.1\n' | sort -V
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 1.1
 1.2
 1.10
@@ -14134,7 +14134,7 @@ printf '1e3\n2.5\n100\n0.5\n' | sort -g
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 0.5
 2.5
 100
@@ -14150,7 +14150,7 @@ printf '1G\n2K\n1M\n' | sort -h
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 2K
 1M
 1G
@@ -14165,7 +14165,7 @@ printf '5 zebra\n5 apple\n5 mango\n' | sort -s -n
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 5 zebra
 5 apple
 5 mango
@@ -14188,7 +14188,7 @@ printf 'apple\nbanana\ncherry\n' | sort -m
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 apple
 banana
 cherry
@@ -14203,7 +14203,7 @@ printf 'b\na\n' | sort --parallel=4
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 a
 b
 ```
@@ -14217,7 +14217,7 @@ printf 'b\na\n' | sort --temporary-directory=/tmp
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 a
 b
 ```
@@ -14272,7 +14272,7 @@ cat ${workdir}/log.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 one
 two
 ```
@@ -14420,7 +14420,7 @@ env time echo x 2>&1 1>/dev/null | grep -c real
 - Fixture file `f.txt` is created.
 #### Inputs
 _Fixture `f.txt`:_
-```
+```text
 data
 ```
 #### When
@@ -14520,7 +14520,7 @@ tsort --help
 ### Scenario: produces a topological order
 #### Inputs
 _stdin for `tsort`:_
-```
+```text
 a b
 b c
 ```
@@ -14533,7 +14533,7 @@ tsort
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 a
 b
 c
@@ -14570,7 +14570,7 @@ printf 'a\na\nb\nc\nc\nc\n' | uniq
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 a
 b
 c
@@ -14585,7 +14585,7 @@ printf 'a\na\nb\nc\nc\nc\n' | uniq -c
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
       2 a
       1 b
       3 c
@@ -14600,7 +14600,7 @@ printf 'a\na\nb\nc\nc\n' | uniq -d
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 a
 c
 ```
@@ -14821,7 +14821,7 @@ yes | head -n 3
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 y
 y
 y
@@ -14836,7 +14836,7 @@ yes mimix | head -n 2
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 mimix
 mimix
 ```
@@ -14865,7 +14865,7 @@ Source: `test/e2e/tools/mimixbox/textutils/cat.atago.yaml`
 - Fixture file `cat.txt` is created.
 #### Inputs
 _Fixture `cat.txt`:_
-```
+```text
 sh
 ash
 csh
@@ -14880,7 +14880,7 @@ cat cat.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 sh
 ash
 csh
@@ -14891,7 +14891,7 @@ bash
 - Fixture file `cat.txt` is created.
 #### Inputs
 _Fixture `cat.txt`:_
-```
+```text
 sh
 ash
 csh
@@ -14906,7 +14906,7 @@ cat -n cat.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
      1	sh
      2	ash
      3	csh
@@ -14925,7 +14925,7 @@ echo "${workdir}/cat.txt" | cat
 - Fixture file `cat.txt` is created.
 #### Inputs
 _Fixture `cat.txt`:_
-```
+```text
 sh
 ash
 csh
@@ -14940,7 +14940,7 @@ echo "${workdir}/cat2.txt" | cat cat.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 sh
 ash
 csh
@@ -14952,14 +14952,14 @@ bash
 - Fixture file `cat2.txt` is created.
 #### Inputs
 _Fixture `cat.txt`:_
-```
+```text
 sh
 ash
 csh
 bash
 ```
 _Fixture `cat2.txt`:_
-```
+```text
 fish
 zsh
 ```
@@ -14972,7 +14972,7 @@ cat cat.txt cat2.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 sh
 ash
 csh
@@ -14986,14 +14986,14 @@ zsh
 - Fixture file `cat2.txt` is created.
 #### Inputs
 _Fixture `cat.txt`:_
-```
+```text
 sh
 ash
 csh
 bash
 ```
 _Fixture `cat2.txt`:_
-```
+```text
 fish
 zsh
 ```
@@ -15006,7 +15006,7 @@ cat -n cat.txt cat2.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
      1	sh
      2	ash
      3	csh
@@ -15019,7 +15019,7 @@ _expected stdout:_
 - Fixture file `cat.txt` is created.
 #### Inputs
 _Fixture `cat.txt`:_
-```
+```text
 sh
 ash
 csh
@@ -15039,7 +15039,7 @@ cat cat2.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 fish
 zsh
 sh
@@ -15095,7 +15095,7 @@ cat --show-all ${workdir}/cat_nonprinting.bin
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 a^Ib^A$
 $
 ^?M-^@$
@@ -15112,7 +15112,7 @@ cat --show-nonprinting ${workdir}/cat_nonprinting.bin
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 a	b^A
 
 ^?M-^@
@@ -15161,12 +15161,12 @@ Source: `test/e2e/tools/mimixbox/textutils/comm.atago.yaml`
 - Fixture file `comm_b.txt` is created.
 #### Inputs
 _Fixture `comm_a.txt`:_
-```
+```text
 apple
 banana
 ```
 _Fixture `comm_b.txt`:_
-```
+```text
 banana
 cherry
 ```
@@ -15185,13 +15185,13 @@ Source: `test/e2e/tools/mimixbox/textutils/comm_gnu.atago.yaml`
 - Fixture file `comm_gnu/b.txt` is created.
 #### Inputs
 _Fixture `comm_gnu/a.txt`:_
-```
+```text
 apple
 banana
 cherry
 ```
 _Fixture `comm_gnu/b.txt`:_
-```
+```text
 banana
 cherry
 date
@@ -15223,12 +15223,12 @@ comm -z -1 -2 ${workdir}/comm_gnu/za.txt ${workdir}/comm_gnu/zb.txt | tr '\0' '#
 - Fixture file `comm_gnu/b.txt` is created.
 #### Inputs
 _Fixture `comm_gnu/unsorted.txt`:_
-```
+```text
 cherry
 banana
 ```
 _Fixture `comm_gnu/b.txt`:_
-```
+```text
 banana
 cherry
 date
@@ -15250,7 +15250,7 @@ Source: `test/e2e/tools/mimixbox/textutils/convert_mode.atago.yaml`
 - Fixture file `d2u.txt` is created.
 #### Inputs
 _Fixture `d2u.txt`:_
-```
+```text
 a
 b
 ```
@@ -15268,7 +15268,7 @@ stat -c '%a' "${workdir}/d2u.txt"
 - Fixture file `u2d.txt` is created.
 #### Inputs
 _Fixture `u2d.txt`:_
-```
+```text
 a
 b
 ```
@@ -15295,7 +15295,7 @@ crc32 --help
 ### Scenario: prints the CRC-32 of stdin
 #### Inputs
 _stdin for `crc32`:_
-```
+```text
 hello
 ```
 #### When
@@ -15312,7 +15312,7 @@ Source: `test/e2e/tools/mimixbox/textutils/dos2unix.atago.yaml`
 - Fixture file `dos2unix/1.txt` is created.
 #### Inputs
 _Fixture `dos2unix/1.txt`:_
-```
+```text
 abc
 def
 ghi
@@ -15327,7 +15327,7 @@ file "${workdir}/dos2unix/1.txt"
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 dos2unix: converting file ${workdir}/dos2unix/1.txt to Unix format...
 ${workdir}/dos2unix/1.txt: ASCII text
 ```
@@ -15336,7 +15336,7 @@ ${workdir}/dos2unix/1.txt: ASCII text
 - Fixture file `dos2unix/1.txt` is created.
 #### Inputs
 _Fixture `dos2unix/1.txt`:_
-```
+```text
 abc
 def
 ghi
@@ -15350,7 +15350,7 @@ dos2unix "${workdir}/dos2unix/1.txt"
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 dos2unix: converting file ${workdir}/dos2unix/1.txt to Unix format...
 ```
 ### Scenario: convert three CRLF files at once and reclassify each
@@ -15360,19 +15360,19 @@ dos2unix: converting file ${workdir}/dos2unix/1.txt to Unix format...
 - Fixture file `dos2unix/3.txt` is created.
 #### Inputs
 _Fixture `dos2unix/1.txt`:_
-```
+```text
 abc
 def
 ghi
 ```
 _Fixture `dos2unix/2.txt`:_
-```
+```text
 abc
 def
 ghi
 ```
 _Fixture `dos2unix/3.txt`:_
-```
+```text
 abc
 def
 ghi
@@ -15389,7 +15389,7 @@ file "${workdir}/dos2unix/3.txt"
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 dos2unix: converting file ${workdir}/dos2unix/1.txt to Unix format...
 dos2unix: converting file ${workdir}/dos2unix/2.txt to Unix format...
 dos2unix: converting file ${workdir}/dos2unix/3.txt to Unix format...
@@ -15404,19 +15404,19 @@ ${workdir}/dos2unix/3.txt: ASCII text
 - Fixture file `dos2unix/3.txt` is created.
 #### Inputs
 _Fixture `dos2unix/1.txt`:_
-```
+```text
 abc
 def
 ghi
 ```
 _Fixture `dos2unix/2.txt`:_
-```
+```text
 abc
 def
 ghi
 ```
 _Fixture `dos2unix/3.txt`:_
-```
+```text
 abc
 def
 ghi
@@ -15430,7 +15430,7 @@ dos2unix "${workdir}/dos2unix/1.txt" "${workdir}/dos2unix/2.txt" "${workdir}/dos
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 dos2unix: converting file ${workdir}/dos2unix/1.txt to Unix format...
 dos2unix: converting file ${workdir}/dos2unix/2.txt to Unix format...
 dos2unix: converting file ${workdir}/dos2unix/3.txt to Unix format...
@@ -15440,7 +15440,7 @@ dos2unix: converting file ${workdir}/dos2unix/3.txt to Unix format...
 - Fixture file `dos2unix/1.txt` is created.
 #### Inputs
 _Fixture `dos2unix/1.txt`:_
-```
+```text
 abc
 def
 ghi
@@ -15458,13 +15458,13 @@ dos2unix ${workdir}/dos2unix
 - Fixture file `dos2unix/3.txt` is created.
 #### Inputs
 _Fixture `dos2unix/1.txt`:_
-```
+```text
 abc
 def
 ghi
 ```
 _Fixture `dos2unix/3.txt`:_
-```
+```text
 abc
 def
 ghi
@@ -15479,7 +15479,7 @@ dos2unix ${workdir}/dos2unix/1.txt ${workdir}/dos2unix ${workdir}/dos2unix/3.txt
 - stderr equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 dos2unix: converting file ${workdir}/dos2unix/1.txt to Unix format...
 dos2unix: converting file ${workdir}/dos2unix/3.txt to Unix format...
 ```
@@ -15506,7 +15506,7 @@ printf 'a\tb\n' | expand -t 4
 - Fixture file `expand.txt` is created.
 #### Inputs
 _Fixture `expand.txt`:_
-```
+```text
 a	b
 ```
 #### When
@@ -15536,7 +15536,7 @@ printf 'aa bb cc dd\n' | fmt -w 5
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 aa bb
 cc dd
 ```
@@ -15552,7 +15552,7 @@ printf 'abcdefgh\n' | fold -w 3
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 abc
 def
 gh
@@ -15564,7 +15564,7 @@ Source: `test/e2e/tools/mimixbox/textutils/head.atago.yaml`
 - Fixture file `head.txt` is created.
 #### Inputs
 _Fixture `head.txt`:_
-```
+```text
 1
 2
 3
@@ -15587,7 +15587,7 @@ head head.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 1
 2
 3
@@ -15604,7 +15604,7 @@ _expected stdout:_
 - Fixture file `head.txt` is created.
 #### Inputs
 _Fixture `head.txt`:_
-```
+```text
 1
 2
 3
@@ -15627,7 +15627,7 @@ head -n 3 head.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 1
 2
 3
@@ -15650,7 +15650,7 @@ printf 'a\nb\nc\nd\n' | head -n 2
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 a
 b
 ```
@@ -15674,7 +15674,7 @@ printf 'a\nb\0c\nd\0' | head -z -n 1 | tr '\0' '|'
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 a
 b|
 ```
@@ -15688,7 +15688,7 @@ printf 'a\nb\0c\nd\0' | head --zero-terminated -n 2 | tr '\0' '|'
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 a
 b|c
 d|
@@ -15750,7 +15750,7 @@ Source: `test/e2e/tools/mimixbox/textutils/man.atago.yaml`
 - Fixture file `man/man1/foo.1` is created.
 #### Inputs
 _Fixture `man/man1/foo.1`:_
-```
+```text
 FOO(1)
 the foo page
 ```
@@ -15763,7 +15763,7 @@ man -M "${workdir}/man" foo
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 FOO(1)
 the foo page
 ```
@@ -15779,7 +15779,7 @@ man -M "${workdir}/man" bar
   - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 BAR(1)
 the bar page
 ```
@@ -15788,7 +15788,7 @@ the bar page
 - Fixture file `man/man1/foo.1` is created.
 #### Inputs
 _Fixture `man/man1/foo.1`:_
-```
+```text
 FOO(1)
 the foo page
 ```
@@ -15806,7 +15806,7 @@ Source: `test/e2e/tools/mimixbox/textutils/md5sum.atago.yaml`
 - Fixture file `md5sum/1.txt` is created.
 #### Inputs
 _Fixture `md5sum/1.txt`:_
-```
+```text
 Dungeon of Regalias
 ```
 #### When
@@ -15821,7 +15821,7 @@ md5sum ${workdir}/md5sum/1.txt
 - Fixture file `md5sum/1.txt` is created.
 #### Inputs
 _Fixture `md5sum/1.txt`:_
-```
+```text
 Dungeon of Regalias
 ```
 #### When
@@ -15846,15 +15846,15 @@ md5sum /not_exist_file
 - Fixture file `md5sum/3.txt` is created.
 #### Inputs
 _Fixture `md5sum/1.txt`:_
-```
+```text
 Dungeon of Regalias
 ```
 _Fixture `md5sum/2.txt`:_
-```
+```text
 DEMONION
 ```
 _Fixture `md5sum/3.txt`:_
-```
+```text
 Dungeon Crusadearz
 ```
 #### When
@@ -15866,7 +15866,7 @@ md5sum ${workdir}/md5sum/1.txt ${workdir}/md5sum/2.txt ${workdir}/md5sum/3.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 d0d8ffef81b3c7160ac655d5939548c5  ${workdir}/md5sum/1.txt
 07e280ad4bd77b9321f0ce3386775019  ${workdir}/md5sum/2.txt
 15e924f84517598e828f49dc85765bc5  ${workdir}/md5sum/3.txt
@@ -15879,19 +15879,19 @@ d0d8ffef81b3c7160ac655d5939548c5  ${workdir}/md5sum/1.txt
 - Fixture file `md5sum/checksum.txt` is created.
 #### Inputs
 _Fixture `md5sum/1.txt`:_
-```
+```text
 Dungeon of Regalias
 ```
 _Fixture `md5sum/2.txt`:_
-```
+```text
 DEMONION
 ```
 _Fixture `md5sum/3.txt`:_
-```
+```text
 Dungeon Crusadearz
 ```
 _Fixture `md5sum/checksum.txt`:_
-```
+```text
 d0d8ffef81b3c7160ac655d5939548c5  ${workdir}/md5sum/1.txt
 07e280ad4bd77b9321f0ce3386775019  ${workdir}/md5sum/2.txt
 15e924f84517598e828f49dc85765bc5  ${workdir}/md5sum/3.txt
@@ -15905,7 +15905,7 @@ md5sum -c ${workdir}/md5sum/checksum.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 ${workdir}/md5sum/1.txt: OK
 ${workdir}/md5sum/2.txt: OK
 ${workdir}/md5sum/3.txt: OK
@@ -15923,7 +15923,7 @@ echo "test" | md5sum
 - Fixture file `md5sum/1.txt` is created.
 #### Inputs
 _Fixture `md5sum/1.txt`:_
-```
+```text
 Dungeon of Regalias
 ```
 #### When
@@ -15940,7 +15940,7 @@ Source: `test/e2e/tools/mimixbox/textutils/nl.atago.yaml`
 - Fixture file `nl.txt` is created.
 #### Inputs
 _Fixture `nl.txt`:_
-```
+```text
 sh
 ash
 csh
@@ -15955,7 +15955,7 @@ nl nl.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
      1	sh
      2	ash
      3	csh
@@ -15966,7 +15966,7 @@ _expected stdout:_
 - Fixture file `nl.txt` is created.
 #### Inputs
 _Fixture `nl.txt`:_
-```
+```text
 sh
 ash
 csh
@@ -15984,7 +15984,7 @@ echo "${workdir}/nl.txt" | nl
 - Fixture file `nl.txt` is created.
 #### Inputs
 _Fixture `nl.txt`:_
-```
+```text
 sh
 ash
 csh
@@ -15999,7 +15999,7 @@ echo "${workdir}/nl.txt" | nl nl.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
      1	sh
      2	ash
      3	csh
@@ -16011,14 +16011,14 @@ _expected stdout:_
 - Fixture file `nl2.txt` is created.
 #### Inputs
 _Fixture `nl.txt`:_
-```
+```text
 sh
 ash
 csh
 bash
 ```
 _Fixture `nl2.txt`:_
-```
+```text
 fish
 zsh
 ```
@@ -16031,7 +16031,7 @@ nl nl.txt nl2.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
      1	sh
      2	ash
      3	csh
@@ -16044,7 +16044,7 @@ _expected stdout:_
 - Fixture file `nl.txt` is created.
 #### Inputs
 _Fixture `nl.txt`:_
-```
+```text
 sh
 ash
 csh
@@ -16063,7 +16063,7 @@ cat nl2.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
      1	fish
      2	zsh
      3	sh
@@ -16076,7 +16076,7 @@ _expected stdout:_
 - Fixture file `nl.txt` is created.
 #### Inputs
 _Fixture `nl.txt`:_
-```
+```text
 sh
 ash
 csh
@@ -16096,7 +16096,7 @@ cat nl2.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
      1	fish
      2	zsh
      3	sh
@@ -16119,7 +16119,7 @@ Source: `test/e2e/tools/mimixbox/textutils/nl_sections.atago.yaml`
 - Fixture file `nl_sec.txt` is created.
 #### Inputs
 _Fixture `nl_sec.txt`:_
-```
+```text
 H1
 \:\:\:
 HDR
@@ -16137,7 +16137,7 @@ nl -h a -b a -f a nl_sec.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
      1	H1
 
      1	HDR
@@ -16151,7 +16151,7 @@ _expected stdout:_
 - Fixture file `nl_sec.txt` is created.
 #### Inputs
 _Fixture `nl_sec.txt`:_
-```
+```text
 H1
 \:\:\:
 HDR
@@ -16169,7 +16169,7 @@ nl -h a -b t -f n nl_sec.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
      1	H1
 
      1	HDR
@@ -16183,7 +16183,7 @@ _expected stdout:_
 - Fixture file `nl_blank.txt` is created.
 #### Inputs
 _Fixture `nl_blank.txt`:_
-```
+```text
 a
 
 
@@ -16200,7 +16200,7 @@ nl -b a -l 2 nl_blank.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
      1	a
        
      2	
@@ -16235,7 +16235,7 @@ Source: `test/e2e/tools/mimixbox/textutils/sha1sum.atago.yaml`
 - Fixture file `sha1sum/1.txt` is created.
 #### Inputs
 _Fixture `sha1sum/1.txt`:_
-```
+```text
 Dungeon of Regalias
 ```
 #### When
@@ -16247,7 +16247,7 @@ sha1sum ${workdir}/sha1sum/1.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 9dc2936d38932f9ffc6738cb677e4a8722116070  ${workdir}/sha1sum/1.txt
 ```
 ### Scenario: cannot get sha1sum of one directory
@@ -16255,7 +16255,7 @@ _expected stdout:_
 - Fixture file `sha1sum/1.txt` is created.
 #### Inputs
 _Fixture `sha1sum/1.txt`:_
-```
+```text
 Dungeon of Regalias
 ```
 #### When
@@ -16280,15 +16280,15 @@ sha1sum /not_exist_file
 - Fixture file `sha1sum/3.txt` is created.
 #### Inputs
 _Fixture `sha1sum/1.txt`:_
-```
+```text
 Dungeon of Regalias
 ```
 _Fixture `sha1sum/2.txt`:_
-```
+```text
 DEMONION
 ```
 _Fixture `sha1sum/3.txt`:_
-```
+```text
 Dungeon Crusadearz
 ```
 #### When
@@ -16300,7 +16300,7 @@ sha1sum ${workdir}/sha1sum/1.txt ${workdir}/sha1sum/2.txt ${workdir}/sha1sum/3.t
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 9dc2936d38932f9ffc6738cb677e4a8722116070  ${workdir}/sha1sum/1.txt
 317e30648976d62fae4662fe4435e6568648e8a7  ${workdir}/sha1sum/2.txt
 d4e9619d949de0c0182a09757346ad22e80114b3  ${workdir}/sha1sum/3.txt
@@ -16313,19 +16313,19 @@ d4e9619d949de0c0182a09757346ad22e80114b3  ${workdir}/sha1sum/3.txt
 - Fixture file `sha1sum/checksum.txt` is created.
 #### Inputs
 _Fixture `sha1sum/1.txt`:_
-```
+```text
 Dungeon of Regalias
 ```
 _Fixture `sha1sum/2.txt`:_
-```
+```text
 DEMONION
 ```
 _Fixture `sha1sum/3.txt`:_
-```
+```text
 Dungeon Crusadearz
 ```
 _Fixture `sha1sum/checksum.txt`:_
-```
+```text
 9dc2936d38932f9ffc6738cb677e4a8722116070  ${workdir}/sha1sum/1.txt
 317e30648976d62fae4662fe4435e6568648e8a7  ${workdir}/sha1sum/2.txt
 d4e9619d949de0c0182a09757346ad22e80114b3  ${workdir}/sha1sum/3.txt
@@ -16339,7 +16339,7 @@ sha1sum -c ${workdir}/sha1sum/checksum.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 ${workdir}/sha1sum/1.txt: OK
 ${workdir}/sha1sum/2.txt: OK
 ${workdir}/sha1sum/3.txt: OK
@@ -16357,7 +16357,7 @@ echo "test" | sha1sum
 - Fixture file `sha1sum/1.txt` is created.
 #### Inputs
 _Fixture `sha1sum/1.txt`:_
-```
+```text
 Dungeon of Regalias
 ```
 #### When
@@ -16369,7 +16369,7 @@ echo "test" | sha1sum ${workdir}/sha1sum/1.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 9dc2936d38932f9ffc6738cb677e4a8722116070  ${workdir}/sha1sum/1.txt
 ```
 ## mimixbox sha256sum
@@ -16379,7 +16379,7 @@ Source: `test/e2e/tools/mimixbox/textutils/sha256sum.atago.yaml`
 - Fixture file `sha256sum/1.txt` is created.
 #### Inputs
 _Fixture `sha256sum/1.txt`:_
-```
+```text
 Dungeon of Regalias
 ```
 #### When
@@ -16391,7 +16391,7 @@ sha256sum ${workdir}/sha256sum/1.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 5f2864b5833190b07b0b95228682ff5ec43a13a2a3f31514c57d5c92aa3fb2e7  ${workdir}/sha256sum/1.txt
 ```
 ### Scenario: cannot get sha256sum of one directory
@@ -16399,7 +16399,7 @@ _expected stdout:_
 - Fixture file `sha256sum/1.txt` is created.
 #### Inputs
 _Fixture `sha256sum/1.txt`:_
-```
+```text
 Dungeon of Regalias
 ```
 #### When
@@ -16424,15 +16424,15 @@ sha256sum /not_exist_file
 - Fixture file `sha256sum/3.txt` is created.
 #### Inputs
 _Fixture `sha256sum/1.txt`:_
-```
+```text
 Dungeon of Regalias
 ```
 _Fixture `sha256sum/2.txt`:_
-```
+```text
 DEMONION
 ```
 _Fixture `sha256sum/3.txt`:_
-```
+```text
 Dungeon Crusadearz
 ```
 #### When
@@ -16444,7 +16444,7 @@ sha256sum ${workdir}/sha256sum/1.txt ${workdir}/sha256sum/2.txt ${workdir}/sha25
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 5f2864b5833190b07b0b95228682ff5ec43a13a2a3f31514c57d5c92aa3fb2e7  ${workdir}/sha256sum/1.txt
 833d8136112b60552a0f83165a2ebffeac4b0c0249480d651ea58b9073ec925b  ${workdir}/sha256sum/2.txt
 8e774f75a5a23c83e6f7d5e92863a2615e0335e06aec18d9c3ec1c5315d1a777  ${workdir}/sha256sum/3.txt
@@ -16457,19 +16457,19 @@ _expected stdout:_
 - Fixture file `sha256sum/checksum.txt` is created.
 #### Inputs
 _Fixture `sha256sum/1.txt`:_
-```
+```text
 Dungeon of Regalias
 ```
 _Fixture `sha256sum/2.txt`:_
-```
+```text
 DEMONION
 ```
 _Fixture `sha256sum/3.txt`:_
-```
+```text
 Dungeon Crusadearz
 ```
 _Fixture `sha256sum/checksum.txt`:_
-```
+```text
 5f2864b5833190b07b0b95228682ff5ec43a13a2a3f31514c57d5c92aa3fb2e7  ${workdir}/sha256sum/1.txt
 833d8136112b60552a0f83165a2ebffeac4b0c0249480d651ea58b9073ec925b  ${workdir}/sha256sum/2.txt
 8e774f75a5a23c83e6f7d5e92863a2615e0335e06aec18d9c3ec1c5315d1a777  ${workdir}/sha256sum/3.txt
@@ -16483,7 +16483,7 @@ sha256sum -c ${workdir}/sha256sum/checksum.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 ${workdir}/sha256sum/1.txt: OK
 ${workdir}/sha256sum/2.txt: OK
 ${workdir}/sha256sum/3.txt: OK
@@ -16498,7 +16498,7 @@ echo "test" | sha256sum
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2  -
 ```
 ### Scenario: get sha256sum for pipe data and file at same time
@@ -16506,7 +16506,7 @@ f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2  -
 - Fixture file `sha256sum/1.txt` is created.
 #### Inputs
 _Fixture `sha256sum/1.txt`:_
-```
+```text
 Dungeon of Regalias
 ```
 #### When
@@ -16518,7 +16518,7 @@ echo "test" | sha256sum ${workdir}/sha256sum/1.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 5f2864b5833190b07b0b95228682ff5ec43a13a2a3f31514c57d5c92aa3fb2e7  ${workdir}/sha256sum/1.txt
 ```
 ## mimixbox sha384sum
@@ -16535,7 +16535,7 @@ sha384sum --help
 ### Scenario: prints the SHA-384 digest of stdin
 #### Inputs
 _stdin for `sha384sum`:_
-```
+```text
 hello
 ```
 #### When
@@ -16547,7 +16547,7 @@ sha384sum
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 1d0f284efe3edea4b9ca3bd514fa134b17eae361ccc7a1eefeff801b9bd6604e01f21f6bf249ef030599f0c218f2ba8c  -
 ```
 ## mimixbox sha3sum
@@ -16562,7 +16562,7 @@ printf 'hello\n' | sha3sum | cut -d' ' -f1
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 b314e28493eae9dab57ac4f0c6d887bddbbeb810e900d818395ace558e96516d
 ```
 ### Scenario: selects SHA3-512 with -a
@@ -16580,7 +16580,7 @@ Source: `test/e2e/tools/mimixbox/textutils/sha512sum.atago.yaml`
 - Fixture file `sha512sum/1.txt` is created.
 #### Inputs
 _Fixture `sha512sum/1.txt`:_
-```
+```text
 Dungeon of Regalias
 ```
 #### When
@@ -16592,7 +16592,7 @@ sha512sum ${workdir}/sha512sum/1.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 05eec7dcf412f63d5a291d019f6b3d62d4f8f5236592815ed171f7d6d0a7969f65a589a092740bd04a2f181d7d5a27ff36808e04a69bd84a854aad0a01da3612  ${workdir}/sha512sum/1.txt
 ```
 ### Scenario: cannot get sha512sum of one directory
@@ -16600,7 +16600,7 @@ _expected stdout:_
 - Fixture file `sha512sum/1.txt` is created.
 #### Inputs
 _Fixture `sha512sum/1.txt`:_
-```
+```text
 Dungeon of Regalias
 ```
 #### When
@@ -16625,15 +16625,15 @@ sha512sum /not_exist_file
 - Fixture file `sha512sum/3.txt` is created.
 #### Inputs
 _Fixture `sha512sum/1.txt`:_
-```
+```text
 Dungeon of Regalias
 ```
 _Fixture `sha512sum/2.txt`:_
-```
+```text
 DEMONION
 ```
 _Fixture `sha512sum/3.txt`:_
-```
+```text
 Dungeon Crusadearz
 ```
 #### When
@@ -16645,7 +16645,7 @@ sha512sum ${workdir}/sha512sum/1.txt ${workdir}/sha512sum/2.txt ${workdir}/sha51
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 05eec7dcf412f63d5a291d019f6b3d62d4f8f5236592815ed171f7d6d0a7969f65a589a092740bd04a2f181d7d5a27ff36808e04a69bd84a854aad0a01da3612  ${workdir}/sha512sum/1.txt
 cb2389a103184f607973b1acd073dc15310c8172b03f340a52bdc3843621cf9fbc6263c7dbbd786ceb0244f5147a83aa32ce09a485f544093b7fc5c7533e564f  ${workdir}/sha512sum/2.txt
 3dafa5f1ec7f09cbe551dc0d4bdb153dedb81104b7e930b7c20733965f7ebb86ee2abea64b6bfa1c54045032865044a3feca5dcc89c28def410b2954094a1890  ${workdir}/sha512sum/3.txt
@@ -16658,19 +16658,19 @@ cb2389a103184f607973b1acd073dc15310c8172b03f340a52bdc3843621cf9fbc6263c7dbbd786c
 - Fixture file `sha512sum/checksum.txt` is created.
 #### Inputs
 _Fixture `sha512sum/1.txt`:_
-```
+```text
 Dungeon of Regalias
 ```
 _Fixture `sha512sum/2.txt`:_
-```
+```text
 DEMONION
 ```
 _Fixture `sha512sum/3.txt`:_
-```
+```text
 Dungeon Crusadearz
 ```
 _Fixture `sha512sum/checksum.txt`:_
-```
+```text
 05eec7dcf412f63d5a291d019f6b3d62d4f8f5236592815ed171f7d6d0a7969f65a589a092740bd04a2f181d7d5a27ff36808e04a69bd84a854aad0a01da3612  ${workdir}/sha512sum/1.txt
 cb2389a103184f607973b1acd073dc15310c8172b03f340a52bdc3843621cf9fbc6263c7dbbd786ceb0244f5147a83aa32ce09a485f544093b7fc5c7533e564f  ${workdir}/sha512sum/2.txt
 3dafa5f1ec7f09cbe551dc0d4bdb153dedb81104b7e930b7c20733965f7ebb86ee2abea64b6bfa1c54045032865044a3feca5dcc89c28def410b2954094a1890  ${workdir}/sha512sum/3.txt
@@ -16684,7 +16684,7 @@ sha512sum -c ${workdir}/sha512sum/checksum.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 ${workdir}/sha512sum/1.txt: OK
 ${workdir}/sha512sum/2.txt: OK
 ${workdir}/sha512sum/3.txt: OK
@@ -16699,7 +16699,7 @@ echo "test" | sha512sum
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 0e3e75234abc68f4378a86b3f4b32a198ba301845b0cd6e50106e874345700cc6663a86c1ea125dc5e92be17c98f9a0f85ca9d5f595db2012f7cc3571945c123  -
 ```
 ### Scenario: get sha512sum for pipe data and file at same time
@@ -16707,7 +16707,7 @@ _expected stdout:_
 - Fixture file `sha512sum/1.txt` is created.
 #### Inputs
 _Fixture `sha512sum/1.txt`:_
-```
+```text
 Dungeon of Regalias
 ```
 #### When
@@ -16719,7 +16719,7 @@ echo "test" | sha512sum ${workdir}/sha512sum/1.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 05eec7dcf412f63d5a291d019f6b3d62d4f8f5236592815ed171f7d6d0a7969f65a589a092740bd04a2f181d7d5a27ff36808e04a69bd84a854aad0a01da3612  ${workdir}/sha512sum/1.txt
 ```
 ## mimixbox shuf
@@ -16744,7 +16744,7 @@ printf '1\n2\n3\n' | split -l 2 - "${workdir}/part-"; cat "${workdir}/part-aa"
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 1
 2
 ```
@@ -16768,7 +16768,7 @@ printf '1\n2\n3\n4\n5\n' | split -l 2 -d - "${workdir}/num-"; cat "${workdir}/nu
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 1
 2
 ```
@@ -16912,7 +16912,7 @@ printf 'hi\000hello\000world' | strings
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 hello
 world
 ```
@@ -16938,7 +16938,7 @@ sum --help
 ### Scenario: prints a BSD checksum and block count for stdin
 #### Inputs
 _stdin for `sum`:_
-```
+```text
 hello
 ```
 #### When
@@ -16955,7 +16955,7 @@ Source: `test/e2e/tools/mimixbox/textutils/tac.atago.yaml`
 - Fixture file `tac.txt` is created.
 #### Inputs
 _Fixture `tac.txt`:_
-```
+```text
 first
 second
 third
@@ -16969,7 +16969,7 @@ tac tac.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 third
 second
 first
@@ -16984,7 +16984,7 @@ printf 'a\nb\nc\n' | tac
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 c
 b
 a
@@ -17004,7 +17004,7 @@ Source: `test/e2e/tools/mimixbox/textutils/tail.atago.yaml`
 - Fixture file `tail.txt` is created.
 #### Inputs
 _Fixture `tail.txt`:_
-```
+```text
 1
 2
 3
@@ -17027,7 +17027,7 @@ tail tail.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 3
 4
 5
@@ -17044,7 +17044,7 @@ _expected stdout:_
 - Fixture file `tail.txt` is created.
 #### Inputs
 _Fixture `tail.txt`:_
-```
+```text
 1
 2
 3
@@ -17067,7 +17067,7 @@ tail -n 3 tail.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 10
 11
 12
@@ -17090,7 +17090,7 @@ printf 'a\nb\nc\nd\n' | tail -n 2
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 c
 d
 ```
@@ -17107,7 +17107,7 @@ tail /no_exist_file
 - Fixture file `follow.txt` is created.
 #### Inputs
 _Fixture `follow.txt`:_
-```
+```text
 start
 ```
 #### When
@@ -17126,7 +17126,7 @@ Source: `test/e2e/tools/mimixbox/textutils/tail_pid.atago.yaml`
 - Fixture file `follow_pid.txt` is created.
 #### Inputs
 _Fixture `follow_pid.txt`:_
-```
+```text
 start
 ```
 #### When
@@ -17152,7 +17152,7 @@ printf 'a\nb\0c\nd\0' | tail -z -n 1 | tr '\0' '|'
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 c
 d|
 ```
@@ -17166,7 +17166,7 @@ printf 'a\nb\0c\nd\0' | tail --zero-terminated -n 2 | tr '\0' '|'
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 a
 b|c
 d|
@@ -17232,7 +17232,7 @@ Source: `test/e2e/tools/mimixbox/textutils/unix2dos.atago.yaml`
 - Fixture file `unix2dos/1.txt` is created.
 #### Inputs
 _Fixture `unix2dos/1.txt`:_
-```
+```text
 abc
 def
 ghi
@@ -17247,7 +17247,7 @@ file "${workdir}/unix2dos/1.txt"
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 unix2dos: converting file ${workdir}/unix2dos/1.txt to DOS format...
 ${workdir}/unix2dos/1.txt: ASCII text, with CRLF line terminators
 ```
@@ -17256,7 +17256,7 @@ ${workdir}/unix2dos/1.txt: ASCII text, with CRLF line terminators
 - Fixture file `unix2dos/1.txt` is created.
 #### Inputs
 _Fixture `unix2dos/1.txt`:_
-```
+```text
 abc
 def
 ghi
@@ -17270,7 +17270,7 @@ unix2dos "${workdir}/unix2dos/1.txt"
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 unix2dos: converting file ${workdir}/unix2dos/1.txt to DOS format...
 ```
 ### Scenario: convert three LF files at once and reclassify each
@@ -17280,19 +17280,19 @@ unix2dos: converting file ${workdir}/unix2dos/1.txt to DOS format...
 - Fixture file `unix2dos/3.txt` is created.
 #### Inputs
 _Fixture `unix2dos/1.txt`:_
-```
+```text
 abc
 def
 ghi
 ```
 _Fixture `unix2dos/2.txt`:_
-```
+```text
 abc
 def
 ghi
 ```
 _Fixture `unix2dos/3.txt`:_
-```
+```text
 abc
 def
 ghi
@@ -17309,7 +17309,7 @@ file "${workdir}/unix2dos/3.txt"
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 unix2dos: converting file ${workdir}/unix2dos/1.txt to DOS format...
 unix2dos: converting file ${workdir}/unix2dos/2.txt to DOS format...
 unix2dos: converting file ${workdir}/unix2dos/3.txt to DOS format...
@@ -17324,19 +17324,19 @@ ${workdir}/unix2dos/3.txt: ASCII text, with CRLF line terminators
 - Fixture file `unix2dos/3.txt` is created.
 #### Inputs
 _Fixture `unix2dos/1.txt`:_
-```
+```text
 abc
 def
 ghi
 ```
 _Fixture `unix2dos/2.txt`:_
-```
+```text
 abc
 def
 ghi
 ```
 _Fixture `unix2dos/3.txt`:_
-```
+```text
 abc
 def
 ghi
@@ -17350,7 +17350,7 @@ unix2dos "${workdir}/unix2dos/1.txt" "${workdir}/unix2dos/2.txt" "${workdir}/uni
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 unix2dos: converting file ${workdir}/unix2dos/1.txt to DOS format...
 unix2dos: converting file ${workdir}/unix2dos/2.txt to DOS format...
 unix2dos: converting file ${workdir}/unix2dos/3.txt to DOS format...
@@ -17360,7 +17360,7 @@ unix2dos: converting file ${workdir}/unix2dos/3.txt to DOS format...
 - Fixture file `unix2dos/1.txt` is created.
 #### Inputs
 _Fixture `unix2dos/1.txt`:_
-```
+```text
 abc
 def
 ghi
@@ -17378,13 +17378,13 @@ unix2dos ${workdir}/unix2dos
 - Fixture file `unix2dos/3.txt` is created.
 #### Inputs
 _Fixture `unix2dos/1.txt`:_
-```
+```text
 abc
 def
 ghi
 ```
 _Fixture `unix2dos/3.txt`:_
-```
+```text
 abc
 def
 ghi
@@ -17399,7 +17399,7 @@ unix2dos ${workdir}/unix2dos/1.txt ${workdir}/unix2dos ${workdir}/unix2dos/3.txt
 - stderr equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 unix2dos: converting file ${workdir}/unix2dos/1.txt to DOS format...
 unix2dos: converting file ${workdir}/unix2dos/3.txt to DOS format...
 ```
@@ -17460,7 +17460,7 @@ uuencode --help
 ### Scenario: uuencodes stdin with a begin header
 #### Inputs
 _stdin for `uuencode`:_
-```
+```text
 hello
 ```
 #### When
@@ -17477,7 +17477,7 @@ Source: `test/e2e/tools/mimixbox/textutils/wc.atago.yaml`
 - Fixture file `game.txt` is created.
 #### Inputs
 _Fixture `game.txt`:_
-```
+```text
 NieR Replicant ver.1.22474487139...
 NieR:Automata
 The Legend of Zelda: Majora's Mask
@@ -17497,7 +17497,7 @@ wc game.txt
 - Fixture file `game.txt` is created.
 #### Inputs
 _Fixture `game.txt`:_
-```
+```text
 NieR Replicant ver.1.22474487139...
 NieR:Automata
 The Legend of Zelda: Majora's Mask
@@ -17517,7 +17517,7 @@ wc -l game.txt
 - Fixture file `game.txt` is created.
 #### Inputs
 _Fixture `game.txt`:_
-```
+```text
 NieR Replicant ver.1.22474487139...
 NieR:Automata
 The Legend of Zelda: Majora's Mask
@@ -17537,7 +17537,7 @@ wc -c game.txt
 - Fixture file `game.txt` is created.
 #### Inputs
 _Fixture `game.txt`:_
-```
+```text
 NieR Replicant ver.1.22474487139...
 NieR:Automata
 The Legend of Zelda: Majora's Mask
@@ -17569,7 +17569,7 @@ wc empty.txt
 - Fixture file `metal.txt` is created.
 #### Inputs
 _Fixture `game.txt`:_
-```
+```text
 NieR Replicant ver.1.22474487139...
 NieR:Automata
 The Legend of Zelda: Majora's Mask
@@ -17578,7 +17578,7 @@ DARK SOULS
 SHADOW HEARTS
 ```
 _Fixture `metal.txt`:_
-```
+```text
 MEGADETH
 GALNERYUS
 SYSTEM OF A DOWN
@@ -17592,7 +17592,7 @@ wc empty.txt game.txt metal.txt
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
   0   0   0 empty.txt
   6  16 126 game.txt
   3   6  36 metal.txt
@@ -17611,7 +17611,7 @@ echo "${workdir}/game.txt" | wc
 - Fixture file `game.txt` is created.
 #### Inputs
 _Fixture `game.txt`:_
-```
+```text
 NieR Replicant ver.1.22474487139...
 NieR:Automata
 The Legend of Zelda: Majora's Mask
@@ -17640,7 +17640,7 @@ wc "${workdir}"
 - Fixture file `game.txt` is created.
 #### Inputs
 _Fixture `game.txt`:_
-```
+```text
 NieR Replicant ver.1.22474487139...
 NieR:Automata
 The Legend of Zelda: Majora's Mask
@@ -17658,7 +17658,7 @@ wc "${workdir}" "${workdir}/game.txt"
 - stderr equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
       0       0       0 ${workdir}
       6      16     126 ${workdir}/game.txt
       6      16     126 total
@@ -17679,13 +17679,13 @@ Source: `test/e2e/tools/mimixbox/textutils/wc_gnu.atago.yaml`
 - Fixture file `wc_b.txt` is created.
 #### Inputs
 _Fixture `wc_a.txt`:_
-```
+```text
 a
 b
 c
 ```
 _Fixture `wc_b.txt`:_
-```
+```text
 x
 ```
 #### When
@@ -17701,13 +17701,13 @@ wc --total=only wc_a.txt wc_b.txt
 - Fixture file `wc_b.txt` is created.
 #### Inputs
 _Fixture `wc_a.txt`:_
-```
+```text
 a
 b
 c
 ```
 _Fixture `wc_b.txt`:_
-```
+```text
 x
 ```
 #### When
@@ -17719,7 +17719,7 @@ wc --total=never "${workdir}/wc_a.txt" "${workdir}/wc_b.txt"
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 3 3 6 ${workdir}/wc_a.txt
 1 1 2 ${workdir}/wc_b.txt
 ```
@@ -17728,7 +17728,7 @@ _expected stdout:_
 - Fixture file `wc_a.txt` is created.
 #### Inputs
 _Fixture `wc_a.txt`:_
-```
+```text
 a
 b
 c
@@ -17742,7 +17742,7 @@ wc --total=always "${workdir}/wc_a.txt"
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 3 3 6 ${workdir}/wc_a.txt
 3 3 6 total
 ```
@@ -17752,13 +17752,13 @@ _expected stdout:_
 - Fixture file `wc_b.txt` is created.
 #### Inputs
 _Fixture `wc_a.txt`:_
-```
+```text
 a
 b
 c
 ```
 _Fixture `wc_b.txt`:_
-```
+```text
 x
 ```
 #### When
@@ -17772,7 +17772,7 @@ wc --files0-from=wc_list.nul
   - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 3 3 6 ${workdir}/wc_a.txt
 1 1 2 ${workdir}/wc_b.txt
 4 4 8 total
@@ -17783,13 +17783,13 @@ _expected stdout:_
 - Fixture file `wc_b.txt` is created.
 #### Inputs
 _Fixture `wc_a.txt`:_
-```
+```text
 a
 b
 c
 ```
 _Fixture `wc_b.txt`:_
-```
+```text
 x
 ```
 #### When
@@ -17801,7 +17801,7 @@ printf '%s\0%s\0' "${workdir}/wc_a.txt" "${workdir}/wc_b.txt" | wc --files0-from
 - stdout equals an exact value
 #### Expected output
 _expected stdout:_
-```
+```text
 3 3 6 ${workdir}/wc_a.txt
 1 1 2 ${workdir}/wc_b.txt
 4 4 8 total
@@ -17812,13 +17812,13 @@ _expected stdout:_
 - Fixture file `wc_b.txt` is created.
 #### Inputs
 _Fixture `wc_a.txt`:_
-```
+```text
 a
 b
 c
 ```
 _Fixture `wc_b.txt`:_
-```
+```text
 x
 ```
 #### When
@@ -18223,7 +18223,7 @@ hd --help
 ### Scenario: hexdumps stdin in canonical form
 #### Inputs
 _stdin for `hd`:_
-```
+```text
 hi
 ```
 #### When
@@ -19000,7 +19000,7 @@ Source: `test/e2e/tools/mimixbox/util-linux/tune2fs.atago.yaml`
 - Fixture file `bad.img` is created.
 #### Inputs
 _Fixture `bad.img`:_
-```
+```text
 not a filesystem
 ```
 #### When

--- a/doc/e2e/minio.md
+++ b/doc/e2e/minio.md
@@ -39,7 +39,7 @@ Source: `test/e2e/thirdparty/minio/minio.atago.yaml`
 - Fixture file `upload.txt` is created.
 #### Inputs
 _Fixture `upload.txt`:_
-```
+```text
 hello object storage
 ```
 #### When
@@ -100,7 +100,7 @@ mc version info --json local/versioned
 - Fixture file `page.txt` is created.
 #### Inputs
 _Fixture `page.txt`:_
-```
+```text
 published via bucket policy
 ```
 #### When

--- a/doc/e2e/mobilepkg.md
+++ b/doc/e2e/mobilepkg.md
@@ -180,7 +180,7 @@ mobilepkg inspect --format xml app.apk
 - Fixture file `notapkg.apk` is created.
 #### Inputs
 _Fixture `notapkg.apk`:_
-```
+```text
 this is not a zip archive
 ```
 #### When

--- a/doc/e2e/prometheus.md
+++ b/doc/e2e/prometheus.md
@@ -15,7 +15,7 @@ Source: `test/e2e/thirdparty/prometheus/prometheus.atago.yaml`
 - Fixture file `broken.yml` is created.
 #### Inputs
 _Fixture `prometheus.yml`:_
-```
+```text
 global:
   scrape_interval: 15s
 scrape_configs:
@@ -24,7 +24,7 @@ scrape_configs:
       - targets: ["127.0.0.1:9090"]
 ```
 _Fixture `broken.yml`:_
-```
+```text
 global:
   scrape_interval: not-a-duration
 ```
@@ -46,7 +46,7 @@ promtool check config broken.yml
 - Fixture file `rules_test.yml` is created.
 #### Inputs
 _Fixture `rules.yml`:_
-```
+```text
 groups:
   - name: atago
     rules:
@@ -61,7 +61,7 @@ groups:
           summary: "Instance down"
 ```
 _Fixture `rules_test.yml`:_
-```
+```text
 rule_files:
   - rules.yml
 evaluation_interval: 1m
@@ -99,7 +99,7 @@ promtool test rules rules_test.yml
 - Fixture file `prometheus.yml` is created.
 #### Inputs
 _Fixture `prometheus.yml`:_
-```
+```text
 global:
   scrape_interval: 15s
 scrape_configs: []
@@ -131,7 +131,7 @@ scrape_configs: []
 - Fixture file `prometheus.yml` is created.
 #### Inputs
 _Fixture `prometheus.yml`:_
-```
+```text
 global:
   scrape_interval: 1s
 scrape_configs:

--- a/doc/e2e/rclone.md
+++ b/doc/e2e/rclone.md
@@ -27,11 +27,11 @@ rclone version
 - Fixture file `src/sub/table.csv` is created.
 #### Inputs
 _Fixture `src/hello.txt`:_
-```
+```text
 hello rclone
 ```
 _Fixture `src/sub/table.csv`:_
-```
+```text
 a,b
 1,2
 ```
@@ -55,11 +55,11 @@ rclone check src dst
 - Fixture file `dst/hello.txt` is created.
 #### Inputs
 _Fixture `src/hello.txt`:_
-```
+```text
 hello rclone
 ```
 _Fixture `dst/hello.txt`:_
-```
+```text
 corrupted replica
 ```
 #### When
@@ -78,11 +78,11 @@ rclone check src dst
 - Fixture file `src/sub/table.csv` is created.
 #### Inputs
 _Fixture `src/hello.txt`:_
-```
+```text
 hello rclone
 ```
 _Fixture `src/sub/table.csv`:_
-```
+```text
 a,b
 1,2
 ```
@@ -108,11 +108,11 @@ rclone size --json src
 - Fixture file `dst/extraneous.txt` is created.
 #### Inputs
 _Fixture `src/keep.txt`:_
-```
+```text
 stays
 ```
 _Fixture `dst/extraneous.txt`:_
-```
+```text
 must be deleted by sync
 ```
 #### When
@@ -145,11 +145,11 @@ rclone reveal ${obscured}
 - Fixture file `src/api/data.json` is created.
 #### Inputs
 _Fixture `src/hello.txt`:_
-```
+```text
 hello over http
 ```
 _Fixture `src/api/data.json`:_
-```
+```text
 {"source":"rclone","ok":true}
 ```
 #### When

--- a/doc/e2e/restic.md
+++ b/doc/e2e/restic.md
@@ -35,11 +35,11 @@ restic init
 - Fixture file `data/sub/notes.md` is created.
 #### Inputs
 _Fixture `data/hello.txt`:_
-```
+```text
 hello from atago
 ```
 _Fixture `data/sub/notes.md`:_
-```
+```text
 # notes kept safe
 ```
 #### When
@@ -69,11 +69,11 @@ restic restore ${snap} --target restored
 - Fixture file `data/added-later.txt` is created.
 #### Inputs
 _Fixture `data/base.txt`:_
-```
+```text
 first generation
 ```
 _Fixture `data/added-later.txt`:_
-```
+```text
 second generation
 ```
 #### When
@@ -99,7 +99,7 @@ restic diff ${first} ${second}
 - Fixture file `data/precious.txt` is created.
 #### Inputs
 _Fixture `data/precious.txt`:_
-```
+```text
 verify me
 ```
 #### When
@@ -118,11 +118,11 @@ restic check
 - Fixture file `data/gen.txt` is created.
 #### Inputs
 _Fixture `data/gen.txt`:_
-```
+```text
 one
 ```
 _Fixture `data/gen.txt`:_
-```
+```text
 two
 ```
 #### When

--- a/doc/e2e/sqly.md
+++ b/doc/e2e/sqly.md
@@ -496,14 +496,14 @@ Source: `test/e2e/tools/sqly/batch.atago.yaml`
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
 grey07,3
 ```
 _stdin for `sqly`:_
-```
+```text
 SELECT user_name FROM user ORDER BY identifier LIMIT 1
 ```
 #### When
@@ -518,14 +518,14 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
 grey07,3
 ```
 _stdin for `sqly`:_
-```
+```text
 .mode ndjson
 SELECT user_name FROM user ORDER BY identifier LIMIT 1
 ```
@@ -542,14 +542,14 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
 grey07,3
 ```
 _stdin for `sqly`:_
-```
+```text
 SELECT user_name FROM user ORDER BY identifier LIMIT 1;
 SELECT * FROM no_such_table;
 ```
@@ -566,14 +566,14 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
 grey07,3
 ```
 _stdin for `sqly`:_
-```
+```text
 SELECT user_name FROM user ORDER BY identifier LIMIT 1;
 SELECT 1;
 SELECT *
@@ -591,14 +591,14 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
 grey07,3
 ```
 _stdin for `sqly`:_
-```
+```text
 .exit
 SELECT * FROM no_such_table
 ```
@@ -613,14 +613,14 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
 grey07,3
 ```
 _stdin for `sqly`:_
-```
+```text
 SELECT * FROM no_such_table;
 .exit
 ```
@@ -636,14 +636,14 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
 grey07,3
 ```
 _stdin for `sqly`:_
-```
+```text
 SELECT user_name
 FROM user
 ORDER BY identifier
@@ -661,14 +661,14 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
 grey07,3
 ```
 _stdin for `sqly`:_
-```
+```text
 .mode csv
 SELECT 1 AS n
 UNION ALL
@@ -689,14 +689,14 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
 grey07,3
 ```
 _stdin for `sqly`:_
-```
+```text
 WITH x AS (
   SELECT user_name FROM user ORDER BY identifier LIMIT 1
 )
@@ -714,14 +714,14 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
 grey07,3
 ```
 _stdin for `sqly`:_
-```
+```text
 .tables
 SELECT COUNT(*) AS c FROM user;
 SELECT user_name FROM user ORDER BY identifier LIMIT 1;
@@ -738,14 +738,14 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
 grey07,3
 ```
 _stdin for `sqly`:_
-```
+```text
 -- comment ;
 SELECT 'v' AS x;
 ```
@@ -761,14 +761,14 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
 grey07,3
 ```
 _stdin for `sqly`:_
-```
+```text
 /* comment ; */
 SELECT 'v' AS x;
 ```
@@ -784,14 +784,14 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
 grey07,3
 ```
 _stdin for `sqly`:_
-```
+```text
 SELECT 'first' AS x; -- trailing ; comment
 SELECT 'second' AS y;
 ```
@@ -807,14 +807,14 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
 grey07,3
 ```
 _stdin for `sqly`:_
-```
+```text
 SELECT 'v' AS [a;b];
 ```
 #### When
@@ -829,14 +829,14 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
 grey07,3
 ```
 _stdin for `sqly`:_
-```
+```text
 SELECT 'v' AS `a;b`;
 ```
 #### When
@@ -851,14 +851,14 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
 grey07,3
 ```
 _stdin for `sqly`:_
-```
+```text
 SELECT * FROM (
 ```
 #### When
@@ -875,13 +875,13 @@ Source: `test/e2e/tools/sqly/batch_failfast.atago.yaml`
 - Fixture file `u.csv` is created.
 #### Inputs
 _Fixture `u.csv`:_
-```
+```text
 user_name,identifier,first_name
 booker12,1,Rachel
 jenkins46,2,Mary
 ```
 _stdin for `sqly`:_
-```
+```text
 SELECT * FROM no_such_table;
 SELECT 1 AS later;
 ```
@@ -898,13 +898,13 @@ sqly u.csv
 - Fixture file `u.csv` is created.
 #### Inputs
 _Fixture `u.csv`:_
-```
+```text
 user_name,identifier,first_name
 booker12,1,Rachel
 jenkins46,2,Mary
 ```
 _stdin for `sqly`:_
-```
+```text
 UPDATE u SET first_name = 'BROKEN' WHERE identifier = 1;
 SELECT * FROM no_such_table;
 .save --force
@@ -923,13 +923,13 @@ sqly u.csv
 - Fixture file `u.csv` is created.
 #### Inputs
 _Fixture `u.csv`:_
-```
+```text
 user_name,identifier,first_name
 booker12,1,Rachel
 jenkins46,2,Mary
 ```
 _stdin for `sqly`:_
-```
+```text
 SELECT * FROM no_such_table;
 .dump u out.csv
 ```
@@ -946,7 +946,7 @@ sqly u.csv
 - Fixture file `u.csv` is created.
 #### Inputs
 _Fixture `u.csv`:_
-```
+```text
 user_name,identifier,first_name
 booker12,1,Rachel
 jenkins46,2,Mary
@@ -967,7 +967,7 @@ Source: `test/e2e/tools/sqly/cache.atago.yaml`
 - Fixture file `data.csv` is created.
 #### Inputs
 _Fixture `data.csv`:_
-```
+```text
 id,name
 1,Alice
 2,Bob
@@ -989,14 +989,14 @@ sqly --cache snap.cache --sql "SELECT COUNT(*) AS n FROM data" data.csv
 - Fixture file `data.csv` is created.
 #### Inputs
 _Fixture `data.csv`:_
-```
+```text
 id,name
 1,Alice
 2,Bob
 3,Carol
 ```
 _Fixture `data.csv`:_
-```
+```text
 id,name
 1,Alice
 2,Bob
@@ -1018,7 +1018,7 @@ sqly --cache snap.cache --sql "SELECT COUNT(*) AS n FROM data" data.csv
 - Fixture file `data.csv` is created.
 #### Inputs
 _Fixture `data.csv`:_
-```
+```text
 id,name
 1,Alice
 2,Bob
@@ -1040,14 +1040,14 @@ sqly --cache snap.cache --cache-clear --sql "SELECT COUNT(*) AS n FROM data" dat
 - Fixture file `snap.cache/keep` is created.
 #### Inputs
 _Fixture `data.csv`:_
-```
+```text
 id,name
 1,Alice
 2,Bob
 3,Carol
 ```
 _Fixture `snap.cache/keep`:_
-```
+```text
 x
 ```
 #### When
@@ -1064,13 +1064,13 @@ sqly --cache snap.cache --sql "SELECT COUNT(*) AS n FROM data" data.csv
 - Fixture file `d.csv` is created.
 #### Inputs
 _Fixture `d.csv`:_
-```
+```text
 id,name
 1,Alice
 2,Bob
 ```
 _Fixture `d.csv`:_
-```
+```text
 id,name
 1,Carol
 2,Eve
@@ -1091,7 +1091,7 @@ sqly --cache snap.cache --sql "SELECT group_concat(name, ',') AS names FROM d" d
 - Fixture file `indir/data.csv` is created.
 #### Inputs
 _Fixture `indir/data.csv`:_
-```
+```text
 id,name
 1,Alice
 2,Bob
@@ -1115,16 +1115,16 @@ sqly --cache indir/snap.cache --sql "SELECT group_concat(name, ',') AS t FROM sq
 - Fixture file `indir/ignore.txt` is created.
 #### Inputs
 _Fixture `indir/data.csv`:_
-```
+```text
 id,name
 1,Alice
 ```
 _Fixture `indir/ignore.txt`:_
-```
+```text
 note
 ```
 _Fixture `indir/ignore.txt`:_
-```
+```text
 changed
 ```
 #### When
@@ -1144,16 +1144,16 @@ sqly --cache snap.cache --sql "SELECT COUNT(*) AS n FROM data" indir
 - Fixture file `indir/data.csv` is created.
 #### Inputs
 _Fixture `indir/data.csv`:_
-```
+```text
 id,name
 1,Alice
 ```
 _Fixture `indir/ignore.txt`:_
-```
+```text
 note
 ```
 _Fixture `indir/data.csv`:_
-```
+```text
 id,name
 1,Alice
 2,Bob
@@ -1199,7 +1199,7 @@ sqly --sql "SELECT 1" does_not_exist.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -1223,7 +1223,7 @@ sqly --no-such-flag
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -1240,13 +1240,13 @@ sqly --csv --json --sql "SELECT 1" user.csv
 - Fixture file `identifier.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
 ```
 _Fixture `identifier.csv`:_
-```
+```text
 id,position
 1,developrt
 2,manager
@@ -1264,7 +1264,7 @@ sqly --csv --sql "SELECT user_name, position FROM user INNER JOIN identifier ON 
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -1281,7 +1281,7 @@ sqly --json --output result.json --sql "SELECT user_name FROM user ORDER BY iden
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -1298,7 +1298,7 @@ sqly --sql "SELECT user_name FROM user ORDER BY identifier LIMIT 1" user.csv --c
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -1317,12 +1317,12 @@ Source: `test/e2e/tools/sqly/collision.atago.yaml`
 - Fixture file `a_b.csv` is created.
 #### Inputs
 _Fixture `a-b.csv`:_
-```
+```text
 id,name
 1,A
 ```
 _Fixture `a_b.csv`:_
-```
+```text
 id,name
 2,B
 ```
@@ -1341,14 +1341,14 @@ Source: `test/e2e/tools/sqly/compare.atago.yaml`
 - Fixture file `rev2.csv` is created.
 #### Inputs
 _Fixture `rev1.csv`:_
-```
+```text
 id,name,age
 1,Alice,30
 2,Bob,25
 3,Carol,40
 ```
 _Fixture `rev2.csv`:_
-```
+```text
 id,name,age
 1,Alice,31
 2,Bob,25
@@ -1370,14 +1370,14 @@ sqly --compare --compare-key id rev1.csv rev2.csv
 - Fixture file `rev2.csv` is created.
 #### Inputs
 _Fixture `rev1.csv`:_
-```
+```text
 id,name,age
 1,Alice,30
 2,Bob,25
 3,Carol,40
 ```
 _Fixture `rev2.csv`:_
-```
+```text
 id,name,age
 1,Alice,31
 2,Bob,25
@@ -1396,14 +1396,14 @@ sqly --compare --compare-key id --compare-format text rev1.csv rev2.csv
 - Fixture file `rev2.csv` is created.
 #### Inputs
 _Fixture `rev1.csv`:_
-```
+```text
 id,name,age
 1,Alice,30
 2,Bob,25
 3,Carol,40
 ```
 _Fixture `rev2.csv`:_
-```
+```text
 id,name,age
 1,Alice,31
 2,Bob,25
@@ -1422,14 +1422,14 @@ sqly --compare --compare-key ID rev1.csv rev2.csv
 - Fixture file `rev2.csv` is created.
 #### Inputs
 _Fixture `rev1.csv`:_
-```
+```text
 id,name,age
 1,Alice,30
 2,Bob,25
 3,Carol,40
 ```
 _Fixture `rev2.csv`:_
-```
+```text
 id,name,age
 1,Alice,31
 2,Bob,25
@@ -1448,13 +1448,13 @@ sqly --compare --compare-key nope rev1.csv rev2.csv
 - Fixture file `single.csv` is created.
 #### Inputs
 _Fixture `dupe.csv`:_
-```
+```text
 id,name
 1,Alice
 1,Bob
 ```
 _Fixture `single.csv`:_
-```
+```text
 id,name
 1,Alice
 ```
@@ -1471,14 +1471,14 @@ sqly --compare --compare-key id dupe.csv single.csv
 - Fixture file `rev2.csv` is created.
 #### Inputs
 _Fixture `rev1.csv`:_
-```
+```text
 id,name,age
 1,Alice,30
 2,Bob,25
 3,Carol,40
 ```
 _Fixture `rev2.csv`:_
-```
+```text
 id,name,age
 1,Alice,31
 2,Bob,25
@@ -1496,7 +1496,7 @@ sqly --compare --compare-tables "nope,rev2" rev1.csv rev2.csv
 - Fixture file `rev1.csv` is created.
 #### Inputs
 _Fixture `rev1.csv`:_
-```
+```text
 id,name,age
 1,Alice,30
 2,Bob,25
@@ -1515,12 +1515,12 @@ sqly --compare rev1.csv
 - Fixture file `ant.csv` is created.
 #### Inputs
 _Fixture `zebra.csv`:_
-```
+```text
 id,name
 1,Alice
 ```
 _Fixture `ant.csv`:_
-```
+```text
 id,name
 1,Alice
 ```
@@ -1537,12 +1537,12 @@ sqly --compare --compare-format text zebra.csv ant.csv
 - Fixture file `ant.csv` is created.
 #### Inputs
 _Fixture `zebra.csv`:_
-```
+```text
 id,name
 1,Alice
 ```
 _Fixture `ant.csv`:_
-```
+```text
 id,name
 1,Alice
 ```
@@ -1559,7 +1559,7 @@ sqly --compare --compare-format text ant.csv zebra.csv
 - Fixture file `big2.csv` is created.
 #### Inputs
 _Fixture `big1.csv`:_
-```
+```text
 id,name,score
 0,name0,0
 1,name1,1
@@ -1583,7 +1583,7 @@ id,name,score
 … (truncated, 31 more lines)
 ```
 _Fixture `big2.csv`:_
-```
+```text
 id,name,score
 0,name0,1
 1,name1,1
@@ -1621,7 +1621,7 @@ Source: `test/e2e/tools/sqly/cross_format.atago.yaml`
 - Fixture file `sales.csv` is created.
 #### Inputs
 _Fixture `sales.csv`:_
-```
+```text
 product_id,quantity
 1,3
 2,10
@@ -1642,12 +1642,12 @@ Source: `test/e2e/tools/sqly/empty_args.atago.yaml`
 - Fixture file `u.csv` is created.
 #### Inputs
 _Fixture `u.csv`:_
-```
+```text
 user_name,identifier,first_name
 booker12,1,Rachel
 ```
 _stdin for `sqly`:_
-```
+```text
 UPDATE u SET first_name = 'EMPTY' WHERE identifier = 1;
 .save ""
 ```
@@ -1665,12 +1665,12 @@ sqly u.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .dump user ""
 ```
 #### When
@@ -1683,7 +1683,7 @@ sqly user.csv
 ### Scenario: rejects .import with an empty path
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 .import ""
 .tables
 ```
@@ -1701,7 +1701,7 @@ Source: `test/e2e/tools/sqly/excel_export.atago.yaml`
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -1721,12 +1721,12 @@ sqly --excel --output out.xlsx --sql "SELECT * FROM user LIMIT 1" user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .mode excel
 .dump user dump.xlsx
 ```
@@ -1748,7 +1748,7 @@ Source: `test/e2e/tools/sqly/export_inference.atago.yaml`
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -1767,7 +1767,7 @@ sqly --sql "SELECT user_name FROM user ORDER BY identifier LIMIT 1" user.csv --o
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -1787,7 +1787,7 @@ sqly --sql "SELECT user_name FROM user ORDER BY identifier LIMIT 1" user.csv --o
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
@@ -1807,7 +1807,7 @@ sqly --csv --sql "SELECT user_name FROM result LIMIT 1" result.csv.gz
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -1828,7 +1828,7 @@ sqly --sql "SELECT user_name FROM user LIMIT 1" user.csv --output out.unknown
 - Fixture file `outdir/.keep` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -1846,12 +1846,12 @@ sqly --sql "SELECT identifier FROM user LIMIT 1" user.csv --output outdir
 - Fixture file `outdir/.keep` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .dump user outdir
 ```
 #### When
@@ -1866,7 +1866,7 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -1882,7 +1882,7 @@ sqly --json --sql "SELECT user_name FROM user LIMIT 1" user.csv --output result.
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -1898,7 +1898,7 @@ sqly --sql "SELECT user_name FROM user LIMIT 1" user.csv --output result.csv.bz2
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -1914,12 +1914,12 @@ sqly --sql "SELECT user_name FROM user LIMIT 1" user.csv --output result.parquet
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .dump user dump.tsv
 ```
 #### When
@@ -1937,7 +1937,7 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
@@ -1957,12 +1957,12 @@ Source: `test/e2e/tools/sqly/extra_args.atago.yaml`
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .schema user extra
 ```
 #### When
@@ -1977,12 +1977,12 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .describe user extra
 ```
 #### When
@@ -1997,12 +1997,12 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .tables extra
 ```
 #### When
@@ -2017,12 +2017,12 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .mode csv extra
 ```
 #### When
@@ -2037,12 +2037,12 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .pwd extra
 ```
 #### When
@@ -2057,12 +2057,12 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .clear extra
 ```
 #### When
@@ -2077,12 +2077,12 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .exit extra
 SELECT 1;
 ```
@@ -2100,14 +2100,14 @@ Source: `test/e2e/tools/sqly/filesql_integration.atago.yaml`
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
 grey07,3
 ```
 _stdin for `sqly`:_
-```
+```text
 SELECT COUNT(*) FROM user
 ```
 #### When
@@ -2122,7 +2122,7 @@ sqly user.csv
 - Fixture file `sample.jsonl` is created.
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 SELECT COUNT(*) FROM sample
 ```
 #### When
@@ -2137,7 +2137,7 @@ sqly sample.jsonl
 - Fixture file `products.parquet` is created.
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 SELECT COUNT(*) FROM products
 ```
 #### When
@@ -2152,7 +2152,7 @@ sqly products.parquet
 - Fixture file `sample.xlsx` is created.
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 SELECT COUNT(*) FROM sample_test_sheet
 ```
 #### When
@@ -2167,7 +2167,7 @@ sqly sample.xlsx
 - Fixture file `ppd-debit.ach` is created.
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 SELECT COUNT(*) FROM ppd_debit_entries
 ```
 #### When
@@ -2182,7 +2182,7 @@ sqly ppd-debit.ach
 - Fixture file `customer-transfer.fed` is created.
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 SELECT COUNT(*) FROM customer_transfer_message
 ```
 #### When
@@ -2197,7 +2197,7 @@ sqly customer-transfer.fed
 - Fixture file `products.parquet` is created.
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 .describe products
 ```
 #### When
@@ -2212,11 +2212,11 @@ sqly products.parquet
 - Fixture file `ppd-debit.ach` is created.
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 .tables
 ```
 _stdin for `sqly`:_
-```
+```text
 .tables
 ```
 #### When
@@ -2234,7 +2234,7 @@ Source: `test/e2e/tools/sqly/helpers.atago.yaml`
 ### Scenario: .help groups commands, shows usage, and flags destructive save
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 .help
 ```
 #### When
@@ -2249,12 +2249,12 @@ sqly
 - Fixture file `testdata/x.csv` is created.
 #### Inputs
 _Fixture `testdata/x.csv`:_
-```
+```text
 id,name
 1,a
 ```
 _stdin for `sqly`:_
-```
+```text
 .cd testdata
 .pwd
 ```
@@ -2270,12 +2270,12 @@ sqly
 - Fixture file `home/sqly_tilde.csv` is created.
 #### Inputs
 _Fixture `home/sqly_tilde.csv`:_
-```
+```text
 id,name
 1,foo
 ```
 _stdin for `sqly`:_
-```
+```text
 .cd ~
 .pwd
 ```
@@ -2291,12 +2291,12 @@ sqly
 - Fixture file `home/sqly_tilde.csv` is created.
 #### Inputs
 _Fixture `home/sqly_tilde.csv`:_
-```
+```text
 id,name
 1,foo
 ```
 _stdin for `sqly`:_
-```
+```text
 .import ~/sqly_tilde.csv
 .tables
 ```
@@ -2310,7 +2310,7 @@ sqly
 ### Scenario: .clear emits no ANSI escapes to stdout in batch mode
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 .clear
 ```
 #### When
@@ -2325,12 +2325,12 @@ sqly
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .clear
 SELECT 1 AS x;
 ```
@@ -2346,12 +2346,12 @@ sqly --json user.csv
 - Fixture file `sqly_e2e space.csv` is created.
 #### Inputs
 _Fixture `sqly_e2e space.csv`:_
-```
+```text
 id,name
 1,foo
 ```
 _stdin for `sqly`:_
-```
+```text
 .import "sqly_e2e space.csv"
 .tables
 ```
@@ -2367,12 +2367,12 @@ sqly
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .mode
 ```
 #### When
@@ -2387,12 +2387,12 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .dump user out.tsv
 ```
 #### When
@@ -2425,7 +2425,7 @@ case "$SQLY_HISTORY_DB_PATH" in "$SQLY_E2E_SANDBOX"*) exit 0 ;; *) exit 1 ;; esa
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -2443,7 +2443,7 @@ Source: `test/e2e/tools/sqly/history_tolerance.atago.yaml`
 - Fixture file `actor.csv` is created.
 #### Inputs
 _Fixture `actor.csv`:_
-```
+```text
 actor
 Adam Sandler
 Harrison Ford
@@ -2461,13 +2461,13 @@ sqly --csv --sql "SELECT actor FROM actor ORDER BY actor LIMIT 1" actor.csv
 - Fixture file `actor.csv` is created.
 #### Inputs
 _Fixture `actor.csv`:_
-```
+```text
 actor
 Adam Sandler
 Harrison Ford
 ```
 _stdin for `sqly`:_
-```
+```text
 .tables
 SELECT actor FROM actor ORDER BY actor LIMIT 1
 ```
@@ -2485,7 +2485,7 @@ sqly actor.csv
 - Fixture file `h.db` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
@@ -2505,7 +2505,7 @@ sqly --sql "SELECT user_name FROM user ORDER BY identifier LIMIT 1" user.csv
 - Fixture file `h.db` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
@@ -2526,13 +2526,13 @@ sqly --inspect user.csv
 - Fixture file `h.db` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
 ```
 _stdin for `sqly`:_
-```
+```text
 SELECT user_name FROM user ORDER BY identifier LIMIT 1
 ```
 #### When
@@ -2552,7 +2552,7 @@ Source: `test/e2e/tools/sqly/import_failure.atago.yaml`
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -2578,7 +2578,7 @@ sqly --sql "SELECT 1" /no/such/a.csv /no/such/b.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -2595,12 +2595,12 @@ sqly --inspect user.csv /no/such/file.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .import user.csv /no/such/file.csv
 .tables
 ```
@@ -2628,13 +2628,13 @@ Source: `test/e2e/tools/sqly/import_quoting.atago.yaml`
 - Fixture file `space name.csv` is created.
 #### Inputs
 _Fixture `space name.csv`:_
-```
+```text
 label,score
 alpha,1
 beta,2
 ```
 _stdin for `sqly`:_
-```
+```text
 .import space\ name.csv
 SELECT label FROM space_name ORDER BY score;
 ```
@@ -2650,13 +2650,13 @@ sqly
 - Fixture file `space name.csv` is created.
 #### Inputs
 _Fixture `space name.csv`:_
-```
+```text
 label,score
 alpha,1
 beta,2
 ```
 _stdin for `sqly`:_
-```
+```text
 .import "space name.csv"
 SELECT label FROM space_name ORDER BY score;
 ```
@@ -2672,13 +2672,13 @@ sqly
 - Fixture file `space name.csv` is created.
 #### Inputs
 _Fixture `space name.csv`:_
-```
+```text
 label,score
 alpha,1
 beta,2
 ```
 _stdin for `sqly`:_
-```
+```text
 .import 'space name.csv'
 SELECT label FROM space_name ORDER BY score;
 ```
@@ -2694,13 +2694,13 @@ sqly
 - Fixture file `space dir/nested.csv` is created.
 #### Inputs
 _Fixture `space dir/nested.csv`:_
-```
+```text
 label,score
 gamma,3
 delta,4
 ```
 _stdin for `sqly`:_
-```
+```text
 .import space\ dir/nested.csv
 SELECT label FROM nested ORDER BY score;
 ```
@@ -2716,13 +2716,13 @@ sqly
 - Fixture file `space name.csv` is created.
 #### Inputs
 _Fixture `space name.csv`:_
-```
+```text
 label,score
 alpha,1
 beta,2
 ```
 _stdin for `sqly`:_
-```
+```text
 .import space name.csv
 ```
 #### When
@@ -2739,7 +2739,7 @@ Source: `test/e2e/tools/sqly/inspect.atago.yaml`
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
@@ -2769,12 +2769,12 @@ sqly --inspect ppd-debit.ach
 - Fixture file `ins/b.csv` is created.
 #### Inputs
 _Fixture `ins/a.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _Fixture `ins/b.csv`:_
-```
+```text
 id,position
 1,developrt
 ```
@@ -2800,7 +2800,7 @@ sqly --inspect
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
@@ -2819,7 +2819,7 @@ sqly --inspect --inspect-sample 0 user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
@@ -2838,7 +2838,7 @@ sqly --inspect --inspect-sample 1 user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
@@ -2858,7 +2858,7 @@ Source: `test/e2e/tools/sqly/inspect_conflicts.atago.yaml`
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -2874,7 +2874,7 @@ sqly --inspect --sql "SELECT * FROM user LIMIT 1" user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -2891,7 +2891,7 @@ sqly --inspect --output out.csv user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -2928,7 +2928,7 @@ Source: `test/e2e/tools/sqly/metamorphic.atago.yaml`
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
@@ -2949,7 +2949,7 @@ sqly --csv --sql "SELECT user_name FROM user" user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
@@ -2970,7 +2970,7 @@ sqly --json --sql "SELECT user_name FROM user WHERE 1=0" user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
@@ -2989,7 +2989,7 @@ sqly --csv --sql "SELECT user_name FROM user ORDER BY user_name DESC" user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
@@ -3007,14 +3007,14 @@ sqly --ndjson --sql "SELECT user_name FROM user ORDER BY identifier" user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
 grey07,3
 ```
 _stdin for `sqly`:_
-```
+```text
 .dump user rt.csv
 ```
 #### When
@@ -3035,12 +3035,12 @@ Source: `test/e2e/tools/sqly/mode_banner.atago.yaml`
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .mode json
 SELECT user_name FROM user LIMIT 1
 ```
@@ -3058,12 +3058,12 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .mode ndjson
 SELECT user_name FROM user LIMIT 1
 ```
@@ -3081,12 +3081,12 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .mode json-typed
 SELECT 7 AS n, 'x' AS s
 ```
@@ -3106,7 +3106,7 @@ Source: `test/e2e/tools/sqly/output_format.atago.yaml`
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
@@ -3126,7 +3126,7 @@ sqly --json --sql "SELECT user_name, identifier FROM user ORDER BY identifier LI
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -3142,7 +3142,7 @@ sqly --json --sql "SELECT user_name FROM user WHERE user_name = 'nobody'" user.c
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
@@ -3161,7 +3161,7 @@ sqly --ndjson --sql "SELECT user_name, identifier FROM user ORDER BY identifier 
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -3177,7 +3177,7 @@ sqly --ndjson --sql "SELECT user_name FROM user WHERE user_name = 'nobody'" user
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
@@ -3197,7 +3197,7 @@ Source: `test/e2e/tools/sqly/output_requires_sql.atago.yaml`
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -3214,12 +3214,12 @@ sqly user.csv --output out.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 SELECT user_name FROM user ORDER BY identifier LIMIT 1
 ```
 #### When
@@ -3237,7 +3237,7 @@ Source: `test/e2e/tools/sqly/output_status.atago.yaml`
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -3257,12 +3257,12 @@ sqly --sql "SELECT 1 AS x" --output out.csv user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .dump user dump.csv
 ```
 #### When
@@ -3281,12 +3281,12 @@ sqly user.csv
 - Fixture file `u.csv` is created.
 #### Inputs
 _Fixture `u.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 UPDATE u SET user_name = 'X' WHERE identifier = 1;
 .save saved
 ```
@@ -3306,14 +3306,14 @@ Source: `test/e2e/tools/sqly/parquet_export.atago.yaml`
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
 grey07,3
 ```
 _stdin for `sqly`:_
-```
+```text
 .mode parquet
 .dump user user.parquet
 ```
@@ -3336,14 +3336,14 @@ sqly --csv --sql "SELECT COUNT(*) AS c FROM user" user.parquet
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
 grey07,3
 ```
 _stdin for `sqly`:_
-```
+```text
 .mode parquet
 .dump user result
 ```
@@ -3360,7 +3360,7 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
@@ -3402,7 +3402,7 @@ sqly --json-typed --sql "SELECT * FROM n" n.parquet
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
@@ -3422,7 +3422,7 @@ Source: `test/e2e/tools/sqly/path_validation.atago.yaml`
 - Fixture file `a/b/c/d/e/f/g/h/i/j/k/user.csv` is created.
 #### Inputs
 _Fixture `a/b/c/d/e/f/g/h/i/j/k/user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
@@ -3440,7 +3440,7 @@ sqly --csv --sql "SELECT COUNT(*) AS c FROM user" a/b/c/d/e/f/g/h/i/j/k/user.csv
 - Fixture file `..%2fuser.csv` is created.
 #### Inputs
 _Fixture `..%2fuser.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -3470,7 +3470,7 @@ _skipped on windows_
 - Fixture file `user_alias.csv` is created.
 #### Inputs
 _Fixture `real.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -3488,7 +3488,7 @@ Source: `test/e2e/tools/sqly/profile.atago.yaml`
 - Fixture file `messy.csv` is created.
 #### Inputs
 _Fixture `messy.csv`:_
-```
+```text
 id,score,note
 1,10, hi
 2,abc,
@@ -3504,7 +3504,7 @@ sqly --profile messy.csv
 ### Scenario: profiles a stdin dataset
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 id,name
 1,Alice
 2,Bob
@@ -3522,14 +3522,14 @@ sqly --stdin csv --profile
 - Fixture file `orders.csv` is created.
 #### Inputs
 _Fixture `messy.csv`:_
-```
+```text
 id,score,note
 1,10, hi
 2,abc,
 3,30,N/A
 ```
 _Fixture `orders.csv`:_
-```
+```text
 oid,amount
 1,9.99
 2,5.00
@@ -3546,7 +3546,7 @@ sqly --profile messy.csv orders.csv
 - Fixture file `orders.csv` is created.
 #### Inputs
 _Fixture `orders.csv`:_
-```
+```text
 oid,amount
 1,9.99
 2,5.00
@@ -3563,7 +3563,7 @@ sqly --profile --profile-format text orders.csv
 - Fixture file `blank.csv` is created.
 #### Inputs
 _Fixture `blank.csv`:_
-```
+```text
 id,v
 x,
 x,A
@@ -3579,7 +3579,7 @@ sqly --profile blank.csv
 - Fixture file `blank.csv` is created.
 #### Inputs
 _Fixture `blank.csv`:_
-```
+```text
 id,v
 x,
 x,A
@@ -3595,7 +3595,7 @@ sqly --profile --profile-format text blank.csv
 - Fixture file `nullspace.csv` is created.
 #### Inputs
 _Fixture `nullspace.csv`:_
-```
+```text
 v
 " NULL "
 ```
@@ -3610,7 +3610,7 @@ sqly --profile nullspace.csv
 - Fixture file `padded.csv` is created.
 #### Inputs
 _Fixture `padded.csv`:_
-```
+```text
 v
 " hello "
 ```
@@ -3626,7 +3626,7 @@ sqly --profile padded.csv
 - Fixture file `commas.csv` is created.
 #### Inputs
 _Fixture `commas.csv`:_
-```
+```text
 amount
 "1,000"
 "2,500"
@@ -3643,7 +3643,7 @@ sqly --profile commas.csv
 - Fixture file `commas.csv` is created.
 #### Inputs
 _Fixture `commas.csv`:_
-```
+```text
 amount
 "1,000"
 "2,500"
@@ -3662,7 +3662,7 @@ Source: `test/e2e/tools/sqly/readme_examples.atago.yaml`
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 jenkins46,2,Mary,Jenkins
@@ -3681,14 +3681,14 @@ sqly --sql "SELECT * FROM user" user.csv
 - Fixture file `identifier.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 jenkins46,2,Mary,Jenkins
 smith79,3,Jamie,Smith
 ```
 _Fixture `identifier.csv`:_
-```
+```text
 id,position
 1,developrt
 2,manager
@@ -3749,7 +3749,7 @@ sqly --csv --sql "SELECT name FROM products ORDER BY CAST(price AS REAL) DESC LI
 - Fixture file `identifier.csv` is created.
 #### Inputs
 _Fixture `identifier.csv`:_
-```
+```text
 id,position
 1,developrt
 2,manager
@@ -3767,7 +3767,7 @@ sqly --csv --sql "SELECT user_name, position FROM user JOIN identifier ON user.i
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 jenkins46,2,Mary,Jenkins
@@ -3786,7 +3786,7 @@ sqly --csv --sql "SELECT user_name, identifier FROM user LIMIT 2" user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 jenkins46,2,Mary,Jenkins
@@ -3803,7 +3803,7 @@ sqly --json --sql "SELECT user_name, identifier FROM user LIMIT 2" user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 jenkins46,2,Mary,Jenkins
@@ -3821,7 +3821,7 @@ sqly --ndjson --sql "SELECT user_name, identifier FROM user LIMIT 2" user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 jenkins46,2,Mary,Jenkins
@@ -3839,7 +3839,7 @@ sqly --markdown --sql "SELECT user_name, identifier FROM user LIMIT 2" user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 jenkins46,2,Mary,Jenkins
@@ -3856,7 +3856,7 @@ sqly --ltsv --sql "SELECT user_name, identifier FROM user LIMIT 1" user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 jenkins46,2,Mary,Jenkins
@@ -3873,7 +3873,7 @@ sqly --sql "SELECT * FROM user" --output out.csv user.csv
 ### Scenario: queries piped CSV through the default stdin table
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 jenkins46,2,Mary,Jenkins
@@ -3891,14 +3891,14 @@ sqly --stdin csv --sql "SELECT user_name FROM stdin LIMIT 1"
 - Fixture file `identifier.csv` is created.
 #### Inputs
 _Fixture `identifier.csv`:_
-```
+```text
 id,position
 1,developrt
 2,manager
 3,neet
 ```
 _stdin for `sqly`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 jenkins46,2,Mary,Jenkins
@@ -3916,14 +3916,14 @@ sqly --stdin csv --csv --sql "SELECT s.user_name, i.position FROM stdin s JOIN i
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 jenkins46,2,Mary,Jenkins
 smith79,3,Jamie,Smith
 ```
 _stdin for `sqly`:_
-```
+```text
 .tables
 SELECT COUNT(*) FROM user
 ```
@@ -3940,14 +3940,14 @@ sqly user.csv
 - Fixture file `join.sql` is created.
 #### Inputs
 _Fixture `identifier.csv`:_
-```
+```text
 id,position
 1,developrt
 2,manager
 3,neet
 ```
 _stdin for `sqly`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 jenkins46,2,Mary,Jenkins
@@ -3965,7 +3965,7 @@ sqly --stdin csv --sql-file join.sql identifier.csv
 - Fixture file `identifier.csv` is created.
 #### Inputs
 _Fixture `identifier.csv`:_
-```
+```text
 id,position
 1,developrt
 2,manager
@@ -3983,7 +3983,7 @@ sqly --inspect --inspect-sample 1 identifier.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 jenkins46,2,Mary,Jenkins
@@ -4001,14 +4001,14 @@ sqly --inspect --inspect-sample 0 user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 jenkins46,2,Mary,Jenkins
 smith79,3,Jamie,Smith
 ```
 _stdin for `sqly`:_
-```
+```text
 .schema user
 ```
 #### When
@@ -4023,14 +4023,14 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 jenkins46,2,Mary,Jenkins
 smith79,3,Jamie,Smith
 ```
 _stdin for `sqly`:_
-```
+```text
 .describe user
 ```
 #### When
@@ -4045,7 +4045,7 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 jenkins46,2,Mary,Jenkins
@@ -4066,7 +4066,7 @@ sqly --sql "UPDATE user SET first_name = 'Rachelle' WHERE identifier = 1" --save
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 jenkins46,2,Mary,Jenkins
@@ -4085,7 +4085,7 @@ sqly --sql "UPDATE user SET identifier = identifier + 100" --save user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 jenkins46,2,Mary,Jenkins
@@ -4104,7 +4104,7 @@ sqly --sql "CREATE TABLE backup AS SELECT * FROM user" --save-dir out user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 jenkins46,2,Mary,Jenkins
@@ -4125,17 +4125,17 @@ sqly --sql "UPDATE user SET identifier = identifier + 100" --save --force user.c
 - Fixture file `imp/identifier.csv` is created.
 #### Inputs
 _Fixture `imp/user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
 _Fixture `imp/identifier.csv`:_
-```
+```text
 id,position
 1,developrt
 ```
 _stdin for `sqly`:_
-```
+```text
 .tables
 ```
 #### When
@@ -4151,7 +4151,7 @@ sqly imp
 - Fixture file `ppd-debit.ach` is created.
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 .tables
 ```
 #### When
@@ -4176,7 +4176,7 @@ sqly --csv --sql "SELECT amount FROM ppd_debit_entries" ppd-debit.ach
 - Fixture file `customer-transfer.fed` is created.
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 .tables
 ```
 #### When
@@ -4193,7 +4193,7 @@ Source: `test/e2e/tools/sqly/save.atago.yaml`
 - Fixture file `u.csv` is created.
 #### Inputs
 _Fixture `u.csv`:_
-```
+```text
 user_name,identifier,first_name
 booker12,1,Rachel
 jenkins46,2,Mary
@@ -4213,7 +4213,7 @@ sqly --sql "UPDATE u SET first_name = 'CHANGED' WHERE identifier = 1" u.csv --sa
 - Fixture file `u.csv` is created.
 #### Inputs
 _Fixture `u.csv`:_
-```
+```text
 user_name,identifier,first_name
 booker12,1,Rachel
 jenkins46,2,Mary
@@ -4231,7 +4231,7 @@ sqly --sql "UPDATE u SET first_name = 'X'" u.csv --save
 - Fixture file `u.csv` is created.
 #### Inputs
 _Fixture `u.csv`:_
-```
+```text
 user_name,identifier,first_name
 booker12,1,Rachel
 jenkins46,2,Mary
@@ -4249,7 +4249,7 @@ sqly --sql "DELETE FROM u WHERE identifier > 1" u.csv --save --force
 - Fixture file `u.csv` is created.
 #### Inputs
 _Fixture `u.csv`:_
-```
+```text
 user_name,identifier,first_name
 booker12,1,Rachel
 jenkins46,2,Mary
@@ -4280,13 +4280,13 @@ sqly --csv --sql "SELECT first_name FROM c WHERE identifier = 1" c.csv.gz
 - Fixture file `u.csv` is created.
 #### Inputs
 _Fixture `u.csv`:_
-```
+```text
 user_name,identifier,first_name
 booker12,1,Rachel
 jenkins46,2,Mary
 ```
 _stdin for `sqly`:_
-```
+```text
 UPDATE u SET first_name = 'BATCH' WHERE identifier = 1;
 .save --force
 ```
@@ -4310,7 +4310,7 @@ sqly --save --force --sql "UPDATE foo SET x = 1"
 ### Scenario: guides a batch .save with no imported tables toward passing input
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 .save --force
 ```
 #### When
@@ -4327,12 +4327,12 @@ Source: `test/e2e/tools/sqly/schema.atago.yaml`
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .schema user
 ```
 #### When
@@ -4347,12 +4347,12 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .mode json
 .schema user
 ```
@@ -4370,12 +4370,12 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 CREATE VIEW v AS SELECT 1 AS x;
 .schema V
 ```
@@ -4392,12 +4392,12 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .schema no_such_table
 ```
 #### When
@@ -4412,12 +4412,12 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .describe user
 ```
 #### When
@@ -4432,12 +4432,12 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .mode json
 .describe user
 ```
@@ -4454,12 +4454,12 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .describe no_such_table
 ```
 #### When
@@ -4476,7 +4476,7 @@ Source: `test/e2e/tools/sqly/sheet_flag.atago.yaml`
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -4492,7 +4492,7 @@ sqly --sql "SELECT * FROM user" --sheet "A test" user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -4518,7 +4518,7 @@ sqly --csv --sql "SELECT * FROM sample_test_sheet" --sheet test_sheet sample.xls
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -4534,7 +4534,7 @@ sqly --inspect --sheet "" user.csv
 - Fixture file `dir/u.csv` is created.
 #### Inputs
 _Fixture `dir/u.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -4550,7 +4550,7 @@ sqly --inspect --sheet anything dir
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -4589,7 +4589,7 @@ Source: `test/e2e/tools/sqly/smoke.atago.yaml`
 - Fixture file `users.csv` is created.
 #### Inputs
 _Fixture `users.csv`:_
-```
+```text
 id,name
 1,Alice
 2,Bob
@@ -4606,7 +4606,7 @@ sqly --sql 'SELECT count(*) AS cnt FROM users' --csv users.csv
 - Fixture file `users.csv` is created.
 #### Inputs
 _Fixture `users.csv`:_
-```
+```text
 id,name
 1,Alice
 2,Bob
@@ -4623,7 +4623,7 @@ sqly --sql 'SELECT name FROM users WHERE id = 1' --csv users.csv
 - Fixture file `users.csv` is created.
 #### Inputs
 _Fixture `users.csv`:_
-```
+```text
 id,name
 1,Alice
 ```
@@ -4643,13 +4643,13 @@ Source: `test/e2e/tools/sqly/sql_file.atago.yaml`
 - Fixture file `q.sql` is created.
 #### Inputs
 _Fixture `actor.csv`:_
-```
+```text
 actor
 Adam Sandler
 Harrison Ford
 ```
 _Fixture `q.sql`:_
-```
+```text
 -- top actor by name
 SELECT actor
 FROM actor
@@ -4669,20 +4669,20 @@ sqly --csv --sql-file q.sql actor.csv
 - Fixture file `join.sql` is created.
 #### Inputs
 _Fixture `identifier.csv`:_
-```
+```text
 id,position
 1,developrt
 2,manager
 ```
 _Fixture `join.sql`:_
-```
+```text
 SELECT s.name, i.position
 FROM stdin s
 JOIN identifier i ON s.id = i.id
 ORDER BY s.id;
 ```
 _stdin for `sqly`:_
-```
+```text
 id,name
 1,alice
 2,bob
@@ -4700,13 +4700,13 @@ sqly --stdin csv --csv --sql-file join.sql identifier.csv
 - Fixture file `multi.sql` is created.
 #### Inputs
 _Fixture `actor.csv`:_
-```
+```text
 actor
 Adam Sandler
 Harrison Ford
 ```
 _Fixture `multi.sql`:_
-```
+```text
 SELECT 'first' AS x;
 SELECT 'second' AS x;
 ```
@@ -4723,13 +4723,13 @@ sqly --csv --sql-file multi.sql actor.csv
 - Fixture file `q.sql` is created.
 #### Inputs
 _Fixture `actor.csv`:_
-```
+```text
 actor
 Adam Sandler
 Harrison Ford
 ```
 _Fixture `q.sql`:_
-```
+```text
 SELECT 1;
 ```
 #### When
@@ -4744,7 +4744,7 @@ sqly --sql "SELECT 1" --sql-file q.sql actor.csv
 - Fixture file `actor.csv` is created.
 #### Inputs
 _Fixture `actor.csv`:_
-```
+```text
 actor
 Adam Sandler
 Harrison Ford
@@ -4762,7 +4762,7 @@ sqly --sql-file no_such.sql actor.csv
 - Fixture file `empty.sql` is created.
 #### Inputs
 _Fixture `actor.csv`:_
-```
+```text
 actor
 Adam Sandler
 Harrison Ford
@@ -4780,13 +4780,13 @@ sqly --sql-file empty.sql actor.csv
 - Fixture file `bad.sql` is created.
 #### Inputs
 _Fixture `actor.csv`:_
-```
+```text
 actor
 Adam Sandler
 Harrison Ford
 ```
 _Fixture `bad.sql`:_
-```
+```text
 SELECT 1;
 SELECT 2;
 SELECT * FROM no_such_table;
@@ -4806,13 +4806,13 @@ Source: `test/e2e/tools/sqly/sqlfile_output.atago.yaml`
 - Fixture file `q.sql` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
 ```
 _Fixture `q.sql`:_
-```
+```text
 SELECT user_name FROM user ORDER BY identifier LIMIT 1;
 ```
 #### When
@@ -4830,13 +4830,13 @@ sqly --sql-file q.sql --output out.csv user.csv
 - Fixture file `q.sql` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
 ```
 _Fixture `q.sql`:_
-```
+```text
 CREATE TEMP TABLE picked AS SELECT user_name FROM user;
 SELECT * FROM picked ORDER BY user_name LIMIT 1;
 ```
@@ -4857,13 +4857,13 @@ sqly --sql-file q.sql --output out.csv user.csv
 - Fixture file `q.sql` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
 ```
 _Fixture `q.sql`:_
-```
+```text
 CREATE TEMP TABLE t AS SELECT 1 AS x;
 ```
 #### When
@@ -4880,13 +4880,13 @@ sqly --sql-file q.sql --output out.csv user.csv
 - Fixture file `q.sql` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 jenkins46,2
 ```
 _Fixture `q.sql`:_
-```
+```text
 SELECT user_name FROM user LIMIT 1;
 SELECT identifier FROM user LIMIT 1;
 ```
@@ -4903,7 +4903,7 @@ Source: `test/e2e/tools/sqly/stdin_dataset.atago.yaml`
 ### Scenario: queries piped CSV through the default stdin table
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 id,name
 1,alice
 2,bob
@@ -4920,7 +4920,7 @@ sqly --stdin csv --csv --sql "SELECT name FROM stdin ORDER BY id"
 ### Scenario: queries piped TSV data
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 id	name
 1	alice
 ```
@@ -4934,7 +4934,7 @@ sqly --stdin tsv --csv --sql "SELECT COUNT(*) AS c FROM stdin"
 ### Scenario: queries piped JSONL data stored in a data column
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 {"id":1,"name":"alice"}
 {"id":2,"name":"bob"}
 ```
@@ -4948,7 +4948,7 @@ sqly --stdin jsonl --csv --sql "SELECT COUNT(*) AS c FROM stdin"
 ### Scenario: overrides the stdin table name with --stdin-name
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 id,name
 1,alice
 2,bob
@@ -4965,13 +4965,13 @@ sqly --stdin csv --stdin-name people --csv --sql "SELECT COUNT(*) FROM people"
 - Fixture file `identifier.csv` is created.
 #### Inputs
 _Fixture `identifier.csv`:_
-```
+```text
 id,position
 1,developrt
 2,manager
 ```
 _stdin for `sqly`:_
-```
+```text
 id,name
 1,alice
 2,bob
@@ -4986,7 +4986,7 @@ sqly --stdin csv --csv --sql "SELECT s.name, i.position FROM stdin s JOIN identi
 ### Scenario: reports a stable stdin source in --inspect, not a temp path
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 id,name
 1,alice
 ```
@@ -5001,7 +5001,7 @@ sqly --stdin csv --inspect
 ### Scenario: rejects --save --force for a stdin-backed table
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 id,name
 1,alice
 ```
@@ -5016,7 +5016,7 @@ sqly --stdin csv --sql "UPDATE stdin SET name = 'x'" --save --force
 ### Scenario: rejects a non-identifier --stdin-name so the name stays queryable
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 id,name
 1,alice
 ```
@@ -5030,7 +5030,7 @@ sqly --stdin csv --stdin-name "my data" --sql 'SELECT * FROM "my data"'
 ### Scenario: rejects a path-like --stdin-name
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 a
 1
 ```
@@ -5045,7 +5045,7 @@ sqly --stdin csv --stdin-name "../escaped" --sql "SELECT 1"
 ### Scenario: reports a clear error for an unsupported stdin format
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 a,b
 1,2
 ```
@@ -5061,12 +5061,12 @@ sqly --stdin xml --sql "SELECT 1"
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .tables
 SELECT user_name FROM user ORDER BY identifier LIMIT 1
 ```
@@ -5106,7 +5106,7 @@ sqly --ndjson-typed --sql "SELECT 7 AS n, 't' AS s"
 - Fixture file `typed_bigint.csv` is created.
 #### Inputs
 _Fixture `typed_bigint.csv`:_
-```
+```text
 id,amount,flag
 1,9007199254740993,true
 2,42,false
@@ -5130,7 +5130,7 @@ sqly --json-typed --sql "SELECT '007' AS code"
 - Fixture file `typed_bigint.csv` is created.
 #### Inputs
 _Fixture `typed_bigint.csv`:_
-```
+```text
 id,amount,flag
 1,9007199254740993,true
 2,42,false
@@ -5146,7 +5146,7 @@ sqly --inspect --json-typed typed_bigint.csv
 - Fixture file `typed_bigint.csv` is created.
 #### Inputs
 _Fixture `typed_bigint.csv`:_
-```
+```text
 id,amount,flag
 1,9007199254740993,true
 2,42,false
@@ -5181,7 +5181,7 @@ sqly --sql-file ""
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -5195,7 +5195,7 @@ sqly --sql "SELECT 1" --save-dir "" user.csv
 ### Scenario: rejects an empty --stdin
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 id,name
 1,a
 ```
@@ -5219,7 +5219,7 @@ sqly --csv --json --sql "SELECT 1 AS x"
 - Fixture file `u.csv` is created.
 #### Inputs
 _Fixture `u.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -5236,7 +5236,7 @@ sqly --csv --sql "UPDATE u SET first_name='X' WHERE identifier=1 RETURNING ident
 - Fixture file `u.csv` is created.
 #### Inputs
 _Fixture `u.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -5253,7 +5253,7 @@ sqly --sql "UPDATE u SET first_name='X' WHERE identifier=1" --output out.csv u.c
 - Fixture file `u.csv` is created.
 #### Inputs
 _Fixture `u.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -5272,7 +5272,7 @@ sqly --csv --sql "UPDATE u SET first_name='X' WHERE identifier=1 RETURNING ident
 - Fixture file `q.sql` is created.
 #### Inputs
 _Fixture `q.sql`:_
-```
+```text
 -- header only
 /* block */
 ```
@@ -5289,7 +5289,7 @@ sqly --sql-file q.sql
 - Fixture file `q.sql` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -5305,12 +5305,12 @@ sqly --csv --sql-file q.sql user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
 _stdin for `sqly`:_
-```
+```text
 ﻿SELECT 7 AS z;
 ```
 #### When
@@ -5326,16 +5326,16 @@ sqly --csv user.csv
 - Fixture file `q.sql` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
 _Fixture `q.sql`:_
-```
+```text
 SELECT 1 AS x;
 ```
 _stdin for `sqly`:_
-```
+```text
 SELECT 999 AS y;
 ```
 #### When
@@ -5348,7 +5348,7 @@ sqly --sql-file q.sql user.csv
 ### Scenario: fails a --stdin dataset run with no query
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 id,name
 1,a
 ```
@@ -5364,7 +5364,7 @@ sqly --stdin csv
 - Fixture file `dir/2023-data.csv` is created.
 #### Inputs
 _Fixture `dir/2023-data.csv`:_
-```
+```text
 id,name
 1,a
 ```
@@ -5382,12 +5382,12 @@ sqly --inspect dir
 - Fixture file `dir/b/user.csv` is created.
 #### Inputs
 _Fixture `dir/a/user.csv`:_
-```
+```text
 id,name
 1,alpha
 ```
 _Fixture `dir/b/user.csv`:_
-```
+```text
 id,name
 2,beta
 ```
@@ -5405,17 +5405,17 @@ sqly --inspect dir
 - Fixture file `cmds.sql` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
 _Fixture `dir/user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 alt1,1,ALT,One
 ```
 _Fixture `cmds.sql`:_
-```
+```text
 .import dir
 SELECT user_name FROM user ORDER BY identifier;
 ```
@@ -5432,7 +5432,7 @@ sqly --sql-file cmds.sql user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -5448,7 +5448,7 @@ sqly --csv --sql "SELECT * FROM user WHERE identifier=1" --output user.csv user.
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -5465,12 +5465,12 @@ sqly --sql "UPDATE user SET first_name='P' WHERE identifier=1" --save-dir . user
 - Fixture file `out/user.csv` is created.
 #### Inputs
 _Fixture `src/user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
 _Fixture `out/user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -5487,7 +5487,7 @@ sqly --sql "UPDATE user SET first_name='Q' WHERE identifier=1" --save-dir out sr
 - Fixture file `sample.xlsx` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -5504,7 +5504,7 @@ sqly --sql "UPDATE user SET first_name='X' WHERE identifier=1" --save-dir out us
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -5592,7 +5592,7 @@ sqly --csv --sql "/* note */ SELECT 1 AS x"
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -5616,7 +5616,7 @@ sqly --csv --sql "VALUES (1), (2)"
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -5640,7 +5640,7 @@ sqly --sql "CREATE TABLE t(x)"
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -5656,7 +5656,7 @@ sqly --sql "ANALYZE" user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -5696,7 +5696,7 @@ sqly --force --sql "SELECT 1 AS x"
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -5712,7 +5712,7 @@ sqly --inspect --csv user.csv
 - Fixture file `empty.json` is created.
 #### Inputs
 _Fixture `empty.json`:_
-```
+```text
 []
 ```
 #### When
@@ -5737,7 +5737,7 @@ sqly --csv --sql "SELECT COUNT(*) AS n FROM empty" empty.jsonl
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -5753,7 +5753,7 @@ sqly --sql "SELECT 1 AS x" --output "outdir/" user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -5767,7 +5767,7 @@ sqly --sql "SELECT identifier FROM user LIMIT 1" --output out.ach user.csv
 ### Scenario: parses a helper command after a terminated statement
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 SELECT 1 AS x;
 .mode csv
 SELECT 2 AS y;
@@ -5783,7 +5783,7 @@ sqly
 ### Scenario: parses a helper command after a leading comment
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 -- header
 .mode csv
 SELECT 1 AS x;
@@ -5801,7 +5801,7 @@ sqly
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -5817,7 +5817,7 @@ sqly --sql "EXPLAIN UPDATE user SET first_name='X' WHERE identifier=1" --save-di
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -5847,7 +5847,7 @@ Source: `test/e2e/tools/sqly/v0_20_bugs.atago.yaml`
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -5864,7 +5864,7 @@ sqly --sql "ALTER TABLE user RENAME COLUMN first_name TO fname" --save --force u
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -5880,7 +5880,7 @@ sqly --sql "DROP TABLE user" --save --force user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -5896,7 +5896,7 @@ sqly --sql "CREATE VIEW v AS SELECT user_name FROM user" --save --force user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -5912,7 +5912,7 @@ sqly --sql "CREATE INDEX idx ON user(identifier)" --save --force user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -5928,7 +5928,7 @@ sqly --sql "CREATE TABLE backup (id INTEGER)" --save --force user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -5944,7 +5944,7 @@ sqly --sql "REINDEX" --save --force user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -5960,7 +5960,7 @@ sqly --sql "ANALYZE" --save --force user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -5978,12 +5978,12 @@ sqly --sql "CREATE TABLE backup AS SELECT * FROM user" --save-dir out user.csv
 - Fixture file `s.sql` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
 _Fixture `s.sql`:_
-```
+```text
 CREATE TABLE backup AS SELECT * FROM user;
 UPDATE user SET first_name='Z' WHERE identifier=1;
 ```
@@ -6000,12 +6000,12 @@ sqly --sql-file s.sql --save-dir out user.csv
 - Fixture file `imp.sql` is created.
 #### Inputs
 _Fixture `testdata/user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
 _Fixture `imp.sql`:_
-```
+```text
 .import testdata/user.csv
 UPDATE user SET first_name='Batch' WHERE identifier=1;
 ```
@@ -6048,7 +6048,7 @@ sqly --sql "ANALYZE"
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -6073,12 +6073,12 @@ sqly --sql "PRAGMA incremental_vacuum"
 - Fixture file `tx.sql` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
 _Fixture `tx.sql`:_
-```
+```text
 BEGIN IMMEDIATE;
 UPDATE user SET first_name='TX' WHERE identifier=1;
 COMMIT;
@@ -6112,7 +6112,7 @@ sqly --sql "VACUUM INTO 'dump.db'"
 - Fixture file `a.sql` is created.
 #### Inputs
 _Fixture `a.sql`:_
-```
+```text
 ATTACH DATABASE 'aux.db' AS aux;
 CREATE TABLE aux.t (id INTEGER);
 ```
@@ -6130,12 +6130,12 @@ sqly --sql-file a.sql
 - Fixture file `t.sql` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
 _Fixture `t.sql`:_
-```
+```text
 CREATE TRIGGER trig_user AFTER UPDATE ON user BEGIN
   UPDATE user SET last_name='Triggered' WHERE identifier=2;
 END;
@@ -6152,12 +6152,12 @@ sqly --sql-file t.sql user.csv
 - Fixture file `testdata/user.csv` is created.
 #### Inputs
 _Fixture `testdata/user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
 _stdin for `sqly`:_
-```
+```text
 .import testdata/user.csv
 .schema main.user
 ```
@@ -6173,12 +6173,12 @@ sqly
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
 _stdin for `sqly`:_
-```
+```text
 CREATE TEMP TABLE temp_t (id INTEGER);
 CREATE VIEW v_user AS SELECT user_name FROM user;
 .tables
@@ -6195,12 +6195,12 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
 _stdin for `sqly`:_
-```
+```text
 CREATE VIEW v_user AS SELECT user_name FROM user;
 .schema v_user
 ```
@@ -6235,7 +6235,7 @@ sqly --sql "SELECT COUNT(*) AS c FROM empty" empty.jsonl.gz
 _skipped on windows_
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 name,score
 a,1
 b,2
@@ -6252,7 +6252,7 @@ sqly --csv --sql "SELECT COUNT(*) AS c FROM stdin" /dev/stdin
 _only on linux_
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 name,score
 a,1
 b,2
@@ -6270,7 +6270,7 @@ sqly --csv --sql "SELECT COUNT(*) AS c FROM sheet_0" /proc/self/fd/0
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -6287,12 +6287,12 @@ sqly --sql "SELECT * FROM user LIMIT 1" --output out.ach.gz.zst user.csv
 - Fixture file `testdata/user.csv` is created.
 #### Inputs
 _Fixture `testdata/user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .import testdata/user.csv
 .dump user out.fed.gz.zst
 ```
@@ -6325,7 +6325,7 @@ sqly --ltsv --sql "SELECT 1 AS x, 2 AS x" --output out.ltsv
 - Fixture file `dup.ltsv` is created.
 #### Inputs
 _Fixture `dup.ltsv`:_
-```
+```text
 x:1	x:2
 ```
 #### When
@@ -6342,12 +6342,12 @@ Source: `test/e2e/tools/sqly/v0_21_bugs.atago.yaml`
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
 _stdin for `sqly`:_
-```
+```text
 CREATE TEMP TABLE user(id TEXT);
 .schema user
 ```
@@ -6364,12 +6364,12 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
 _stdin for `sqly`:_
-```
+```text
 CREATE TEMP VIEW user AS SELECT 1 AS id;
 .schema user
 ```
@@ -6385,12 +6385,12 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
 _stdin for `sqly`:_
-```
+```text
 CREATE TEMP TABLE user(id TEXT);
 .tables
 ```
@@ -6404,7 +6404,7 @@ sqly user.csv
 ### Scenario: targets a literal dotted table name in .schema
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 CREATE TABLE "a.b"(id INTEGER);
 .schema "a.b"
 ```
@@ -6418,7 +6418,7 @@ sqly
 ### Scenario: targets a literal dotted table name in .describe
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 CREATE TABLE "a.b"(id INTEGER);
 .describe "a.b"
 ```
@@ -6432,7 +6432,7 @@ sqly
 ### Scenario: targets a literal dotted table name in .header
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 CREATE TABLE "a.b"(id INTEGER);
 .header "a.b"
 ```
@@ -6446,7 +6446,7 @@ sqly
 ### Scenario: targets a literal dotted table name in .dump
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 CREATE TABLE "a.b"(id INTEGER);
 .dump "a.b" ab.csv
 ```
@@ -6460,7 +6460,7 @@ sqly
 ### Scenario: prints a paste-safe quoted identifier in .tables
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 CREATE TABLE "two words"(id INTEGER);
 .tables
 ```
@@ -6474,7 +6474,7 @@ sqly
 ### Scenario: keeps the full spaced table name in .header
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 CREATE TABLE "two words"(id INTEGER);
 .header "two words"
 ```
@@ -6488,7 +6488,7 @@ sqly
 ### Scenario: keeps the TEMP keyword for a temp-qualified table in .schema
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 CREATE TEMP TABLE t(id INTEGER PRIMARY KEY);
 .schema temp.t
 ```
@@ -6502,7 +6502,7 @@ sqly
 ### Scenario: keeps the TEMP keyword for a temp-qualified view in .schema
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 CREATE TEMP VIEW v AS SELECT 1 AS id;
 .schema temp.v
 ```
@@ -6518,7 +6518,7 @@ sqly
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -6534,7 +6534,7 @@ sqly --sql "SELECT 1 AS x; SELECT 2 AS y" user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -6559,7 +6559,7 @@ sqly --csv --sql "SELECT 1 AS x; SELECT 2 AS y" --output out.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -6576,7 +6576,7 @@ sqly --sql "PRAGMA user_version=1" --save --force user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -6593,7 +6593,7 @@ sqly --sql "PRAGMA incremental_vacuum" --save --force user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -6610,7 +6610,7 @@ sqly --sql "PRAGMA journal_mode=OFF" --save --force user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -6627,7 +6627,7 @@ sqly --sql "PRAGMA user_version=1" --save-dir out user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
@@ -6650,7 +6650,7 @@ sqly --sql "END"
 ### Scenario: rejects END in batch stdin
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 END;
 ```
 #### When
@@ -6665,7 +6665,7 @@ sqly
 - Fixture file `end.sql` is created.
 #### Inputs
 _Fixture `end.sql`:_
-```
+```text
 END;
 ```
 #### When
@@ -6704,12 +6704,12 @@ sqly --sql "SELECT 1 AS x" --output out.xlsx.gz.zst
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
 _stdin for `sqly`:_
-```
+```text
 .dump user d.csv.gz.zst
 ```
 #### When
@@ -6724,12 +6724,12 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
 _stdin for `sqly`:_
-```
+```text
 .mode json
 .tables
 ```
@@ -6746,12 +6746,12 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier,first_name,last_name
 booker12,1,Rachel,Booker
 ```
 _stdin for `sqly`:_
-```
+```text
 .mode ndjson
 .header user
 ```
@@ -6768,12 +6768,12 @@ sqly user.csv
 - Fixture file `ro.csv` is created.
 #### Inputs
 _Fixture `ro.csv`:_
-```
+```text
 user_name,identifier
 alice,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .save --force
 ```
 #### When
@@ -6788,12 +6788,12 @@ sqly ro.csv
 - Fixture file `ro2.csv` is created.
 #### Inputs
 _Fixture `ro2.csv`:_
-```
+```text
 user_name,identifier
 alice,1
 ```
 _stdin for `sqly`:_
-```
+```text
 SELECT 1;
 .save out
 ```
@@ -6811,7 +6811,7 @@ Source: `test/e2e/tools/sqly/v0_22_bugs.atago.yaml`
 ### Scenario: inspects a literal "main.x" table with .schema
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 CREATE TABLE "main.x"(litcol INTEGER);
 .schema "main.x"
 ```
@@ -6825,7 +6825,7 @@ sqly
 ### Scenario: inspects a literal "temp.x" table with .describe
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 CREATE TABLE "temp.x"(litcol INTEGER);
 .describe "temp.x"
 ```
@@ -6839,7 +6839,7 @@ sqly
 ### Scenario: inspects a literal "main.v" view with .header
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 CREATE VIEW "main.v" AS SELECT 1 AS litcol;
 .header "main.v"
 ```
@@ -6853,7 +6853,7 @@ sqly
 ### Scenario: exports a literal "temp.v" view with .dump
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 CREATE VIEW "temp.v" AS SELECT 1 AS litcol;
 .dump "temp.v" tv.csv
 ```
@@ -6867,7 +6867,7 @@ sqly
 ### Scenario: prints a paste-safe literal "main.x" name in .tables
 #### Inputs
 _stdin for `sqly`:_
-```
+```text
 CREATE TABLE "main.x"(litcol INTEGER);
 .tables
 ```
@@ -6907,12 +6907,12 @@ sqly --sql "SELECT 1 AS x" --output fake.ach.gzip.zst
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .dump user fake.parquet.gzip.zst
 ```
 #### When
@@ -6959,13 +6959,13 @@ sqly --sql ";ATTACH DATABASE 'x.db' AS aux"
 - Fixture file `temp_only.csv` is created.
 #### Inputs
 _Fixture `temp_only.csv`:_
-```
+```text
 name,age
 alice,30
 bob,25
 ```
 _stdin for `sqly`:_
-```
+```text
 CREATE TEMP TABLE scratch(id INTEGER);
 INSERT INTO scratch VALUES (1);
 .save --force
@@ -6984,12 +6984,12 @@ sqly temp_only.csv
 - Fixture file `data.jsonl` is created.
 #### Inputs
 _Fixture `data.jsonl`:_
-```
+```text
 {"id":1}
 {"id":2}
 ```
 _stdin for `sqly`:_
-```
+```text
 CREATE TABLE scratch(id INTEGER);
 INSERT INTO scratch VALUES (1);
 .save --force
@@ -7008,13 +7008,13 @@ sqly data.jsonl
 - Fixture file `netzero.csv` is created.
 #### Inputs
 _Fixture `netzero.csv`:_
-```
+```text
 name,age
 alice,30
 bob,25
 ```
 _stdin for `sqly`:_
-```
+```text
 UPDATE netzero SET age=99 WHERE name='alice';
 UPDATE netzero SET age=30 WHERE name='alice';
 .save --force
@@ -7034,13 +7034,13 @@ sqly netzero.csv
 - Fixture file `netzero.sql` is created.
 #### Inputs
 _Fixture `netzero_file.csv`:_
-```
+```text
 name,age
 alice,30
 bob,25
 ```
 _Fixture `netzero.sql`:_
-```
+```text
 UPDATE netzero_file SET age=99 WHERE name='alice';
 UPDATE netzero_file SET age=30 WHERE name='alice';
 ```
@@ -7057,13 +7057,13 @@ sqly --sql-file netzero.sql --save --force netzero_file.csv
 - Fixture file `genuine.csv` is created.
 #### Inputs
 _Fixture `genuine.csv`:_
-```
+```text
 name,age
 alice,30
 bob,25
 ```
 _stdin for `sqly`:_
-```
+```text
 UPDATE genuine SET age=999 WHERE name='alice';
 .save --force
 ```
@@ -7083,7 +7083,7 @@ Source: `test/e2e/tools/sqly/v0_25_bugs.atago.yaml`
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -7109,7 +7109,7 @@ sqly
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
@@ -7137,12 +7137,12 @@ sqly --stdin csv --sql "SELECT COUNT(*) FROM stdin"
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .schema
 SELECT 1;
 ```
@@ -7158,12 +7158,12 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .header
 ```
 #### When
@@ -7178,12 +7178,12 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .describe
 ```
 #### When
@@ -7198,12 +7198,12 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .mode
 ```
 #### When
@@ -7218,12 +7218,12 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .dump
 ```
 #### When
@@ -7238,12 +7238,12 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .import
 ```
 #### When
@@ -7258,12 +7258,12 @@ sqly user.csv
 - Fixture file `user.csv` is created.
 #### Inputs
 _Fixture `user.csv`:_
-```
+```text
 user_name,identifier
 booker12,1
 ```
 _stdin for `sqly`:_
-```
+```text
 .save
 ```
 #### When
@@ -7278,7 +7278,7 @@ sqly user.csv
 - Fixture file `space dir/d.csv` is created.
 #### Inputs
 _Fixture `space dir/d.csv`:_
-```
+```text
 a
 1
 ```
@@ -7295,7 +7295,7 @@ sqly --inspect "space dir"
 - Fixture file `space dir/d.csv` is created.
 #### Inputs
 _Fixture `space dir/d.csv`:_
-```
+```text
 a
 1
 ```

--- a/doc/e2e/transfersh.md
+++ b/doc/e2e/transfersh.md
@@ -48,7 +48,7 @@ cmp pixel.png downloaded.png
 - Fixture file `notes.txt` is created.
 #### Inputs
 _Fixture `notes.txt`:_
-```
+```text
 shared through a multipart form
 ```
 #### When

--- a/doc/e2e/webhook.md
+++ b/doc/e2e/webhook.md
@@ -12,7 +12,7 @@ Source: `test/e2e/thirdparty/webhook/webhook.atago.yaml`
 - Fixture file `hooks.json` is created.
 #### Inputs
 _Fixture `hooks.json`:_
-```
+```text
 [
   {
     "id": "greet",

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -56,6 +56,115 @@ func TestRunCmd_Passing(t *testing.T) {
 	}
 }
 
+// TestRunCmd_Verbose covers the --verbose contract (#6): a passing scenario's
+// command, captured output, and assertion verdicts become visible; without the
+// flag the console stays dots-only; secrets are masked in traces; combining
+// --verbose with a machine report keeps stdout machine-readable by routing the
+// trace to stderr; and a failing run renders the full FAILED block exactly once.
+func TestRunCmd_Verbose(t *testing.T) {
+	dir := t.TempDir()
+	p := writeSpec(t, dir, "ok.atago.yaml", `
+version: "1"
+suite:
+  name: vdemo
+scenarios:
+  - name: greets
+    steps:
+      - run: {shell: true, command: echo hello-verbose}
+      - assert:
+          exit_code: 0
+          stdout: {contains: hello-verbose}
+`)
+
+	// --verbose shows the command, its output, and per-assert verdicts.
+	var out, errb bytes.Buffer
+	if got := Main([]string{"run", "--verbose", p}, &out, &errb); got != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitOK, errb.String())
+	}
+	for _, want := range []string{"echo hello-verbose", "hello-verbose", "ok   assert"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("verbose stdout = %q, want %q", out.String(), want)
+		}
+	}
+
+	// Without --verbose the trace is absent (dots + summary only).
+	out.Reset()
+	errb.Reset()
+	if got := Main([]string{"run", p}, &out, &errb); got != ExitOK {
+		t.Fatalf("exit = %d, want %d", got, ExitOK)
+	}
+	if strings.Contains(out.String(), "echo hello-verbose") {
+		t.Errorf("non-verbose stdout = %q, must not contain the trace", out.String())
+	}
+}
+
+// TestRunCmd_VerboseMasksSecrets proves declared secrets never reach a verbose
+// trace — the same masking contract as failure output and snapshots (#6).
+func TestRunCmd_VerboseMasksSecrets(t *testing.T) {
+	t.Setenv("VTEST_TOKEN", "sup3r-s3cret-value")
+	dir := t.TempDir()
+	p := writeSpec(t, dir, "sec.atago.yaml", `
+version: "1"
+suite:
+  name: vsec
+secrets:
+  - VTEST_TOKEN
+scenarios:
+  - name: leaks a token to stdout
+    steps:
+      - run: {shell: true, command: "echo token=${env:VTEST_TOKEN}"}
+      - assert: {exit_code: 0}
+`)
+	var out, errb bytes.Buffer
+	if got := Main([]string{"run", "--verbose", p}, &out, &errb); got != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitOK, errb.String())
+	}
+	if strings.Contains(out.String(), "sup3r-s3cret-value") {
+		t.Error("verbose trace leaked the raw secret")
+	}
+	if !strings.Contains(out.String(), "***") {
+		t.Errorf("verbose stdout = %q, want the masked marker", out.String())
+	}
+}
+
+// TestRunCmd_VerboseWithJSONReportSeparatesStreams proves --verbose + --report
+// json keeps stdout pure JSON (schema_version intact) and puts the trace on
+// stderr (#6).
+func TestRunCmd_VerboseWithJSONReportSeparatesStreams(t *testing.T) {
+	dir := t.TempDir()
+	p := writeSpec(t, dir, "ok.atago.yaml", passingSpec)
+	var out, errb bytes.Buffer
+	if got := Main([]string{"run", "--verbose", "--report", "json", p}, &out, &errb); got != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitOK, errb.String())
+	}
+	var doc struct {
+		SchemaVersion string `json:"schema_version"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &doc); err != nil {
+		t.Fatalf("stdout is not valid JSON under --verbose: %v\n%s", err, out.String())
+	}
+	if doc.SchemaVersion != "1" {
+		t.Errorf("schema_version = %q, want 1", doc.SchemaVersion)
+	}
+	if !strings.Contains(errb.String(), "exit 0") {
+		t.Errorf("stderr = %q, want the verbose trace there", errb.String())
+	}
+}
+
+// TestRunCmd_VerboseFailureBlockRenderedOnce proves the full FAILED block is
+// not duplicated between the trace and the console report (#6).
+func TestRunCmd_VerboseFailureBlockRenderedOnce(t *testing.T) {
+	dir := t.TempDir()
+	p := writeSpec(t, dir, "fail.atago.yaml", failingSpec)
+	var out, errb bytes.Buffer
+	if got := Main([]string{"run", "--verbose", p}, &out, &errb); got != ExitFailures {
+		t.Fatalf("exit = %d, want %d", got, ExitFailures)
+	}
+	if n := strings.Count(out.String(), "FAILED:"); n != 1 {
+		t.Errorf("stdout renders %d FAILED blocks, want exactly 1:\n%s", n, out.String())
+	}
+}
+
 // TestRunCmd_SelectionMatchesNothingWarns proves a --filter/--tag that selects
 // zero scenarios warns on stderr (a typo'd selection in CI must not greenlight
 // in silence), while still exiting 0.

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -37,6 +37,7 @@ var runFlags = []string{
 	"--skip-tag",
 	"--tag",
 	"--update-snapshots",
+	"--verbose",
 }
 
 // completionShells is the sorted set of shells `atago completion` supports.

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -35,8 +35,9 @@ func runCmd(args []string, stdout, stderr io.Writer) int {
 	skipTag := fs.String("skip-tag", "", "skip scenarios with any of these comma-separated tags")
 	artifactsDir := fs.String("artifacts-dir", "", "write deterministic failure artifacts (actual/expected payloads) under DIR for review tooling")
 	rerunFailed := fs.Bool("rerun-failed", false, "run only the scenarios that failed on the previous run (recorded in .atago/last-failed.json)")
+	verbose := fs.Bool("verbose", false, "trace every scenario as it finishes: commands, exit codes, captured output, and per-assertion verdicts — for passing scenarios too")
 	fs.Usage = func() {
-		fmt.Fprint(stderr, "Usage: atago run [--report console|json|junit|gha|tap] [--update-snapshots] [--parallel N] [--fail-fast] [--filter S] [--tag T] [--skip-tag T] [--rerun-failed] [--artifacts-dir DIR] [--ci] <path | dir>...\n  (directories are searched recursively)\n")
+		fmt.Fprint(stderr, "Usage: atago run [--report console|json|junit|gha|tap] [--update-snapshots] [--parallel N] [--fail-fast] [--filter S] [--tag T] [--skip-tag T] [--rerun-failed] [--artifacts-dir DIR] [--verbose] [--ci] <path | dir>...\n  (directories are searched recursively)\n")
 		fs.PrintDefaults()
 	}
 	if err := fs.Parse(args); err != nil {
@@ -108,8 +109,15 @@ func runCmd(args []string, stdout, stderr io.Writer) int {
 
 	// In console mode, stream a live dot per scenario as it finishes, so a run
 	// visibly zips along. JSON output stays pure (no dots on stdout).
+	// --verbose (#6) replaces the dots with a full per-scenario trace; with a
+	// machine report the trace goes to stderr so stdout stays machine-readable.
 	var progress *report.Progress
-	if format == report.FormatConsole {
+	switch {
+	case *verbose && format == report.FormatConsole:
+		eng.OnScenario = report.NewVerbose(stdout).Scenario
+	case *verbose:
+		eng.OnScenario = report.NewVerbose(stderr).Scenario
+	case format == report.FormatConsole:
 		progress = report.NewProgress(stdout)
 		eng.OnScenario = progress.Scenario
 	}

--- a/internal/cli/testdata/completion/bash.txt
+++ b/internal/cli/testdata/completion/bash.txt
@@ -8,7 +8,7 @@ _atago() {
         prev="${COMP_WORDS[COMP_CWORD-1]}"
     }
     local commands="completion doc explain help init list manifest run snapshot version"
-    local run_flags="--artifacts-dir --ci --fail-fast --filter --parallel --report --rerun-failed --skip-tag --tag --update-snapshots"
+    local run_flags="--artifacts-dir --ci --fail-fast --filter --parallel --report --rerun-failed --skip-tag --tag --update-snapshots --verbose"
     if [ "${COMP_CWORD}" -eq 1 ]; then
         COMPREPLY=( $(compgen -W "${commands}" -- "${cur}") )
         return 0

--- a/internal/cli/testdata/completion/fish.txt
+++ b/internal/cli/testdata/completion/fish.txt
@@ -21,3 +21,4 @@ complete -c atago -n '__fish_seen_subcommand_from run' -l rerun-failed
 complete -c atago -n '__fish_seen_subcommand_from run' -l skip-tag
 complete -c atago -n '__fish_seen_subcommand_from run' -l tag
 complete -c atago -n '__fish_seen_subcommand_from run' -l update-snapshots
+complete -c atago -n '__fish_seen_subcommand_from run' -l verbose

--- a/internal/cli/testdata/completion/powershell.txt
+++ b/internal/cli/testdata/completion/powershell.txt
@@ -3,7 +3,7 @@
 Register-ArgumentCompleter -Native -CommandName atago -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
     $commands = @('completion', 'doc', 'explain', 'help', 'init', 'list', 'manifest', 'run', 'snapshot', 'version')
-    $runFlags = @('--artifacts-dir', '--ci', '--fail-fast', '--filter', '--parallel', '--report', '--rerun-failed', '--skip-tag', '--tag', '--update-snapshots')
+    $runFlags = @('--artifacts-dir', '--ci', '--fail-fast', '--filter', '--parallel', '--report', '--rerun-failed', '--skip-tag', '--tag', '--update-snapshots', '--verbose')
     $tokens = $commandAst.CommandElements
     if ($tokens.Count -le 2) {
         $commands | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {

--- a/internal/cli/testdata/completion/zsh.txt
+++ b/internal/cli/testdata/completion/zsh.txt
@@ -4,7 +4,7 @@
 _atago() {
     local -a commands run_flags
     commands=(completion doc explain help init list manifest run snapshot version)
-    run_flags=(--artifacts-dir --ci --fail-fast --filter --parallel --report --rerun-failed --skip-tag --tag --update-snapshots)
+    run_flags=(--artifacts-dir --ci --fail-fast --filter --parallel --report --rerun-failed --skip-tag --tag --update-snapshots --verbose)
     if (( CURRENT == 2 )); then
         compadd -- ${commands}
         return

--- a/internal/docgen/docgen.go
+++ b/internal/docgen/docgen.go
@@ -157,11 +157,17 @@ func matrixExpander(sc *spec.Scenario) func(string) string {
 func writePreviews(md *markdown.Markdown, blocks []previewBlock) {
 	for _, b := range blocks {
 		md.PlainTextf("_%s:_", b.label)
+		lang := b.lang
+		if lang == "" {
+			// "text" keeps the generated docs markdownlint-clean (MD040)
+			// without guessing the payload's real format.
+			lang = "text"
+		}
 		switch {
 		case b.image && b.body != "":
 			md.PlainTextf("![%s](%s)", b.label, b.body)
 		case b.body != "":
-			md.CodeBlocks(markdown.SyntaxHighlight(b.lang), b.body)
+			md.CodeBlocks(markdown.SyntaxHighlight(lang), b.body)
 		}
 	}
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -175,6 +175,7 @@ func (e *Engine) Run(ctx context.Context, s *spec.Spec, specPath string) *SuiteR
 					}
 				}
 				sc := e.runScenario(ctx, idx, &s.Scenarios[idx], rc)
+				sc.Suite = s.Suite.Name
 				if e.Sem != nil {
 					<-e.Sem
 				}
@@ -204,7 +205,7 @@ func (e *Engine) Run(ctx context.Context, s *spec.Spec, specPath string) *SuiteR
 	res.Scenarios = make([]ScenarioResult, 0, len(selected))
 	for _, i := range selected {
 		if !done[i] {
-			results[i] = ScenarioResult{Name: s.Scenarios[i].Name, Status: StatusSkipped, SkipReason: unrunReason}
+			results[i] = ScenarioResult{Name: s.Scenarios[i].Name, Suite: s.Suite.Name, Status: StatusSkipped, SkipReason: unrunReason}
 		}
 		res.Scenarios = append(res.Scenarios, results[i])
 		res.Status = worseStatus(res.Status, results[i].Status)

--- a/internal/engine/result.go
+++ b/internal/engine/result.go
@@ -42,7 +42,11 @@ type StepResult struct {
 
 // ScenarioResult aggregates the steps of one scenario.
 type ScenarioResult struct {
-	Name   string
+	Name string
+	// Suite is the owning suite's name, so per-scenario consumers (the
+	// OnScenario stream, verbose traces) can label output without threading
+	// the SuiteResult alongside.
+	Suite  string
 	Status Status
 	Steps  []StepResult
 	// Teardown records the scenario's teardown steps. They always run (pass,

--- a/internal/report/verbose.go
+++ b/internal/report/verbose.go
@@ -1,0 +1,131 @@
+package report
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/nao1215/atago/internal/engine"
+)
+
+// traceExcerptLimit bounds captured output in a verbose trace, matching the
+// failure-output excerpt limit so both surfaces truncate identically.
+const traceExcerptLimit = 2000
+
+// Verbose streams a per-scenario execution trace: every step's expanded
+// command, exit code, captured output, and each assertion's one-line verdict —
+// for passing scenarios too (#6). It answers "what did my command actually
+// print?" without forcing the author to break an assertion. Failing checks are
+// a one-line verdict only; the full Expected/Actual/Hint block remains the
+// console report's job, so it is never duplicated.
+//
+// Everything rendered comes from the already-masked StepResult fields, so
+// declared secrets never reach a trace.
+type Verbose struct {
+	mu    sync.Mutex
+	w     io.Writer
+	color bool
+}
+
+// NewVerbose returns a Verbose tracer writing to w. Color is enabled only when
+// w is a terminal.
+func NewVerbose(w io.Writer) *Verbose {
+	return &Verbose{w: w, color: isTTY(w)}
+}
+
+// Scenario renders one finished scenario's trace. It is safe to use directly
+// as engine.Engine.OnScenario, including from concurrent suites: the whole
+// trace is built first and written in a single call so traces never interleave.
+func (v *Verbose) Scenario(res engine.ScenarioResult) {
+	var b strings.Builder
+
+	status := string(res.Status)
+	header := fmt.Sprintf("=== %s / %s (%s, %s)", res.Suite, res.Name, status, res.Duration.Round(time.Millisecond))
+	fmt.Fprintln(&b, colorize(v.color, headerColor(res.Status), header))
+	if res.Status == engine.StatusSkipped && res.SkipReason != "" {
+		fmt.Fprintf(&b, "    skipped: %s\n", res.SkipReason)
+	}
+
+	for i := range res.Steps {
+		v.writeStep(&b, "", &res.Steps[i])
+	}
+	for i := range res.Teardown {
+		v.writeStep(&b, "teardown ", &res.Teardown[i])
+	}
+
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	fmt.Fprint(v.w, b.String())
+}
+
+// writeStep renders one step: its label line, the executed command and outcome
+// for run-family steps, captured output, any execution error, and one verdict
+// line per assertion check.
+func (v *Verbose) writeStep(b *strings.Builder, phase string, sr *engine.StepResult) {
+	label := string(sr.Kind)
+	if sr.Setup {
+		label = setupPhaseLabel
+	}
+	fmt.Fprintf(b, "  [%s%d] %s", phase, sr.Index, label)
+	if sr.Run != nil && sr.Run.Command != "" {
+		fmt.Fprintf(b, ": %s", sr.Run.Command)
+	}
+	fmt.Fprintln(b)
+
+	if sr.Run != nil {
+		switch {
+		case sr.Run.IsHTTP:
+			fmt.Fprintf(b, "      status %d\n", sr.Run.StatusCode)
+			writeStream(b, "body", sr.Run.Body)
+		default:
+			fmt.Fprintf(b, "      exit %d\n", sr.Run.ExitCode)
+			writeStream(b, "stdout", sr.Run.Stdout)
+			writeStream(b, "stderr", sr.Run.Stderr)
+		}
+	}
+	if sr.ErrMsg != "" {
+		fmt.Fprintf(b, "      %s %s\n", colorize(v.color, cRed+cBold, "error:"), sr.ErrMsg)
+	}
+	for _, ck := range sr.Checks {
+		if ck == nil {
+			continue
+		}
+		if ck.OK {
+			fmt.Fprintf(b, "      %s %s\n", colorize(v.color, cGreen, "ok  "), ck.Desc)
+		} else {
+			fmt.Fprintf(b, "      %s %s\n", colorize(v.color, cRed+cBold, "FAIL"), ck.Desc)
+		}
+	}
+}
+
+// writeStream renders one captured stream as an indented block, excerpted at
+// the shared limit. Empty streams are omitted to keep traces compact.
+func writeStream(b *strings.Builder, name string, data []byte) {
+	if len(data) == 0 {
+		return
+	}
+	s := string(data)
+	if len(s) > traceExcerptLimit {
+		s = s[:traceExcerptLimit] + "\n... (truncated)"
+	}
+	fmt.Fprintf(b, "      %s |\n", name)
+	for _, line := range strings.Split(strings.TrimRight(s, "\n"), "\n") {
+		fmt.Fprintf(b, "        %s\n", line)
+	}
+}
+
+// headerColor picks the trace-header color for a scenario status.
+func headerColor(s engine.Status) string {
+	switch s {
+	case engine.StatusPassed:
+		return cGreen
+	case engine.StatusFailed, engine.StatusError:
+		return cRed + cBold
+	case engine.StatusSkipped:
+		return cYellow
+	default:
+		return ""
+	}
+}

--- a/internal/report/verbose.go
+++ b/internal/report/verbose.go
@@ -74,11 +74,20 @@ func (v *Verbose) writeStep(b *strings.Builder, phase string, sr *engine.StepRes
 	}
 	fmt.Fprintln(b)
 
+	// Each result family renders its own observable surface; treating a DB,
+	// gRPC, or CDP result like a process would print a misleading "exit 0".
 	if sr.Run != nil {
 		switch {
 		case sr.Run.IsHTTP:
 			fmt.Fprintf(b, "      status %d\n", sr.Run.StatusCode)
 			writeStream(b, "body", sr.Run.Body)
+		case sr.Run.IsDB:
+			writeStream(b, "rows", sr.Run.RowsJSON)
+		case sr.Run.IsGRPC:
+			fmt.Fprintf(b, "      grpc status %d\n", sr.Run.GRPCStatus)
+			writeStream(b, "message", sr.Run.MessageJSON)
+		case sr.Run.IsCDP:
+			writeStream(b, "value", sr.Run.CDPValue)
 		default:
 			fmt.Fprintf(b, "      exit %d\n", sr.Run.ExitCode)
 			writeStream(b, "stdout", sr.Run.Stdout)

--- a/internal/report/verbose_test.go
+++ b/internal/report/verbose_test.go
@@ -100,6 +100,36 @@ func TestVerbose_TruncatesLongOutput(t *testing.T) {
 	}
 }
 
+// TestVerbose_NonProcessFamiliesRenderTheirOwnSurface proves DB/gRPC/CDP/HTTP
+// results are traced by family instead of as a misleading process-style
+// "exit 0" block (CodeRabbit finding on #9).
+func TestVerbose_NonProcessFamiliesRenderTheirOwnSurface(t *testing.T) {
+	t.Parallel()
+	res := engine.ScenarioResult{
+		Suite:  "demo",
+		Name:   "families",
+		Status: engine.StatusPassed,
+		Steps: []engine.StepResult{
+			{Index: 0, Kind: spec.StepQuery, Run: &runner.Result{IsDB: true, RowsJSON: []byte(`[{"id":1}]`)}},
+			{Index: 1, Kind: spec.StepGRPC, Run: &runner.Result{IsGRPC: true, GRPCStatus: 0, MessageJSON: []byte(`{"ok":true}`)}},
+			{Index: 2, Kind: spec.StepCDP, Run: &runner.Result{IsCDP: true, CDPValue: []byte("page-title")}},
+			{Index: 3, Kind: spec.StepHTTP, Run: &runner.Result{IsHTTP: true, StatusCode: 201, Body: []byte(`{"id":9}`)}},
+		},
+	}
+	var b strings.Builder
+	NewVerbose(&b).Scenario(res)
+	out := b.String()
+
+	for _, want := range []string{`[{"id":1}]`, "grpc status 0", `{"ok":true}`, "page-title", "status 201"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("trace = %q, want %q", out, want)
+		}
+	}
+	if strings.Contains(out, "exit 0") {
+		t.Errorf("trace = %q, must not render a process-style exit for non-process families", out)
+	}
+}
+
 // TestVerbose_SkippedScenarioShowsReason proves a skipped scenario's reason —
 // currently visible only in the JSON report — is spelled out in the trace.
 func TestVerbose_SkippedScenarioShowsReason(t *testing.T) {

--- a/internal/report/verbose_test.go
+++ b/internal/report/verbose_test.go
@@ -1,0 +1,144 @@
+package report
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nao1215/atago/internal/assert"
+	"github.com/nao1215/atago/internal/engine"
+	"github.com/nao1215/atago/internal/runner"
+	"github.com/nao1215/atago/internal/spec"
+)
+
+// TestVerbose_TracePassingScenario proves the verbose trace shows what a
+// PASSING scenario actually did — the expanded command, its exit code, the
+// captured output, and each assertion's one-line verdict — which is exactly
+// the information a spec author otherwise only sees by breaking an assertion
+// (#6).
+func TestVerbose_TracePassingScenario(t *testing.T) {
+	t.Parallel()
+	res := engine.ScenarioResult{
+		Suite:    "demo",
+		Name:     "says hello",
+		Status:   engine.StatusPassed,
+		Duration: 12 * time.Millisecond,
+		Steps: []engine.StepResult{
+			{Index: 0, Kind: spec.StepRun, Run: &runner.Result{Command: "echo hello", ExitCode: 0, Stdout: []byte("hello\n")}},
+			{Index: 1, Kind: spec.StepAssert, Checks: []*assert.CheckResult{{OK: true, Desc: `assert stdout contains "hello"`}}},
+		},
+	}
+	var b strings.Builder
+	NewVerbose(&b).Scenario(res)
+	out := b.String()
+
+	for _, want := range []string{
+		"demo / says hello",
+		"echo hello",
+		"exit 0",
+		"hello",
+		`ok   assert stdout contains "hello"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("trace = %q, want it to contain %q", out, want)
+		}
+	}
+}
+
+// TestVerbose_FailingCheckIsOneLine proves a failing assertion appears in the
+// trace as a one-line verdict only — the full FAILED block (Expected/Actual/
+// Hint) stays the console report's job, so it is never duplicated (#6).
+func TestVerbose_FailingCheckIsOneLine(t *testing.T) {
+	t.Parallel()
+	res := engine.ScenarioResult{
+		Suite:  "demo",
+		Name:   "fails",
+		Status: engine.StatusFailed,
+		Steps: []engine.StepResult{
+			{Index: 0, Kind: spec.StepAssert, Checks: []*assert.CheckResult{{
+				OK: false, Desc: `assert stdout contains "goodbye"`,
+				Expected: "stdout contains goodbye", Actual: "hello", Hint: "the substring was not present",
+			}}},
+		},
+	}
+	var b strings.Builder
+	NewVerbose(&b).Scenario(res)
+	out := b.String()
+
+	if !strings.Contains(out, `FAIL assert stdout contains "goodbye"`) {
+		t.Errorf("trace = %q, want a one-line FAIL verdict", out)
+	}
+	for _, forbidden := range []string{"Expected:", "Actual:", "Hint:"} {
+		if strings.Contains(out, forbidden) {
+			t.Errorf("trace = %q, must not duplicate the failure block field %q", out, forbidden)
+		}
+	}
+}
+
+// TestVerbose_TruncatesLongOutput proves captured output is excerpted at the
+// same deterministic limit failure output uses, ending with a marker (#6).
+func TestVerbose_TruncatesLongOutput(t *testing.T) {
+	t.Parallel()
+	long := strings.Repeat("x", 5000)
+	res := engine.ScenarioResult{
+		Suite:  "demo",
+		Name:   "chatty",
+		Status: engine.StatusPassed,
+		Steps: []engine.StepResult{
+			{Index: 0, Kind: spec.StepRun, Run: &runner.Result{Command: "yes", Stdout: []byte(long)}},
+		},
+	}
+	var b strings.Builder
+	NewVerbose(&b).Scenario(res)
+	out := b.String()
+
+	if !strings.Contains(out, "(truncated)") {
+		t.Errorf("trace should carry the truncation marker, got %d bytes without it", len(out))
+	}
+	if strings.Contains(out, long) {
+		t.Error("trace contains the full 5000-byte payload; want it excerpted")
+	}
+}
+
+// TestVerbose_SkippedScenarioShowsReason proves a skipped scenario's reason —
+// currently visible only in the JSON report — is spelled out in the trace.
+func TestVerbose_SkippedScenarioShowsReason(t *testing.T) {
+	t.Parallel()
+	res := engine.ScenarioResult{
+		Suite:      "demo",
+		Name:       "windows only",
+		Status:     engine.StatusSkipped,
+		SkipReason: "only on os=windows (host is linux)",
+	}
+	var b strings.Builder
+	NewVerbose(&b).Scenario(res)
+	if !strings.Contains(b.String(), "only on os=windows") {
+		t.Errorf("trace = %q, want the skip reason", b.String())
+	}
+}
+
+// TestVerbose_TeardownStepsLabeled proves teardown steps are traced too, and
+// are visually distinguishable from the scenario's own steps.
+func TestVerbose_TeardownStepsLabeled(t *testing.T) {
+	t.Parallel()
+	res := engine.ScenarioResult{
+		Suite:  "demo",
+		Name:   "with cleanup",
+		Status: engine.StatusPassed,
+		Steps: []engine.StepResult{
+			{Index: 0, Kind: spec.StepRun, Run: &runner.Result{Command: "echo main-step"}},
+		},
+		Teardown: []engine.StepResult{
+			{Index: 0, Kind: spec.StepRun, Run: &runner.Result{Command: "echo cleanup-step"}},
+		},
+	}
+	var b strings.Builder
+	NewVerbose(&b).Scenario(res)
+	out := b.String()
+	if !strings.Contains(out, "teardown") {
+		t.Errorf("trace = %q, want a teardown label", out)
+	}
+	if !strings.Contains(out, "echo cleanup-step") {
+		t.Errorf("trace = %q, want the teardown command", out)
+	}
+}

--- a/test/e2e/atago/verbose.atago.yaml
+++ b/test/e2e/atago/verbose.atago.yaml
@@ -1,0 +1,120 @@
+# --verbose (#6): trace every scenario as it finishes — expanded command, exit
+# code, captured output, per-assertion verdicts — for PASSING scenarios too.
+# Without the flag the console stays dots-only; with a machine report the trace
+# moves to stderr so stdout stays machine-readable.
+version: "1"
+
+suite:
+  name: atago self-hosting / verbose
+
+scenarios:
+  - name: verbose shows a passing scenario's command, output, and verdicts
+    steps:
+      - fixture:
+          file: ok.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: sample
+            scenarios:
+              - name: greets
+                steps:
+                  - run:
+                      shell: true
+                      command: echo hello-trace
+                  - assert:
+                      exit_code: 0
+                      stdout:
+                        contains: hello-trace
+      - run:
+          command: ${atago} run --verbose ok.atago.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            contains:
+              - "sample / greets"
+              - "echo hello-trace"
+              - "exit 0"
+              - "ok   assert"
+
+  - name: without --verbose the trace is absent
+    steps:
+      - fixture:
+          file: ok.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: sample
+            scenarios:
+              - name: greets
+                steps:
+                  - run:
+                      shell: true
+                      command: echo hello-trace
+                  - assert:
+                      exit_code: 0
+      - run:
+          command: ${atago} run ok.atago.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            not_contains: "echo hello-trace"
+
+  - name: verbose with a JSON report keeps stdout pure and traces to stderr
+    steps:
+      - fixture:
+          file: ok.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: sample
+            scenarios:
+              - name: greets
+                steps:
+                  - run:
+                      shell: true
+                      command: echo hello-trace
+                  - assert:
+                      exit_code: 0
+      - run:
+          command: ${atago} run --verbose --report json ok.atago.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            json:
+              path: "$.schema_version"
+              equals: "1"
+      - assert:
+          stderr:
+            contains: "exit 0"
+
+  - name: a failing run under --verbose renders the FAILED block exactly once
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: sample
+            scenarios:
+              - name: mismatch
+                steps:
+                  - run:
+                      shell: true
+                      command: echo hello
+                  - assert:
+                      stdout:
+                        contains: goodbye
+      - run:
+          command: ${atago} run --verbose bad.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "FAIL assert"
+              - "FAILED:"
+      # Exactly one full FAILED block: the trace carries a one-line verdict
+      # only, so "FAILED:" must not appear twice.
+      - assert:
+          stdout:
+            not_matches: "(?s)FAILED:.*FAILED:"


### PR DESCRIPTION
Closes #6.

## Summary

`atago run --verbose` traces every scenario as it finishes — for **passing** scenarios too — so authoring a spec no longer requires deliberately breaking an assertion to see what a command printed.

Each trace shows: the suite/scenario header with status and duration, every step's expanded command (or HTTP status), exit code, captured stdout/stderr as indented blocks (excerpted at the same 2000-byte limit as failure output), skip reasons, teardown steps (labeled), and each assertion's one-line `ok`/`FAIL` verdict.

Design decisions from the issue:

- **Masking**: traces render the already-masked `StepResult` fields, so declared `secrets:` never appear (test-covered).
- **Stream separation**: with a machine report (`--report json|junit|gha|tap`) the trace goes to **stderr**; stdout stays machine-readable (test asserts stdout still parses as the `schema_version: "1"` document).
- **No duplication**: failing checks are one-line verdicts in the trace; the full Expected/Actual/Hint FAILED block is still rendered exactly once by the console report (test counts occurrences).
- Traces are built per scenario and written in a single call, so concurrent suites never interleave mid-trace.

## TDD

Written test-first (all listed in #6): 5 renderer unit tests (`internal/report/verbose_test.go`), 4 CLI tests (flag on/off, masking, stream separation, FAILED-once), and a 4-scenario self-hosted E2E spec (`test/e2e/atago/verbose.atago.yaml`) driving the real binary — which uses the `not_matches` matcher to assert block uniqueness.

Shell-completion goldens regenerated for the new flag (drift-guard caught it); behavior docs and site regenerated.

## Verification

- `go test ./...` green, golangci-lint 0 issues
- `make e2e`: 138 scenarios (134 + 4 new), 137 passed / 1 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--verbose` support for the `atago run` command.
  * Verbose runs now show per-scenario tracing with commands, exit codes, HTTP status, captured output, skip reasons, teardown steps, and assertion results.
  * Shell completion now includes the new flag.

* **Bug Fixes**
  * Kept machine-readable reports clean by sending verbose traces to error output when needed.
  * Ensured sensitive values are masked in verbose output.
  * Prevented duplicate failure blocks in verbose runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->