### PR TITLE
chore(release): prepare v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-07-03
+
+Suite-level bootstrap, interactive terminal testing, and verbose scenario
+tracing — the three features real ShellSpec migrations were still missing.
+
 ### Added
 
 - Suite-level `setup:` / `teardown:` / `env:` (#7) — the bootstrap shell


### PR DESCRIPTION
## Summary

Cut the changelog for **v0.2.0**: suite-level bootstrap (`suite.setup`/`services`/`teardown`, #7), interactive terminal testing (`pty` steps, #8), verbose scenario tracing (`--verbose`, #6), plus the jq/openssl/sqlite3 third-party suites — stamped as `[0.2.0] - 2026-07-03` with an empty `[Unreleased]` section kept on top.

## Release flow

After this merges: `git tag v0.2.0 && git push origin v0.2.0` triggers GoReleaser (archives, cosign-signed checksums, SBOMs, SLSA provenance, Homebrew cask).

## Verification

Base commit is green across all workflows; the self-hosted E2E suite is at 144 scenarios.