### PR TITLE
fix(dogfood): run the mimixbox slice serially to avoid kill-by-name races

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,11 @@ dogfood-mimixbox: ## Full mimixbox applet e2e (builds + --full-installs applets;
 	# Builds the mimixbox multi-call binary, installs every applet into an
 	# isolated bin dir put FIRST on PATH, then runs the atago specs against the
 	# real applets (the atago replacement for mimixbox's ShellSpec suite).
-	bash ./test/e2e/tools/mimixbox/run.sh --parallel $(PARALLEL)
+	# --parallel 1 on purpose: the kill-family scenarios (killall/pkill/pgrep)
+	# signal processes BY NAME, so running them alongside other scenarios'
+	# `sleep` processes is a cross-scenario race (seen as a flaky
+	# "sleeps then returns" failure under --parallel 8).
+	bash ./test/e2e/tools/mimixbox/run.sh --parallel 1
 
 dogfood-mobilepkg: ## Full mobilepkg e2e (builds latest mobilepkg; set MOBILEPKG_REPO)
 	bash ./test/e2e/tools/mobilepkg/run.sh --parallel $(PARALLEL)


### PR DESCRIPTION
## Summary

`make dogfood-mimixbox` ran with `--parallel $(PARALLEL)` (default 8). The mimixbox suite contains kill-family scenarios — `killall sleep`, `pkill`, `pgrep` — that signal processes **by name**, so under parallelism they race any concurrently running scenario that happens to have a `sleep` in flight. This surfaced as a flaky failure in mimixbox's own CI after the suite was ported there (PR nao1215/mimixbox#995): *mimixbox sleep / sleeps then returns* died with exit 143 (SIGTERM) because a parallel `killall sleep` scenario shot it down.

The mimixbox repo now pins its `make e2e` to `--parallel 1`; this applies the same fix to atago's dogfood slice (ShellSpec, which these specs were ported from, was sequential too). The suite is cheap serially (~10s for 1,522 scenarios), so nothing meaningful is lost.

## Verification

- `test/e2e/tools/mimixbox/run.sh --parallel 1` against mimixbox HEAD: 1,522 scenarios — 1,520 passed, 2 skipped (documented sandbox gates), repeated 4x with no flakes.