### PR TITLE
feat(engine): add suite-level setup, services, and teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Suite-level `setup:` / `teardown:` / `env:` (#7) — the bootstrap shell
+  scripts real ShellSpec migrations could not shed (build a helper binary,
+  start a shared peer, warm a cache) become spec YAML. `suite.setup` is an
+  ordered list of steps run ONCE before any scenario inside a suite-scoped
+  scratch dir (`${suitedir}`); a `service:` step — valid only there — starts a
+  suite-wide background process at that exact point in the sequence, so
+  build-then-serve-then-warm bootstraps keep their order. Setup stores and
+  `ready.store` captures seed every scenario's store; `suite.env` is layered
+  beneath each scenario's env. A failing setup step errors every scenario
+  (labeled `suite setup`; nothing runs); `suite.teardown` always runs after
+  the last scenario — pass, fail, error, or interrupt (bounded context) —
+  while suite services are still up (services stop last, LIFO), and its
+  failures are loud (console `SUITE TEARDOWN FAILED`, JSON
+  `setup_failures`/`teardown_failures`) but never change the verdict.
+  Surfaced in the JSON schema, `explain`, `manifest`
+  (`suite_env`/`suite_setup`/`suite_teardown`), and a runnable example.
+
 - `atago run --verbose` (#6): trace every scenario as it finishes — the
   expanded command, exit code / HTTP status, captured stdout/stderr (excerpted
   at the same limit as failure output), skip reasons, teardown steps, and each

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Every feature has a commented, runnable spec under [examples/](examples/). The e
 | [snapshot](examples/snapshot.atago.yaml) | golden-file testing with normalized output |
 | [services](examples/services.atago.yaml) | background servers: readiness probes, `ready.store`, teardown |
 | [defaults](examples/defaults.atago.yaml) | sharing `shell`/`env`/`service` fragments across scenarios |
+| [suite_setup](examples/suite_setup.atago.yaml) | once-per-suite bootstrap: ordered setup steps, suite-wide `service:` steps, `${suitedir}`, suite env, always-run suite teardown |
 | [select_skip_only](examples/select_skip_only.atago.yaml) | tags, and gating scenarios by OS, env var, or a probe command |
 | [db](examples/db.atago.yaml) | SQL via the bundled SQLite driver, `rows` assertions, value binding |
 | [image_and_pdf](examples/image_and_pdf.atago.yaml) | image format/dimension/similarity checks, PDF page/metadata/text checks |

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-40 suites · 133 scenarios
+41 suites · 137 scenarios
 ## Contents
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 3 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
@@ -164,6 +164,11 @@
 - [atago self-hosting / store](#atago-self-hosting--store) — 2 scenarios
   - [a stored JSON value is reusable in later commands](#scenario-a-stored-json-value-is-reusable-in-later-commands)
   - [storing from a missing JSON path is an execution error](#scenario-storing-from-a-missing-json-path-is-an-execution-error)
+- [atago self-hosting / suite setup](#atago-self-hosting--suite-setup) — 4 scenarios
+  - [setup runs once, shares stores and env, and teardown always runs](#scenario-setup-runs-once-shares-stores-and-env-and-teardown-always-runs)
+  - [a failing setup errors every scenario and none runs (exit 4)](#scenario-a-failing-setup-errors-every-scenario-and-none-runs-exit-4)
+  - [a suite service starts once and its store reaches every scenario](#scenario-a-suite-service-starts-once-and-its-store-reaches-every-scenario)
+  - [a failing suite teardown is loud but does not flip the verdict](#scenario-a-failing-suite-teardown-is-loud-but-does-not-flip-the-verdict)
 - [atago self-hosting / verbose](#atago-self-hosting--verbose) — 4 scenarios
   - [verbose shows a passing scenario's command, output, and verdicts](#scenario-verbose-shows-a-passing-scenarios-command-output-and-verdicts)
   - [without --verbose the trace is absent](#scenario-without---verbose-the-trace-is-absent)
@@ -2876,6 +2881,129 @@ ${atago} run bad-store.atago.yaml
 #### Then
 - exit code is `4`
 - stdout contains `ERROR`
+## atago self-hosting / suite setup
+Source: `test/e2e/atago/suite_setup.atago.yaml`
+### Scenario: setup runs once, shares stores and env, and teardown always runs
+#### Given
+- Fixture file `ok.atago.yaml` is created.
+#### Inputs
+_Fixture `ok.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: inner
+  env:
+    FLAG: suite-env-flag
+  setup:
+    - run:
+        shell: true
+        command: "echo boot-42 > ${suitedir}/t.txt && cat ${suitedir}/t.txt"
+    - store:
+        name: bootid
+        from:
+          stdout:
+            matches: "boot-[0-9]+"
+  teardown:
+    - run:
+        shell: true
+        command: "echo swept ${bootid}"
+scenarios:
+  - name: one
+… (truncated, 12 more lines)
+```
+#### When
+```shell
+${atago} run --verbose ok.atago.yaml
+```
+#### Then
+- exit code is `0`
+- stdout contains `2 passed`
+### Scenario: a failing setup errors every scenario and none runs (exit 4)
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: inner
+  setup:
+    - run: {command: definitely-not-a-real-binary-xyz}
+scenarios:
+  - name: never runs
+    steps:
+      - run: {shell: true, command: echo unreached}
+  - name: never runs either
+    steps:
+      - run: {shell: true, command: echo unreached}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `4`
+- stdout contains `suite setup`, `0 passed`, `2 errored`
+- stdout does not contain `unreached`
+### Scenario: a suite service starts once and its store reaches every scenario
+#### Given
+- Fixture file `svc.atago.yaml` is created.
+#### Inputs
+_Fixture `svc.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: inner
+  setup:
+    - service:
+        name: peer
+        shell: true
+        command: "echo addr-9999 > ${suitedir}/ready.txt && sleep 30"
+        ready:
+          file: "${suitedir}/ready.txt"
+          store: addr
+          timeout: 5s
+scenarios:
+  - name: dials
+    steps:
+      - run: {shell: true, command: "echo dial ${addr}"}
+      - assert:
+          stdout: {contains: dial addr-9999}
+```
+#### When
+```shell
+${atago} run svc.atago.yaml
+```
+#### Then
+- exit code is `0`
+- stdout contains `1 passed`
+### Scenario: a failing suite teardown is loud but does not flip the verdict
+#### Given
+- Fixture file `td.atago.yaml` is created.
+#### Inputs
+_Fixture `td.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: inner
+  setup:
+    - run: {shell: true, command: echo fine}
+  teardown:
+    - run: {command: definitely-not-a-real-binary-xyz}
+scenarios:
+  - name: passes
+    steps:
+      - run: {shell: true, command: echo ok}
+      - assert:
+          stdout: {contains: ok}
+```
+#### When
+```shell
+${atago} run td.atago.yaml
+```
+#### Then
+- exit code is `0`
+- stdout contains `1 passed`, `SUITE TEARDOWN FAILED`
 ## atago self-hosting / verbose
 Source: `test/e2e/atago/verbose.atago.yaml`
 ### Scenario: verbose shows a passing scenario's command, output, and verdicts

--- a/doc/e2e/jq.md
+++ b/doc/e2e/jq.md
@@ -17,7 +17,7 @@ Source: `test/e2e/thirdparty/jq/jq.atago.yaml`
 ### Scenario: identity filter echoes the document from stdin
 #### Inputs
 _stdin for `jq`:_
-```
+```text
 {"b":2,"a":1}
 ```
 #### When
@@ -31,7 +31,7 @@ jq -c .
 ### Scenario: sort-keys output is deterministic and exact
 #### Inputs
 _stdin for `jq`:_
-```
+```text
 {"b":2,"a":1}
 ```
 #### When
@@ -46,7 +46,7 @@ jq -c --sort-keys .
 - Fixture file `user.json` is created.
 #### Inputs
 _Fixture `user.json`:_
-```
+```text
 {"name":"alice","admin":true}
 ```
 #### When
@@ -59,7 +59,7 @@ jq -r .name user.json
 ### Scenario: arguments flow in with --arg
 #### Inputs
 _stdin for `jq`:_
-```
+```text
 null
 ```
 #### When
@@ -74,7 +74,7 @@ jq -c --arg who atago '{greeting: ("hello " + $who)}'
 - Fixture file `nums.json` is created.
 #### Inputs
 _Fixture `nums.json`:_
-```
+```text
 [1,2,3,4,5]
 ```
 #### When
@@ -87,7 +87,7 @@ jq 'reduce .[] as $n (0; . + $n)' nums.json
 ### Scenario: -e exits 1 when the result is false
 #### Inputs
 _stdin for `jq`:_
-```
+```text
 {"present":1}
 ```
 #### When
@@ -99,7 +99,7 @@ jq -e '.missing'
 ### Scenario: a program that does not compile exits 3 with a diagnostic on stderr
 #### Inputs
 _stdin for `jq`:_
-```
+```text
 {}
 ```
 #### When
@@ -113,7 +113,7 @@ jq '.foo['
 ### Scenario: invalid JSON input fails loudly and keeps stdout clean
 #### Inputs
 _stdin for `jq`:_
-```
+```text
 not json at all
 ```
 #### When
@@ -126,7 +126,7 @@ jq .
 ### Scenario: streaming several documents produces one result per document
 #### Inputs
 _stdin for `jq`:_
-```
+```text
 {"n":1}
 {"n":2}
 ```

--- a/doc/e2e/openssl.md
+++ b/doc/e2e/openssl.md
@@ -17,7 +17,7 @@ Source: `test/e2e/thirdparty/openssl/openssl.atago.yaml`
 - Fixture file `msg.txt` is created.
 #### Inputs
 _Fixture `msg.txt`:_
-```
+```text
 the quick brown fox
 ```
 #### When
@@ -30,11 +30,11 @@ openssl dgst -sha256 -r msg.txt
 ### Scenario: base64 encode and decode round-trip via stdin
 #### Inputs
 _stdin for `openssl`:_
-```
+```text
 round-trip me
 ```
 _stdin for `openssl`:_
-```
+```text
 ${encoded}
 ```
 #### When
@@ -78,7 +78,7 @@ openssl pkey -in key.pem -pubout -out pub.pem
 - Fixture file `secret.txt` is created.
 #### Inputs
 _Fixture `secret.txt`:_
-```
+```text
 attack at dawn
 ```
 #### When
@@ -122,11 +122,11 @@ openssl verify -CAfile ca.crt ca.crt
 - Fixture file `payload.txt` is created.
 #### Inputs
 _Fixture `payload.txt`:_
-```
+```text
 sign me
 ```
 _Fixture `payload.txt`:_
-```
+```text
 sign me (tampered)
 ```
 #### When

--- a/doc/e2e/sqlite3.md
+++ b/doc/e2e/sqlite3.md
@@ -78,7 +78,7 @@ sqlite3 copy.db "SELECT name FROM u WHERE id=1;"
 - Fixture file `people.csv` is created.
 #### Inputs
 _Fixture `people.csv`:_
-```
+```text
 id,name
 1,carol
 2,dave

--- a/examples/suite_setup.atago.yaml
+++ b/examples/suite_setup.atago.yaml
@@ -1,0 +1,70 @@
+version: "1"
+
+# suite.setup runs ONCE before any scenario — in order, inside a suite-scoped
+# scratch dir (${suitedir}) — and exists so bootstrap shell scripts (build a
+# helper, start a shared peer, warm a cache) become spec YAML. A `service:`
+# step starts a suite-wide background process at that exact point in the
+# sequence; its ready.store value reaches every scenario. suite.env is exported
+# to every scenario (a scenario's own env wins per key), and suite.teardown
+# always runs after the last scenario — pass or fail — while suite services are
+# still up. A teardown failure never changes the verdict.
+# The setup/service commands here are POSIX-shell; on Windows validate it with
+# `atago explain`. Runs green as-is on Linux/macOS:
+#   atago run examples/suite_setup.atago.yaml
+
+suite:
+  name: suite setup
+  env:
+    GREETING: from-suite
+  setup:
+    # Ordinary run steps, executed once. ${suitedir} lives until the suite ends.
+    - run:
+        shell: true
+        command: "echo shared-token-123 > ${suitedir}/token.txt"
+    - run:
+        shell: true
+        command: "cat ${suitedir}/token.txt"
+    - store:
+        name: token
+        from:
+          stdout:
+            matches: "shared-token-[0-9]+"
+    # A suite-wide service: started here, stopped after suite.teardown (LIFO).
+    # Its ready file doubles as the readiness signal.
+    - service:
+        name: beacon
+        shell: true
+        command: "echo up > ${suitedir}/ready.txt && sleep 30"
+        ready:
+          file: "${suitedir}/ready.txt"
+          timeout: 5s
+  teardown:
+    - run:
+        shell: true
+        command: "echo cleaned up ${token}"
+    - assert:
+        stdout:
+          contains: cleaned up shared-token-123
+
+scenarios:
+  - name: scenarios share the setup store and suite env
+    steps:
+      - run:
+          shell: true
+          command: "echo got ${token} greeting=$GREETING"
+      - assert:
+          exit_code: 0
+          stdout:
+            contains:
+              - got shared-token-123
+              - greeting=from-suite
+
+  - name: the suite service outlives individual scenarios
+    steps:
+      - run:
+          shell: true
+          command: "cat ${suitedir}/ready.txt"
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: up

--- a/examples_test.go
+++ b/examples_test.go
@@ -35,6 +35,7 @@ var exampleSpecs = map[string]bool{ // path -> hermetic (run, not just validate)
 	"examples/snapshot.atago.yaml":            true,
 	"examples/ssh.atago.yaml":                 false,
 	"examples/store_and_variables.atago.yaml": true,
+	"examples/suite_setup.atago.yaml":         false,
 	"examples/teardown.atago.yaml":            true,
 }
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -119,6 +119,50 @@ func (e *Engine) Run(ctx context.Context, s *spec.Spec, specPath string) *SuiteR
 
 	selected := e.selectScenarios(s, specPath)
 
+	// Suite lifecycle (#7): run suite.setup once before any scenario, expose
+	// its scratch dir/stores/services to every scenario, and guarantee
+	// suite.teardown runs after the last one (before services stop, LIFO).
+	suiteRT, rtErr := e.newSuiteRuntime(s)
+	if rtErr != nil {
+		res.Status = StatusError
+		for _, i := range selected {
+			res.Scenarios = append(res.Scenarios, ScenarioResult{Name: s.Scenarios[i].Name, Suite: s.Suite.Name, Status: StatusError,
+				Steps: []StepResult{{Kind: spec.StepNone, Setup: true, ErrMsg: suiteSetupLabel + ": " + rtErr.Error()}}})
+		}
+		res.Duration = time.Since(start)
+		return res
+	}
+	if suiteRT != nil {
+		defer suiteRT.stop()
+		var setupOK bool
+		res.Setup, setupOK = e.runSuiteSteps(ctx, s.Suite.Setup, suiteRT, rc, true)
+		if !setupOK {
+			// Every selected scenario is errored with the suite-setup phase
+			// named; none of their steps run. Teardown still runs: a partially
+			// executed setup may have created external state worth cleaning.
+			res.Status = StatusError
+			failure := suiteSetupFailure(res.Setup)
+			for _, i := range selected {
+				sr := ScenarioResult{Name: s.Scenarios[i].Name, Suite: s.Suite.Name, Status: StatusError,
+					Steps: []StepResult{{Kind: spec.StepNone, Setup: true, ErrMsg: failure}}}
+				if e.OnScenario != nil {
+					e.OnScenario(sr)
+				}
+				res.Scenarios = append(res.Scenarios, sr)
+			}
+			res.Teardown = e.runSuiteTeardown(ctx, s, suiteRT, rc)
+			res.Duration = time.Since(start)
+			return res
+		}
+		rc.suiteVars = suiteRT.vars
+		rc.suiteEnv = suiteRT.env
+		defer func() {
+			// Deferred after suiteRT.stop ⇒ runs before it, so teardown can
+			// still reach the suite services.
+			res.Teardown = e.runSuiteTeardown(ctx, s, suiteRT, rc)
+		}()
+	}
+
 	results := make([]ScenarioResult, len(s.Scenarios))
 	done := make([]bool, len(s.Scenarios))
 	jobs := make(chan int)
@@ -272,6 +316,12 @@ type runConfig struct {
 	masker   *security.Masker
 	runners  map[string]spec.Runner
 	allow    []string
+	// suiteVars is the suite store snapshot (#7): ${suitedir} plus values
+	// captured by suite.setup (store steps, service ready.store). Seeded into
+	// every scenario's store before its own vars.
+	suiteVars map[string]string
+	// suiteEnv is the raw suite.env, layered beneath each scenario's env.
+	suiteEnv map[string]string
 }
 
 func (e *Engine) runScenario(ctx context.Context, scenarioIdx int, sc *spec.Scenario, rc runConfig) ScenarioResult {
@@ -295,6 +345,11 @@ func (e *Engine) runScenario(ctx context.Context, scenarioIdx int, sc *spec.Scen
 	for k, v := range e.builtins {
 		st.Set(k, v)
 	}
+	// Suite-level values (#7) come before the scenario's own: ${suitedir} and
+	// suite.setup captures are shared context every scenario may reference.
+	for k, v := range rc.suiteVars {
+		st.Set(k, v)
+	}
 	// ${workdir} is the absolute path of this scenario's isolated temp dir, so
 	// specs can build absolute env paths (e.g. HOME=${workdir}/home,
 	// GOBIN=${workdir}/gobin) that child toolchains require.
@@ -304,6 +359,9 @@ func (e *Engine) runScenario(ctx context.Context, scenarioIdx int, sc *spec.Scen
 	for k, v := range sc.Vars {
 		st.Set(k, v)
 	}
+	// suite.env layers beneath the scenario's own env (the scenario wins per
+	// key); scEnv replaces sc.Env for every use below.
+	scEnv := mergedEnv(rc.suiteEnv, sc.Env)
 	// Database connections are opened lazily per scenario and closed at its end,
 	// so a dsn referencing ${workdir} yields a fresh isolated DB each time.
 	dbConns := map[string]*dbrunner.Runner{}
@@ -356,7 +414,7 @@ func (e *Engine) runScenario(ctx context.Context, scenarioIdx int, sc *spec.Scen
 		}
 	}()
 	for i := range sc.Services {
-		proc, captured, err := servicerunner.Start(ctx, expandService(st, sc.Env, &sc.Services[i]), workdir)
+		proc, captured, err := servicerunner.Start(ctx, expandService(st, scEnv, &sc.Services[i]), workdir)
 		if err != nil {
 			out.Status = StatusError
 			// Preserve the failed service's log (and any peers already started) as a
@@ -414,7 +472,7 @@ func (e *Engine) runScenario(ctx context.Context, scenarioIdx int, sc *spec.Scen
 					return sr, StatusError, false
 				}
 			}
-			run := mergeScenarioEnv(sc.Env, expandRun(st, step.Run), st)
+			run := mergeScenarioEnv(scEnv, expandRun(st, step.Run), st)
 			r, untilChecks, err := e.runStep(ctx, run, st, workdir, specDir, rc, sshConns)
 			if err != nil {
 				sr.ErrMsg = err.Error()

--- a/internal/engine/expand.go
+++ b/internal/engine/expand.go
@@ -172,3 +172,20 @@ func expandCDP(st *store.Store, c *spec.CDP) *spec.CDP {
 	}
 	return &out
 }
+
+// mergedEnv layers base beneath own (own wins per key) without mutating either.
+// It returns own unchanged when base is empty, so the common no-suite-env case
+// allocates nothing.
+func mergedEnv(base, own map[string]string) map[string]string {
+	if len(base) == 0 {
+		return own
+	}
+	out := make(map[string]string, len(base)+len(own))
+	for k, v := range base {
+		out[k] = v
+	}
+	for k, v := range own {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/engine/result.go
+++ b/internal/engine/result.go
@@ -90,7 +90,13 @@ type SuiteResult struct {
 	SpecPath  string
 	Status    Status
 	Scenarios []ScenarioResult
-	Duration  time.Duration
+	// Setup records the suite.setup steps (#7). A failed setup step errors
+	// every scenario (none runs) and the failure is visible here.
+	Setup []StepResult
+	// Teardown records the suite.teardown steps (#7). They always run after
+	// the last scenario; failures are reported but never change Status.
+	Teardown []StepResult
+	Duration time.Duration
 	// SecurityViolation is true when any scenario breached the security policy.
 	SecurityViolation bool
 }

--- a/internal/engine/suite.go
+++ b/internal/engine/suite.go
@@ -1,0 +1,211 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/nao1215/atago/internal/assert"
+	"github.com/nao1215/atago/internal/fixture"
+	"github.com/nao1215/atago/internal/runner"
+	servicerunner "github.com/nao1215/atago/internal/runner/service"
+	sshrunner "github.com/nao1215/atago/internal/runner/ssh"
+	"github.com/nao1215/atago/internal/spec"
+	"github.com/nao1215/atago/internal/store"
+)
+
+// suiteSetupLabel names the phase of a scenario error caused by a failed
+// suite.setup step, mirroring the "service setup" labeling for pre-step
+// failures (#7).
+const suiteSetupLabel = "suite setup"
+
+// suiteRuntime carries the once-per-suite state created by suite.setup (#7):
+// the ${suitedir} scratch directory, the suite store (builtins, ${suitedir},
+// setup-captured values), the suite-wide background services, and the variable
+// snapshot seeded into every scenario's store.
+type suiteRuntime struct {
+	dir      string
+	st       *store.Store
+	services []*servicerunner.Proc
+	env      map[string]string // raw suite.env; expanded per use
+	vars     map[string]string // seeded into every scenario store
+	sshConns map[string]*sshrunner.Runner
+}
+
+// set records a suite variable in both the suite store (for later setup steps)
+// and the snapshot every scenario receives.
+func (rt *suiteRuntime) set(name, value string) {
+	rt.st.Set(name, value)
+	rt.vars[name] = value
+}
+
+// stop tears the suite runtime down: services in LIFO order (after suite
+// teardown has run — the caller sequences that), ssh connections, and the
+// scratch directory.
+func (rt *suiteRuntime) stop() {
+	for i := len(rt.services) - 1; i >= 0; i-- {
+		rt.services[i].Stop()
+	}
+	for _, c := range rt.sshConns {
+		_ = c.Close()
+	}
+	if rt.dir != "" {
+		_ = os.RemoveAll(rt.dir)
+	}
+}
+
+// newSuiteRuntime prepares the suite scratch dir and store. It returns nil
+// when the spec declares no suite-level blocks, so the common case pays
+// nothing.
+func (e *Engine) newSuiteRuntime(s *spec.Spec) (*suiteRuntime, error) {
+	if len(s.Suite.Setup) == 0 && len(s.Suite.Teardown) == 0 && len(s.Suite.Env) == 0 {
+		return nil, nil
+	}
+	dir, err := os.MkdirTemp("", "atago-suite-")
+	if err != nil {
+		return nil, fmt.Errorf("could not create suite dir: %w", err)
+	}
+	rt := &suiteRuntime{
+		dir:      dir,
+		st:       store.New(),
+		env:      s.Suite.Env,
+		vars:     map[string]string{},
+		sshConns: map[string]*sshrunner.Runner{},
+	}
+	for k, v := range e.builtins {
+		rt.st.Set(k, v)
+	}
+	rt.set("suitedir", dir)
+	return rt, nil
+}
+
+// runSuiteSteps executes one suite-level block (setup or teardown) in order.
+// Setup (stopOnFailure=true) aborts at the first failed step — every scenario
+// is then errored by the caller. Teardown (stopOnFailure=false) always runs
+// every step: cleanups of independent resources must not shadow each other.
+// The returned bool reports whether every step succeeded.
+func (e *Engine) runSuiteSteps(ctx context.Context, steps []spec.Step, rt *suiteRuntime, rc runConfig, stopOnFailure bool) ([]StepResult, bool) {
+	var out []StepResult
+	var current *runner.Result
+	ok := true
+
+	for i := range steps {
+		step := &steps[i]
+		sr := StepResult{Index: i, Kind: step.Kind()}
+		failed := false
+
+		if ctx.Err() != nil {
+			sr.ErrMsg = fmt.Sprintf("run cancelled: %v", ctx.Err())
+			out = append(out, sr)
+			return out, false
+		}
+
+		switch step.Kind() {
+		case spec.StepFixture:
+			if err := fixture.Write(expandFixture(rt.st, step.Fixture), rt.dir, rc.specDir); err != nil {
+				sr.ErrMsg = err.Error()
+				failed = true
+			}
+		case spec.StepRun:
+			run := mergeScenarioEnv(rt.env, expandRun(rt.st, step.Run), rt.st)
+			r, untilChecks, err := e.runStep(ctx, run, rt.st, rt.dir, rc.specDir, rc, rt.sshConns)
+			if err != nil {
+				sr.ErrMsg = err.Error()
+				failed = true
+				break
+			}
+			current = r
+			sr.Run = maskResult(rc.masker, r)
+			if len(untilChecks) > 0 {
+				sr.Checks = untilChecks
+				if !assert.AllOK(untilChecks) {
+					failed = true
+				}
+			}
+		case spec.StepStore:
+			val, err := extractValue(expandStore(rt.st, step.Store), current, rt.dir)
+			if err != nil {
+				sr.ErrMsg = err.Error()
+				failed = true
+			} else {
+				rt.set(step.Store.Name, val)
+			}
+		case spec.StepAssert:
+			crs := assert.CheckAll(expandAssert(rt.st, step.Assert), current, assert.Env{
+				Workdir:         rt.dir,
+				SpecDir:         rc.specDir,
+				UpdateSnapshots: e.UpdateSnapshots,
+				Secrets:         rc.masker.MaskBytes,
+			})
+			sr.Checks = crs
+			if !assert.AllOK(crs) {
+				failed = true
+			}
+		case spec.StepService:
+			proc, captured, err := servicerunner.Start(ctx, expandService(rt.st, rt.env, step.Service), rt.dir)
+			if proc != nil {
+				rt.services = append(rt.services, proc)
+			}
+			if err != nil {
+				sr.ErrMsg = err.Error()
+				failed = true
+				break
+			}
+			if step.Service.Ready != nil && step.Service.Ready.Store != "" {
+				rt.set(step.Service.Ready.Store, captured)
+			}
+		default:
+			sr.ErrMsg = fmt.Sprintf("%s steps are not allowed at suite level", step.Kind())
+			failed = true
+		}
+
+		sr.ErrMsg = rc.masker.Mask(sr.ErrMsg)
+		out = append(out, sr)
+		if failed {
+			ok = false
+			if stopOnFailure {
+				return out, false
+			}
+		}
+	}
+	return out, ok
+}
+
+// suiteSetupFailure summarizes a failed setup block for the per-scenario error.
+func suiteSetupFailure(setup []StepResult) string {
+	if len(setup) == 0 {
+		return suiteSetupLabel + " failed"
+	}
+	last := setup[len(setup)-1]
+	if last.ErrMsg != "" {
+		return fmt.Sprintf("%s failed at step %d (%s): %s", suiteSetupLabel, last.Index, last.Kind, last.ErrMsg)
+	}
+	for _, ck := range last.Checks {
+		if ck != nil && !ck.OK {
+			return fmt.Sprintf("%s failed at step %d (%s): %s", suiteSetupLabel, last.Index, last.Kind, ck.Desc)
+		}
+	}
+	return fmt.Sprintf("%s failed at step %d (%s)", suiteSetupLabel, last.Index, last.Kind)
+}
+
+// runSuiteTeardown executes suite.teardown on a context that survives an
+// interrupt (bounded, like scenario teardown) while suite services are still
+// up. Failures are recorded but never change the suite verdict.
+func (e *Engine) runSuiteTeardown(ctx context.Context, s *spec.Spec, rt *suiteRuntime, rc runConfig) []StepResult {
+	if rt == nil || len(s.Suite.Teardown) == 0 {
+		return nil
+	}
+	tctx := ctx
+	if ctx.Err() != nil {
+		var cancel context.CancelFunc
+		tctx, cancel = context.WithTimeout(context.Background(), teardownInterruptTimeout)
+		defer cancel()
+	}
+	out, _ := e.runSuiteSteps(tctx, s.Suite.Teardown, rt, rc, false)
+	return out
+}
+
+// suiteTimeNow is a seam kept trivial on purpose; suite phases reuse the
+// scenario duration accounting via time.Since at the call sites.
+var _ = time.Now

--- a/internal/engine/suite.go
+++ b/internal/engine/suite.go
@@ -96,7 +96,7 @@ func (e *Engine) runSuiteSteps(ctx context.Context, steps []spec.Step, rt *suite
 		failed := false
 
 		if ctx.Err() != nil {
-			sr.ErrMsg = fmt.Sprintf("run cancelled: %v", ctx.Err())
+			sr.ErrMsg = fmt.Sprintf("run canceled: %v", ctx.Err())
 			out = append(out, sr)
 			return out, false
 		}

--- a/internal/engine/suite_setup_test.go
+++ b/internal/engine/suite_setup_test.go
@@ -42,7 +42,7 @@ suite:
 scenarios:
   - name: first sees the shared store and env
     steps:
-      - run: {shell: true, command: "echo got ${token} flag=$SHARED_FLAG"}
+      - run: {shell: true, command: "echo got ${token} flag=` + envRef("SHARED_FLAG") + `"}
       - assert:
           exit_code: 0
           stdout:
@@ -88,13 +88,10 @@ version: "1"
 suite:
   name: s
   setup:
-    - run:
-        shell: true
-        command: "echo addr-127.0.0.1:7777 > ${suitedir}/seed.txt"
     - service:
         name: peer
         shell: true
-        command: '` + copyThenIdle("${suitedir}/seed.txt", "${suitedir}/ready.txt", 30) + `'
+        command: '` + publishEchoIdle("addr-127.0.0.1:7777", "${suitedir}/ready.txt", "serving", 30) + `'
         ready:
           file: "${suitedir}/ready.txt"
           store: addr

--- a/internal/engine/suite_setup_test.go
+++ b/internal/engine/suite_setup_test.go
@@ -1,0 +1,239 @@
+package engine
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/atago/internal/loader"
+)
+
+// The suite.setup block (#7) exists so the bootstrap shell scripts real
+// migrations could not shed (build a helper, start a shared peer, warm a
+// cache) become spec YAML: an ordered list of steps run ONCE before any
+// scenario, in a suite-scoped scratch dir (${suitedir}), where a `service:`
+// step starts a suite-wide background process at that exact point in the
+// sequence. suite.teardown always runs after the last scenario; suite
+// services stop last (LIFO).
+
+// TestEngine_SuiteSetup_RunsOnceAndSharesStore proves setup runs exactly once
+// (not per scenario), its captured stores and ${suitedir} are visible to every
+// scenario, and suite.env is layered into scenario commands.
+func TestEngine_SuiteSetup_RunsOnceAndSharesStore(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: s
+  env:
+    SHARED_FLAG: from-suite
+  setup:
+    - run:
+        shell: true
+        command: "echo setup >> ${suitedir}/count.txt"
+    - run:
+        shell: true
+        command: echo bootstrap-token-99
+    - store:
+        name: token
+        from:
+          stdout:
+            matches: "bootstrap-token-[0-9]+"
+scenarios:
+  - name: first sees the shared store and env
+    steps:
+      - run: {shell: true, command: "echo got ${token} flag=$SHARED_FLAG"}
+      - assert:
+          exit_code: 0
+          stdout:
+            contains:
+              - got bootstrap-token-99
+              - flag=from-suite
+  - name: second sees them too
+    steps:
+      - run: {shell: true, command: "echo again ${token}"}
+      - assert:
+          stdout: {contains: again bootstrap-token-99}
+  - name: setup ran exactly once
+    steps:
+      - run: {shell: true, command: "wc -l < ${suitedir}/count.txt"}
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "1"
+`
+	s, err := loader.LoadBytes("t.atago.yaml", []byte(src))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	eng := New()
+	eng.Parallel = 4 // setup must still run once even with parallel scenarios
+	res := eng.Run(context.Background(), s, "t.atago.yaml")
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed: %+v", res.Status, res.Scenarios)
+	}
+	if len(res.Setup) != 3 {
+		t.Fatalf("recorded %d setup step results, want 3", len(res.Setup))
+	}
+}
+
+// TestEngine_SuiteService_StartsOnceReadyStoreShared proves a `service:` setup
+// step starts a suite-wide process whose ready.store value reaches every
+// scenario, ordered relative to surrounding run steps (the service command
+// uses a file the preceding run step created).
+func TestEngine_SuiteService_StartsOnceReadyStoreShared(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: s
+  setup:
+    - run:
+        shell: true
+        command: "echo addr-127.0.0.1:7777 > ${suitedir}/seed.txt"
+    - service:
+        name: peer
+        shell: true
+        command: '` + copyThenIdle("${suitedir}/seed.txt", "${suitedir}/ready.txt", 30) + `'
+        ready:
+          file: "${suitedir}/ready.txt"
+          store: addr
+          timeout: 5s
+scenarios:
+  - name: one
+    steps:
+      - run: {shell: true, command: "echo dial ${addr}"}
+      - assert:
+          stdout: {contains: "dial addr-127.0.0.1:7777"}
+  - name: two
+    steps:
+      - run: {shell: true, command: "echo redial ${addr}"}
+      - assert:
+          stdout: {contains: "redial addr-127.0.0.1:7777"}
+`
+	s, err := loader.LoadBytes("t.atago.yaml", []byte(src))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	res := New().Run(context.Background(), s, "t.atago.yaml")
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed: %+v", res.Status, res.Scenarios)
+	}
+}
+
+// TestEngine_SuiteSetupFailure_ErrsEveryScenario proves a failing setup step
+// marks every scenario errored with the suite-setup phase label, and no
+// scenario step ever runs.
+func TestEngine_SuiteSetupFailure_ErrsEveryScenario(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: s
+  setup:
+    - run: {command: definitely-not-a-real-binary-xyz}
+scenarios:
+  - name: never runs
+    steps:
+      - run: {shell: true, command: echo unreached}
+  - name: never runs either
+    steps:
+      - run: {shell: true, command: echo unreached}
+`
+	s, err := loader.LoadBytes("t.atago.yaml", []byte(src))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	res := New().Run(context.Background(), s, "t.atago.yaml")
+	if res.Status != StatusError {
+		t.Fatalf("status = %s, want error", res.Status)
+	}
+	if len(res.Scenarios) != 2 {
+		t.Fatalf("got %d scenario results, want 2", len(res.Scenarios))
+	}
+	for i, sc := range res.Scenarios {
+		if sc.Status != StatusError {
+			t.Errorf("scenario[%d] status = %s, want error", i, sc.Status)
+		}
+		if len(sc.Steps) != 1 || !sc.Steps[0].Setup {
+			t.Errorf("scenario[%d] should carry a single setup-phase step result, got %+v", i, sc.Steps)
+		}
+		if !strings.Contains(sc.Steps[0].ErrMsg, "suite setup") {
+			t.Errorf("scenario[%d] ErrMsg = %q, want it to name the suite setup phase", i, sc.Steps[0].ErrMsg)
+		}
+	}
+}
+
+// TestEngine_SuiteTeardown_AlwaysRunsAndServicesOutliveIt proves suite
+// teardown runs after the last scenario even when scenarios fail, can still
+// talk to suite services (they stop last), and its failures never change the
+// suite verdict.
+func TestEngine_SuiteTeardown_AlwaysRunsAndServicesOutliveIt(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: s
+  setup:
+    - service:
+        name: peer
+        shell: true
+        command: '` + publishEchoIdle("up", "${suitedir}/ready.txt", "serving", 30) + `'
+        ready:
+          file: "${suitedir}/ready.txt"
+          timeout: 5s
+  teardown:
+    - run:
+        shell: true
+        command: "` + catCmd() + ` ${suitedir}/ready.txt && echo teardown-saw-service > ${suitedir}/td.txt"
+    - run: {command: definitely-not-a-real-binary-xyz}
+scenarios:
+  - name: fails on purpose
+    steps:
+      - run: {shell: true, command: echo hello}
+      - assert:
+          stdout: {contains: goodbye}
+`
+	s, err := loader.LoadBytes("t.atago.yaml", []byte(src))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	res := New().Run(context.Background(), s, "t.atago.yaml")
+	// The scenario failed; a failing suite-teardown step must not upgrade or
+	// rescue that verdict.
+	if res.Status != StatusFailed {
+		t.Fatalf("status = %s, want failed: %+v", res.Status, res.Scenarios)
+	}
+	if len(res.Teardown) != 2 {
+		t.Fatalf("recorded %d suite teardown steps, want 2 (all run despite the failure)", len(res.Teardown))
+	}
+	if res.Teardown[0].ErrMsg != "" {
+		t.Errorf("teardown[0] should have reached the still-running service: %+v", res.Teardown[0])
+	}
+	if res.Teardown[1].ErrMsg == "" {
+		t.Error("teardown[1] should record its execution error")
+	}
+}
+
+// TestEngine_SuiteSetup_AbsentIsNoOp proves specs without the block behave
+// exactly as before (backward compatibility).
+func TestEngine_SuiteSetup_AbsentIsNoOp(t *testing.T) {
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: s
+scenarios:
+  - name: plain
+    steps:
+      - run: {shell: true, command: echo plain}
+      - assert:
+          stdout: {contains: plain}
+`)
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed", res.Status)
+	}
+	if len(res.Setup) != 0 || len(res.Teardown) != 0 {
+		t.Errorf("no-block spec recorded setup/teardown results: %+v / %+v", res.Setup, res.Teardown)
+	}
+}

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -22,6 +22,8 @@ func Explain(w io.Writer, s *spec.Spec, path string) error {
 		fmt.Fprintf(&b, "Secrets declared: %s\n", strings.Join(s.Secrets, ", "))
 	}
 	fmt.Fprintf(&b, "Network policy: %s\n", networkPolicy(s))
+	explainSuiteBlock(&b, "Suite setup (runs once before any scenario)", s.Suite.Setup)
+	explainSuiteBlock(&b, "Suite teardown (always runs after the last scenario)", s.Suite.Teardown)
 
 	for i := range s.Scenarios {
 		explainScenario(&b, &s.Scenarios[i])
@@ -38,6 +40,33 @@ func networkPolicy(s *spec.Spec) string {
 	// every host is permitted (security.CheckHost). Say so plainly instead of
 	// implying a restrictive default that does not exist (issue #41).
 	return "unrestricted (no allowlist set; all hosts permitted)"
+}
+
+// explainSuiteBlock summarizes suite.setup / suite.teardown (#7) so a reviewer
+// sees the once-per-suite bootstrap (built helpers, suite-wide services,
+// cleanup) without reading YAML.
+func explainSuiteBlock(b *strings.Builder, label string, steps []spec.Step) {
+	if len(steps) == 0 {
+		return
+	}
+	fmt.Fprintf(b, "%s:\n", label)
+	for i := range steps {
+		step := &steps[i]
+		switch step.Kind() {
+		case spec.StepRun:
+			fmt.Fprintf(b, "  - %s\n", describeRun(step.Run))
+		case spec.StepService:
+			fmt.Fprintf(b, "  - start suite service %q: %s\n", step.Service.Name, step.Service.Command)
+		case spec.StepFixture:
+			fmt.Fprintf(b, "  - %s\n", describeFixture(step.Fixture))
+		case spec.StepStore:
+			fmt.Fprintf(b, "  - store %s\n", step.Store.Name)
+		case spec.StepAssert:
+			for _, d := range describeAsserts(step.Assert) {
+				fmt.Fprintf(b, "  - expect %s\n", d)
+			}
+		}
+	}
 }
 
 func explainScenario(b *strings.Builder, sc *spec.Scenario) {

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -209,6 +209,42 @@ func TestLoadBytes_Errors(t *testing.T) {
 			wantMsg:  "is not an octal file mode",
 		},
 		{
+			name:     "service step inside a scenario is rejected",
+			src:      "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps:\n      - service: {name: p, command: ./p}\n      - run: {command: echo}",
+			wantKind: KindValidation,
+			wantMsg:  "service steps are only allowed in suite.setup",
+		},
+		{
+			name:     "service step inside scenario teardown is rejected",
+			src:      "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps:\n      - run: {command: echo}\n    teardown:\n      - service: {name: p, command: ./p}",
+			wantKind: KindValidation,
+			wantMsg:  "service steps are only allowed in suite.setup",
+		},
+		{
+			name:     "service step inside suite teardown is rejected",
+			src:      "version: \"1\"\nsuite:\n  name: x\n  teardown:\n    - service: {name: p, command: ./p}\nscenarios:\n  - name: a\n    steps:\n      - run: {command: echo}",
+			wantKind: KindValidation,
+			wantMsg:  "service steps are only allowed in suite.setup",
+		},
+		{
+			name:     "http step at suite level is rejected with a pointer",
+			src:      "version: \"1\"\nsuite:\n  name: x\n  setup:\n    - http: {method: GET, path: /}\nscenarios:\n  - name: a\n    steps:\n      - run: {command: echo}",
+			wantKind: KindValidation,
+			wantMsg:  "per-scenario",
+		},
+		{
+			name:     "duplicate suite service names are rejected",
+			src:      "version: \"1\"\nsuite:\n  name: x\n  setup:\n    - service: {name: p, command: ./p}\n    - service: {name: p, command: ./q}\nscenarios:\n  - name: a\n    steps:\n      - run: {command: echo}",
+			wantKind: KindValidation,
+			wantMsg:  "duplicate suite service name",
+		},
+		{
+			name:     "suite setup run without a command is rejected",
+			src:      "version: \"1\"\nsuite:\n  name: x\n  setup:\n    - run: {shell: true}\nscenarios:\n  - name: a\n    steps:\n      - run: {command: echo}",
+			wantKind: KindValidation,
+			wantMsg:  "run.command is required",
+		},
+		{
 			name:     "invalid fixture mtime fails at load",
 			src:      "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps:\n      - fixture: {file: f.txt, content: x, mtime: \"yesterday\"}\n      - run: {command: echo}",
 			wantKind: KindValidation,

--- a/internal/loader/validate.go
+++ b/internal/loader/validate.go
@@ -34,6 +34,8 @@ func validate(s *spec.Spec) []string {
 	}
 	validateRunners(add, s.Runners)
 	validateDefaults(add, s.Defaults)
+	validateSuiteBlock(add, "suite.setup", s.Suite.Setup, s.Runners, true)
+	validateSuiteBlock(add, "suite.teardown", s.Suite.Teardown, s.Runners, false)
 
 	seen := make(map[string]bool, len(s.Scenarios))
 	for i := range s.Scenarios {
@@ -200,6 +202,62 @@ func validateServices(add func(string, ...any), where string, services []spec.Se
 	}
 }
 
+// validateSuiteBlock checks suite.setup / suite.teardown (#7): steps run once
+// per suite in the ${suitedir} scratch dir, so only the suite-scoped kinds are
+// allowed — fixture, run, store, assert, and (setup only) `service:`. The
+// runner-backed kinds (http/query/grpc/cdp) are per-scenario machinery and are
+// rejected with a pointer to where they belong.
+func validateSuiteBlock(add func(string, ...any), where string, steps []spec.Step, runners map[string]spec.Runner, allowService bool) {
+	seenService := map[string]bool{}
+	for i := range steps {
+		st := &steps[i]
+		sw := fmt.Sprintf("%s[%d]", where, i)
+		keys := st.SetKeys()
+		if len(keys) != 1 {
+			add("%s: step must set exactly one action (got %v)", sw, keys)
+			continue
+		}
+		switch st.Kind() {
+		case spec.StepFixture:
+			validateFixture(add, sw, st.Fixture)
+		case spec.StepRun:
+			validateRunnerRef(add, sw, "run", st.Run.Runner, runners)
+			if st.Run.Timeout != "" {
+				if _, err := time.ParseDuration(st.Run.Timeout); err != nil {
+					add("%s.run.timeout %q is not a valid duration (e.g. \"30s\")", sw, st.Run.Timeout)
+				}
+			}
+			if st.Run.Command == "" {
+				add("%s.run.command is required", sw)
+			}
+			validateRetry(add, sw+".run", st.Run.Retry)
+		case spec.StepStore:
+			validateStore(add, sw, st.Store)
+		case spec.StepAssert:
+			validateAssert(add, sw, st.Assert)
+		case spec.StepService:
+			if !allowService {
+				add("%s: service steps are only allowed in suite.setup", sw)
+				continue
+			}
+			svc := st.Service
+			if svc.Name == "" {
+				add("%s.service.name is required", sw)
+			} else if seenService[svc.Name] {
+				add("%s: duplicate suite service name %q", where, svc.Name)
+			} else {
+				seenService[svc.Name] = true
+			}
+			if svc.Command == "" {
+				add("%s.service.command is required", sw)
+			}
+			validateReady(add, sw+".service", svc.Ready)
+		default:
+			add("%s: %s steps are per-scenario (they need a scenario workdir and runners); move it into a scenario", sw, st.Kind())
+		}
+	}
+}
+
 func validateReady(add func(string, ...any), where string, r *spec.Ready) {
 	if r == nil {
 		return
@@ -356,6 +414,8 @@ func validateStep(add func(string, ...any), where string, st *spec.Step, runners
 		validateCDPActions(add, where, st.CDP.Actions)
 	case spec.StepStore:
 		validateStore(add, where, st.Store)
+	case spec.StepService:
+		add("%s: service steps are only allowed in suite.setup (scenario-scoped peers go under the scenario's services: list)", where)
 	}
 }
 

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -67,11 +67,18 @@ type Spec struct {
 	Suite    string `json:"suite"`
 	// Source is the authored location of the suite declaration (#80). Omitted
 	// when positions are unavailable.
-	Source    *Source    `json:"source,omitempty"`
-	Secrets   []string   `json:"secrets,omitempty"`
-	Network   Network    `json:"network"`
-	Runners   []Runner   `json:"runners,omitempty"`
-	Scenarios []Scenario `json:"scenarios"`
+	Source  *Source  `json:"source,omitempty"`
+	Secrets []string `json:"secrets,omitempty"`
+	Network Network  `json:"network"`
+	Runners []Runner `json:"runners,omitempty"`
+	// SuiteEnv, SuiteSetup, and SuiteTeardown mirror the suite-level lifecycle
+	// (#7): env exported to every scenario, steps run once before any scenario
+	// (setup may contain service steps starting suite-wide peers), and steps
+	// that always run after the last scenario.
+	SuiteEnv      []string   `json:"suite_env,omitempty"`
+	SuiteSetup    []Step     `json:"suite_setup,omitempty"`
+	SuiteTeardown []Step     `json:"suite_teardown,omitempty"`
+	Scenarios     []Scenario `json:"scenarios"`
 }
 
 // Network summarizes the spec's network policy.
@@ -193,6 +200,23 @@ func buildSpec(in Input) Spec {
 	}
 	if in.Source != nil {
 		out.Source = sourceFrom(in.Source.SuitePos())
+	}
+	// Suite lifecycle (#7). Env is emitted as sorted key names only — values
+	// may embed credentials, same rule as a db runner's dsn.
+	if len(s.Suite.Env) > 0 {
+		keys := make([]string, 0, len(s.Suite.Env))
+		for k := range s.Suite.Env {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		out.SuiteEnv = keys
+	}
+	suiteVars := map[string]bool{}
+	for i := range s.Suite.Setup {
+		out.SuiteSetup = append(out.SuiteSetup, buildStep(i, &s.Suite.Setup[i], suiteVars))
+	}
+	for i := range s.Suite.Teardown {
+		out.SuiteTeardown = append(out.SuiteTeardown, buildStep(i, &s.Suite.Teardown[i], suiteVars))
 	}
 	for i := range s.Scenarios {
 		out.Scenarios = append(out.Scenarios, buildScenario(&s.Scenarios[i], in.Source))

--- a/internal/manifest/scenario.go
+++ b/internal/manifest/scenario.go
@@ -86,6 +86,14 @@ func buildStep(index int, step *spec.Step, vars map[string]bool) Step {
 		st.Action = "write fixture " + step.Fixture.File
 		collectVars(vars, step.Fixture.File, step.Fixture.Content, step.Fixture.Symlink)
 
+	case spec.StepService:
+		svc := step.Service
+		st.Command = svc.Command
+		st.Shell = svc.ShellEnabled()
+		st.Target = svc.Name
+		st.Action = "start suite service " + svc.Name
+		collectVars(vars, svc.Command, svc.Cwd)
+
 	case spec.StepRun:
 		r := step.Run
 		st.Command = r.Command

--- a/internal/report/console.go
+++ b/internal/report/console.go
@@ -107,6 +107,39 @@ func writeDetail(b *strings.Builder, color bool, suite string, sc *engine.Scenar
 	}
 }
 
+// writeSuiteDetail prints suite-level setup/teardown failure blocks (#7).
+// A setup failure already errors every scenario; the block explains why. A
+// teardown failure never changes the verdict but must stay loud.
+func writeSuiteDetail(b *strings.Builder, color bool, res *engine.SuiteResult) {
+	writeSuiteSteps(b, color, res.Suite, "SUITE SETUP FAILED:", res.Setup)
+	writeSuiteSteps(b, color, res.Suite, "SUITE TEARDOWN FAILED:", res.Teardown)
+}
+
+func writeSuiteSteps(b *strings.Builder, color bool, suite, label string, steps []engine.StepResult) {
+	for _, step := range steps {
+		for _, ck := range step.Checks {
+			if ck == nil || ck.OK {
+				continue
+			}
+			fmt.Fprintf(b, "\n%s %s\n", colorize(color, cRed+cBold, label), suite)
+			fmt.Fprintf(b, "\nStep:\n  %s\n", ck.Desc)
+			if ck.Expected != "" {
+				fmt.Fprintf(b, "\nExpected:\n%s\n", indent(ck.Expected))
+			}
+			if ck.Actual != "" {
+				fmt.Fprintf(b, "\nActual:\n%s\n", indent(ck.Actual))
+			}
+			if ck.Hint != "" {
+				fmt.Fprintf(b, "\nHint:\n  %s\n", ck.Hint)
+			}
+		}
+		if step.ErrMsg != "" {
+			fmt.Fprintf(b, "\n%s %s\n  step %d (%s): %s\n",
+				colorize(color, cRed+cBold, label), suite, step.Index, step.Kind, step.ErrMsg)
+		}
+	}
+}
+
 // lastCommand returns the most recent run command in a scenario, for context.
 func lastCommand(sc *engine.ScenarioResult) string {
 	cmd := ""

--- a/internal/report/json.go
+++ b/internal/report/json.go
@@ -29,6 +29,11 @@ type jsonReport struct {
 	DurationMS int64          `json:"duration_ms"`
 	Scenarios  []jsonScenario `json:"scenarios"`
 	Failures   []jsonFailure  `json:"failures"`
+	// SetupFailures / TeardownFailures list failed suite.setup / suite.teardown
+	// steps (#7). Setup failures also error every scenario; teardown failures
+	// never change the suite status but incomplete cleanup must stay visible.
+	SetupFailures    []jsonFailure `json:"setup_failures,omitempty"`
+	TeardownFailures []jsonFailure `json:"teardown_failures,omitempty"`
 }
 
 type jsonScenario struct {
@@ -81,6 +86,8 @@ func buildJSON(res *engine.SuiteResult) jsonReport {
 		Scenarios:  make([]jsonScenario, 0, len(res.Scenarios)),
 		Failures:   []jsonFailure{},
 	}
+	out.SetupFailures = suiteStepFailures(res.Suite, res.Setup)
+	out.TeardownFailures = suiteStepFailures(res.Suite, res.Teardown)
 	for i := range res.Scenarios {
 		sc := &res.Scenarios[i]
 		out.Scenarios = append(out.Scenarios, jsonScenario{
@@ -121,6 +128,34 @@ func serviceLogsOf(sc *engine.ScenarioResult) []jsonServiceLog {
 		out = append(out, jsonServiceLog{Name: sl.Name, Path: sl.Path})
 	}
 	return out
+}
+
+// suiteStepFailures maps failed/errored suite-level steps (#7) into the
+// jsonFailure shape, using the suite name as the scenario label.
+func suiteStepFailures(suite string, steps []engine.StepResult) []jsonFailure {
+	var fs []jsonFailure
+	for _, step := range steps {
+		for _, ck := range step.Checks {
+			if ck == nil || ck.OK {
+				continue
+			}
+			fs = append(fs, jsonFailure{
+				Scenario: suite,
+				Step:     ck.Desc,
+				Expected: ck.Expected,
+				Actual:   ck.Actual,
+				Hint:     ck.Hint,
+			})
+		}
+		if step.ErrMsg != "" {
+			fs = append(fs, jsonFailure{
+				Scenario: suite,
+				Step:     stepPhase(step),
+				Error:    step.ErrMsg,
+			})
+		}
+	}
+	return fs
 }
 
 // teardownFailuresOf maps failed/errored teardown steps into the jsonFailure

--- a/internal/report/render.go
+++ b/internal/report/render.go
@@ -25,6 +25,7 @@ func Render(w io.Writer, f Format, results []*engine.SuiteResult) error {
 			for i := range res.Scenarios {
 				writeDetail(&b, color, res.Suite, &res.Scenarios[i])
 			}
+			writeSuiteDetail(&b, color, res)
 			c := res.Counts()
 			agg.Passed += c.Passed
 			agg.Failed += c.Failed

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -56,6 +56,23 @@ type ScenarioDefaults struct {
 // Suite groups scenarios under a name.
 type Suite struct {
 	Name string `yaml:"name"`
+	// Env is exported to every scenario, setup, and teardown step in the
+	// suite (a scenario's own env wins per key). Values get ${name} expansion
+	// against the suite store (${suitedir}, ${env:NAME}, setup stores).
+	Env map[string]string `yaml:"env,omitempty"`
+	// Setup steps run ONCE before any scenario, in declaration order, inside a
+	// suite-scoped scratch directory exposed as ${suitedir} (#7). They exist
+	// so bootstrap shell scripts (build a helper binary, start a shared peer,
+	// warm a cache) become spec YAML. Allowed kinds: fixture, run, store,
+	// assert, and — unique to this block — `service:`, which starts a
+	// suite-wide background process at that exact point in the sequence.
+	// Values captured here (store, ready.store) seed every scenario's store.
+	// A failing setup step marks every scenario errored; no scenario runs.
+	Setup []Step `yaml:"setup,omitempty"`
+	// Teardown steps always run after the last scenario — pass, fail, error,
+	// or interrupt — while suite services are still up (services stop last,
+	// LIFO). Failures are reported but never change the suite verdict.
+	Teardown []Step `yaml:"teardown,omitempty"`
 }
 
 // Runner declares a named runner. cmd is the implicit default for run steps;
@@ -221,6 +238,11 @@ type Step struct {
 	CDP     *CDP     `yaml:"cdp,omitempty"`
 	Assert  *Assert  `yaml:"assert,omitempty"`
 	Store   *Store   `yaml:"store,omitempty"`
+	// Service starts a suite-wide background process (#7). It is valid only
+	// inside suite.setup — the loader rejects it anywhere else — so its
+	// position in the setup sequence controls ordering relative to the run
+	// steps around it (build the binary, then serve it, then warm a cache).
+	Service *Service `yaml:"service,omitempty"`
 }
 
 // Query runs a SQL statement through a named db runner (ADR-0026). The result

--- a/internal/spec/step.go
+++ b/internal/spec/step.go
@@ -13,6 +13,7 @@ const (
 	StepCDP     StepKind = "cdp"
 	StepAssert  StepKind = "assert"
 	StepStore   StepKind = "store"
+	StepService StepKind = "service"
 )
 
 // SetKeys returns the action keys that are present on the step. A valid step has
@@ -42,6 +43,9 @@ func (s *Step) SetKeys() []StepKind {
 	}
 	if s.Store != nil {
 		keys = append(keys, StepStore)
+	}
+	if s.Service != nil {
+		keys = append(keys, StepService)
 	}
 	return keys
 }

--- a/schema/atago.schema.json
+++ b/schema/atago.schema.json
@@ -15,7 +15,26 @@
       "type": "object",
       "required": ["name"],
       "additionalProperties": false,
-      "properties": { "name": { "type": "string", "minLength": 1 } }
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "env": {
+          "description": "Environment exported to every scenario, setup, and teardown step (a scenario's own env wins per key).",
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "setup": {
+          "description": "Steps run ONCE before any scenario, in order, inside the ${suitedir} scratch dir. Allowed kinds: fixture, run, store, assert, and service (a suite-wide background process started at that point in the sequence). A failing setup step errors every scenario.",
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/step" }
+        },
+        "teardown": {
+          "description": "Steps that always run after the last scenario, while suite services are still up (services stop last, LIFO). Failures are reported but never change the suite verdict.",
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/step" }
+        }
+      }
     },
     "runners": {
       "type": "object",
@@ -252,7 +271,8 @@
         { "required": ["grpc"] },
         { "required": ["cdp"] },
         { "required": ["assert"] },
-        { "required": ["store"] }
+        { "required": ["store"] },
+        { "required": ["service"] }
       ],
       "properties": {
         "fixture": { "$ref": "#/$defs/fixture" },
@@ -261,6 +281,10 @@
         "query": { "$ref": "#/$defs/query" },
         "grpc": { "$ref": "#/$defs/grpc" },
         "cdp": { "$ref": "#/$defs/cdp" },
+        "service": {
+          "$ref": "#/$defs/service",
+          "description": "Starts a suite-wide background process at this point in the sequence. Valid only inside suite.setup; the loader rejects it anywhere else."
+        },
         "assert": { "$ref": "#/$defs/assert" },
         "store": { "$ref": "#/$defs/store" }
       }

--- a/test/e2e/atago/suite_setup.atago.yaml
+++ b/test/e2e/atago/suite_setup.atago.yaml
@@ -1,0 +1,139 @@
+# suite.setup / suite.teardown (#7): once-per-suite bootstrap steps (including
+# suite-wide `service:` steps) with ${suitedir}, suite.env, and store sharing;
+# teardown always runs and never changes the verdict.
+version: "1"
+
+suite:
+  name: atago self-hosting / suite setup
+
+scenarios:
+  - name: setup runs once, shares stores and env, and teardown always runs
+    steps:
+      - fixture:
+          file: ok.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: inner
+              env:
+                FLAG: suite-env-flag
+              setup:
+                - run:
+                    shell: true
+                    command: "echo boot-42 > ${suitedir}/t.txt && cat ${suitedir}/t.txt"
+                - store:
+                    name: bootid
+                    from:
+                      stdout:
+                        matches: "boot-[0-9]+"
+              teardown:
+                - run:
+                    shell: true
+                    command: "echo swept ${bootid}"
+            scenarios:
+              - name: one
+                steps:
+                  - run: {shell: true, command: "echo one sees ${bootid} $FLAG"}
+                  - assert:
+                      stdout:
+                        contains:
+                          - one sees boot-42
+                          - suite-env-flag
+              - name: two
+                steps:
+                  - run: {shell: true, command: "echo two sees ${bootid}"}
+                  - assert:
+                      stdout: {contains: two sees boot-42}
+      - run:
+          command: ${atago} run --verbose ok.atago.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "2 passed"
+
+  - name: a failing setup errors every scenario and none runs (exit 4)
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: inner
+              setup:
+                - run: {command: definitely-not-a-real-binary-xyz}
+            scenarios:
+              - name: never runs
+                steps:
+                  - run: {shell: true, command: echo unreached}
+              - name: never runs either
+                steps:
+                  - run: {shell: true, command: echo unreached}
+      - run:
+          command: ${atago} run bad.atago.yaml
+      - assert:
+          exit_code: 4
+          stdout:
+            contains:
+              - "suite setup"
+              - "0 passed"
+              - "2 errored"
+      - assert:
+          stdout:
+            not_contains: unreached
+
+  - name: a suite service starts once and its store reaches every scenario
+    steps:
+      - fixture:
+          file: svc.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: inner
+              setup:
+                - service:
+                    name: peer
+                    shell: true
+                    command: "echo addr-9999 > ${suitedir}/ready.txt && sleep 30"
+                    ready:
+                      file: "${suitedir}/ready.txt"
+                      store: addr
+                      timeout: 5s
+            scenarios:
+              - name: dials
+                steps:
+                  - run: {shell: true, command: "echo dial ${addr}"}
+                  - assert:
+                      stdout: {contains: dial addr-9999}
+      - run:
+          command: ${atago} run svc.atago.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "1 passed"
+
+  - name: a failing suite teardown is loud but does not flip the verdict
+    steps:
+      - fixture:
+          file: td.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: inner
+              setup:
+                - run: {shell: true, command: echo fine}
+              teardown:
+                - run: {command: definitely-not-a-real-binary-xyz}
+            scenarios:
+              - name: passes
+                steps:
+                  - run: {shell: true, command: echo ok}
+                  - assert:
+                      stdout: {contains: ok}
+      - run:
+          command: ${atago} run td.atago.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            contains:
+              - "1 passed"
+              - "SUITE TEARDOWN FAILED"


### PR DESCRIPTION
Closes #7.

## Summary

The gup/sqly ShellSpec→atago migrations both kept a bootstrap **shell script** atago could not absorb: build a helper binary, start a shared peer once, warm a cache, export env. This PR makes that bootstrap spec YAML.

- **`suite.setup:`** — an ordered list of steps run ONCE before any scenario, inside a suite-scoped scratch dir exposed as **`${suitedir}`** (lives until the suite ends). Allowed kinds: `fixture`, `run`, `store`, `assert`, and — unique to this block — **`service:`**, which starts a suite-wide background process *at that exact point in the sequence*. Ordering is the point: real bootstraps interleave build → serve → warm, which the issue's original two-phase design could not express.
- **Sharing** — setup `store` captures and service `ready.store` values seed every scenario's store; `suite.env` layers beneath each scenario's env (scenario wins per key).
- **Failure semantics** — a failing setup step errors **every** scenario with a `suite setup` phase label and nothing runs (exit 4); suite teardown still runs (partial setup may have created external state).
- **`suite.teardown:`** — always runs after the last scenario (pass/fail/error/interrupt, bounded context on interrupt) while suite services are **still up** (services stop last, LIFO). Every teardown step runs even if an earlier one fails; failures are loud — console `SUITE TEARDOWN FAILED` blocks and JSON `setup_failures`/`teardown_failures` — but never change the verdict.
- Surfaced everywhere: JSON schema (suite block + `service` step), `explain` (suite sections), `manifest` (`suite_env` as key names only — values may embed credentials — plus `suite_setup`/`suite_teardown`), a runnable example, and the README examples table.

## TDD

Engine contract tests written first (`internal/engine/suite_setup_test.go`): setup runs exactly once under `--parallel 4`; ordered `service:` steps see files created by preceding run steps and their `ready.store` reaches every scenario; setup failure errors all scenarios with the phase label; teardown always runs, reaches still-running services, and a failing teardown never flips the verdict; absent blocks are a no-op. Loader tests pin the placement rules (`service:` rejected in scenario steps/teardown and suite.teardown; runner-backed kinds rejected at suite level with a pointer; duplicate suite service names). A 4-scenario self-hosted E2E spec drives the real binary, including the exit-4 setup-failure path and the `SUITE TEARDOWN FAILED` console block.

## Verification

- `go test ./...` green, golangci-lint 0 issues
- `make e2e`: **142 scenarios** (138 + 4 new), 141 passed / 1 skipped
- `examples/suite_setup.atago.yaml` runs green on POSIX (validate-only on Windows: suite blocks are unconditional, so a POSIX bootstrap cannot be scenario-`skip`ped — noted in the example header)