### PR TITLE
fix(pty): drain the reader before closing the master so fast-exit output is kept

### DIFF
--- a/internal/runner/ptyrun/ptyrun_unix.go
+++ b/internal/runner/ptyrun/ptyrun_unix.go
@@ -22,6 +22,11 @@ import (
 // pollInterval is how often an expect re-checks the accumulated transcript.
 const pollInterval = 10 * time.Millisecond
 
+// drainGrace bounds how long finish waits for the reader to hit EIO before
+// closing the master: an orphaned grandchild that inherited the slave can hold
+// the terminal open indefinitely, and its output is not worth hanging for.
+const drainGrace = 2 * time.Second
+
 // Run executes p.Command inside a pseudo-terminal in workdir, drives the
 // expect/send session, waits for the process to exit within the session
 // budget, and returns the transcript as the result's stdout. A never-matching
@@ -109,6 +114,14 @@ func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runne
 	}
 
 	finish := func(timedOut bool, waitErr error, ef *ExpectFailure) (*runner.Result, *ExpectFailure, error) {
+		// Drain before closing: a fast-exiting child's final output may still
+		// sit in the pty buffer, and closing the master discards it. Once the
+		// last slave fd is gone the reader hits EIO and readDone closes on its
+		// own; drainGrace bounds the wait in case a descendant kept the slave.
+		select {
+		case <-readDone:
+		case <-time.After(drainGrace):
+		}
 		_ = master.Close()
 		<-readDone
 		res := &runner.Result{

--- a/internal/runner/ptyrun/ptyrun_unix_test.go
+++ b/internal/runner/ptyrun/ptyrun_unix_test.go
@@ -1,0 +1,41 @@
+//go:build !windows
+
+package ptyrun
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/atago/internal/spec"
+)
+
+// TestRun_FastExitOutputNotLost is a regression test for a drain race: a child
+// that writes and exits immediately could lose its output when the master was
+// closed before the reader goroutine drained the pty buffer (seen as a flaky
+// examples/pty.atago.yaml failure under coverage instrumentation). Repeating
+// the fast-exit case many times makes the lost-output window reliably visible.
+func TestRun_FastExitOutputNotLost(t *testing.T) {
+	t.Parallel()
+
+	shell := true
+	for i := range 200 {
+		p := &spec.PTY{
+			Shell:   &shell,
+			Command: "if [ -t 0 ]; then echo is-a-tty; else echo is-a-pipe; fi",
+		}
+		res, ef, err := Run(context.Background(), p, t.TempDir(), nil)
+		if err != nil {
+			t.Fatalf("iteration %d: unexpected error: %v", i, err)
+		}
+		if ef != nil {
+			t.Fatalf("iteration %d: unexpected expect failure: %+v", i, ef)
+		}
+		if res.ExitCode != 0 {
+			t.Fatalf("iteration %d: exit code = %d, want 0 (stdout %q)", i, res.ExitCode, res.Stdout)
+		}
+		if !strings.Contains(string(res.Stdout), "is-a-tty") {
+			t.Fatalf("iteration %d: transcript lost the child's output: %q", i, res.Stdout)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The `Coverage` workflow on `main` (commit 5e5efc7, a CHANGELOG-only change) failed in `TestExamples_HermeticRunGreen/examples/pty.atago.yaml`: the *the program sees a real terminal* scenario got an **empty transcript** even though the child printed `is-a-tty`.

Root cause: `finish()` closed the pty master **before** waiting for the reader goroutine. When the child writes and exits immediately, `cmd.Wait()` can return before the reader goroutine ever gets scheduled; closing the master then discards the output still sitting in the pty buffer, so the transcript comes back empty. Coverage instrumentation just shifted the timing enough to expose it.

## Fix

`finish()` now waits for the reader to hit EIO (`readDone`) **before** closing the master — once the last slave fd is gone the reader drains the buffer and exits on its own. The wait is bounded by a 2s `drainGrace` so an orphaned grandchild that inherited the slave cannot hang the step; after the grace the master is closed and the reader unblocks as before.

## Reproduction / TDD

`TestRun_FastExitOutputNotLost` runs the exact failing probe 200 times. Before the fix it fails reliably under `GOMAXPROCS=1` (empty transcript, same as CI); after the fix it is green under `GOMAXPROCS=1`, `-race`, and coverage instrumentation.

## Verification

- `GOMAXPROCS=1 go test -run TestRun_FastExitOutputNotLost -count=10 ./internal/runner/ptyrun/` — fails before, green after
- `go test -race ./internal/runner/ptyrun/` — green
- `go test ./...` / `golangci-lint run` / `make docs` / `make site` — green, no drift