### PR TITLE
feat(engine): add default step timeout and suite-level timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Hermetic environment control (#16): `clear_env: true` on `run`, `service`,
+  and `pty` steps (and `defaults.run` / `defaults.service`) starts the child
+  from an EMPTY environment instead of inheriting the host's, so host vars
+  (`LANG`, `GIT_*`, proxies, ...) cannot silently change the behavior under
+  test. `pass_env: [PATH, HOME]` re-admits an explicit allowlist (unset host
+  vars are skipped); explicit `env:` overrides layer on top in the existing
+  suite → scenario → step order. On Windows a system-critical set
+  (`SystemRoot`, `SystemDrive`, `TEMP`, `TMP`, `PATHEXT`) is always retained.
+  `pass_env` without `clear_env: true` is a load-time error (exit 2).
+  See `examples/hermetic_env.atago.yaml`.
+- Suite-level default step timeout (#17): `suite.timeout: 2m` bounds every
+  `run`/`http`/`query`/`grpc` step that has no more specific timeout.
+  Precedence: step > runner `timeout` > `defaults.run.timeout` >
+  `suite.timeout` > built-in 60s. `timeout: "0"` (or `"0s"`) at any level
+  disables the bound. A timeout kill names the level that supplied the bound
+  in its failure hint. See `examples/timeouts.atago.yaml`.
+
+### Changed
+
+- **Steps are now bounded by a built-in 60s default timeout** (#17): a
+  `run`/`http`/`query`/`grpc` step with no timeout configured at any level
+  (step, runner, `defaults.run`, `suite.timeout`) now fails after 60s with
+  "the command timed out ... and was killed" instead of hanging the run (or a
+  CI job) forever. Specs relying on unbounded runs must either set a real
+  bound (`suite.timeout: 10m`) or opt out explicitly with `timeout: "0"`.
+- `defaults.run.timeout` is no longer string-merged into steps at load time;
+  the engine resolves the timeout precedence chain itself so a runner-common
+  `timeout` now correctly outranks `defaults.run.timeout`, and the failure
+  hint can name the level that supplied the bound (#17).
+
 ## [0.2.0] - 2026-07-03
 
 Suite-level bootstrap, interactive terminal testing, and verbose scenario

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ scenarios:
             empty: true
 ```
 
-`atago run` accepts spec files and directories (searched recursively for `*.atago.yaml`). Each scenario runs in its own temporary directory, and progress streams as a dot per scenario (`.` pass, `F` fail, `E` error, `s` skip). For full reproducibility a step can also opt out of the inherited host environment with `clear_env: true` (re-admitting an allowlist via `pass_env`), so host vars like `LANG` or `GIT_*` cannot make a spec pass on one machine and fail on another:
+`atago run` accepts spec files and directories (searched recursively for `*.atago.yaml`). Each scenario runs in its own temporary directory, and progress streams as a dot per scenario (`.` pass, `F` fail, `E` error, `s` skip). For full reproducibility a step can also opt out of the inherited host environment with `clear_env: true` (re-admitting an allowlist via `pass_env`), so host vars like `LANG` or `GIT_*` cannot make a spec pass on one machine and fail on another. Every run/http/query/grpc step is bounded by a built-in 60s default timeout, so a hanging command fails loudly instead of stalling CI — set `suite.timeout` (or a step/runner `timeout`) to change the budget, or `timeout: "0"` to opt a legitimately long step out:
 
 ```shell
 $ atago run ./specs
@@ -137,6 +137,7 @@ Every feature has a commented, runnable spec under [examples/](examples/). The e
 | [store_and_variables](examples/store_and_variables.atago.yaml) | capturing values into `${name}`, `${workdir}`, `${env:NAME}` host-environment reads, the `$${...}` literal escape |
 | [teardown](examples/teardown.atago.yaml) | cleanup steps that always run — pass or fail — sharing the scenario's variables |
 | [hermetic_env](examples/hermetic_env.atago.yaml) | `clear_env: true` starts commands from an empty environment, `pass_env` re-admits an allowlist of host variables |
+| [timeouts](examples/timeouts.atago.yaml) | the built-in 60s default step timeout, `suite.timeout`, per-step overrides, and the `timeout: "0"` escape hatch |
 | [matrix](examples/matrix.atago.yaml) | one template scenario expanded per parameter row |
 | [pty](examples/pty.atago.yaml) | interactive testing in a real pseudo-terminal: expect/send sessions, TTY-detection (POSIX-only) |
 | [retry](examples/retry.atago.yaml) | polling a command until an assertion passes |

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-43 suites · 144 scenarios
+44 suites · 148 scenarios
 ## Contents
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 3 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
@@ -178,6 +178,11 @@
   - [a failing setup errors every scenario and none runs (exit 4)](#scenario-a-failing-setup-errors-every-scenario-and-none-runs-exit-4)
   - [a suite service starts once and its store reaches every scenario](#scenario-a-suite-service-starts-once-and-its-store-reaches-every-scenario)
   - [a failing suite teardown is loud but does not flip the verdict](#scenario-a-failing-suite-teardown-is-loud-but-does-not-flip-the-verdict)
+- [atago self-hosting / step timeouts (suite default + escape hatch)](#atago-self-hosting--step-timeouts-suite-default--escape-hatch) — 4 scenarios
+  - [suite.timeout kills a hanging step and the hint names it](#scenario-suitetimeout-kills-a-hanging-step-and-the-hint-names-it)
+  - [a step timeout beats the suite timeout and the hint says run.timeout](#scenario-a-step-timeout-beats-the-suite-timeout-and-the-hint-says-runtimeout)
+  - [timeout zero disables a short suite bound](#scenario-timeout-zero-disables-a-short-suite-bound)
+  - [an invalid suite.timeout is a load-time error](#scenario-an-invalid-suitetimeout-is-a-load-time-error)
 - [atago self-hosting / verbose](#atago-self-hosting--verbose) — 4 scenarios
   - [verbose shows a passing scenario's command, output, and verdicts](#scenario-verbose-shows-a-passing-scenarios-command-output-and-verdicts)
   - [without --verbose the trace is absent](#scenario-without---verbose-the-trace-is-absent)
@@ -3147,6 +3152,113 @@ ${atago} run td.atago.yaml
 #### Then
 - exit code is `0`
 - stdout contains `1 passed`, `SUITE TEARDOWN FAILED`
+## atago self-hosting / step timeouts (suite default + escape hatch)
+Source: `test/e2e/atago/timeouts.atago.yaml`
+### Scenario: suite.timeout kills a hanging step and the hint names it
+_skipped on windows_
+#### Given
+- Fixture file `hang.atago.yaml` is created.
+#### Inputs
+_Fixture `hang.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: hang
+  timeout: 1s
+scenarios:
+  - name: sleeps past the suite bound
+    steps:
+      - run:
+          shell: true
+          command: sleep 300
+      - assert:
+          exit_code: 0
+```
+#### When
+```shell
+${atago} run hang.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `timed out`, `suite.timeout`
+### Scenario: a step timeout beats the suite timeout and the hint says run.timeout
+_skipped on windows_
+#### Given
+- Fixture file `step_wins.atago.yaml` is created.
+#### Inputs
+_Fixture `step_wins.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: step-wins
+  timeout: 30s
+scenarios:
+  - name: the step's own 1s bound fires first
+    steps:
+      - run:
+          shell: true
+          command: sleep 300
+          timeout: 1s
+      - assert:
+          exit_code: 0
+```
+#### When
+```shell
+${atago} run step_wins.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `timed out`, `run.timeout`
+### Scenario: timeout zero disables a short suite bound
+_skipped on windows_
+#### Given
+- Fixture file `optout.atago.yaml` is created.
+#### Inputs
+_Fixture `optout.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: optout
+  timeout: 1s
+scenarios:
+  - name: the opted-out step outlives the suite bound
+    steps:
+      - run:
+          shell: true
+          command: sleep 2
+          timeout: "0"
+      - assert:
+          exit_code: 0
+```
+#### When
+```shell
+${atago} run optout.atago.yaml
+```
+#### Then
+- exit code is `0`
+### Scenario: an invalid suite.timeout is a load-time error
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: bad
+  timeout: fast
+scenarios:
+  - name: never runs
+    steps:
+      - run:
+          command: echo hi
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `suite.timeout`
 ## atago self-hosting / verbose
 Source: `test/e2e/atago/verbose.atago.yaml`
 ### Scenario: verbose shows a passing scenario's command, output, and verdicts

--- a/examples/timeouts.atago.yaml
+++ b/examples/timeouts.atago.yaml
@@ -1,0 +1,56 @@
+version: "1"
+
+# Step timeouts (#17). Every run/http/query/grpc step is bounded so a hanging
+# command fails loudly instead of stalling the run (or a CI job) forever.
+# Precedence, most specific wins:
+#
+#   step timeout > runner timeout > defaults.run.timeout > suite.timeout
+#   > built-in 60s default
+#
+# `timeout: "0"` (or "0s") at any level explicitly disables the bound — the
+# escape hatch for legitimately long-running commands. A step killed by a
+# timeout fails with "the command timed out after ... and was killed" and the
+# hint names WHICH level supplied the timeout (run.timeout / runner.timeout /
+# defaults.run.timeout / suite.timeout / built-in 60s default timeout).
+# Runs green as-is on every OS: atago run examples/timeouts.atago.yaml
+
+suite:
+  name: timeouts
+  # Suite-level default: every step without a more specific timeout gets 2m.
+  timeout: 2m
+
+scenarios:
+  - name: the suite timeout bounds every step by default
+    steps:
+      # No step timeout here, so the suite's 2m applies (instead of the
+      # built-in 60s that would apply if suite.timeout were absent).
+      - run:
+          command: echo bounded-by-suite
+      - assert:
+          exit_code: 0
+          stdout:
+            equals: bounded-by-suite
+
+  - name: a step timeout overrides the suite default
+    steps:
+      # The most specific level wins: this step is bounded at 5s, not 2m.
+      - run:
+          command: echo bounded-by-step
+          timeout: 5s
+      - assert:
+          exit_code: 0
+          stdout:
+            equals: bounded-by-step
+
+  - name: timeout zero disables the bound entirely
+    steps:
+      # "0" opts this step out of every level, including the built-in 60s
+      # default — use it for commands that legitimately run long (builds,
+      # downloads). Prefer a generous real bound where you can.
+      - run:
+          command: echo unbounded
+          timeout: "0"
+      - assert:
+          exit_code: 0
+          stdout:
+            equals: unbounded

--- a/examples_test.go
+++ b/examples_test.go
@@ -39,6 +39,7 @@ var exampleSpecs = map[string]bool{ // path -> hermetic (run, not just validate)
 	"examples/store_and_variables.atago.yaml": true,
 	"examples/suite_setup.atago.yaml":         false,
 	"examples/teardown.atago.yaml":            true,
+	"examples/timeouts.atago.yaml":            true,
 }
 
 // TestExamples_EveryFileCategorized fails when a spec is added to examples/

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -184,7 +184,13 @@ func checkExitCode(e *spec.ExitCode, res *runner.Result) *CheckResult {
 		}
 		hint := fmt.Sprintf("expected exit code %d but the command exited with %d", *e.Equals, res.ExitCode)
 		if res.TimedOut {
-			hint = fmt.Sprintf("the command hit its run.timeout after %s and was killed before exiting", res.Duration.Round(time.Millisecond))
+			// Name the level that supplied the timeout (step/runner/defaults/
+			// suite/built-in, #17) so the user knows which knob to adjust.
+			source := res.TimeoutSource
+			if source == "" {
+				source = "run.timeout"
+			}
+			hint = fmt.Sprintf("the command hit its %s after %s and was killed before exiting", source, res.Duration.Round(time.Millisecond))
 		}
 		return &CheckResult{
 			Desc:     desc,

--- a/internal/assert/assert_test.go
+++ b/internal/assert/assert_test.go
@@ -58,6 +58,20 @@ func TestCheck_ExitCode_TimedOut(t *testing.T) {
 	}
 }
 
+// TestCheck_ExitCode_TimedOutNamesSource proves the hint names the level that
+// supplied the timeout when the engine's resolver recorded one (#17).
+func TestCheck_ExitCode_TimedOutNamesSource(t *testing.T) {
+	t.Parallel()
+	res := &runner.Result{ExitCode: -1, TimedOut: true, TimeoutSource: "suite.timeout", Duration: 200 * time.Millisecond}
+	got := Check(&spec.Assert{ExitCode: &spec.ExitCode{Equals: intp(0)}}, res, Env{})
+	if got.OK {
+		t.Fatal("OK = true, want a failure for a timed-out command")
+	}
+	if !strings.Contains(got.Hint, "suite.timeout") {
+		t.Errorf("Hint = %q, want it to name suite.timeout", got.Hint)
+	}
+}
+
 func TestCheck_Stream(t *testing.T) {
 	t.Parallel()
 	res := &runner.Result{Stdout: []byte("Alice and Bob\n"), Stderr: []byte("")}

--- a/internal/engine/browser.go
+++ b/internal/engine/browser.go
@@ -24,7 +24,7 @@ func (e *Engine) runCDP(ctx context.Context, c *spec.CDP, workdir string, st *st
 // browserConn returns the scenario's session for a named browser runner,
 // launching it on first use.
 func browserConn(name string, _ *store.Store, rc runConfig, conns map[string]*browserrunner.Runner) (*browserrunner.Runner, error) {
-	return resolveConn(name, "cdp step", "browser", rc, conns, func(rdef spec.Runner, timeout time.Duration) (*browserrunner.Runner, error) {
+	return resolveConn(name, "cdp step", "browser", rc, conns, false, func(rdef spec.Runner, timeout time.Duration) (*browserrunner.Runner, error) {
 		// Headless defaults to true; an explicit `headless: false` runs headed.
 		headless := rdef.Headless == nil || *rdef.Headless
 		return browserrunner.Open(browserrunner.Config{

--- a/internal/engine/conn.go
+++ b/internal/engine/conn.go
@@ -16,11 +16,16 @@ import (
 //
 // stepVerb names the step kind for the unknown-runner error (e.g. "query step");
 // wantType is the required runner.Type; open builds and opens the typed
-// connection from the runner definition and its parsed timeout.
+// connection from the runner definition and its parsed timeout. defaultBounded
+// opts the runner family into the step-timeout precedence chain (#17): query
+// and grpc steps fall back to suite.timeout and the built-in 60s default when
+// the runner declares no timeout, while ssh and browser keep their historical
+// "empty means unbounded" behavior (their long-lived sessions are not steps).
 func resolveConn[T io.Closer](
 	name, stepVerb, wantType string,
 	rc runConfig,
 	conns map[string]T,
+	defaultBounded bool,
 	open func(rdef spec.Runner, timeout time.Duration) (T, error),
 ) (T, error) {
 	var zero T
@@ -34,11 +39,15 @@ func resolveConn[T io.Closer](
 	if rdef.Type != wantType {
 		return zero, fmt.Errorf("runner %q is not a %s runner (type %q)", name, wantType, rdef.Type)
 	}
+	timeoutStr := rdef.Timeout
+	if defaultBounded {
+		timeoutStr, _ = resolveTimeout("", rdef.Timeout, "", rc.suiteTimeout)
+	}
 	var timeout time.Duration
-	if rdef.Timeout != "" {
-		d, err := time.ParseDuration(rdef.Timeout)
+	if timeoutStr != "" {
+		d, err := time.ParseDuration(timeoutStr)
 		if err != nil {
-			return zero, fmt.Errorf("runner %q has invalid timeout %q: %w", name, rdef.Timeout, err)
+			return zero, fmt.Errorf("runner %q has invalid timeout %q: %w", name, timeoutStr, err)
 		}
 		timeout = d
 	}

--- a/internal/engine/db.go
+++ b/internal/engine/db.go
@@ -25,7 +25,7 @@ func (e *Engine) runQuery(ctx context.Context, q *spec.Query, st *store.Store, r
 // first use. Connections are scoped to a scenario (closed when it ends) so a dsn
 // referencing ${workdir} yields a fresh, isolated database per scenario.
 func dbConn(name string, st *store.Store, rc runConfig, conns map[string]*dbrunner.Runner) (*dbrunner.Runner, error) {
-	return resolveConn(name, "query step", "db", rc, conns, func(rdef spec.Runner, timeout time.Duration) (*dbrunner.Runner, error) {
+	return resolveConn(name, "query step", "db", rc, conns, true, func(rdef spec.Runner, timeout time.Duration) (*dbrunner.Runner, error) {
 		cfg, err := dbrunner.Resolve(rdef.Driver, st.Expand(rdef.DSN))
 		if err != nil {
 			return nil, err

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -105,11 +105,15 @@ func (e *Engine) Run(ctx context.Context, s *spec.Spec, specPath string) *SuiteR
 	start := time.Now()
 	res := &SuiteResult{Suite: s.Suite.Name, SpecPath: specPath, Status: StatusPassed}
 	rc := runConfig{
-		specDir:  filepath.Dir(specPath),
-		specPath: specPath,
-		masker:   security.NewMaskerForSpec(s),
-		runners:  s.Runners,
-		allow:    allowedHosts(s),
+		specDir:      filepath.Dir(specPath),
+		specPath:     specPath,
+		masker:       security.NewMaskerForSpec(s),
+		runners:      s.Runners,
+		allow:        allowedHosts(s),
+		suiteTimeout: s.Suite.Timeout,
+	}
+	if s.Defaults != nil && s.Defaults.Run != nil {
+		rc.defaultsRunTimeout = s.Defaults.Run.Timeout
 	}
 
 	workers := e.Parallel
@@ -322,6 +326,13 @@ type runConfig struct {
 	suiteVars map[string]string
 	// suiteEnv is the raw suite.env, layered beneath each scenario's env.
 	suiteEnv map[string]string
+	// suiteTimeout / defaultsRunTimeout feed the step-timeout precedence
+	// resolver (#17): step > runner > defaults.run > suite > built-in 60s.
+	// They stay separate strings (instead of being merged into each step at
+	// load time) so the resolver knows which level supplied the winning value
+	// and can name it in the timeout-kill hint.
+	suiteTimeout       string
+	defaultsRunTimeout string
 }
 
 func (e *Engine) runScenario(ctx context.Context, scenarioIdx int, sc *spec.Scenario, rc runConfig) ScenarioResult {
@@ -690,36 +701,46 @@ func (e *Engine) probeSucceeds(ctx context.Context, command string) bool {
 // later steps observe (ADR-0022).
 func (e *Engine) runStep(ctx context.Context, run *spec.Run, st *store.Store, workdir, specDir string, rc runConfig, sshConns map[string]*sshrunner.Runner) (*runner.Result, []*assert.CheckResult, error) {
 	// A run step naming an ssh runner executes remotely (ADR-0027); otherwise it
-	// runs locally via the cmd runner.
+	// runs locally via the cmd runner. The runner is resolved once (not per
+	// retry attempt) so the timeout precedence below sees the pristine authored
+	// step value.
+	remote := false
+	var runnerTimeout string
+	if run.Runner != "" {
+		rdef, ok := rc.runners[run.Runner]
+		if !ok {
+			return nil, nil, fmt.Errorf("run step references unknown runner %q", run.Runner)
+		}
+		switch rdef.Type {
+		case "ssh":
+			remote = true
+		case "cmd", "":
+			// Layer the runner's cwd beneath the step's own value; the step
+			// wins. run is the caller's expanded copy, so mutating it is safe;
+			// cwd gets the same use-time ${name} expansion as the other runner
+			// families' fields.
+			if run.Cwd == "" {
+				run.Cwd = st.Expand(rdef.Cwd)
+			}
+			runnerTimeout = rdef.Timeout
+		default:
+			return nil, nil, fmt.Errorf("runner %q (type %q) cannot run a command step; use a step matching its type", run.Runner, rdef.Type)
+		}
+	}
+	if !remote {
+		// Resolve the effective timeout across all five levels (#17) and
+		// remember which level supplied it so a timeout kill can name the knob
+		// in its hint. Remote (ssh) runs are bounded by the ssh runner's own
+		// connection timeout instead.
+		run.Timeout, run.TimeoutSource = resolveTimeout(run.Timeout, runnerTimeout, rc.defaultsRunTimeout, rc.suiteTimeout)
+	}
 	exec := func(ctx context.Context) (*runner.Result, error) {
-		if run.Runner != "" {
-			rdef, ok := rc.runners[run.Runner]
-			if !ok {
-				return nil, fmt.Errorf("run step references unknown runner %q", run.Runner)
+		if remote {
+			conn, err := sshConn(run.Runner, st, rc, sshConns)
+			if err != nil {
+				return nil, err
 			}
-			switch rdef.Type {
-			case "ssh":
-				conn, err := sshConn(run.Runner, st, rc, sshConns)
-				if err != nil {
-					return nil, err
-				}
-				return conn.Run(ctx, run.Command)
-			case "cmd", "":
-				// Layer the runner's cwd/timeout beneath the step's own values
-				//; the
-				// step wins. run is the caller's expanded copy, so mutating it is
-				// safe; cwd gets the same use-time ${name} expansion as the other
-				// runner families' fields.
-				if run.Cwd == "" {
-					run.Cwd = st.Expand(rdef.Cwd)
-				}
-				if run.Timeout == "" {
-					run.Timeout = rdef.Timeout
-				}
-				// fall through to the local cmd runner
-			default:
-				return nil, fmt.Errorf("runner %q (type %q) cannot run a command step; use a step matching its type", run.Runner, rdef.Type)
-			}
+			return conn.Run(ctx, run.Command)
 		}
 		return e.cmd.Run(ctx, run, workdir)
 	}

--- a/internal/engine/grpc.go
+++ b/internal/engine/grpc.go
@@ -34,7 +34,7 @@ func (e *Engine) runGRPC(ctx context.Context, g *spec.GRPC, st *store.Store, rc 
 // grpcConn returns the scenario's connection for a named grpc runner, opening it
 // on first use.
 func grpcConn(name string, st *store.Store, rc runConfig, conns map[string]*grpcrunner.Runner) (*grpcrunner.Runner, error) {
-	return resolveConn(name, "grpc step", "grpc", rc, conns, func(rdef spec.Runner, timeout time.Duration) (*grpcrunner.Runner, error) {
+	return resolveConn(name, "grpc step", "grpc", rc, conns, true, func(rdef spec.Runner, timeout time.Duration) (*grpcrunner.Runner, error) {
 		cfg := grpcrunner.Config{Target: st.Expand(rdef.Target), TLS: rdef.TLS, Timeout: timeout}
 		// Enforce the network allowlist before dialing (issue #17): grpc egress is
 		// confined to permissions.network.allow just like HTTP.

--- a/internal/engine/http.go
+++ b/internal/engine/http.go
@@ -83,24 +83,26 @@ func (e *Engine) runHTTP(ctx context.Context, h *spec.HTTP, st *store.Store, rc 
 // so it can reference stored values or built-ins.
 func resolveHTTPConfig(h *spec.HTTP, st *store.Store, rc runConfig) (httprunner.Config, error) {
 	cfg := httprunner.Config{Allow: rc.allow}
-	if h.Runner == "" {
-		return cfg, nil
-	}
-	r, ok := rc.runners[h.Runner]
-	if !ok {
-		return cfg, fmt.Errorf("http step references unknown runner %q", h.Runner)
-	}
-	if r.Type != "http" {
-		return cfg, fmt.Errorf("runner %q is not an http runner (type %q)", h.Runner, r.Type)
-	}
-	cfg.BaseURL = st.Expand(r.BaseURL)
-	if r.Timeout != "" {
-		d, err := time.ParseDuration(r.Timeout)
-		if err != nil {
-			return cfg, fmt.Errorf("runner %q has invalid timeout %q: %w", h.Runner, r.Timeout, err)
+	var runnerTimeout string
+	if h.Runner != "" {
+		r, ok := rc.runners[h.Runner]
+		if !ok {
+			return cfg, fmt.Errorf("http step references unknown runner %q", h.Runner)
 		}
-		cfg.Timeout = d
+		if r.Type != "http" {
+			return cfg, fmt.Errorf("runner %q is not an http runner (type %q)", h.Runner, r.Type)
+		}
+		cfg.BaseURL = st.Expand(r.BaseURL)
+		runnerTimeout = r.Timeout
 	}
+	// http requests join the step-timeout precedence chain (#17): runner
+	// timeout > suite.timeout > built-in 60s ("0" disables).
+	timeoutStr, _ := resolveTimeout("", runnerTimeout, "", rc.suiteTimeout)
+	d, err := time.ParseDuration(timeoutStr)
+	if err != nil {
+		return cfg, fmt.Errorf("runner %q has invalid timeout %q: %w", h.Runner, timeoutStr, err)
+	}
+	cfg.Timeout = d
 	return cfg, nil
 }
 

--- a/internal/engine/ssh.go
+++ b/internal/engine/ssh.go
@@ -14,7 +14,7 @@ import (
 // are ${name}-expanded so host/user/password/key can reference stored values or
 // built-ins (e.g. a key written under ${workdir}).
 func sshConn(name string, st *store.Store, rc runConfig, conns map[string]*sshrunner.Runner) (*sshrunner.Runner, error) {
-	return resolveConn(name, "run step", "ssh", rc, conns, func(rdef spec.Runner, timeout time.Duration) (*sshrunner.Runner, error) {
+	return resolveConn(name, "run step", "ssh", rc, conns, false, func(rdef spec.Runner, timeout time.Duration) (*sshrunner.Runner, error) {
 		cfg := sshrunner.Config{
 			Addr:            st.Expand(rdef.Host),
 			User:            st.Expand(rdef.User),

--- a/internal/engine/timeout.go
+++ b/internal/engine/timeout.go
@@ -1,0 +1,30 @@
+package engine
+
+// DefaultStepTimeout is the built-in bound applied to run/http/query/grpc
+// steps when no level configures a timeout (#17), so an unconfigured hanging
+// command fails loudly instead of stalling the run (or a CI job) forever.
+const DefaultStepTimeout = "60s"
+
+// defaultTimeoutSource is the hint label for the built-in bound; it names the
+// value so the failure message tells the user what budget they exceeded.
+const defaultTimeoutSource = "built-in 60s default timeout"
+
+// resolveTimeout walks the timeout precedence chain (#17) — step >
+// runner-common > defaults.run > suite > built-in 60s — and returns the
+// winning duration string plus a source label for the timeout-kill hint. An
+// explicit "0"/"0s" at any level stops the walk and disables the bound (the
+// documented escape hatch); an empty string means "unset, keep looking". All
+// candidate strings are duration-validated at load time.
+func resolveTimeout(step, runnerCommon, defaultsRun, suite string) (value, source string) {
+	for _, c := range []struct{ v, src string }{
+		{step, "run.timeout"},
+		{runnerCommon, "runner.timeout"},
+		{defaultsRun, "defaults.run.timeout"},
+		{suite, "suite.timeout"},
+	} {
+		if c.v != "" {
+			return c.v, c.src
+		}
+	}
+	return DefaultStepTimeout, defaultTimeoutSource
+}

--- a/internal/engine/timeout_test.go
+++ b/internal/engine/timeout_test.go
@@ -1,0 +1,176 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestResolveTimeout proves the five-level precedence chain (#17): step >
+// runner > defaults.run > suite > built-in 60s, with an explicit "0" at any
+// level stopping the walk (the documented escape hatch).
+func TestResolveTimeout(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name, step, runner, defaults, suite string
+		wantValue, wantSource               string
+	}{
+		{"step wins over all", "1s", "2s", "3s", "4s", "1s", "run.timeout"},
+		{"runner beats defaults and suite", "", "2s", "3s", "4s", "2s", "runner.timeout"},
+		{"defaults beats suite", "", "", "3s", "4s", "3s", "defaults.run.timeout"},
+		{"suite beats built-in", "", "", "", "4s", "4s", "suite.timeout"},
+		{"built-in when nothing set", "", "", "", "", "60s", "built-in 60s default timeout"},
+		{"explicit step 0 disables", "0", "2s", "3s", "4s", "0", "run.timeout"},
+		{"explicit suite 0s disables the built-in", "", "", "", "0s", "0s", "suite.timeout"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			v, src := resolveTimeout(tc.step, tc.runner, tc.defaults, tc.suite)
+			if v != tc.wantValue || src != tc.wantSource {
+				t.Errorf("resolveTimeout(%q,%q,%q,%q) = (%q,%q), want (%q,%q)",
+					tc.step, tc.runner, tc.defaults, tc.suite, v, src, tc.wantValue, tc.wantSource)
+			}
+		})
+	}
+}
+
+// timeoutHint digs the exit_code check hint out of the first failing step so
+// the tests can assert which level the timeout-kill message names.
+func timeoutHint(t *testing.T, res *SuiteResult) string {
+	t.Helper()
+	for _, sc := range res.Scenarios {
+		for _, st := range sc.Steps {
+			for _, c := range st.Checks {
+				if c != nil && !c.OK && strings.Contains(c.Hint, "was killed") {
+					return c.Hint
+				}
+			}
+		}
+	}
+	t.Fatalf("no timeout-kill hint found in result: %+v", res.Scenarios)
+	return ""
+}
+
+// TestEngine_SuiteTimeoutBoundsSteps proves suite.timeout bounds a step with
+// no timeout of its own (#17) and the failure hint names suite.timeout.
+func TestEngine_SuiteTimeoutBoundsSteps(t *testing.T) {
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: s
+  timeout: 150ms
+scenarios:
+  - name: suite timeout kills the sleeping step
+    steps:
+      - run: {shell: true, command: `+sleepCmd(5)+`}
+      - assert:
+          exit_code: 0
+`)
+	if res.Status != StatusFailed {
+		t.Fatalf("status = %s, want failed: %+v", res.Status, res.Scenarios)
+	}
+	if hint := timeoutHint(t, res); !strings.Contains(hint, "suite.timeout") {
+		t.Errorf("hint = %q, want it to name suite.timeout", hint)
+	}
+}
+
+// TestEngine_DefaultsRunTimeoutApplies proves defaults.run.timeout bounds a
+// bare step (#17) and the hint names defaults.run.timeout — even though the
+// loader no longer string-merges it into the step.
+func TestEngine_DefaultsRunTimeoutApplies(t *testing.T) {
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: s
+  timeout: 10s
+defaults:
+  run:
+    timeout: 150ms
+scenarios:
+  - name: defaults timeout kills the sleeping step
+    steps:
+      - run: {shell: true, command: `+sleepCmd(5)+`}
+      - assert:
+          exit_code: 0
+`)
+	if res.Status != StatusFailed {
+		t.Fatalf("status = %s, want failed: %+v", res.Status, res.Scenarios)
+	}
+	if hint := timeoutHint(t, res); !strings.Contains(hint, "defaults.run.timeout") {
+		t.Errorf("hint = %q, want it to name defaults.run.timeout", hint)
+	}
+}
+
+// TestEngine_RunnerTimeoutBeatsDefaultsRun proves the runner-common timeout
+// outranks defaults.run.timeout in the chain (#17) — the level the loader
+// string-merge used to invert.
+func TestEngine_RunnerTimeoutBeatsDefaultsRun(t *testing.T) {
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: s
+runners:
+  slow:
+    type: cmd
+    timeout: 10s
+defaults:
+  run:
+    timeout: 50ms
+scenarios:
+  - name: runner timeout wins so the short sleep survives
+    steps:
+      - run: {shell: true, runner: slow, command: `+sleepCmd(1)+`}
+      - assert:
+          exit_code: 0
+`)
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed (runner 10s must beat defaults 50ms): %+v", res.Status, res.Scenarios)
+	}
+}
+
+// TestEngine_StepTimeoutZeroDisables proves `timeout: "0"` opts a step out of
+// every timeout level, including a short suite.timeout (#17).
+func TestEngine_StepTimeoutZeroDisables(t *testing.T) {
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: s
+  timeout: 150ms
+scenarios:
+  - name: step zero disables the suite bound
+    steps:
+      - run: {shell: true, timeout: "0", command: `+sleepCmd(1)+`}
+      - assert:
+          exit_code: 0
+`)
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed (timeout 0 must disable the 150ms suite bound): %+v", res.Status, res.Scenarios)
+	}
+}
+
+// TestEngine_StepTimeoutHintNamesRunTimeout proves a step-authored timeout
+// kill still says run.timeout (#17).
+func TestEngine_StepTimeoutHintNamesRunTimeout(t *testing.T) {
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: s
+scenarios:
+  - name: step timeout kills the sleeping step
+    steps:
+      - run: {shell: true, timeout: 150ms, command: `+sleepCmd(5)+`}
+      - assert:
+          exit_code: 0
+`)
+	if res.Status != StatusFailed {
+		t.Fatalf("status = %s, want failed: %+v", res.Status, res.Scenarios)
+	}
+	if hint := timeoutHint(t, res); !strings.Contains(hint, "run.timeout") {
+		t.Errorf("hint = %q, want it to name run.timeout", hint)
+	}
+}

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -18,6 +18,9 @@ func Explain(w io.Writer, s *spec.Spec, path string) error {
 
 	fmt.Fprintf(&b, "Spec: %s\n", path)
 	fmt.Fprintf(&b, "Suite: %s\n", s.Suite.Name)
+	if s.Suite.Timeout != "" {
+		fmt.Fprintf(&b, "Default step timeout: %s (suite.timeout; a step or runner timeout overrides it)\n", s.Suite.Timeout)
+	}
 	if len(s.Secrets) > 0 {
 		fmt.Fprintf(&b, "Secrets declared: %s\n", strings.Join(s.Secrets, ", "))
 	}

--- a/internal/loader/defaults.go
+++ b/internal/loader/defaults.go
@@ -74,9 +74,12 @@ func mergeRunDefaults(def, r *spec.Run) {
 	if r.Cwd == "" {
 		r.Cwd = def.Cwd
 	}
-	if r.Timeout == "" {
-		r.Timeout = def.Timeout
-	}
+	// Timeout is deliberately NOT merged here: the engine resolves the full
+	// precedence chain (step > runner > defaults.run > suite > built-in, #17)
+	// itself, and merging at load time would erase which level supplied the
+	// value — the timeout-kill hint names that level, and a runner-common
+	// timeout must beat defaults.run.timeout, which a string-fill here would
+	// invert.
 	if r.Stdin == "" {
 		r.Stdin = def.Stdin
 	}

--- a/internal/loader/defaults_test.go
+++ b/internal/loader/defaults_test.go
@@ -277,6 +277,58 @@ scenarios:
 	}
 }
 
+// TestValidate_SuiteTimeoutInvalid proves an unparsable suite.timeout is a
+// load-time validation error (exit 2) naming the field (#17).
+func TestValidate_SuiteTimeoutInvalid(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: sample
+  timeout: fast
+scenarios:
+  - name: s
+    steps:
+      - run:
+          command: echo hi
+`
+	_, err := LoadBytes("sample.atago.yaml", []byte(src))
+	if err == nil {
+		t.Fatal("LoadBytes() = nil error, want a suite.timeout validation error")
+	}
+	if !strings.Contains(err.Error(), "suite.timeout") {
+		t.Errorf("error = %q, want it to mention suite.timeout", err)
+	}
+}
+
+// TestApplyDefaults_DoesNotMergeTimeout proves defaults.run.timeout is left to
+// the engine's precedence resolver instead of being string-merged into steps
+// (#17): the merged step keeps an empty timeout so the resolver can tell the
+// levels apart.
+func TestApplyDefaults_DoesNotMergeTimeout(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: sample
+defaults:
+  run:
+    timeout: 5s
+scenarios:
+  - name: s
+    steps:
+      - run:
+          command: echo hi
+`
+	s, err := LoadBytes("sample.atago.yaml", []byte(src))
+	if err != nil {
+		t.Fatalf("LoadBytes() error = %v", err)
+	}
+	if got := s.Scenarios[0].Steps[0].Run.Timeout; got != "" {
+		t.Errorf("run.timeout = %q, want empty (the engine resolves defaults.run.timeout itself)", got)
+	}
+}
+
 // TestApplyDefaults_Service proves defaults.service fills shell/env and copies a
 // whole ready probe into a service that declares none, while a service with its
 // own ready keeps it.

--- a/internal/loader/validate.go
+++ b/internal/loader/validate.go
@@ -29,6 +29,7 @@ func validate(s *spec.Spec) []string {
 	if s.Suite.Name == "" {
 		add("suite.name is required")
 	}
+	validateSuiteTimeout(add, &s.Suite)
 	if len(s.Scenarios) == 0 {
 		add("scenarios must contain at least one scenario")
 	}
@@ -72,6 +73,16 @@ func validate(s *spec.Spec) []string {
 // ignore is reported here instead. Fields the loader does merge are validated on
 // the concrete elements after applyDefaults (and, for a shared readiness probe,
 // here too, so a wrong probe fails even when no scenario declares a service).
+// validateSuiteTimeout checks the suite-level default step timeout (#17).
+func validateSuiteTimeout(add func(string, ...any), s *spec.Suite) {
+	if s.Timeout == "" {
+		return
+	}
+	if _, err := time.ParseDuration(s.Timeout); err != nil {
+		add("suite.timeout %q is not a valid duration (e.g. \"2m\"); use \"0\" to disable the built-in default", s.Timeout)
+	}
+}
+
 func validateDefaults(add func(string, ...any), d *spec.Defaults) {
 	if d == nil {
 		return

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -65,6 +65,9 @@ type Document struct {
 type Spec struct {
 	SpecPath string `json:"spec_path"`
 	Suite    string `json:"suite"`
+	// SuiteTimeout mirrors suite.timeout, the suite-level default step timeout
+	// (#17); empty when the built-in default applies.
+	SuiteTimeout string `json:"suite_timeout,omitempty"`
 	// Source is the authored location of the suite declaration (#80). Omitted
 	// when positions are unavailable.
 	Source  *Source  `json:"source,omitempty"`
@@ -198,12 +201,13 @@ func buildSpec(in Input) Spec {
 	out := Spec{
 		// Forward slashes keep spec_path stable across platforms (Windows
 		// filepath.Clean uses backslashes), so the manifest is a portable contract.
-		SpecPath:  filepath.ToSlash(in.Path),
-		Suite:     s.Suite.Name,
-		Secrets:   append([]string(nil), s.Secrets...),
-		Network:   buildNetwork(s),
-		Runners:   buildRunners(s.Runners, in.Source),
-		Scenarios: make([]Scenario, 0, len(s.Scenarios)),
+		SpecPath:     filepath.ToSlash(in.Path),
+		Suite:        s.Suite.Name,
+		SuiteTimeout: s.Suite.Timeout,
+		Secrets:      append([]string(nil), s.Secrets...),
+		Network:      buildNetwork(s),
+		Runners:      buildRunners(s.Runners, in.Source),
+		Scenarios:    make([]Scenario, 0, len(s.Scenarios)),
 	}
 	if in.Source != nil {
 		out.Source = sourceFrom(in.Source.SuitePos())

--- a/internal/runner/cmd/cmd.go
+++ b/internal/runner/cmd/cmd.go
@@ -87,9 +87,12 @@ func (r *Runner) Run(ctx context.Context, run *spec.Run, workdir string) (*runne
 	}
 
 	// A step's own timeout (run.timeout) is an observable outcome, not an error:
-	// mark it TimedOut and let assertions inspect it.
+	// mark it TimedOut and let assertions inspect it. TimeoutSource carries the
+	// engine-resolved level (step/runner/defaults/suite/built-in, #17) into the
+	// failure hint.
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		res.TimedOut = true
+		res.TimeoutSource = run.TimeoutSource
 		res.ExitCode = -1
 		return res, nil
 	}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -25,6 +25,11 @@ type Result struct {
 	Duration time.Duration
 	Workdir  string
 	TimedOut bool
+	// TimeoutSource names the level that supplied the timeout that killed the
+	// command (run.timeout / runner.timeout / defaults.run.timeout /
+	// suite.timeout / built-in default), so the failure hint can say which
+	// knob to adjust (#17). Empty when TimedOut is false.
+	TimeoutSource string
 
 	// HTTP fields, set only by the http runner (IsHTTP reports which family is
 	// populated, since a zero StatusCode is indistinguishable from "no response").

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -56,6 +56,12 @@ type ScenarioDefaults struct {
 // Suite groups scenarios under a name.
 type Suite struct {
 	Name string `yaml:"name"`
+	// Timeout is the suite-level default step timeout (#17): every run, http,
+	// query, and grpc step without a more specific timeout (step > runner >
+	// defaults.run > suite) is bounded by this Go duration. "0"/"0s" disables
+	// the bound. When no level configures one, a built-in 60s default applies
+	// so a hanging command fails instead of stalling the run forever.
+	Timeout string `yaml:"timeout,omitempty"`
 	// Env is exported to every scenario, setup, and teardown step in the
 	// suite (a scenario's own env wins per key). Values get ${name} expansion
 	// against the suite store (${suitedir}, ${env:NAME}, setup stores).
@@ -386,10 +392,16 @@ type Run struct {
 	// Shell is a pointer so an authored `shell: false` is distinguishable from
 	// "unset" when `defaults.run.shell` is layered in (an authored value always
 	// wins over a default).
-	Shell   *bool             `yaml:"shell,omitempty"`
-	Cwd     string            `yaml:"cwd,omitempty"`
-	Timeout string            `yaml:"timeout,omitempty"`
-	Env     map[string]string `yaml:"env,omitempty"`
+	Shell   *bool  `yaml:"shell,omitempty"`
+	Cwd     string `yaml:"cwd,omitempty"`
+	Timeout string `yaml:"timeout,omitempty"`
+	// TimeoutSource names the level that supplied the effective Timeout
+	// (run.timeout / runner.timeout / defaults.run.timeout / suite.timeout /
+	// built-in default). It is set by the engine's precedence resolver (#17),
+	// never authored, and lets a timeout-kill failure hint say which level to
+	// adjust.
+	TimeoutSource string            `yaml:"-"`
+	Env           map[string]string `yaml:"env,omitempty"`
 	// ClearEnv starts the child from an empty environment instead of inheriting
 	// the host environment (#16), so host vars (LANG, GIT_*, proxies, ...) cannot
 	// silently change the behavior under test. A pointer so an authored

--- a/schema/atago.schema.json
+++ b/schema/atago.schema.json
@@ -17,6 +17,10 @@
       "additionalProperties": false,
       "properties": {
         "name": { "type": "string", "minLength": 1 },
+        "timeout": {
+          "type": "string",
+          "description": "Suite-level default step timeout (#17): every run/http/query/grpc step without a more specific timeout (step > runner > defaults.run > suite) is bounded by this Go duration. \"0\" disables. When no level configures one, a built-in 60s default applies."
+        },
         "env": {
           "description": "Environment exported to every scenario, setup, and teardown step (a scenario's own env wins per key).",
           "type": "object",

--- a/schema/manifest.schema.json
+++ b/schema/manifest.schema.json
@@ -41,6 +41,10 @@
           "description": "Suite name declared by the spec.",
           "type": "string"
         },
+        "suite_timeout": {
+          "description": "Suite-level default step timeout (suite.timeout, #17); omitted when the built-in default applies.",
+          "type": "string"
+        },
         "secrets": {
           "description": "Declared secret names (omitted when none).",
           "type": "array",

--- a/schema_test.go
+++ b/schema_test.go
@@ -142,6 +142,19 @@ scenarios:
 	}
 }
 
+// TestSchema_AcceptsSuiteTimeout confirms suite.timeout (#17) is accepted.
+func TestSchema_AcceptsSuiteTimeout(t *testing.T) {
+	s := loadSchema(t)
+	src := `version: "1"
+suite: {name: x, timeout: 2m}
+scenarios:
+  - name: a
+    steps: [{run: {command: echo, timeout: "0"}}]`
+	if err := s.Validate(yamlToAny(t, []byte(src))); err != nil {
+		t.Errorf("schema rejected valid suite.timeout spec:\n%v", err)
+	}
+}
+
 // TestSchema_RejectsInvalid confirms the schema actually catches bad specs.
 func TestSchema_RejectsInvalid(t *testing.T) {
 	s := loadSchema(t)
@@ -225,6 +238,12 @@ suite: {name: x}
 scenarios:
   - name: a
     steps: [{run: {command: env, clear_env: "yes"}}]`,
+		// Issue #17: suite.timeout is a Go duration string, not a number.
+		"suite timeout as number": `version: "1"
+suite: {name: x, timeout: 30}
+scenarios:
+  - name: a
+    steps: [{run: {command: echo}}]`,
 	}
 	for name, src := range bad {
 		t.Run(name, func(t *testing.T) {

--- a/test/e2e/atago/timeouts.atago.yaml
+++ b/test/e2e/atago/timeouts.atago.yaml
@@ -1,0 +1,117 @@
+version: "1"
+
+suite:
+  name: atago self-hosting / step timeouts (suite default + escape hatch)
+
+# Exercises #17: suite.timeout bounds every step without a more specific
+# timeout, the failure hint names the level that supplied the bound, and
+# `timeout: "0"` opts a step back out. The probes use POSIX `sleep`, so these
+# scenarios skip on Windows; the precedence chain itself is covered by unit
+# tests on every OS.
+scenarios:
+  - name: suite.timeout kills a hanging step and the hint names it
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: hang.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: hang
+              timeout: 1s
+            scenarios:
+              - name: sleeps past the suite bound
+                steps:
+                  - run:
+                      shell: true
+                      command: sleep 300
+                  - assert:
+                      exit_code: 0
+      - run:
+          command: ${atago} run hang.atago.yaml
+          timeout: 30s
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "timed out"
+              - "suite.timeout"
+
+  - name: a step timeout beats the suite timeout and the hint says run.timeout
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: step_wins.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: step-wins
+              timeout: 30s
+            scenarios:
+              - name: the step's own 1s bound fires first
+                steps:
+                  - run:
+                      shell: true
+                      command: sleep 300
+                      timeout: 1s
+                  - assert:
+                      exit_code: 0
+      - run:
+          command: ${atago} run step_wins.atago.yaml
+          timeout: 30s
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "timed out"
+              - "run.timeout"
+
+  - name: timeout zero disables a short suite bound
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: optout.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: optout
+              timeout: 1s
+            scenarios:
+              - name: the opted-out step outlives the suite bound
+                steps:
+                  - run:
+                      shell: true
+                      command: sleep 2
+                      timeout: "0"
+                  - assert:
+                      exit_code: 0
+      - run:
+          command: ${atago} run optout.atago.yaml
+          timeout: 30s
+      - assert:
+          exit_code: 0
+
+  - name: an invalid suite.timeout is a load-time error
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: bad
+              timeout: fast
+            scenarios:
+              - name: never runs
+                steps:
+                  - run:
+                      command: echo hi
+      - run:
+          command: ${atago} run bad.atago.yaml
+      # A spec-content (validation) error exits 2.
+      - assert:
+          exit_code: 2
+          stderr:
+            contains: "suite.timeout"


### PR DESCRIPTION
## Summary

This PR introduces a built-in 60s default timeout for run/http/query/grpc steps and a suite-level `suite.timeout` override (#17), so an unconfigured hanging command fails loudly within a bounded budget instead of stalling a run (or CI job) forever. `timeout: "0"` (or "0s") at any level is the documented escape hatch that disables the bound entirely.

## Changes

- `internal/engine/timeout.go`: a single precedence resolver — step > runner common `timeout` > `defaults.run.timeout` > `suite.timeout` > built-in 60s — that returns both the winning duration and a source label; an explicit "0" at any level stops the walk and disables the bound.
- `internal/engine`: `runStep` resolves the timeout once (before the retry loop) for local cmd runs; `resolveConn` gains a `defaultBounded` flag so query/grpc join the chain while ssh/browser keep their historical unbounded-when-empty behavior; `resolveHTTPConfig` joins the chain for http steps; `runConfig` threads `suiteTimeout` and `defaultsRunTimeout`.
- `internal/spec`: new `Suite.Timeout` field and an engine-populated `Run.TimeoutSource` (yaml:"-") carrying the resolved level into the runner.
- `internal/runner` / `internal/assert`: `Result.TimeoutSource` flows into the timeout-kill hint, which now names the level that supplied the bound ("the command hit its suite.timeout after 150ms and was killed before exiting"); the old hardcoded "run.timeout" wording remains the fallback.
- `internal/loader`: `suite.timeout` is duration-validated (exit 2 on garbage); `defaults.run.timeout` is no longer string-merged into steps at load time so the engine can tell the levels apart — this also fixes the chain order (runner common timeout now correctly outranks `defaults.run.timeout`).
- `schema/atago.schema.json` (suite.timeout) and `schema/manifest.schema.json` (`suite_timeout`); `atago explain` prints a "Default step timeout" line; the manifest emits `suite_timeout`.
- New `examples/timeouts.atago.yaml` (hermetic, registered), README prose + Examples row, and a prominent CHANGELOG "Changed" entry for the behavior change.
- Tests: resolver table test (all five levels + "0"), engine tests for suite/defaults bounds, runner-beats-defaults ordering, step "0" opt-out, and hint naming; loader tests for invalid `suite.timeout` and the removed merge; assert hint test; schema accept/reject; self-hosted E2E `test/e2e/atago/timeouts.atago.yaml` driving inner atago runs (POSIX scenarios skip on Windows; the load-error scenario runs everywhere).

## Design Decisions

- The precedence is resolved in ONE engine-side resolver instead of the loader's string-merge because the merge erased which level supplied the value (the hint must name it) and inverted the intended runner-vs-defaults order.
- ssh and browser runners deliberately stay out of the default bound: their timeout governs a long-lived session/connection rather than one step, and the issue scopes the default to run/http/query/grpc.
- This is a documented behavior change: specs relying on unbounded steps must set a real bound or opt out with `timeout: "0"`. All in-repo suites were audited (longest step budget found: 30s sleeps in service fixtures, which are services and unaffected).

Closes #17