### PR TITLE
feat(engine): add hermetic environment control with clear_env and pass_env

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ scenarios:
             empty: true
 ```
 
-`atago run` accepts spec files and directories (searched recursively for `*.atago.yaml`). Each scenario runs in its own temporary directory, and progress streams as a dot per scenario (`.` pass, `F` fail, `E` error, `s` skip):
+`atago run` accepts spec files and directories (searched recursively for `*.atago.yaml`). Each scenario runs in its own temporary directory, and progress streams as a dot per scenario (`.` pass, `F` fail, `E` error, `s` skip). For full reproducibility a step can also opt out of the inherited host environment with `clear_env: true` (re-admitting an allowlist via `pass_env`), so host vars like `LANG` or `GIT_*` cannot make a spec pass on one machine and fail on another:
 
 ```shell
 $ atago run ./specs
@@ -136,6 +136,7 @@ Every feature has a commented, runnable spec under [examples/](examples/). The e
 | [files_and_fixtures](examples/files_and_fixtures.atago.yaml) | input fixtures (text and base64), `file` and `dir` assertions |
 | [store_and_variables](examples/store_and_variables.atago.yaml) | capturing values into `${name}`, `${workdir}`, `${env:NAME}` host-environment reads, the `$${...}` literal escape |
 | [teardown](examples/teardown.atago.yaml) | cleanup steps that always run — pass or fail — sharing the scenario's variables |
