### PR TITLE
feat(engine): add pty steps for interactive terminal testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,18 @@ and this project follows [Semantic Versioning](https://semver.org/).
   `setup_failures`/`teardown_failures`) but never change the verdict.
   Surfaced in the JSON schema, `explain`, `manifest`
   (`suite_env`/`suite_setup`/`suite_teardown`), and a runnable example.
+- Interactive terminal testing via `pty` steps (#8) — run one command inside a
+  REAL pseudo-terminal and drive it with a declarative expect/send session,
+  for CLIs that branch on TTY-ness or present interactive prompts (REPLs,
+  wizards). `expect` waits until the transcript matches a regexp; `send` types
+  into the terminal (an empty send transmits EOF/^D); the whole session is
+  bounded by `timeout` (default 30s). The transcript (terminal echo included)
+  becomes the step's stdout, so all stream matchers, snapshots (with their
+  ANSI normalization), and `store from.stdout` work unchanged; a
+  never-matching expect fails like an assertion with the pattern and
+  transcript in the failure block (and as an --artifacts-dir sidecar).
+  POSIX-only for now: the loader accepts the step everywhere, Windows reports
+  a clear execution error (gate with `skip: {os: windows}`).
 
 - `atago run --verbose` (#6): trace every scenario as it finishes — the
   expanded command, exit code / HTTP status, captured stdout/stderr (excerpted

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Every feature has a commented, runnable spec under [examples/](examples/). The e
 | [store_and_variables](examples/store_and_variables.atago.yaml) | capturing values into `${name}`, `${workdir}`, `${env:NAME}` host-environment reads, the `$${...}` literal escape |
 | [teardown](examples/teardown.atago.yaml) | cleanup steps that always run — pass or fail — sharing the scenario's variables |
 | [matrix](examples/matrix.atago.yaml) | one template scenario expanded per parameter row |
+| [pty](examples/pty.atago.yaml) | interactive testing in a real pseudo-terminal: expect/send sessions, TTY-detection (POSIX-only) |
 | [retry](examples/retry.atago.yaml) | polling a command until an assertion passes |
 | [snapshot](examples/snapshot.atago.yaml) | golden-file testing with normalized output |
 | [services](examples/services.atago.yaml) | background servers: readiness probes, `ready.store`, teardown |

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-41 suites · 137 scenarios
+42 suites · 139 scenarios
 ## Contents
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 3 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
@@ -116,6 +116,9 @@
 - [atago self-hosting / pdf assertion](#atago-self-hosting--pdf-assertion) — 2 scenarios
   - [pdf assertions cover page count, metadata, and text](#scenario-pdf-assertions-cover-page-count-metadata-and-text)
   - [a non-pdf file fails the pdf target](#scenario-a-non-pdf-file-fails-the-pdf-target)
+- [atago self-hosting / pty](#atago-self-hosting--pty) — 2 scenarios
+  - [a pty step sees a terminal where a run step sees a pipe](#scenario-a-pty-step-sees-a-terminal-where-a-run-step-sees-a-pipe)
+  - [a never-matching expect fails with the pattern in the block](#scenario-a-never-matching-expect-fails-with-the-pattern-in-the-block)
 - [atago self-hosting / reports](#atago-self-hosting--reports) — 4 scenarios
   - [JUnit report is XML with a testsuite and testcase](#scenario-junit-report-is-xml-with-a-testsuite-and-testcase)
   - [GitHub Actions annotations are emitted on failure](#scenario-github-actions-annotations-are-emitted-on-failure)
@@ -1947,6 +1950,62 @@ ${atago} version
 ```
 #### Then
 - exit code is `0`
+## atago self-hosting / pty
+Source: `test/e2e/atago/pty.atago.yaml`
+### Scenario: a pty step sees a terminal where a run step sees a pipe
+_skipped on windows_
+#### Given
+- Fixture file `tty.atago.yaml` is created.
+#### Inputs
+_Fixture `tty.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: inner
+scenarios:
+  - name: tty
+    steps:
+      - pty:
+          shell: true
+          command: 'if [ -t 0 ]; then echo saw-a-tty; else echo saw-a-pipe; fi'
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: saw-a-tty
+```
+#### When
+```shell
+${atago} run tty.atago.yaml
+```
+#### Then
+- exit code is `0`
+- stdout contains `1 passed`
+### Scenario: a never-matching expect fails with the pattern in the block
+_skipped on windows_
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: inner
+scenarios:
+  - name: waits forever
+    steps:
+      - pty:
+          command: cat
+          timeout: 2s
+          session:
+            - expect: "prompt-that-never-comes"
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `pty expect /prompt-that-never-comes/`, `never appeared in the terminal transcript`
 ## atago self-hosting / reports
 Source: `test/e2e/atago/reports.atago.yaml`
 ### Scenario: JUnit report is XML with a testsuite and testcase

--- a/examples/pty.atago.yaml
+++ b/examples/pty.atago.yaml
@@ -1,0 +1,49 @@
+version: "1"
+
+# A `pty` step runs one command inside a REAL pseudo-terminal and drives it
+# with a declarative expect/send session — for CLIs that branch on TTY-ness or
+# present an interactive prompt (REPLs, wizards). The captured transcript
+# (terminal echo included) becomes the step's stdout, so every stream matcher,
+# snapshot, and `store from.stdout` works unchanged. An `expect` waits until
+# the transcript matches the regexp; a `send` types into the terminal (include
+# "\n" to press enter; an empty send: "" transmits EOF, i.e. Ctrl-D). The
+# whole session is bounded by `timeout` (default 30s) — a prompt that never
+# appears fails loudly instead of hanging.
+# POSIX-only for now; on Windows the step reports a clear execution error.
+# Runs green as-is on Linux/macOS: atago run examples/pty.atago.yaml
+
+suite:
+  name: pty
+
+scenarios:
+  - name: the program sees a real terminal
+    skip:
+      os: windows
+    steps:
+      # `[ -t 0 ]` is the classic "am I connected to a TTY?" probe. Under a
+      # plain `run:` step stdin is a pipe and this prints is-a-pipe.
+      - pty:
+          shell: true
+          command: 'if [ -t 0 ]; then echo is-a-tty; else echo is-a-pipe; fi'
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: is-a-tty
+
+  - name: drive an interactive session with expect and send
+    skip:
+      os: windows
+    steps:
+      # cat in a terminal behaves like a tiny echo-REPL: each line you type is
+      # echoed back. expect gates each send; the final empty send is Ctrl-D.
+      - pty:
+          command: cat
+          timeout: 10s
+          session:
+            - send: "hello interactive world\n"
+            - expect: "hello interactive world"
+            - send: ""
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: hello interactive world

--- a/examples_test.go
+++ b/examples_test.go
@@ -27,6 +27,7 @@ var exampleSpecs = map[string]bool{ // path -> hermetic (run, not just validate)
 	"examples/image_and_pdf.atago.yaml":       true,
 	"examples/json_and_yaml.atago.yaml":       true,
 	"examples/matrix.atago.yaml":              true,
+	"examples/pty.atago.yaml":                 true,
 	"examples/retry.atago.yaml":               true,
 	"examples/run_and_assert.atago.yaml":      true,
 	"examples/select_skip_only.atago.yaml":    true,

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26
 require (
 	github.com/chromedp/cdproto v0.0.0-20260321001828-e3e3800016bc
 	github.com/chromedp/chromedp v0.15.1
+	github.com/creack/pty v1.1.24
 	github.com/gliderlabs/ssh v0.3.8
 	github.com/go-sql-driver/mysql v1.10.0
 	github.com/goccy/go-yaml v1.19.2

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/clipperhouse/stringish v0.1.1 h1:+NSqMOr3GR6k1FdRhhnXrLfztGzuG+VuFDfa
 github.com/clipperhouse/stringish v0.1.1/go.mod h1:v/WhFtE1q0ovMta2+m+UbpZ+2/HEXNWYXQgCt4hdOzA=
 github.com/clipperhouse/uax29/v2 v2.3.0 h1:SNdx9DVUqMoBuBoW3iLOj4FQv3dN5mDtuqwuhIGpJy4=
 github.com/clipperhouse/uax29/v2 v2.3.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=

--- a/internal/docgen/docgen.go
+++ b/internal/docgen/docgen.go
@@ -234,6 +234,10 @@ func commands(steps []spec.Step, expand func(string) string) []string {
 			if step.GRPC != nil {
 				out = append(out, fmt.Sprintf("# gRPC %s via %s", step.GRPC.Method, step.GRPC.Runner))
 			}
+		case spec.StepPTY:
+			if step.PTY != nil {
+				out = append(out, fmt.Sprintf("# interactive (pty): %s", expand(step.PTY.Command)))
+			}
 		case spec.StepCDP:
 			if step.CDP != nil {
 				out = append(out, "# CDP via "+step.CDP.Runner+": "+cdpActions(step.CDP))

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -544,6 +544,22 @@ func (e *Engine) runScenario(ctx context.Context, scenarioIdx int, sc *spec.Scen
 			}
 			current = r
 			sr.Run = maskResult(masker, r)
+		case spec.StepPTY:
+			r, ef, err := e.runPTY(ctx, step.PTY, st, sc.Env, workdir)
+			if err != nil {
+				sr.ErrMsg = err.Error()
+				return sr, StatusError, false
+			}
+			current = r
+			sr.Run = maskResult(masker, r)
+			if ef != nil {
+				// A never-matching expect fails like an assertion: the pattern
+				// and the transcript excerpt land in the failure block.
+				ck := ptyExpectCheck(ef)
+				e.recordChecks(masker, []*assert.CheckResult{ck}, rc.specPath, sc.Name, scenarioIdx, i)
+				sr.Checks = []*assert.CheckResult{ck}
+				status = StatusFailed
+			}
 		case spec.StepCDP:
 			r, err := e.runCDP(ctx, expandCDP(st, step.CDP), workdir, st, rc, browserConns)
 			if err != nil {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -545,7 +545,7 @@ func (e *Engine) runScenario(ctx context.Context, scenarioIdx int, sc *spec.Scen
 			current = r
 			sr.Run = maskResult(masker, r)
 		case spec.StepPTY:
-			r, ef, err := e.runPTY(ctx, step.PTY, st, sc.Env, workdir)
+			r, ef, err := e.runPTY(ctx, step.PTY, st, scEnv, workdir)
 			if err != nil {
 				sr.ErrMsg = err.Error()
 				return sr, StatusError, false

--- a/internal/engine/pty.go
+++ b/internal/engine/pty.go
@@ -1,0 +1,56 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nao1215/atago/internal/assert"
+	"github.com/nao1215/atago/internal/runner"
+	runnercmd "github.com/nao1215/atago/internal/runner/cmd"
+	"github.com/nao1215/atago/internal/runner/ptyrun"
+	"github.com/nao1215/atago/internal/spec"
+	"github.com/nao1215/atago/internal/store"
+)
+
+// runPTY executes a pty step (#8): expand ${name} in the command and session,
+// compose the process environment (scenario env layered under the step's own,
+// both expanded), and drive the terminal session in the scenario workdir.
+func (e *Engine) runPTY(ctx context.Context, p *spec.PTY, st *store.Store, scenarioEnv map[string]string, workdir string) (*runner.Result, *ptyrun.ExpectFailure, error) {
+	c := *p
+	c.Command = st.Expand(p.Command)
+	c.Cwd = st.Expand(p.Cwd)
+	merged := make(map[string]string, len(scenarioEnv)+len(p.Env))
+	for k, v := range st.ExpandMap(scenarioEnv) {
+		merged[k] = v
+	}
+	for k, v := range st.ExpandMap(p.Env) { // step env overrides scenario env
+		merged[k] = v
+	}
+	c.Env = merged
+	if len(p.Session) > 0 {
+		c.Session = make([]spec.PTYAction, len(p.Session))
+		for i, a := range p.Session {
+			na := spec.PTYAction{Expect: st.Expand(a.Expect)}
+			if a.Send != nil {
+				sent := st.Expand(*a.Send)
+				na.Send = &sent
+			}
+			c.Session[i] = na
+		}
+	}
+	return ptyrun.Run(ctx, &c, workdir, runnercmd.BuildEnv(c.Env))
+}
+
+// ptyExpectCheck converts a never-matched session expect into the structured
+// check shape every other failure uses, so the console block and JSON report
+// need no new machinery.
+func ptyExpectCheck(ef *ptyrun.ExpectFailure) *assert.CheckResult {
+	return &assert.CheckResult{
+		Desc:           fmt.Sprintf("pty expect /%s/", ef.Pattern),
+		Expected:       fmt.Sprintf("terminal transcript matches /%s/", ef.Pattern),
+		Actual:         ef.Transcript,
+		Hint:           "the expected pattern never appeared in the terminal transcript before the session timeout",
+		ArtifactKind:   "pty",
+		ArtifactActual: []byte(ef.Transcript),
+	}
+}

--- a/internal/engine/pty_test.go
+++ b/internal/engine/pty_test.go
@@ -119,6 +119,33 @@ scenarios:
 	}
 }
 
+// TestEngine_PTY_SeesSuiteEnv proves suite.env reaches pty commands like it
+// reaches run steps (CodeRabbit finding on #12: the pty step dropped it).
+func TestEngine_PTY_SeesSuiteEnv(t *testing.T) {
+	skipOnWindows(t)
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: s
+  env:
+    PTY_SUITE_FLAG: from-suite-env
+scenarios:
+  - name: pty inherits the suite environment
+    steps:
+      - pty:
+          shell: true
+          command: echo flag=$PTY_SUITE_FLAG
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: flag=from-suite-env
+`)
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed: %+v", res.Status, res.Scenarios)
+	}
+}
+
 // TestEngine_PTY_StoreAndVariablesFlow proves ${name} expansion reaches send
 // payloads and the transcript feeds `store from.stdout` like any run step.
 func TestEngine_PTY_StoreAndVariablesFlow(t *testing.T) {

--- a/internal/engine/pty_test.go
+++ b/internal/engine/pty_test.go
@@ -1,0 +1,159 @@
+package engine
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// The pty step (#8) runs one command inside a real pseudo-terminal and drives
+// it with a declarative expect/send session — the gap that kept sqly's
+// interactive-shell coverage on a hand-written Go PTY harness when its
+// ShellSpec suite moved to atago. The transcript feeds the stdout assertion
+// target, so all stream matchers work unchanged.
+
+func skipOnWindows(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("pty steps are POSIX-only for now (ConPTY later)")
+	}
+}
+
+// TestEngine_PTY_AllocatesARealTerminal is the reason the step exists: a
+// program that branches on TTY-ness must see a terminal. A plain run step
+// pipes stdin and would print "pipe".
+func TestEngine_PTY_AllocatesARealTerminal(t *testing.T) {
+	skipOnWindows(t)
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: s
+scenarios:
+  - name: stdin is a tty under pty
+    steps:
+      - pty:
+          shell: true
+          command: 'if [ -t 0 ]; then echo is-a-tty; else echo is-a-pipe; fi'
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: is-a-tty
+  - name: stdin is a pipe under plain run
+    steps:
+      - run:
+          shell: true
+          command: 'if [ -t 0 ]; then echo is-a-tty; else echo is-a-pipe; fi'
+      - assert:
+          stdout:
+            contains: is-a-pipe
+`)
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed: %+v", res.Status, res.Scenarios)
+	}
+}
+
+// TestEngine_PTY_ExpectSendSession drives a cat "REPL": terminal echo means
+// every sent line lands in the transcript, expect gates each send, and an EOF
+// (^D) ends the session with exit 0.
+func TestEngine_PTY_ExpectSendSession(t *testing.T) {
+	skipOnWindows(t)
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: s
+scenarios:
+  - name: drive cat interactively
+    steps:
+      - pty:
+          command: cat
+          timeout: 10s
+          session:
+            - send: "hello-repl\n"
+            - expect: "hello-repl"
+            - send: "second-line\n"
+            - expect: "second-line"
+            - send: ""
+      - assert:
+          exit_code: 0
+          stdout:
+            contains:
+              - hello-repl
+              - second-line
+`)
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed: %+v", res.Status, res.Scenarios)
+	}
+}
+
+// TestEngine_PTY_ExpectTimeoutFailsTheStep proves a never-matching expect
+// fails like an assertion (scenario failed, not errored), names the pattern,
+// and does not leak the child process.
+func TestEngine_PTY_ExpectTimeoutFailsTheStep(t *testing.T) {
+	skipOnWindows(t)
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: s
+scenarios:
+  - name: expect never matches
+    steps:
+      - pty:
+          command: cat
+          timeout: 2s
+          session:
+            - send: "something-else\n"
+            - expect: "never-going-to-appear"
+`)
+	if res.Status != StatusFailed {
+		t.Fatalf("status = %s, want failed: %+v", res.Status, res.Scenarios)
+	}
+	checks := res.Scenarios[0].Steps[0].Checks
+	if len(checks) == 0 || checks[0].OK {
+		t.Fatalf("want a failing expect check, got %+v", checks)
+	}
+	if !strings.Contains(checks[0].Desc, "never-going-to-appear") {
+		t.Errorf("check desc = %q, want it to name the pattern", checks[0].Desc)
+	}
+}
+
+// TestEngine_PTY_StoreAndVariablesFlow proves ${name} expansion reaches send
+// payloads and the transcript feeds `store from.stdout` like any run step.
+func TestEngine_PTY_StoreAndVariablesFlow(t *testing.T) {
+	skipOnWindows(t)
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: s
+scenarios:
+  - name: variables flow through the session
+    steps:
+      - run: {shell: true, command: echo token-777}
+      - store:
+          name: tok
+          from:
+            stdout:
+              matches: "token-[0-9]+"
+      - pty:
+          command: cat
+          timeout: 10s
+          session:
+            - send: "use ${tok}\n"
+            - expect: "use token-777"
+            - send: ""
+      - store:
+          name: fromtty
+          from:
+            stdout:
+              matches: "use token-[0-9]+"
+      - run: {shell: true, command: "echo captured ${fromtty}"}
+      - assert:
+          stdout: {contains: captured use token-777}
+`)
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed: %+v", res.Status, res.Scenarios)
+	}
+}

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -125,6 +125,11 @@ func explainScenario(b *strings.Builder, sc *spec.Scenario) {
 				commands = append(commands, fmt.Sprintf("gRPC %s via %s", step.GRPC.Method, step.GRPC.Runner))
 				collectVars(vars, step.GRPC.Method)
 			}
+		case spec.StepPTY:
+			if step.PTY != nil {
+				commands = append(commands, fmt.Sprintf("interactive (pty): %s  [%d session actions]", step.PTY.Command, len(step.PTY.Session)))
+				collectVars(vars, step.PTY.Command)
+			}
 		case spec.StepCDP:
 			if step.CDP != nil {
 				commands = append(commands, describeCDP(step.CDP))

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -128,7 +128,16 @@ func explainScenario(b *strings.Builder, sc *spec.Scenario) {
 		case spec.StepPTY:
 			if step.PTY != nil {
 				commands = append(commands, fmt.Sprintf("interactive (pty): %s  [%d session actions]", step.PTY.Command, len(step.PTY.Session)))
-				collectVars(vars, step.PTY.Command)
+				collectVars(vars, step.PTY.Command, step.PTY.Cwd)
+				for _, v := range step.PTY.Env {
+					collectVars(vars, v)
+				}
+				for _, a := range step.PTY.Session {
+					collectVars(vars, a.Expect)
+					if a.Send != nil {
+						collectVars(vars, *a.Send)
+					}
+				}
 			}
 		case spec.StepCDP:
 			if step.CDP != nil {

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -245,6 +245,24 @@ func TestLoadBytes_Errors(t *testing.T) {
 			wantMsg:  "run.command is required",
 		},
 		{
+			name:     "pty session entry needs exactly one of expect and send",
+			src:      "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps:\n      - pty:\n          command: cat\n          session:\n            - expect: hi\n              send: \"yo\\n\"",
+			wantKind: KindValidation,
+			wantMsg:  "set exactly one of expect/send",
+		},
+		{
+			name:     "pty expect must be a valid regexp",
+			src:      "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps:\n      - pty:\n          command: cat\n          session:\n            - expect: \"hi[\"",
+			wantKind: KindValidation,
+			wantMsg:  "is not a valid regexp",
+		},
+		{
+			name:     "pty timeout must be a duration",
+			src:      "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps:\n      - pty: {command: cat, timeout: \"soon\"}",
+			wantKind: KindValidation,
+			wantMsg:  "pty.timeout \"soon\" is not a valid duration",
+		},
+		{
 			name:     "invalid fixture mtime fails at load",
 			src:      "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps:\n      - fixture: {file: f.txt, content: x, mtime: \"yesterday\"}\n      - run: {command: echo}",
 			wantKind: KindValidation,

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -257,6 +257,18 @@ func TestLoadBytes_Errors(t *testing.T) {
 			wantMsg:  "is not a valid regexp",
 		},
 		{
+			name:     "pty timeout must be positive",
+			src:      "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps:\n      - pty: {command: cat, timeout: \"0s\"}",
+			wantKind: KindValidation,
+			wantMsg:  "pty.timeout must be positive",
+		},
+		{
+			name:     "pty rows above the terminal limit are rejected",
+			src:      "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps:\n      - pty: {command: cat, rows: 70000}",
+			wantKind: KindValidation,
+			wantMsg:  "rows/cols must be between 0 and 65535",
+		},
+		{
 			name:     "pty timeout must be a duration",
 			src:      "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps:\n      - pty: {command: cat, timeout: \"soon\"}",
 			wantKind: KindValidation,

--- a/internal/loader/validate.go
+++ b/internal/loader/validate.go
@@ -429,12 +429,18 @@ func validatePTY(add func(string, ...any), where string, p *spec.PTY) {
 		add("%s.pty.command is required", where)
 	}
 	if p.Timeout != "" {
-		if _, err := time.ParseDuration(p.Timeout); err != nil {
+		d, err := time.ParseDuration(p.Timeout)
+		switch {
+		case err != nil:
 			add("%s.pty.timeout %q is not a valid duration (e.g. \"30s\")", where, p.Timeout)
+		case d <= 0:
+			add("%s.pty.timeout must be positive (got %q); omit it for the 30s default", where, p.Timeout)
 		}
 	}
-	if p.Rows < 0 || p.Cols < 0 {
-		add("%s.pty: rows/cols must be >= 0", where)
+	// A pty size is a uint16 on the wire; reject values the terminal cannot
+	// represent instead of silently truncating.
+	if p.Rows < 0 || p.Cols < 0 || p.Rows > 65535 || p.Cols > 65535 {
+		add("%s.pty: rows/cols must be between 0 and 65535", where)
 	}
 	for i, a := range p.Session {
 		aw := fmt.Sprintf("%s.pty.session[%d]", where, i)

--- a/internal/loader/validate.go
+++ b/internal/loader/validate.go
@@ -416,6 +416,40 @@ func validateStep(add func(string, ...any), where string, st *spec.Step, runners
 		validateStore(add, where, st.Store)
 	case spec.StepService:
 		add("%s: service steps are only allowed in suite.setup (scenario-scoped peers go under the scenario's services: list)", where)
+	case spec.StepPTY:
+		validatePTY(add, where, st.PTY)
+	}
+}
+
+// validatePTY checks a pty step (#8): a command, sane duration/size values,
+// and a session whose entries each set exactly one of expect/send with
+// compilable expect regexps.
+func validatePTY(add func(string, ...any), where string, p *spec.PTY) {
+	if p.Command == "" {
+		add("%s.pty.command is required", where)
+	}
+	if p.Timeout != "" {
+		if _, err := time.ParseDuration(p.Timeout); err != nil {
+			add("%s.pty.timeout %q is not a valid duration (e.g. \"30s\")", where, p.Timeout)
+		}
+	}
+	if p.Rows < 0 || p.Cols < 0 {
+		add("%s.pty: rows/cols must be >= 0", where)
+	}
+	for i, a := range p.Session {
+		aw := fmt.Sprintf("%s.pty.session[%d]", where, i)
+		hasExpect := a.Expect != ""
+		hasSend := a.Send != nil
+		switch {
+		case hasExpect && hasSend:
+			add("%s: set exactly one of expect/send (got both)", aw)
+		case !hasExpect && !hasSend:
+			add("%s: set exactly one of expect/send (an empty send: \"\" transmits EOF)", aw)
+		case hasExpect:
+			if _, err := regexp.Compile(a.Expect); err != nil {
+				add("%s.expect %q is not a valid regexp: %v", aw, a.Expect, err)
+			}
+		}
 	}
 }
 

--- a/internal/manifest/scenario.go
+++ b/internal/manifest/scenario.go
@@ -176,6 +176,9 @@ func buildStep(index int, step *spec.Step, vars map[string]bool) Step {
 		st.Shell = pt.Shell != nil && *pt.Shell
 		st.Action = "interactive (pty) " + pt.Command
 		collectVars(vars, pt.Command, pt.Cwd)
+		for _, v := range pt.Env {
+			collectVars(vars, v)
+		}
 		for _, a := range pt.Session {
 			if a.Send != nil {
 				collectVars(vars, *a.Send)

--- a/internal/manifest/scenario.go
+++ b/internal/manifest/scenario.go
@@ -170,6 +170,19 @@ func buildStep(index int, step *spec.Step, vars map[string]bool) Step {
 			}
 		}
 
+	case spec.StepPTY:
+		pt := step.PTY
+		st.Command = pt.Command
+		st.Shell = pt.Shell != nil && *pt.Shell
+		st.Action = "interactive (pty) " + pt.Command
+		collectVars(vars, pt.Command, pt.Cwd)
+		for _, a := range pt.Session {
+			if a.Send != nil {
+				collectVars(vars, *a.Send)
+			}
+			collectVars(vars, a.Expect)
+		}
+
 	case spec.StepAssert:
 		st.Target = assertTarget(step.Assert)
 		st.Action = "assert " + st.Target

--- a/internal/runner/ptyrun/ptyrun.go
+++ b/internal/runner/ptyrun/ptyrun.go
@@ -1,0 +1,63 @@
+// Package ptyrun runs one command inside a real pseudo-terminal and drives it
+// with a declarative expect/send session (#8). It exists for CLIs that branch
+// on TTY-ness (readline prompts, spinners, interactive shells) — the one
+// surface a piped `run` step cannot reach. The captured transcript (terminal
+// echo included) becomes the step's stdout, so the ordinary stream matchers,
+// snapshots, and `store from.stdout` all work unchanged.
+package ptyrun
+
+import (
+	"regexp"
+	"time"
+
+	"github.com/nao1215/atago/internal/spec"
+)
+
+// defaultSessionTimeout bounds a pty session when the spec sets none: an
+// interactive program that never produces the expected prompt (or never
+// exits) must fail loudly instead of hanging the run.
+const defaultSessionTimeout = 30 * time.Second
+
+// defaultRows / defaultCols are the terminal size when the spec sets none.
+const (
+	defaultRows = 24
+	defaultCols = 80
+)
+
+// ExpectFailure describes the first session `expect` that never matched within
+// the session budget. The engine reports it like a failed assertion (the
+// scenario fails; it is not an execution error).
+type ExpectFailure struct {
+	Pattern    string // the regexp that never matched
+	Transcript string // the transcript at the moment the budget elapsed
+}
+
+// compileSession validates and compiles the expect patterns up front so a bad
+// regexp is one error for the whole step. The loader already validated shape;
+// this is the runtime backstop.
+func compileSession(actions []spec.PTYAction) ([]*regexp.Regexp, error) {
+	res := make([]*regexp.Regexp, len(actions))
+	for i, a := range actions {
+		if a.Expect == "" {
+			continue
+		}
+		re, err := regexp.Compile(a.Expect)
+		if err != nil {
+			return nil, err
+		}
+		res[i] = re
+	}
+	return res, nil
+}
+
+// sessionTimeout resolves the whole-session budget.
+func sessionTimeout(p *spec.PTY) time.Duration {
+	if p.Timeout == "" {
+		return defaultSessionTimeout
+	}
+	d, err := time.ParseDuration(p.Timeout)
+	if err != nil || d <= 0 {
+		return defaultSessionTimeout
+	}
+	return d
+}

--- a/internal/runner/ptyrun/ptyrun_unix.go
+++ b/internal/runner/ptyrun/ptyrun_unix.go
@@ -142,6 +142,16 @@ func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runne
 		return finish(true, nil, ef)
 	}
 
+	// failHard cleans up (kill, reap, close, drain) before surfacing a hard
+	// error, so a failed terminal write never leaks the child or goroutines.
+	failHard := func(err error) (*runner.Result, *ExpectFailure, error) {
+		kill()
+		<-waitCh
+		_ = master.Close()
+		<-readDone
+		return nil, nil, err
+	}
+
 	// Drive the session in order. expect polls the transcript; send writes to
 	// the terminal; an empty send transmits EOF (^D).
 	for i, a := range p.Session {
@@ -168,12 +178,12 @@ func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runne
 			if *a.Send == "" {
 				// EOF: ^D. Terminals deliver it as VEOF on an empty input line.
 				if _, werr := master.Write([]byte{0x04}); werr != nil {
-					return nil, nil, fmt.Errorf("pty: send EOF: %w", werr)
+					return failHard(fmt.Errorf("pty: send EOF: %w", werr))
 				}
 				continue
 			}
 			if _, werr := master.Write([]byte(*a.Send)); werr != nil {
-				return nil, nil, fmt.Errorf("pty: send: %w", werr)
+				return failHard(fmt.Errorf("pty: send: %w", werr))
 			}
 		}
 	}

--- a/internal/runner/ptyrun/ptyrun_unix.go
+++ b/internal/runner/ptyrun/ptyrun_unix.go
@@ -1,0 +1,200 @@
+//go:build !windows
+
+package ptyrun
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/creack/pty"
+
+	"github.com/nao1215/atago/internal/runner"
+	runnercmd "github.com/nao1215/atago/internal/runner/cmd"
+	"github.com/nao1215/atago/internal/spec"
+)
+
+// pollInterval is how often an expect re-checks the accumulated transcript.
+const pollInterval = 10 * time.Millisecond
+
+// Run executes p.Command inside a pseudo-terminal in workdir, drives the
+// expect/send session, waits for the process to exit within the session
+// budget, and returns the transcript as the result's stdout. A never-matching
+// expect is returned as an ExpectFailure (reported like a failed assertion);
+// only "could not start/drive the terminal" conditions are hard errors.
+func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runner.Result, *ExpectFailure, error) {
+	expects, err := compileSession(p.Session)
+	if err != nil {
+		return nil, nil, fmt.Errorf("pty: invalid expect regexp: %w", err)
+	}
+
+	name, args, err := runnercmd.CommandLine(p.Command, p.Shell != nil && *p.Shell)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	budget := sessionTimeout(p)
+	ctx, cancel := context.WithTimeout(ctx, budget)
+	defer cancel()
+
+	// CommandContext gives noctx its context; Cancel is overridden below so a
+	// timeout kills the whole process group (Setsid), not only the child.
+	cmd := exec.CommandContext(ctx, name, args...) //nolint:gosec // the spec author's declared command is the subject under test
+	cmd.Cancel = func() error {
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+	cmd.Dir = workdir
+	if p.Cwd != "" {
+		cmd.Dir = resolveCwd(workdir, p.Cwd)
+	}
+	cmd.Env = env
+	// A fresh process group so cleanup kills the whole tree, mirroring the cmd
+	// runner's teardown discipline.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+
+	rows, cols := uint16(defaultRows), uint16(defaultCols)
+	if p.Rows > 0 && p.Rows < 1<<16 {
+		rows = uint16(p.Rows)
+	}
+	if p.Cols > 0 && p.Cols < 1<<16 {
+		cols = uint16(p.Cols)
+	}
+	master, err := pty.StartWithSize(cmd, &pty.Winsize{Rows: rows, Cols: cols})
+	if err != nil {
+		return nil, nil, fmt.Errorf("pty: start %q: %w", p.Command, err)
+	}
+
+	start := time.Now()
+
+	// Reap exactly once, from one place: probing a zombie with signal 0 keeps
+	// succeeding, so liveness must come from Wait itself.
+	waitCh := make(chan error, 1)
+	go func() { waitCh <- cmd.Wait() }()
+
+	// Transcript accumulator: one goroutine drains the master so the child
+	// never blocks on a full terminal buffer. Reads end when the child exits
+	// (EIO) or the master is closed.
+	var mu sync.Mutex
+	var transcript []byte
+	readDone := make(chan struct{})
+	go func() {
+		defer close(readDone)
+		buf := make([]byte, 4096)
+		for {
+			n, rerr := master.Read(buf)
+			if n > 0 {
+				mu.Lock()
+				transcript = append(transcript, buf[:n]...)
+				mu.Unlock()
+			}
+			if rerr != nil {
+				return
+			}
+		}
+	}()
+	snapshot := func() []byte {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]byte(nil), transcript...)
+	}
+
+	kill := func() {
+		// Negative pid signals the whole process group created by Setsid.
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+
+	finish := func(timedOut bool, waitErr error, ef *ExpectFailure) (*runner.Result, *ExpectFailure, error) {
+		_ = master.Close()
+		<-readDone
+		res := &runner.Result{
+			Command:  p.Command,
+			Stdout:   snapshot(),
+			Duration: time.Since(start),
+			Workdir:  cmd.Dir,
+			TimedOut: timedOut,
+		}
+		switch {
+		case timedOut:
+			res.ExitCode = -1
+		case waitErr == nil:
+			res.ExitCode = 0
+		default:
+			var exitErr *exec.ExitError
+			if errors.As(waitErr, &exitErr) {
+				res.ExitCode = exitErr.ExitCode()
+			} else {
+				res.ExitCode = -1
+			}
+		}
+		return res, ef, nil
+	}
+
+	// abort kills the tree and reaps it, then finishes as timed out.
+	abort := func(ef *ExpectFailure) (*runner.Result, *ExpectFailure, error) {
+		kill()
+		waitErr := <-waitCh
+		_ = waitErr
+		return finish(true, nil, ef)
+	}
+
+	// Drive the session in order. expect polls the transcript; send writes to
+	// the terminal; an empty send transmits EOF (^D).
+	for i, a := range p.Session {
+		if expects[i] != nil {
+			matched := false
+			for !matched {
+				if expects[i].Match(snapshot()) {
+					matched = true
+					break
+				}
+				select {
+				case <-ctx.Done():
+				case <-time.After(pollInterval):
+					continue
+				}
+				break
+			}
+			if !matched {
+				return abort(&ExpectFailure{Pattern: a.Expect, Transcript: string(snapshot())})
+			}
+			continue
+		}
+		if a.Send != nil {
+			if *a.Send == "" {
+				// EOF: ^D. Terminals deliver it as VEOF on an empty input line.
+				if _, werr := master.Write([]byte{0x04}); werr != nil {
+					return nil, nil, fmt.Errorf("pty: send EOF: %w", werr)
+				}
+				continue
+			}
+			if _, werr := master.Write([]byte(*a.Send)); werr != nil {
+				return nil, nil, fmt.Errorf("pty: send: %w", werr)
+			}
+		}
+	}
+
+	// Session complete: wait for the child to exit within the budget.
+	select {
+	case waitErr := <-waitCh:
+		return finish(false, waitErr, nil)
+	case <-ctx.Done():
+		return abort(nil)
+	}
+}
+
+// resolveCwd resolves a step cwd against the scenario workdir like the cmd
+// runner does: relative paths nest inside the workdir.
+func resolveCwd(workdir, cwd string) string {
+	if cwd == "" {
+		return workdir
+	}
+	if len(cwd) > 0 && cwd[0] == '/' {
+		return cwd
+	}
+	return workdir + string(os.PathSeparator) + cwd
+}

--- a/internal/runner/ptyrun/ptyrun_windows.go
+++ b/internal/runner/ptyrun/ptyrun_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package ptyrun
+
+import (
+	"context"
+	"errors"
+
+	"github.com/nao1215/atago/internal/runner"
+	"github.com/nao1215/atago/internal/spec"
+)
+
+// Run reports that pty steps are POSIX-only for now. The loader accepts the
+// step on every platform so specs stay portable to author; at execution time
+// Windows gets one clear error (an execution error, exit 4) instead of a
+// confusing terminal failure. ConPTY support can lift this later.
+func Run(_ context.Context, _ *spec.PTY, _ string, _ []string) (*runner.Result, *ExpectFailure, error) {
+	return nil, nil, errors.New("pty steps are not supported on Windows yet (POSIX-only; gate the scenario with `skip: {os: windows}`)")
+}

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -243,6 +243,11 @@ type Step struct {
 	// position in the setup sequence controls ordering relative to the run
 	// steps around it (build the binary, then serve it, then warm a cache).
 	Service *Service `yaml:"service,omitempty"`
+	// PTY runs one command inside a real pseudo-terminal and drives it with a
+	// declarative expect/send session (#8) — for CLIs that branch on TTY-ness
+	// or present an interactive prompt. POSIX-only for now; the loader accepts
+	// the step everywhere and the engine reports a clear error on Windows.
+	PTY *PTY `yaml:"pty,omitempty"`
 }
 
 // Query runs a SQL statement through a named db runner (ADR-0026). The result
@@ -411,6 +416,41 @@ type Retry struct {
 	// Until is a single assertion polled after each attempt; the loop stops as
 	// soon as it passes. When it never passes, the run step fails.
 	Until *Assert `yaml:"until"`
+}
+
+// PTY runs a command inside a pseudo-terminal (#8). The captured transcript
+// (terminal echo included, ANSI intact) becomes the step's stdout, so every
+// stream matcher, snapshot (with its ANSI normalization), and
+// `store from.stdout` works unchanged.
+type PTY struct {
+	Command string `yaml:"command"`
+	// Shell runs Command through the shell like run.shell.
+	Shell *bool  `yaml:"shell,omitempty"`
+	Cwd   string `yaml:"cwd,omitempty"`
+	// Rows / Cols set the terminal size (default 24x80).
+	Rows int `yaml:"rows,omitempty"`
+	Cols int `yaml:"cols,omitempty"`
+	// Timeout bounds the WHOLE session as a Go duration (default "30s"): a
+	// prompt that never appears or a program that never exits fails loudly
+	// instead of hanging the run.
+	Timeout string            `yaml:"timeout,omitempty"`
+	Env     map[string]string `yaml:"env,omitempty"`
+	// Session is the ordered expect/send script. Each entry sets exactly one
+	// of Expect (wait until the accumulated transcript matches the regexp) or
+	// Send (write the string to the terminal; an empty send transmits EOF,
+	// i.e. ^D). Deliberately no branching — atago is not a scripting language.
+	Session []PTYAction `yaml:"session,omitempty"`
+}
+
+// PTYAction is one expect-or-send entry in a pty session (#8).
+type PTYAction struct {
+	// Expect waits until the transcript matches this regexp. A never-matching
+	// expect fails the step (reported like an assertion) when the session
+	// timeout elapses.
+	Expect string `yaml:"expect,omitempty"`
+	// Send writes this string to the terminal verbatim (include "\n" to press
+	// enter). The empty string sends EOF (^D). ${name} expansion applies.
+	Send *string `yaml:"send,omitempty"`
 }
 
 // HTTP issues an HTTP request (post-MVP).

--- a/internal/spec/step.go
+++ b/internal/spec/step.go
@@ -14,6 +14,7 @@ const (
 	StepAssert  StepKind = "assert"
 	StepStore   StepKind = "store"
 	StepService StepKind = "service"
+	StepPTY     StepKind = "pty"
 )
 
 // SetKeys returns the action keys that are present on the step. A valid step has
@@ -46,6 +47,9 @@ func (s *Step) SetKeys() []StepKind {
 	}
 	if s.Service != nil {
 		keys = append(keys, StepService)
+	}
+	if s.PTY != nil {
+		keys = append(keys, StepPTY)
 	}
 	return keys
 }

--- a/schema/atago.schema.json
+++ b/schema/atago.schema.json
@@ -272,7 +272,8 @@
         { "required": ["cdp"] },
         { "required": ["assert"] },
         { "required": ["store"] },
-        { "required": ["service"] }
+        { "required": ["service"] },
+        { "required": ["pty"] }
       ],
       "properties": {
         "fixture": { "$ref": "#/$defs/fixture" },
@@ -285,6 +286,7 @@
           "$ref": "#/$defs/service",
           "description": "Starts a suite-wide background process at this point in the sequence. Valid only inside suite.setup; the loader rejects it anywhere else."
         },
+        "pty": { "$ref": "#/$defs/pty" },
         "assert": { "$ref": "#/$defs/assert" },
         "store": { "$ref": "#/$defs/store" }
       }
@@ -438,6 +440,34 @@
         "times": { "type": "integer", "minimum": 1 },
         "interval": { "type": "string" },
         "until": { "$ref": "#/$defs/assert" }
+      }
+    },
+    "pty": {
+      "type": "object",
+      "required": ["command"],
+      "additionalProperties": false,
+      "description": "Runs one command inside a real pseudo-terminal and drives it with a declarative expect/send session (#8) — for CLIs that branch on TTY-ness or present interactive prompts. POSIX-only at runtime; Windows reports a clear execution error.",
+      "properties": {
+        "command": { "type": "string", "minLength": 1 },
+        "shell": { "type": "boolean" },
+        "cwd": { "type": "string" },
+        "rows": { "type": "integer", "minimum": 0 },
+        "cols": { "type": "integer", "minimum": 0 },
+        "timeout": { "type": "string", "description": "Go duration bounding the WHOLE session (default 30s)." },
+        "env": { "type": "object", "additionalProperties": { "type": "string" } },
+        "session": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Exactly one of expect (wait until the transcript matches the regexp) or send (write to the terminal; \"\" sends EOF/^D).",
+            "properties": {
+              "expect": { "type": "string" },
+              "send": { "type": "string" }
+            }
+          }
+        }
       }
     },
     "http": {

--- a/test/e2e/atago/pty.atago.yaml
+++ b/test/e2e/atago/pty.atago.yaml
@@ -1,0 +1,61 @@
+# pty steps (#8): a real pseudo-terminal with a declarative expect/send
+# session. POSIX-only; every scenario here skips on Windows.
+version: "1"
+
+suite:
+  name: atago self-hosting / pty
+
+scenarios:
+  - name: a pty step sees a terminal where a run step sees a pipe
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: tty.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: inner
+            scenarios:
+              - name: tty
+                steps:
+                  - pty:
+                      shell: true
+                      command: 'if [ -t 0 ]; then echo saw-a-tty; else echo saw-a-pipe; fi'
+                  - assert:
+                      exit_code: 0
+                      stdout:
+                        contains: saw-a-tty
+      - run:
+          command: ${atago} run tty.atago.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "1 passed"
+
+  - name: a never-matching expect fails with the pattern in the block
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: inner
+            scenarios:
+              - name: waits forever
+                steps:
+                  - pty:
+                      command: cat
+                      timeout: 2s
+                      session:
+                        - expect: "prompt-that-never-comes"
+      - run:
+          command: ${atago} run bad.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "pty expect /prompt-that-never-comes/"
+              - "never appeared in the terminal transcript"


### PR DESCRIPTION
Closes #8 (option A from the issue).

## Summary

A `pty:` step runs one command inside a **real pseudo-terminal** and drives it with a declarative expect/send session — the gap that kept sqly's interactive-shell coverage on a hand-written Go PTY harness when its ShellSpec suite migrated.

- `expect:` waits until the accumulated transcript matches a regexp; `send:` types into the terminal (`""` transmits EOF/^D). Deliberately no branching — mirroring the cdp action-list design.
- The whole session is bounded by `timeout:` (default 30s): a prompt that never appears **fails like an assertion** — the failure block carries `pty expect /pattern/`, the transcript as Actual, and the transcript as an `--artifacts-dir` sidecar — and the child process group is killed.
- The transcript (terminal echo included) becomes the step's stdout, so every stream matcher, snapshot (ANSI normalization included), and `store from.stdout` works unchanged; `${name}`/`${env:NAME}` expand in command/sends/expects.
- **POSIX-only for now** (creack/pty): the loader accepts the step everywhere so specs stay portable to author; Windows reports one clear execution error suggesting `skip: {os: windows}`. ConPTY can lift this later.
- Surfaced in the JSON schema, `explain`, `doc`, `manifest`, a hermetic example, and a self-hosted E2E spec.

## TDD

Engine tests written first: the motivating TTY-detection pair (`[ -t 0 ]` prints `is-a-tty` under pty, `is-a-pipe` under plain run), an expect/send session against a `cat` echo-REPL ending in EOF with exit 0, a never-matching expect failing the scenario (not erroring) with the pattern named, and `${name}` flowing in / the transcript flowing out through `store`. Loader tests pin session shape (exactly one of expect/send), regexp compilation, and duration validation.

The first implementation had a real bug the tests caught: liveness was probed with `Signal(0)`, which keeps succeeding on a **zombie** — every session "hung" until its timeout. Reaping now happens exactly once through a `Wait` goroutine, and a context timeout kills the whole process group via `cmd.Cancel`.

## Verification

- `go test ./...` green, golangci-lint 0 issues
- `make e2e`: 140 scenarios (138 + 2 new), 139 passed / 1 skipped
- `examples/pty.atago.yaml` (hermetic; scenarios skip on Windows) runs green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for interactive terminal steps using a real pseudo-terminal.
  * You can now drive CLI sessions with declarative `expect` and `send` actions, including EOF handling.

* **Bug Fixes**
  * PTY interactions now surface clear failures when an expected prompt or output never appears.
  * Added validation for terminal-step settings, including timeouts, dimensions, and session entries.

* **Documentation**
  * Updated examples, changelog, schema, and behavior docs to cover the new terminal-interaction workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->