+| [hermetic_env](examples/hermetic_env.atago.yaml) | `clear_env: true` starts commands from an empty environment, `pass_env` re-admits an allowlist of host variables |
 | [matrix](examples/matrix.atago.yaml) | one template scenario expanded per parameter row |
 | [pty](examples/pty.atago.yaml) | interactive testing in a real pseudo-terminal: expect/send sessions, TTY-detection (POSIX-only) |
 | [retry](examples/retry.atago.yaml) | polling a command until an assertion passes |

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-42 suites · 139 scenarios
+43 suites · 144 scenarios
 ## Contents
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 3 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
@@ -61,6 +61,12 @@
 - [atago self-hosting / grpc runner](#atago-self-hosting--grpc-runner) — 2 scenarios
   - [a grpc runner without a target fails validation (exit 2)](#scenario-a-grpc-runner-without-a-target-fails-validation-exit-2)
   - [a grpc step naming an undeclared runner fails validation (exit 2)](#scenario-a-grpc-step-naming-an-undeclared-runner-fails-validation-exit-2)
+- [atago self-hosting / hermetic environment (clear_env + pass_env)](#atago-self-hosting--hermetic-environment-clear_env--pass_env) — 5 scenarios
+  - [clear_env drops inherited host variables](#scenario-clear_env-drops-inherited-host-variables)
+  - [pass_env re-admits an allowlist of host variables](#scenario-pass_env-re-admits-an-allowlist-of-host-variables)
+  - [explicit env wins over a passed-through host variable](#scenario-explicit-env-wins-over-a-passed-through-host-variable)
+  - [pass_env without clear_env is a load-time error](#scenario-pass_env-without-clear_env-is-a-load-time-error)
+  - [unset host variables in pass_env are skipped, not an error](#scenario-unset-host-variables-in-pass_env-are-skipped-not-an-error)
 - [atago self-hosting / http runner](#atago-self-hosting--http-runner) — 2 scenarios
   - [a denied host is a security policy violation (exit 6)](#scenario-a-denied-host-is-a-security-policy-violation-exit-6)
   - [an http step with an undeclared runner fails validation (exit 2)](#scenario-an-http-step-with-an-undeclared-runner-fails-validation-exit-2)
@@ -1109,6 +1115,84 @@ ${atago} run norunner.atago.yaml
 #### Then
 - exit code is `2`
 - stderr contains `is not declared`
+## atago self-hosting / hermetic environment (clear_env + pass_env)
+Source: `test/e2e/atago/hermetic_env.atago.yaml`
+### Scenario: clear_env drops inherited host variables
+_skipped on windows_
+#### Given
+- The command runs with a cleared environment.
+#### When
+```shell
+env
+env
+```
+#### Then
+- after `env`:
+  - exit code is `0`
+  - stdout contains `ATAGO_HERMETIC_CANARY`
+- after `env`:
+  - exit code is `0`
+  - stdout contains `ATAGO_HERMETIC_CANARY=leaked-from-scenario`
+  - stdout does not contain `PATH=/`
+### Scenario: pass_env re-admits an allowlist of host variables
+_skipped on windows_
+#### Given
+- The command runs with a cleared environment (passing through: PATH).
+#### When
+```shell
+env
+```
+#### Then
+- exit code is `0`
+- stdout contains `PATH=`
+- stdout does not contain `HOME=`
+### Scenario: explicit env wins over a passed-through host variable
+_skipped on windows_
+#### Given
+- Environment variables are set: HOME.
+- The command runs with a cleared environment (passing through: HOME).
+#### When
+```shell
+printf '%s\n' "$HOME"
+```
+#### Then
+- exit code is `0`
+- stdout equals an exact value
+### Scenario: pass_env without clear_env is a load-time error
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: bad
+scenarios:
+  - name: forgot clear_env
+    steps:
+      - run:
+          command: env
+          pass_env: [PATH]
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `pass_env requires clear_env: true`, `steps[0].run`
+### Scenario: unset host variables in pass_env are skipped, not an error
+_skipped on windows_
+#### Given
+- The command runs with a cleared environment (passing through: PATH, ATAGO_SURELY_UNSET_VAR_2026).
+#### When
+```shell
+env
+```
+#### Then
+- exit code is `0`
+- stdout contains `PATH=`
+- stdout does not contain `ATAGO_SURELY_UNSET_VAR_2026`
 ## atago self-hosting / http runner
 Source: `test/e2e/atago/http.atago.yaml`
 ### Scenario: a denied host is a security policy violation (exit 6)

--- a/examples/hermetic_env.atago.yaml
+++ b/examples/hermetic_env.atago.yaml
@@ -1,0 +1,75 @@
+version: "1"
+
+# Hermetic environment control (#16): `clear_env: true` starts the child from
+# an EMPTY environment instead of inheriting the host's, so host vars (LANG,
+# GIT_*, NO_COLOR, proxy settings, ...) cannot silently change the behavior
+# under test — the spec passes on your machine and in CI for the same reason.
+# `pass_env` re-admits an explicit allowlist of host variables (unset ones are
+# skipped); explicit `env:` overrides are layered on top as always.
+#
+# Note the distinction from `${env:NAME}` interpolation: `${env:NAME}` is
+# resolved by atago itself (it reads the real host environment and substitutes
+# the value into the spec string), while clear_env/pass_env control what the
+# CHILD PROCESS sees in its own environment block. A value injected via
+# `${env:...}` into `env:` survives clear_env because it became an explicit
+# override.
+#
+# On Windows a small system-critical set (SystemRoot, SystemDrive, TEMP, TMP,
+# PATHEXT) is always retained so processes can start at all. The probe
+# commands below are POSIX, so these scenarios skip on Windows.
+# Runs green as-is on Linux/macOS: atago run examples/hermetic_env.atago.yaml
+
+suite:
+  name: hermetic environment
+
+scenarios:
+  - name: clear_env hides the host environment from the child
+    skip:
+      os: windows
+    steps:
+      # `env` prints the child's environment, one VAR=value per line. With
+      # clear_env and only an explicit env override, that is ALL the child sees.
+      - run:
+          command: env
+          clear_env: true
+          env:
+            ONLY_THIS: survives
+      - assert:
+          exit_code: 0
+          stdout:
+            equals: ONLY_THIS=survives
+
+  - name: pass_env re-admits an allowlist of host variables
+    skip:
+      os: windows
+    steps:
+      # PATH is copied from the host; HOME is not listed, so it stays hidden.
+      - run:
+          command: env
+          clear_env: true
+          pass_env: [PATH]
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "PATH="
+      # A stream assert sets exactly one matcher, so the negative check is its
+      # own step: HOME was not in the allowlist and stays hidden.
+      - assert:
+          stdout:
+            not_contains: "HOME="
+
+  - name: explicit env still wins over a passed-through host variable
+    skip:
+      os: windows
+    steps:
+      - run:
+          shell: true
+          command: "printf '%s\\n' \"$HOME\""
+          clear_env: true
+          pass_env: [HOME]
+          env:
+            HOME: /hermetic/home
+      - assert:
+          exit_code: 0
+          stdout:
+            equals: /hermetic/home

--- a/examples_test.go
+++ b/examples_test.go
@@ -23,6 +23,7 @@ var exampleSpecs = map[string]bool{ // path -> hermetic (run, not just validate)
 	"examples/defaults.atago.yaml":            true,
 	"examples/files_and_fixtures.atago.yaml":  true,
 	"examples/grpc.atago.yaml":                false,
+	"examples/hermetic_env.atago.yaml":        true,
 	"examples/http.atago.yaml":                false,
 	"examples/image_and_pdf.atago.yaml":       true,
 	"examples/json_and_yaml.atago.yaml":       true,

--- a/internal/docgen/docgen.go
+++ b/internal/docgen/docgen.go
@@ -206,6 +206,13 @@ func givenBullets(sc *spec.Scenario, expand func(string) string) []string {
 			if len(step.Run.Env) > 0 {
 				out = append(out, "Environment variables are set: "+strings.Join(sortedEnvKeys(step.Run.Env), ", ")+".")
 			}
+			if step.Run.ClearEnvEnabled() {
+				bullet := "The command runs with a cleared environment"
+				if len(step.Run.PassEnv) > 0 {
+					bullet += " (passing through: " + strings.Join(step.Run.PassEnv, ", ") + ")"
+				}
+				out = append(out, bullet+".")
+			}
 		}
 	}
 	return out

--- a/internal/docgen/docgen.go
+++ b/internal/docgen/docgen.go
@@ -207,15 +207,25 @@ func givenBullets(sc *spec.Scenario, expand func(string) string) []string {
 				out = append(out, "Environment variables are set: "+strings.Join(sortedEnvKeys(step.Run.Env), ", ")+".")
 			}
 			if step.Run.ClearEnvEnabled() {
-				bullet := "The command runs with a cleared environment"
-				if len(step.Run.PassEnv) > 0 {
-					bullet += " (passing through: " + strings.Join(step.Run.PassEnv, ", ") + ")"
-				}
-				out = append(out, bullet+".")
+				out = append(out, clearedEnvBullet(step.Run.PassEnv))
+			}
+		case spec.StepPTY:
+			if step.PTY.ClearEnvEnabled() {
+				out = append(out, clearedEnvBullet(step.PTY.PassEnv))
 			}
 		}
 	}
 	return out
+}
+
+// clearedEnvBullet renders the hermetic-environment Given bullet shared by run
+// and pty steps (#16).
+func clearedEnvBullet(passEnv []string) string {
+	bullet := "The command runs with a cleared environment"
+	if len(passEnv) > 0 {
+		bullet += " (passing through: " + strings.Join(passEnv, ", ") + ")"
+	}
+	return bullet + "."
 }
 
 // commands renders the "When" narrative. It covers every action step kind, not

--- a/internal/docgen/docgen_test.go
+++ b/internal/docgen/docgen_test.go
@@ -148,6 +148,8 @@ scenarios:
           content: "{}"
       - run:
           command: gup list --json
+          clear_env: true
+          pass_env: [PATH]
           env:
             GOBIN: ./tmp/bin
       - assert:
@@ -178,6 +180,7 @@ scenarios:
 		"#### Given",
 		"Fixture file `config.yaml` is created.",
 		"Environment variables are set: GOBIN.",
+		"The command runs with a cleared environment (passing through: PATH).",
 		"#### When",
 		"```shell",
 		"gup list --json",

--- a/internal/docgen/docgen_test.go
+++ b/internal/docgen/docgen_test.go
@@ -154,6 +154,12 @@ scenarios:
             GOBIN: ./tmp/bin
       - assert:
           exit_code: 0
+      - pty:
+          command: gup interactive
+          clear_env: true
+          pass_env: [TERM]
+          session:
+            - send: ""
       - assert:
           stdout:
             json:
@@ -181,6 +187,7 @@ scenarios:
 		"Fixture file `config.yaml` is created.",
 		"Environment variables are set: GOBIN.",
 		"The command runs with a cleared environment (passing through: PATH).",
+		"The command runs with a cleared environment (passing through: TERM).",
 		"#### When",
 		"```shell",
 		"gup list --json",

--- a/internal/engine/pty.go
+++ b/internal/engine/pty.go
@@ -38,7 +38,7 @@ func (e *Engine) runPTY(ctx context.Context, p *spec.PTY, st *store.Store, scena
 			c.Session[i] = na
 		}
 	}
-	return ptyrun.Run(ctx, &c, workdir, runnercmd.BuildEnv(c.Env))
+	return ptyrun.Run(ctx, &c, workdir, runnercmd.BuildEnv(c.Env, c.ClearEnvEnabled(), c.PassEnv))
 }
 
 // ptyExpectCheck converts a never-matched session expect into the structured

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -127,7 +127,15 @@ func explainScenario(b *strings.Builder, sc *spec.Scenario) {
 			}
 		case spec.StepPTY:
 			if step.PTY != nil {
-				commands = append(commands, fmt.Sprintf("interactive (pty): %s  [%d session actions]", step.PTY.Command, len(step.PTY.Session)))
+				desc := fmt.Sprintf("interactive (pty): %s  [%d session actions]", step.PTY.Command, len(step.PTY.Session))
+				if step.PTY.ClearEnvEnabled() {
+					note := "  (cleared environment"
+					if len(step.PTY.PassEnv) > 0 {
+						note += ", passes: " + strings.Join(step.PTY.PassEnv, ", ")
+					}
+					desc += note + ")"
+				}
+				commands = append(commands, desc)
 				collectVars(vars, step.PTY.Command, step.PTY.Cwd)
 				for _, v := range step.PTY.Env {
 					collectVars(vars, v)

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -214,6 +214,13 @@ func explainScenario(b *strings.Builder, sc *spec.Scenario) {
 // readiness is decided (ADR-0031).
 func describeService(svc *spec.Service) string {
 	desc := svc.Name + ": " + svc.Command
+	if svc.ClearEnvEnabled() {
+		note := "  [cleared environment"
+		if len(svc.PassEnv) > 0 {
+			note += ", passes: " + strings.Join(svc.PassEnv, ", ")
+		}
+		desc += note + "]"
+	}
 	if svc.Ready == nil {
 		return desc
 	}
@@ -259,6 +266,13 @@ func describeRun(r *spec.Run) string {
 	}
 	if len(r.Env) > 0 {
 		notes = append(notes, "env: "+strings.Join(sortedKeys(toSet(r.Env)), ", "))
+	}
+	if r.ClearEnvEnabled() {
+		note := "cleared environment"
+		if len(r.PassEnv) > 0 {
+			note += " (passes: " + strings.Join(r.PassEnv, ", ") + ")"
+		}
+		notes = append(notes, note)
 	}
 	if r.ShellEnabled() {
 		notes = append(notes, "shell")

--- a/internal/explain/explain_test.go
+++ b/internal/explain/explain_test.go
@@ -397,6 +397,14 @@ scenarios:
           clear_env: true
       - assert:
           exit_code: 0
+      - pty:
+          command: cat
+          clear_env: true
+          pass_env: [TERM]
+          session:
+            - send: ""
+      - assert:
+          exit_code: 0
 `
 	s, err := loader.LoadBytes("t.atago.yaml", []byte(src))
 	if err != nil {
@@ -411,6 +419,7 @@ scenarios:
 		"cleared environment (passes: PATH, HOME)",
 		"cleared environment)",
 		"[cleared environment, passes: PATH]",
+		"(cleared environment, passes: TERM)",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("explain output missing %q\n--- got ---\n%s", want, out)

--- a/internal/explain/explain_test.go
+++ b/internal/explain/explain_test.go
@@ -370,6 +370,54 @@ scenarios:
 	}
 }
 
+// TestExplain_HermeticEnv proves explain surfaces clear_env/pass_env on run
+// steps and services (#16) so a reviewer sees the hermetic-environment intent.
+func TestExplain_HermeticEnv(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: hermetic
+scenarios:
+  - name: cleared
+    services:
+      - name: srv
+        command: ./srv
+        clear_env: true
+        pass_env: [PATH]
+    steps:
+      - run:
+          command: env
+          clear_env: true
+          pass_env: [PATH, HOME]
+      - assert:
+          exit_code: 0
+      - run:
+          command: env
+          clear_env: true
+      - assert:
+          exit_code: 0
+`
+	s, err := loader.LoadBytes("t.atago.yaml", []byte(src))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	var b bytes.Buffer
+	if err := Explain(&b, s, "t.atago.yaml"); err != nil {
+		t.Fatal(err)
+	}
+	out := b.String()
+	for _, want := range []string{
+		"cleared environment (passes: PATH, HOME)",
+		"cleared environment)",
+		"[cleared environment, passes: PATH]",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("explain output missing %q\n--- got ---\n%s", want, out)
+		}
+	}
+}
+
 // TestExplain_AssertVariants exercises describeAssert/describeStream/
 // describeFile/describeImage/jsonMatcher across every matcher shape.
 func TestExplain_AssertVariants(t *testing.T) {

--- a/internal/loader/defaults.go
+++ b/internal/loader/defaults.go
@@ -81,6 +81,14 @@ func mergeRunDefaults(def, r *spec.Run) {
 		r.Stdin = def.Stdin
 	}
 	r.Env = mergeStringMap(def.Env, r.Env)
+	if r.ClearEnv == nil {
+		r.ClearEnv = def.ClearEnv
+	}
+	// pass_env is meaningless without clear_env, so a step that authored
+	// `clear_env: false` does not inherit the default allowlist (#16).
+	if r.PassEnv == nil && r.ClearEnvEnabled() {
+		r.PassEnv = def.PassEnv
+	}
 }
 
 // mergeServiceDefaults layers def beneath an authored service. Name and Command
@@ -95,6 +103,13 @@ func mergeServiceDefaults(def, svc *spec.Service) {
 		svc.Cwd = def.Cwd
 	}
 	svc.Env = mergeStringMap(def.Env, svc.Env)
+	if svc.ClearEnv == nil {
+		svc.ClearEnv = def.ClearEnv
+	}
+	// Mirrors mergeRunDefaults: no allowlist inheritance without clear_env (#16).
+	if svc.PassEnv == nil && svc.ClearEnvEnabled() {
+		svc.PassEnv = def.PassEnv
+	}
 	if svc.Ready == nil && def.Ready != nil {
 		ready := *def.Ready
 		svc.Ready = &ready

--- a/internal/loader/defaults_test.go
+++ b/internal/loader/defaults_test.go
@@ -101,6 +101,182 @@ scenarios:
 	}
 }
 
+// TestApplyDefaults_ClearEnvPassEnv proves defaults.run.clear_env /
+// defaults.run.pass_env layer into steps under the authored-value-wins rule,
+// and the same for defaults.service (#16).
+func TestApplyDefaults_ClearEnvPassEnv(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: sample
+defaults:
+  run:
+    clear_env: true
+    pass_env: [PATH, HOME]
+  service:
+    clear_env: true
+    pass_env: [PATH]
+scenarios:
+  - name: hermetic by default
+    services:
+      - name: mock
+        command: ./mock
+    steps:
+      - run:
+          command: echo hi
+      - run:
+          command: echo bye
+          clear_env: false
+      - run:
+          command: echo own
+          pass_env: [LANG]
+`
+	s, err := LoadBytes("sample.atago.yaml", []byte(src))
+	if err != nil {
+		t.Fatalf("LoadBytes() error = %v", err)
+	}
+	sc := s.Scenarios[0]
+	if !sc.Steps[0].Run.ClearEnvEnabled() {
+		t.Error("step 0: clear_env default not applied")
+	}
+	if got := sc.Steps[0].Run.PassEnv; len(got) != 2 || got[0] != "PATH" || got[1] != "HOME" {
+		t.Errorf("step 0: pass_env = %v, want default [PATH HOME]", got)
+	}
+	if sc.Steps[1].Run.ClearEnvEnabled() {
+		t.Error("step 1: authored clear_env: false must win over the default")
+	}
+	if got := sc.Steps[1].Run.PassEnv; len(got) != 0 {
+		t.Errorf("step 1: pass_env = %v, want none (pass_env is not inherited when clear_env is off)", got)
+	}
+	if got := sc.Steps[2].Run.PassEnv; len(got) != 1 || got[0] != "LANG" {
+		t.Errorf("step 2: pass_env = %v, want the authored [LANG] to win", got)
+	}
+	if !sc.Services[0].ClearEnvEnabled() {
+		t.Error("service: clear_env default not applied")
+	}
+	if got := sc.Services[0].PassEnv; len(got) != 1 || got[0] != "PATH" {
+		t.Errorf("service: pass_env = %v, want default [PATH]", got)
+	}
+}
+
+// TestValidate_PassEnvRequiresClearEnv proves pass_env without clear_env: true
+// is a load-time validation error with a positioned message (#16).
+func TestValidate_PassEnvRequiresClearEnv(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name, src, wantPos string
+	}{
+		{
+			name: "run step",
+			src: `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: s
+    steps:
+      - run:
+          command: echo hi
+          pass_env: [PATH]
+`,
+			wantPos: `scenario "s".steps[0].run`,
+		},
+		{
+			name: "scenario service",
+			src: `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: s
+    services:
+      - name: mock
+        command: ./mock
+        pass_env: [PATH]
+    steps:
+      - run:
+          command: echo hi
+`,
+			wantPos: `service "mock"`,
+		},
+		{
+			name: "pty step",
+			src: `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: s
+    steps:
+      - pty:
+          command: cat
+          pass_env: [PATH]
+`,
+			wantPos: `scenario "s".steps[0].pty`,
+		},
+		{
+			name: "suite setup service",
+			src: `
+version: "1"
+suite:
+  name: sample
+  setup:
+    - service:
+        name: shared
+        command: ./mock
+        pass_env: [PATH]
+scenarios:
+  - name: s
+    steps:
+      - run:
+          command: echo hi
+`,
+			wantPos: "suite.setup[0].service",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := LoadBytes("sample.atago.yaml", []byte(tc.src))
+			if err == nil {
+				t.Fatal("LoadBytes() = nil error, want a pass_env-requires-clear_env validation error")
+			}
+			if !strings.Contains(err.Error(), "pass_env") || !strings.Contains(err.Error(), "clear_env") {
+				t.Errorf("error = %q, want it to mention pass_env requiring clear_env", err)
+			}
+			if !strings.Contains(err.Error(), tc.wantPos) {
+				t.Errorf("error = %q, want position %q", err, tc.wantPos)
+			}
+		})
+	}
+}
+
+// TestValidate_PassEnvEmptyEntryRejected proves an empty variable name inside
+// pass_env is rejected at load time (#16).
+func TestValidate_PassEnvEmptyEntryRejected(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: s
+    steps:
+      - run:
+          command: echo hi
+          clear_env: true
+          pass_env: ["PATH", ""]
+`
+	_, err := LoadBytes("sample.atago.yaml", []byte(src))
+	if err == nil {
+		t.Fatal("LoadBytes() = nil error, want an empty-pass_env-entry validation error")
+	}
+	if !strings.Contains(err.Error(), "pass_env") {
+		t.Errorf("error = %q, want it to mention pass_env", err)
+	}
+}
+
 // TestApplyDefaults_Service proves defaults.service fills shell/env and copies a
 // whole ready probe into a service that declares none, while a service with its
 // own ready keeps it.

--- a/internal/loader/validate.go
+++ b/internal/loader/validate.go
@@ -88,6 +88,7 @@ func validateDefaults(add func(string, ...any), d *spec.Defaults) {
 				add("defaults.run.timeout %q is not a valid duration (e.g. \"30s\")", r.Timeout)
 			}
 		}
+		validateHermeticEnv(add, "defaults.run", r.ClearEnv, r.PassEnv)
 	}
 	if sv := d.Service; sv != nil {
 		if sv.Name != "" {
@@ -96,7 +97,26 @@ func validateDefaults(add func(string, ...any), d *spec.Defaults) {
 		if sv.Command != "" {
 			add("defaults.service.command is not supported (each service sets its own command)")
 		}
+		validateHermeticEnv(add, "defaults.service", sv.ClearEnv, sv.PassEnv)
 		validateReady(add, "defaults.service", sv.Ready)
+	}
+}
+
+// validateHermeticEnv checks the clear_env/pass_env pairing (#16): pass_env is
+// only meaningful when clear_env starts the environment empty, so an
+// allowlist without clear_env: true is authoring confusion and is rejected
+// instead of silently ignored. Empty variable names are rejected too.
+func validateHermeticEnv(add func(string, ...any), where string, clearEnv *bool, passEnv []string) {
+	if len(passEnv) == 0 {
+		return
+	}
+	if clearEnv == nil || !*clearEnv {
+		add("%s.pass_env requires clear_env: true (pass_env selects host vars for a cleared environment)", where)
+	}
+	for i, name := range passEnv {
+		if name == "" {
+			add("%s.pass_env[%d] must not be an empty variable name", where, i)
+		}
 	}
 }
 
@@ -198,6 +218,7 @@ func validateServices(add func(string, ...any), where string, services []spec.Se
 		if svc.Command == "" {
 			add("%s.command is required", sw)
 		}
+		validateHermeticEnv(add, sw, svc.ClearEnv, svc.PassEnv)
 		validateReady(add, sw, svc.Ready)
 	}
 }
@@ -230,6 +251,7 @@ func validateSuiteBlock(add func(string, ...any), where string, steps []spec.Ste
 			if st.Run.Command == "" {
 				add("%s.run.command is required", sw)
 			}
+			validateHermeticEnv(add, sw+".run", st.Run.ClearEnv, st.Run.PassEnv)
 			validateRetry(add, sw+".run", st.Run.Retry)
 		case spec.StepStore:
 			validateStore(add, sw, st.Store)
@@ -251,6 +273,7 @@ func validateSuiteBlock(add func(string, ...any), where string, steps []spec.Ste
 			if svc.Command == "" {
 				add("%s.service.command is required", sw)
 			}
+			validateHermeticEnv(add, sw+".service", svc.ClearEnv, svc.PassEnv)
 			validateReady(add, sw+".service", svc.Ready)
 		default:
 			add("%s: %s steps are per-scenario (they need a scenario workdir and runners); move it into a scenario", sw, st.Kind())
@@ -369,6 +392,7 @@ func validateStep(add func(string, ...any), where string, st *spec.Step, runners
 					"or use `stdout_to` / `stderr_to` for redirection", where, tok)
 			}
 		}
+		validateHermeticEnv(add, where+".run", st.Run.ClearEnv, st.Run.PassEnv)
 		validateRetry(add, where+".run", st.Run.Retry)
 	case spec.StepAssert:
 		validateAssert(add, where, st.Assert)
@@ -437,6 +461,7 @@ func validatePTY(add func(string, ...any), where string, p *spec.PTY) {
 			add("%s.pty.timeout must be positive (got %q); omit it for the 30s default", where, p.Timeout)
 		}
 	}
+	validateHermeticEnv(add, where+".pty", p.ClearEnv, p.PassEnv)
 	// A pty size is a uint16 on the wire; reject values the terminal cannot
 	// represent instead of silently truncating.
 	if p.Rows < 0 || p.Cols < 0 || p.Rows > 65535 || p.Cols > 65535 {

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -143,6 +143,9 @@ type Service struct {
 	Name    string `json:"name"`
 	Command string `json:"command"`
 	Shell   bool   `json:"shell,omitempty"`
+	// ClearEnv / PassEnv mirror the hermetic-environment controls (#16).
+	ClearEnv bool     `json:"clear_env,omitempty"`
+	PassEnv  []string `json:"pass_env,omitempty"`
 	// Ready is the readiness signal kind ("file", "port", "log", "delay") or
 	// empty when the steps start as soon as the process spawns.
 	Ready string `json:"ready,omitempty"`
@@ -158,13 +161,17 @@ type Step struct {
 	// Kind-specific fields, all optional.
 	Command string `json:"command,omitempty"`
 	Shell   bool   `json:"shell,omitempty"`
-	Runner  string `json:"runner,omitempty"`
-	Method  string `json:"method,omitempty"`
-	Path    string `json:"path,omitempty"`
-	SQL     string `json:"sql,omitempty"`
-	File    string `json:"file,omitempty"`
-	Target  string `json:"target,omitempty"` // assert target / store name
-	Retry   *Retry `json:"retry,omitempty"`
+	// ClearEnv / PassEnv mirror the hermetic-environment controls on run, pty,
+	// and suite service steps (#16).
+	ClearEnv bool     `json:"clear_env,omitempty"`
+	PassEnv  []string `json:"pass_env,omitempty"`
+	Runner   string   `json:"runner,omitempty"`
+	Method   string   `json:"method,omitempty"`
+	Path     string   `json:"path,omitempty"`
+	SQL      string   `json:"sql,omitempty"`
+	File     string   `json:"file,omitempty"`
+	Target   string   `json:"target,omitempty"` // assert target / store name
+	Retry    *Retry   `json:"retry,omitempty"`
 	// Source is the authored location of this step (#80).
 	Source *Source `json:"source,omitempty"`
 }

--- a/internal/manifest/scenario.go
+++ b/internal/manifest/scenario.go
@@ -58,7 +58,7 @@ func buildScenario(sc *spec.Scenario, src SourceLocator) Scenario {
 }
 
 func buildService(svc *spec.Service) Service {
-	out := Service{Name: svc.Name, Command: svc.Command, Shell: svc.ShellEnabled()}
+	out := Service{Name: svc.Name, Command: svc.Command, Shell: svc.ShellEnabled(), ClearEnv: svc.ClearEnvEnabled(), PassEnv: svc.PassEnv}
 	if svc.Ready != nil {
 		switch {
 		case svc.Ready.File != "":
@@ -90,6 +90,8 @@ func buildStep(index int, step *spec.Step, vars map[string]bool) Step {
 		svc := step.Service
 		st.Command = svc.Command
 		st.Shell = svc.ShellEnabled()
+		st.ClearEnv = svc.ClearEnvEnabled()
+		st.PassEnv = svc.PassEnv
 		st.Target = svc.Name
 		st.Action = "start suite service " + svc.Name
 		collectVars(vars, svc.Command, svc.Cwd)
@@ -98,6 +100,8 @@ func buildStep(index int, step *spec.Step, vars map[string]bool) Step {
 		r := step.Run
 		st.Command = r.Command
 		st.Shell = r.ShellEnabled()
+		st.ClearEnv = r.ClearEnvEnabled()
+		st.PassEnv = r.PassEnv
 		st.Runner = r.Runner
 		st.Action = "run " + r.Command
 		if r.Retry != nil {
@@ -174,6 +178,8 @@ func buildStep(index int, step *spec.Step, vars map[string]bool) Step {
 		pt := step.PTY
 		st.Command = pt.Command
 		st.Shell = pt.Shell != nil && *pt.Shell
+		st.ClearEnv = pt.ClearEnvEnabled()
+		st.PassEnv = pt.PassEnv
 		st.Action = "interactive (pty) " + pt.Command
 		collectVars(vars, pt.Command, pt.Cwd)
 		for _, v := range pt.Env {

--- a/internal/runner/cmd/cmd.go
+++ b/internal/runner/cmd/cmd.go
@@ -51,7 +51,7 @@ func (r *Runner) Run(ctx context.Context, run *spec.Run, workdir string) (*runne
 		ConfigureShell(cmd, run.Command)
 	}
 	cmd.Dir = resolveDir(workdir, run.Cwd)
-	cmd.Env = buildEnv(run.Env)
+	cmd.Env = buildEnv(run.Env, run.ClearEnvEnabled(), run.PassEnv)
 	// On cancellation (Ctrl-C / suite cancel / step timeout), kill the whole
 	// process group, not just the shell we spawned: `sh -c "sleep 30"` orphans its
 	// child, and that orphan keeps the stdout/stderr pipe open, so cmd.Wait would
@@ -249,9 +249,13 @@ func parseTimeout(s string) (time.Duration, error) {
 // interpreted relative to the scenario workdir (shared with the service runner).
 func ResolveDir(workdir, cwd string) string { return resolveDir(workdir, cwd) }
 
-// BuildEnv inherits the parent environment and applies per-command overrides
-// (shared with the service runner).
-func BuildEnv(overrides map[string]string) []string { return buildEnv(overrides) }
+// BuildEnv composes a child process environment: it inherits the parent
+// environment (or starts empty when clearEnv is set, re-admitting only the
+// passEnv allowlist) and applies per-command overrides on top (shared with the
+// service and pty runners) (#16).
+func BuildEnv(overrides map[string]string, clearEnv bool, passEnv []string) []string {
+	return buildEnv(overrides, clearEnv, passEnv)
+}
 
 // resolveDir returns the working directory for the command. cwd is interpreted
 // relative to the scenario workdir.
@@ -265,14 +269,60 @@ func resolveDir(workdir, cwd string) string {
 	return filepath.Join(workdir, cwd)
 }
 
-// buildEnv inherits the parent environment and applies per-step overrides.
-func buildEnv(overrides map[string]string) []string {
-	if len(overrides) == 0 {
-		return nil // nil → inherit os.Environ() (exec default)
+// windowsCriticalEnv is the documented set of system-critical variables always
+// retained under clear_env on Windows so processes can start at all (#16).
+var windowsCriticalEnv = []string{"SystemRoot", "SystemDrive", "TEMP", "TMP", "PATHEXT"}
+
+// buildEnv composes the child environment. Without clearEnv it inherits the
+// parent environment and appends per-step overrides (a nil return means
+// "inherit os.Environ()", exec's default). With clearEnv it starts empty:
+// only the passEnv allowlist (plus the Windows system-critical set) is copied
+// from the host, and overrides are layered on top so the existing
+// suite → scenario → step precedence is preserved (#16).
+func buildEnv(overrides map[string]string, clearEnv bool, passEnv []string) []string {
+	if !clearEnv {
+		if len(overrides) == 0 {
+			return nil // nil → inherit os.Environ() (exec default)
+		}
+		env := os.Environ()
+		for k, v := range overrides {
+			env = append(env, k+"="+v)
+		}
+		return env
 	}
-	env := os.Environ()
+	env := make([]string, 0, len(passEnv)+len(overrides)+len(windowsCriticalEnv))
+	if runtime.GOOS == "windows" {
+		for _, name := range windowsCriticalEnv {
+			if v, ok := lookupHostEnv(name); ok {
+				env = append(env, name+"="+v)
+			}
+		}
+	}
+	for _, name := range passEnv {
+		if v, ok := lookupHostEnv(name); ok {
+			env = append(env, name+"="+v)
+		}
+	}
 	for k, v := range overrides {
 		env = append(env, k+"="+v)
 	}
 	return env
+}
+
+// lookupHostEnv reads a host variable for pass_env. Windows environment names
+// are case-insensitive (PATH arrives as "Path"), so fall back to a
+// case-insensitive scan there; os.LookupEnv is case-sensitive everywhere.
+func lookupHostEnv(name string) (string, bool) {
+	if v, ok := os.LookupEnv(name); ok {
+		return v, true
+	}
+	if runtime.GOOS == "windows" {
+		for _, kv := range os.Environ() {
+			k, v, found := strings.Cut(kv, "=")
+			if found && strings.EqualFold(k, name) {
+				return v, true
+			}
+		}
+	}
+	return "", false
 }

--- a/internal/runner/cmd/cmd_test.go
+++ b/internal/runner/cmd/cmd_test.go
@@ -126,6 +126,113 @@ func TestRun_ShellAndEnvAndCwd(t *testing.T) {
 	}
 }
 
+// envMap converts an exec-style env slice into a map for assertions (last
+// entry wins, matching exec.Cmd's dedup semantics).
+func envMap(env []string) map[string]string {
+	m := make(map[string]string, len(env))
+	for _, kv := range env {
+		k, v, _ := strings.Cut(kv, "=")
+		m[k] = v
+	}
+	return m
+}
+
+// TestBuildEnv_ClearEnvDropsHostEnv proves clear_env: true starts from an
+// empty environment: a canary host var must not reach the child (#16).
+func TestBuildEnv_ClearEnvDropsHostEnv(t *testing.T) {
+	t.Setenv("ATAGO_TEST_CANARY", "leaked")
+	env := BuildEnv(nil, true, nil)
+	if env == nil {
+		t.Fatal("BuildEnv(clear) = nil, want a non-nil slice (nil inherits os.Environ)")
+	}
+	if _, ok := envMap(env)["ATAGO_TEST_CANARY"]; ok {
+		t.Errorf("canary host var leaked into cleared env: %v", env)
+	}
+}
+
+// TestBuildEnv_PassEnvCopiesListedVars proves pass_env copies exactly the
+// listed host vars and skips unset ones (#16).
+func TestBuildEnv_PassEnvCopiesListedVars(t *testing.T) {
+	t.Setenv("ATAGO_TEST_KEEP", "kept")
+	t.Setenv("ATAGO_TEST_DROP", "dropped")
+	env := envMap(BuildEnv(nil, true, []string{"ATAGO_TEST_KEEP", "ATAGO_TEST_UNSET"}))
+	if got := env["ATAGO_TEST_KEEP"]; got != "kept" {
+		t.Errorf("passed var = %q, want kept", got)
+	}
+	if _, ok := env["ATAGO_TEST_DROP"]; ok {
+		t.Error("unlisted host var leaked into cleared env")
+	}
+	if _, ok := env["ATAGO_TEST_UNSET"]; ok {
+		t.Error("unset host var should be skipped, not set")
+	}
+}
+
+// TestBuildEnv_OverridesLayerOnTop proves explicit env overrides win over
+// passed-through host vars, preserving the existing layering order (#16).
+func TestBuildEnv_OverridesLayerOnTop(t *testing.T) {
+	t.Setenv("ATAGO_TEST_LAYER", "host")
+	env := envMap(BuildEnv(map[string]string{"ATAGO_TEST_LAYER": "step"}, true, []string{"ATAGO_TEST_LAYER"}))
+	if got := env["ATAGO_TEST_LAYER"]; got != "step" {
+		t.Errorf("override = %q, want step (explicit env wins over pass_env)", got)
+	}
+}
+
+// TestBuildEnv_NoClearKeepsInheritance proves the pre-#16 behavior is
+// untouched when clear_env is off.
+func TestBuildEnv_NoClearKeepsInheritance(t *testing.T) {
+	if env := BuildEnv(nil, false, nil); env != nil {
+		t.Errorf("BuildEnv(no overrides) = %v, want nil (inherit os.Environ)", env)
+	}
+	t.Setenv("ATAGO_TEST_INHERIT", "here")
+	env := envMap(BuildEnv(map[string]string{"EXTRA": "1"}, false, nil))
+	if got := env["ATAGO_TEST_INHERIT"]; got != "here" {
+		t.Errorf("inherited var = %q, want here", got)
+	}
+	if got := env["EXTRA"]; got != "1" {
+		t.Errorf("override = %q, want 1", got)
+	}
+}
+
+// TestBuildEnv_WindowsKeepsSystemCriticalVars proves the documented
+// system-critical set survives clear_env on Windows so processes can start.
+func TestBuildEnv_WindowsKeepsSystemCriticalVars(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("windows-only behavior")
+	}
+	env := envMap(BuildEnv(nil, true, nil))
+	for _, name := range []string{"SystemRoot", "SystemDrive", "PATHEXT"} {
+		if _, ok := env[name]; !ok {
+			t.Errorf("system-critical var %s missing from cleared env", name)
+		}
+	}
+}
+
+// TestRun_ClearEnvEndToEnd proves a run step with clear_env does not see a
+// canary host var, and sees it again without clear_env (#16).
+func TestRun_ClearEnvEndToEnd(t *testing.T) {
+	t.Setenv("ATAGO_E2E_CANARY", "leaky")
+	r := New()
+	cmdLine := argvCommand("env", "cmd /c set")
+	hermetic, err := r.Run(context.Background(), &spec.Run{
+		Command:  cmdLine,
+		ClearEnv: spec.Bool(true),
+		PassEnv:  []string{"PATH"},
+	}, t.TempDir())
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if strings.Contains(string(hermetic.Stdout), "ATAGO_E2E_CANARY") {
+		t.Errorf("clear_env child saw the canary var:\n%s", hermetic.Stdout)
+	}
+	plain, err := r.Run(context.Background(), &spec.Run{Command: cmdLine}, t.TempDir())
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !strings.Contains(string(plain.Stdout), "ATAGO_E2E_CANARY") {
+		t.Errorf("non-hermetic child should inherit the canary var:\n%s", plain.Stdout)
+	}
+}
+
 func TestRun_Stdin(t *testing.T) {
 	t.Parallel()
 	r := New()

--- a/internal/runner/service/service.go
+++ b/internal/runner/service/service.go
@@ -61,7 +61,7 @@ func Start(ctx context.Context, svc *spec.Service, workdir string) (*Proc, strin
 		cmd.ConfigureShell(pc.cmd, svc.Command)
 	}
 	pc.cmd.Dir = cmd.ResolveDir(workdir, svc.Cwd)
-	pc.cmd.Env = cmd.BuildEnv(svc.Env)
+	pc.cmd.Env = cmd.BuildEnv(svc.Env, svc.ClearEnvEnabled(), svc.PassEnv)
 	pc.cmd.Stdout = out
 	pc.cmd.Stderr = out
 

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -189,6 +189,14 @@ type Service struct {
 	// Env sets process environment variables (layered over the scenario env and
 	// the inherited host environment), with ${name} expansion on the values.
 	Env map[string]string `yaml:"env,omitempty"`
+	// ClearEnv starts the service from an empty environment instead of
+	// inheriting the host environment (#16). A pointer so an authored
+	// `clear_env: false` is distinguishable from "unset" when
+	// `defaults.service.clear_env` is layered in.
+	ClearEnv *bool `yaml:"clear_env,omitempty"`
+	// PassEnv copies the listed host variables into the cleared environment
+	// (#16). Only meaningful with ClearEnv; unset host variables are skipped.
+	PassEnv []string `yaml:"pass_env,omitempty"`
 	// Ready declares how to wait until the service is accepting work before the
 	// steps run. When omitted, the steps start as soon as the process is spawned.
 	Ready *Ready `yaml:"ready,omitempty"`
@@ -382,7 +390,17 @@ type Run struct {
 	Cwd     string            `yaml:"cwd,omitempty"`
 	Timeout string            `yaml:"timeout,omitempty"`
 	Env     map[string]string `yaml:"env,omitempty"`
-	Stdin   string            `yaml:"stdin,omitempty"`
+	// ClearEnv starts the child from an empty environment instead of inheriting
+	// the host environment (#16), so host vars (LANG, GIT_*, proxies, ...) cannot
+	// silently change the behavior under test. A pointer so an authored
+	// `clear_env: false` is distinguishable from "unset" when
+	// `defaults.run.clear_env` is layered in.
+	ClearEnv *bool `yaml:"clear_env,omitempty"`
+	// PassEnv copies the listed host variables into the cleared environment
+	// (#16). Only meaningful with ClearEnv (the loader rejects it otherwise);
+	// unset host variables are skipped, not an error.
+	PassEnv []string `yaml:"pass_env,omitempty"`
+	Stdin   string   `yaml:"stdin,omitempty"`
 	// StdoutTo / StderrTo redirect the command's captured stdout / stderr to a
 	// workdir-relative file (create/truncate), so a `shell: false` step can write
 	// output to a file without borrowing the shell's `>` operator. The streams are
@@ -404,6 +422,15 @@ func (r *Run) ShellEnabled() bool { return r.Shell != nil && *r.Shell }
 
 // ShellEnabled reports whether the service opts into shell execution.
 func (s *Service) ShellEnabled() bool { return s.Shell != nil && *s.Shell }
+
+// ClearEnvEnabled reports whether the step opts into a cleared environment (#16).
+func (r *Run) ClearEnvEnabled() bool { return r.ClearEnv != nil && *r.ClearEnv }
+
+// ClearEnvEnabled reports whether the service opts into a cleared environment (#16).
+func (s *Service) ClearEnvEnabled() bool { return s.ClearEnv != nil && *s.ClearEnv }
+
+// ClearEnvEnabled reports whether the pty step opts into a cleared environment (#16).
+func (p *PTY) ClearEnvEnabled() bool { return p.ClearEnv != nil && *p.ClearEnv }
 
 // Retry re-runs a command until Until passes or the attempt budget is exhausted.
 // The last attempt's result is what subsequent steps observe.
@@ -435,6 +462,12 @@ type PTY struct {
 	// instead of hanging the run.
 	Timeout string            `yaml:"timeout,omitempty"`
 	Env     map[string]string `yaml:"env,omitempty"`
+	// ClearEnv starts the pty child from an empty environment instead of
+	// inheriting the host environment (#16), mirroring run.clear_env.
+	ClearEnv *bool `yaml:"clear_env,omitempty"`
+	// PassEnv copies the listed host variables into the cleared environment
+	// (#16). Only meaningful with ClearEnv; unset host variables are skipped.
+	PassEnv []string `yaml:"pass_env,omitempty"`
 	// Session is the ordered expect/send script. Each entry sets exactly one
 	// of Expect (wait until the accumulated transcript matches the regexp) or
 	// Send (write the string to the terminal; an empty send transmits EOF,

--- a/schema/atago.schema.json
+++ b/schema/atago.schema.json
@@ -84,6 +84,8 @@
             "cwd": { "type": "string" },
             "timeout": { "type": "string" },
             "env": { "type": "object", "additionalProperties": { "type": "string" } },
+            "clear_env": { "type": "boolean", "description": "Start the child from an empty environment instead of inheriting the host environment (#16). On Windows a small system-critical set (SystemRoot, SystemDrive, TEMP, TMP, PATHEXT) is always retained." },
+            "pass_env": { "type": "array", "items": { "type": "string", "minLength": 1 }, "description": "Host variables copied into the cleared environment (#16). Requires clear_env: true; unset host variables are skipped." },
             "stdin": { "type": "string" }
           }
         },
@@ -103,6 +105,8 @@
             "shell": { "type": "boolean" },
             "cwd": { "type": "string" },
             "env": { "type": "object", "additionalProperties": { "type": "string" } },
+            "clear_env": { "type": "boolean", "description": "Start the child from an empty environment instead of inheriting the host environment (#16). On Windows a small system-critical set (SystemRoot, SystemDrive, TEMP, TMP, PATHEXT) is always retained." },
+            "pass_env": { "type": "array", "items": { "type": "string", "minLength": 1 }, "description": "Host variables copied into the cleared environment (#16). Requires clear_env: true; unset host variables are skipped." },
             "ready": {
               "type": "object",
               "additionalProperties": false,
@@ -246,6 +250,8 @@
         "shell": { "type": "boolean" },
         "cwd": { "type": "string" },
         "env": { "type": "object", "additionalProperties": { "type": "string" } },
+        "clear_env": { "type": "boolean", "description": "Start the child from an empty environment instead of inheriting the host environment (#16). On Windows a small system-critical set (SystemRoot, SystemDrive, TEMP, TMP, PATHEXT) is always retained." },
+        "pass_env": { "type": "array", "items": { "type": "string", "minLength": 1 }, "description": "Host variables copied into the cleared environment (#16). Requires clear_env: true; unset host variables are skipped." },
         "ready": {
           "type": "object",
           "additionalProperties": false,
@@ -426,6 +432,8 @@
         "cwd": { "type": "string" },
         "timeout": { "type": "string" },
         "env": { "type": "object", "additionalProperties": { "type": "string" } },
+        "clear_env": { "type": "boolean", "description": "Start the child from an empty environment instead of inheriting the host environment (#16). On Windows a small system-critical set (SystemRoot, SystemDrive, TEMP, TMP, PATHEXT) is always retained." },
+        "pass_env": { "type": "array", "items": { "type": "string", "minLength": 1 }, "description": "Host variables copied into the cleared environment (#16). Requires clear_env: true; unset host variables are skipped." },
         "stdin": { "type": "string" },
         "stdout_to": { "type": "string", "minLength": 1, "description": "Write the command's captured stdout to this workdir-relative file (create/truncate), without needing shell redirection." },
         "stderr_to": { "type": "string", "minLength": 1, "description": "Write the command's captured stderr to this workdir-relative file (create/truncate), without needing shell redirection." },
@@ -455,6 +463,8 @@
         "cols": { "type": "integer", "minimum": 0 },
         "timeout": { "type": "string", "description": "Go duration bounding the WHOLE session (default 30s)." },
         "env": { "type": "object", "additionalProperties": { "type": "string" } },
+        "clear_env": { "type": "boolean", "description": "Start the child from an empty environment instead of inheriting the host environment (#16). On Windows a small system-critical set (SystemRoot, SystemDrive, TEMP, TMP, PATHEXT) is always retained." },
+        "pass_env": { "type": "array", "items": { "type": "string", "minLength": 1 }, "description": "Host variables copied into the cleared environment (#16). Requires clear_env: true; unset host variables are skipped." },
         "session": {
           "type": "array",
           "minItems": 1,

--- a/schema/manifest.schema.json
+++ b/schema/manifest.schema.json
@@ -248,6 +248,17 @@
         "shell": {
           "type": "boolean"
         },
+        "clear_env": {
+          "description": "The service starts from a cleared environment (#16).",
+          "type": "boolean"
+        },
+        "pass_env": {
+          "description": "Host variables passed through into the cleared environment (#16).",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "ready": {
           "description": "Readiness signal kind, or empty when steps start as soon as the process spawns.",
           "type": "string",
@@ -289,6 +300,17 @@
         },
         "shell": {
           "type": "boolean"
+        },
+        "clear_env": {
+          "description": "The command runs with a cleared environment (#16).",
+          "type": "boolean"
+        },
+        "pass_env": {
+          "description": "Host variables passed through into the cleared environment (#16).",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "runner": {
           "type": "string"

--- a/schema_test.go
+++ b/schema_test.go
@@ -118,6 +118,30 @@ scenarios:
 	}
 }
 
+// TestSchema_AcceptsHermeticEnv confirms clear_env/pass_env (#16) are accepted
+// on run, pty, service, and the defaults blocks.
+func TestSchema_AcceptsHermeticEnv(t *testing.T) {
+	s := loadSchema(t)
+	src := `version: "1"
+suite:
+  name: x
+  setup:
+    - service: {name: shared, command: ./srv, clear_env: true, pass_env: [PATH]}
+defaults:
+  run: {clear_env: true, pass_env: [PATH, HOME]}
+  service: {clear_env: true, pass_env: [PATH]}
+scenarios:
+  - name: a
+    services:
+      - {name: mock, command: ./mock, clear_env: true, pass_env: [PATH]}
+    steps:
+      - run: {command: env, clear_env: true, pass_env: [PATH, HOME], env: {A: b}}
+      - pty: {command: cat, clear_env: true, pass_env: [TERM], session: [{send: ""}]}`
+	if err := s.Validate(yamlToAny(t, []byte(src))); err != nil {
+		t.Errorf("schema rejected valid hermetic-env spec:\n%v", err)
+	}
+}
+
 // TestSchema_RejectsInvalid confirms the schema actually catches bad specs.
 func TestSchema_RejectsInvalid(t *testing.T) {
 	s := loadSchema(t)
@@ -189,6 +213,18 @@ runners:
 scenarios:
   - name: a
     steps: [{run: {command: echo}}]`,
+		// Issue #16: pass_env entries are variable names, not key=value pairs.
+		"pass_env with non-string entry": `version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps: [{run: {command: env, clear_env: true, pass_env: [{PATH: yes}]}}]`,
+		// Issue #16: clear_env is a boolean, not a string.
+		"clear_env with string value": `version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps: [{run: {command: env, clear_env: "yes"}}]`,
 	}
 	for name, src := range bad {
 		t.Run(name, func(t *testing.T) {

--- a/test/e2e/atago/hermetic_env.atago.yaml
+++ b/test/e2e/atago/hermetic_env.atago.yaml
@@ -1,0 +1,111 @@
+version: "1"
+
+suite:
+  name: atago self-hosting / hermetic environment (clear_env + pass_env)
+
+# Exercises #16: `clear_env: true` starts the child from an empty environment
+# (so host vars cannot silently change the behavior under test) and `pass_env`
+# re-admits an explicit allowlist of host variables. Explicit `env:` overrides
+# are layered on top, preserving the suite → scenario → step order.
+# The probing commands (`env`, `sh`) are POSIX, so these scenarios skip on
+# Windows; the runner behavior itself is covered on Windows by unit tests.
+scenarios:
+  - name: clear_env drops inherited host variables
+    skip:
+      os: windows
+    env:
+      ATAGO_HERMETIC_CANARY: leaked-from-scenario
+    steps:
+      # Without clear_env the canary is visible: scenario env layers over the
+      # inherited host environment as always.
+      - run:
+          command: env
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: ATAGO_HERMETIC_CANARY
+      # With clear_env the child starts empty; only explicit env survives.
+      # The scenario env is an explicit override, so it is still layered in —
+      # clear_env drops the *inherited host* environment, not authored env.
+      - run:
+          command: env
+          clear_env: true
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: ATAGO_HERMETIC_CANARY=leaked-from-scenario
+      - assert:
+          stdout:
+            not_contains: "PATH=/"
+
+  - name: pass_env re-admits an allowlist of host variables
+    skip:
+      os: windows
+    steps:
+      - run:
+          command: env
+          clear_env: true
+          pass_env: [PATH]
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "PATH="
+      - assert:
+          stdout:
+            not_contains: "HOME="
+
+  - name: explicit env wins over a passed-through host variable
+    skip:
+      os: windows
+    steps:
+      - run:
+          shell: true
+          command: "printf '%s\\n' \"$HOME\""
+          clear_env: true
+          pass_env: [HOME]
+          env:
+            HOME: /hermetic/home
+      - assert:
+          exit_code: 0
+          stdout:
+            equals: /hermetic/home
+
+  - name: pass_env without clear_env is a load-time error
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: bad
+            scenarios:
+              - name: forgot clear_env
+                steps:
+                  - run:
+                      command: env
+                      pass_env: [PATH]
+      - run:
+          command: ${atago} run bad.atago.yaml
+      # A spec-content (validation) error exits 2 with a positioned message.
+      - assert:
+          exit_code: 2
+          stderr:
+            contains:
+              - "pass_env requires clear_env: true"
+              - steps[0].run
+
+  - name: unset host variables in pass_env are skipped, not an error
+    skip:
+      os: windows
+    steps:
+      - run:
+          command: env
+          clear_env: true
+          pass_env: [PATH, ATAGO_SURELY_UNSET_VAR_2026]
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "PATH="
+      - assert:
+          stdout:
+            not_contains: ATAGO_SURELY_UNSET_VAR_2026


### PR DESCRIPTION
## Summary

This PR adds declarative environment hermeticity to run, service, and pty steps (#16): `clear_env: true` starts the child process from an empty environment instead of inheriting the full host environment, and `pass_env: [PATH, HOME]` re-admits an explicit allowlist of host variables. Host vars like `LANG`, `GIT_*`, or proxy settings can no longer silently change the behavior under test, which makes specs reproducible across machines — a differentiator neither ShellSpec nor runn offers.

## Changes

- `internal/spec`: add `ClearEnv *bool` / `PassEnv []string` to `Run`, `Service`, and `PTY` with `ClearEnvEnabled()` accessors (pointer keeps an authored `clear_env: false` distinct from unset, per ADR-0039 rules).
- `internal/runner/cmd`: `buildEnv`/`BuildEnv` now compose the cleared environment — Windows system-critical set (`SystemRoot`, `SystemDrive`, `TEMP`, `TMP`, `PATHEXT`) first, then the `pass_env` allowlist (case-insensitive lookup on Windows, unset vars skipped), then explicit `env` overrides, preserving the suite → scenario → step layering.
- `internal/runner/service` and `internal/engine` (pty): thread the new fields into the shared `BuildEnv`.
- `internal/loader`: `defaults.run` / `defaults.service` merge the new fields (authored value wins; `pass_env` is not inherited when the merged step has `clear_env` off); validation rejects `pass_env` without `clear_env: true` and empty variable names with positioned messages (exit 2) on run, pty, scenario services, suite setup services, and the defaults blocks.
- `schema/atago.schema.json` and `schema/manifest.schema.json`: new fields on run/pty/service and both defaults blocks; manifest emits `clear_env`/`pass_env` on steps and services.
- `atago explain` notes "cleared environment (passes: ...)" on run steps and services; `atago doc` adds a Given bullet; `doc/e2e/atago.md` regenerated.
- New `examples/hermetic_env.atago.yaml` (hermetic, registered in `examples_test.go`) documenting the `${env:NAME}`-vs-`pass_env` distinction, README Examples row and feature prose.
- Tests: unit coverage for buildEnv (clear/pass/layering/no-clear regression/Windows set), loader merge + validation cases, schema accept/reject cases, docgen/explain assertions, and a self-hosted E2E spec `test/e2e/atago/hermetic_env.atago.yaml` (POSIX scenarios skip on Windows; the load-time-error scenario runs everywhere).

## Design Decisions

- `${env:NAME}` interpolation still reads the real host environment because it is resolved by atago at expansion time, not by the child process; a value injected through it into `env:` survives `clear_env` as an explicit override. This distinction is documented in the example.
- `pass_env` without `clear_env` is rejected rather than ignored, and a step that authors `clear_env: false` does not inherit a default `pass_env`, so the allowlist can never apply to a non-cleared environment.
- exec's "nil Env inherits os.Environ()" convention made the old zero-override fast path return nil; the cleared path always returns a non-nil slice so an empty environment is honored.

Closes #16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running commands and services with a cleared environment, while optionally passing through selected host variables.
  * Expanded documentation, schema support, and examples to cover the new environment controls.

* **Bug Fixes**
  * Enforced validation so pass-through variables can only be used with cleared environments.
  * Improved environment handling so explicit values override passed-through values, and unset pass-through variables are skipped.

* **Tests**
  * Added coverage for documentation generation, schema validation, loader behavior, and end-to-end environment isolation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->