### PR TITLE
feat(engine): accept stdin from a workdir file and binary base64 stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project follows [Semantic Versioning](https://semver.org/).
   (`SystemRoot`, `SystemDrive`, `TEMP`, `TMP`, `PATHEXT`) is always retained.
   `pass_env` without `clear_env: true` is a load-time error (exit 2).
   See `examples/hermetic_env.atago.yaml`.
+- stdin sources (#18): `run.stdin` now also accepts `{file: path}` (a
+  workdir-relative, `${name}`-expanded, path-confined file whose bytes are fed
+  to the child) and `{base64: data}` (binary stdin, validated at load time; no
+  `${name}` expansion, mirroring `fixture.base64`), alongside the historical
+  inline string. The mapping form sets exactly one of file/base64 (exit 2
+  otherwise). See `examples/stdin.atago.yaml`.
 - Suite-level default step timeout (#17): `suite.timeout: 2m` bounds every
   `run`/`http`/`query`/`grpc` step that has no more specific timeout.
   Precedence: step > runner `timeout` > `defaults.run.timeout` >
@@ -34,6 +40,8 @@ and this project follows [Semantic Versioning](https://semver.org/).
   "the command timed out ... and was killed" instead of hanging the run (or a
   CI job) forever. Specs relying on unbounded runs must either set a real
   bound (`suite.timeout: 10m`) or opt out explicitly with `timeout: "0"`.
+- `defaults.run.stdin` is no longer accepted (#18): stdin is per-step input
+  data, the same category as `command`. Declare it on each step.
 - `defaults.run.timeout` is no longer string-merged into steps at load time;
   the engine resolves the timeout precedence chain itself so a runner-common
   `timeout` now correctly outranks `defaults.run.timeout`, and the failure

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Every feature has a commented, runnable spec under [examples/](examples/). The e
 | [teardown](examples/teardown.atago.yaml) | cleanup steps that always run — pass or fail — sharing the scenario's variables |
 | [hermetic_env](examples/hermetic_env.atago.yaml) | `clear_env: true` starts commands from an empty environment, `pass_env` re-admits an allowlist of host variables |
 | [timeouts](examples/timeouts.atago.yaml) | the built-in 60s default step timeout, `suite.timeout`, per-step overrides, and the `timeout: "0"` escape hatch |
+| [stdin](examples/stdin.atago.yaml) | stdin sources: inline text, `stdin: {file: ...}` from a workdir file, and binary input via `stdin: {base64: ...}` |
 | [matrix](examples/matrix.atago.yaml) | one template scenario expanded per parameter row |
 | [pty](examples/pty.atago.yaml) | interactive testing in a real pseudo-terminal: expect/send sessions, TTY-detection (POSIX-only) |
 | [retry](examples/retry.atago.yaml) | polling a command until an assertion passes |

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-44 suites · 148 scenarios
+45 suites · 153 scenarios
 ## Contents
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 3 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
@@ -170,6 +170,12 @@
 - [atago self-hosting / ssh runner](#atago-self-hosting--ssh-runner) — 2 scenarios
   - [an ssh runner without host/user fails validation (exit 2)](#scenario-an-ssh-runner-without-hostuser-fails-validation-exit-2)
   - [a run step naming an undeclared runner fails validation (exit 2)](#scenario-a-run-step-naming-an-undeclared-runner-fails-validation-exit-2)
+- [atago self-hosting / stdin sources (file + base64)](#atago-self-hosting--stdin-sources-file--base64) — 5 scenarios
+  - [base64 stdin delivers the exact byte count](#scenario-base64-stdin-delivers-the-exact-byte-count)
+  - [stdin file is expanded and read from the workdir](#scenario-stdin-file-is-expanded-and-read-from-the-workdir)
+  - [a stdin file outside the workdir is rejected at runtime](#scenario-a-stdin-file-outside-the-workdir-is-rejected-at-runtime)
+  - [stdin with both file and base64 is a load-time error](#scenario-stdin-with-both-file-and-base64-is-a-load-time-error)
+  - [invalid base64 stdin is a load-time error](#scenario-invalid-base64-stdin-is-a-load-time-error)
 - [atago self-hosting / store](#atago-self-hosting--store) — 2 scenarios
   - [a stored JSON value is reusable in later commands](#scenario-a-stored-json-value-is-reusable-in-later-commands)
   - [storing from a missing JSON path is an execution error](#scenario-storing-from-a-missing-json-path-is-an-execution-error)
@@ -2961,6 +2967,116 @@ ${atago} run norunner.atago.yaml
 #### Then
 - exit code is `2`
 - stderr contains `is not declared`
+## atago self-hosting / stdin sources (file + base64)
+Source: `test/e2e/atago/stdin_sources.atago.yaml`
+### Scenario: base64 stdin delivers the exact byte count
+_skipped on windows_
+#### Inputs
+_stdin for `wc`:_
+```text
+(binary, 8 base64 chars)
+```
+#### When
+```shell
+wc -c
+```
+#### Then
+- exit code is `0`
+- stdout matches `/^\s*4\s*$/`
+### Scenario: stdin file is expanded and read from the workdir
+_skipped on windows_
+#### Given
+- Fixture file `payload.txt` is created.
+#### Inputs
+_Fixture `payload.txt`:_
+```text
+from-a-file
+```
+_stdin for `cat`:_
+```text
+(read from file ${workdir}/payload.txt)
+```
+#### When
+```shell
+cat
+```
+#### Then
+- exit code is `0`
+- stdout equals an exact value
+### Scenario: a stdin file outside the workdir is rejected at runtime
+_skipped on windows_
+#### Given
+- Fixture file `escape.atago.yaml` is created.
+#### Inputs
+_Fixture `escape.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: escape
+scenarios:
+  - name: tries to read outside the workdir
+    steps:
+      - run:
+          command: cat
+          stdin:
+            file: ../outside.txt
+```
+#### When
+```shell
+${atago} run escape.atago.yaml
+```
+#### Then
+- exit code is not `0`
+- stdout contains `run.stdin.file`
+### Scenario: stdin with both file and base64 is a load-time error
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: bad
+scenarios:
+  - name: both sources
+    steps:
+      - run:
+          command: cat
+          stdin:
+            file: in.txt
+            base64: AAEC
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `exactly one of file/base64`
+### Scenario: invalid base64 stdin is a load-time error
+#### Given
+- Fixture file `badb64.atago.yaml` is created.
+#### Inputs
+_Fixture `badb64.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: badb64
+scenarios:
+  - name: bad payload
+    steps:
+      - run:
+          command: cat
+          stdin:
+            base64: "not!!base64"
+```
+#### When
+```shell
+${atago} run badb64.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `not valid base64`
 ## atago self-hosting / store
 Source: `test/e2e/atago/store.atago.yaml`
 ### Scenario: a stored JSON value is reusable in later commands

--- a/doc/e2e/jq.md
+++ b/doc/e2e/jq.md
@@ -29,10 +29,16 @@ jq -c .
 - stdout at `$.a` equals `1`
 - stderr is empty
 ### Scenario: sort-keys output is deterministic and exact
+#### Given
+- Fixture file `input.json` is created.
 #### Inputs
-_stdin for `jq`:_
+_Fixture `input.json`:_
 ```text
 {"b":2,"a":1}
+```
+_stdin for `jq`:_
+```text
+(read from file input.json)
 ```
 #### When
 ```shell

--- a/examples/stdin.atago.yaml
+++ b/examples/stdin.atago.yaml
@@ -1,0 +1,69 @@
+version: "1"
+
+# Standard-input sources (#18). Filter-style CLIs (jq, sort, iconv, pandoc)
+# live on stdin, and `stdin:` accepts three shapes:
+#
+#   stdin: "inline text"        # the historical scalar form, fed verbatim
+#   stdin: {file: input.txt}    # a workdir-relative file's bytes (expanded,
+#                               # path-confined like assertion paths)
+#   stdin: {base64: AAEC/w==}   # binary bytes, decoded before the run
+#
+# The mapping form sets exactly one of file/base64 (the loader rejects both or
+# neither, exit 2), and an invalid base64 payload is a load-time error too.
+# base64 gets no ${name} expansion — binary payloads stay byte-exact.
+# The probes below are POSIX commands, so these scenarios skip on Windows.
+# Runs green as-is on Linux/macOS: atago run examples/stdin.atago.yaml
+
+suite:
+  name: stdin sources
+
+scenarios:
+  - name: inline text is fed to stdin verbatim
+    skip:
+      os: windows
+    steps:
+      - run:
+          command: cat
+          stdin: "hello from stdin"
+      - assert:
+          exit_code: 0
+          stdout:
+            equals: hello from stdin
+
+  - name: stdin from a workdir file
+    skip:
+      os: windows
+    steps:
+      # Fixtures write the input; stdin: {file: ...} pipes it in. The path is
+      # ${name}-expanded and confined to the scenario workdir.
+      - fixture:
+          file: input.txt
+          content: |
+            beta
+            alpha
+      - run:
+          command: sort
+          stdin:
+            file: input.txt
+      - assert:
+          exit_code: 0
+          stdout:
+            contains:
+              - alpha
+              - beta
+
+  - name: binary stdin via base64
+    skip:
+      os: windows
+    steps:
+      # AAEC/w== decodes to the four bytes 00 01 02 ff — content no inline
+      # YAML string could carry. `wc -c` proves all four arrived.
+      - run:
+          shell: true
+          command: wc -c
+          stdin:
+            base64: AAEC/w==
+      - assert:
+          exit_code: 0
+          stdout:
+            matches: "^\\s*4\\s*$"

--- a/examples_test.go
+++ b/examples_test.go
@@ -36,6 +36,7 @@ var exampleSpecs = map[string]bool{ // path -> hermetic (run, not just validate)
 	"examples/shell_and_redirect.atago.yaml":  true,
 	"examples/snapshot.atago.yaml":            true,
 	"examples/ssh.atago.yaml":                 false,
+	"examples/stdin.atago.yaml":               true,
 	"examples/store_and_variables.atago.yaml": true,
 	"examples/suite_setup.atago.yaml":         false,
 	"examples/teardown.atago.yaml":            true,

--- a/internal/docgen/preview.go
+++ b/internal/docgen/preview.go
@@ -48,11 +48,24 @@ func inputPreviews(sc *spec.Scenario) []previewBlock {
 				})
 			}
 		case spec.StepRun:
-			if step.Run.Stdin != "" {
+			switch s := step.Run.Stdin; {
+			case s.Inline != "":
 				out = append(out, previewBlock{
 					label: fmt.Sprintf("stdin for `%s`", firstToken(step.Run.Command)),
 					lang:  "",
-					body:  truncatePreview(step.Run.Stdin),
+					body:  truncatePreview(s.Inline),
+				})
+			case s.File != "":
+				out = append(out, previewBlock{
+					label: fmt.Sprintf("stdin for `%s`", firstToken(step.Run.Command)),
+					lang:  "",
+					body:  "(read from file " + s.File + ")",
+				})
+			case s.Base64 != "":
+				out = append(out, previewBlock{
+					label: fmt.Sprintf("stdin for `%s`", firstToken(step.Run.Command)),
+					lang:  "",
+					body:  fmt.Sprintf("(binary, %d base64 chars)", len(s.Base64)),
 				})
 			}
 		}

--- a/internal/engine/expand.go
+++ b/internal/engine/expand.go
@@ -13,7 +13,11 @@ func expandRun(st *store.Store, r *spec.Run) *spec.Run {
 	c := *r
 	c.Command = st.Expand(r.Command)
 	c.Cwd = st.Expand(r.Cwd)
-	c.Stdin = st.Expand(r.Stdin)
+	// Stdin: inline text and the file path are ${name}-expanded; base64 is
+	// deliberately not (binary payloads must stay byte-exact, mirroring the
+	// fixture.base64 rule) (#18).
+	c.Stdin.Inline = st.Expand(r.Stdin.Inline)
+	c.Stdin.File = st.Expand(r.Stdin.File)
 	c.Env = st.ExpandMap(r.Env)
 	return &c
 }

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -105,7 +105,7 @@ func explainScenario(b *strings.Builder, sc *spec.Scenario) {
 			collectVars(vars, step.Fixture.File, step.Fixture.Content)
 		case spec.StepRun:
 			commands = append(commands, describeRun(step.Run))
-			collectVars(vars, step.Run.Command, step.Run.Cwd, step.Run.Stdin)
+			collectVars(vars, step.Run.Command, step.Run.Cwd, step.Run.Stdin.Inline, step.Run.Stdin.File)
 		case spec.StepAssert:
 			expects = append(expects, describeAsserts(step.Assert)...)
 		case spec.StepStore:
@@ -183,7 +183,7 @@ func explainScenario(b *strings.Builder, sc *spec.Scenario) {
 		switch step.Kind() {
 		case spec.StepRun:
 			teardown = append(teardown, describeRun(step.Run))
-			collectVars(vars, step.Run.Command, step.Run.Cwd, step.Run.Stdin)
+			collectVars(vars, step.Run.Command, step.Run.Cwd, step.Run.Stdin.Inline, step.Run.Stdin.File)
 		case spec.StepHTTP:
 			teardown = append(teardown, fmt.Sprintf("HTTP %s %s", step.HTTP.Method, step.HTTP.Path))
 			collectVars(vars, step.HTTP.Path, step.HTTP.Body)
@@ -284,6 +284,12 @@ func describeRun(r *spec.Run) string {
 			note += " (passes: " + strings.Join(r.PassEnv, ", ") + ")"
 		}
 		notes = append(notes, note)
+	}
+	switch {
+	case r.Stdin.File != "":
+		notes = append(notes, "stdin from file "+r.Stdin.File)
+	case r.Stdin.Base64 != "":
+		notes = append(notes, "binary stdin (base64)")
 	}
 	if r.ShellEnabled() {
 		notes = append(notes, "shell")

--- a/internal/loader/defaults.go
+++ b/internal/loader/defaults.go
@@ -80,9 +80,8 @@ func mergeRunDefaults(def, r *spec.Run) {
 	// value — the timeout-kill hint names that level, and a runner-common
 	// timeout must beat defaults.run.timeout, which a string-fill here would
 	// invert.
-	if r.Stdin == "" {
-		r.Stdin = def.Stdin
-	}
+	// Stdin is deliberately NOT merged: like command it is per-step input
+	// data, and the validator rejects it on defaults.run (#18).
 	r.Env = mergeStringMap(def.Env, r.Env)
 	if r.ClearEnv == nil {
 		r.ClearEnv = def.ClearEnv

--- a/internal/loader/defaults_test.go
+++ b/internal/loader/defaults_test.go
@@ -277,6 +277,105 @@ scenarios:
 	}
 }
 
+// TestValidate_StdinShapes proves the stdin one-of rule and base64 validation
+// fire at load time with positioned messages (#18).
+func TestValidate_StdinShapes(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name, src, wantMsg string
+	}{
+		{
+			name: "empty mapping",
+			src: `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: s
+    steps:
+      - run:
+          command: cat
+          stdin: {}
+`,
+			wantMsg: "exactly one of file/base64",
+		},
+		{
+			name: "both file and base64",
+			src: `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: s
+    steps:
+      - run:
+          command: cat
+          stdin: {file: in.txt, base64: AAEC}
+`,
+			wantMsg: "exactly one of file/base64",
+		},
+		{
+			name: "invalid base64",
+			src: `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: s
+    steps:
+      - run:
+          command: cat
+          stdin: {base64: "not!!base64"}
+`,
+			wantMsg: "not valid base64",
+		},
+		{
+			name: "unknown stdin key",
+			src: `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: s
+    steps:
+      - run:
+          command: cat
+          stdin: {fil: in.txt}
+`,
+			wantMsg: "accepted: file, base64",
+		},
+		{
+			name: "defaults.run.stdin rejected",
+			src: `
+version: "1"
+suite:
+  name: sample
+defaults:
+  run:
+    stdin: "shared input"
+scenarios:
+  - name: s
+    steps:
+      - run:
+          command: cat
+`,
+			wantMsg: "defaults.run.stdin is not supported",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := LoadBytes("sample.atago.yaml", []byte(tc.src))
+			if err == nil {
+				t.Fatal("LoadBytes() = nil error, want a stdin validation error")
+			}
+			if !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Errorf("error = %q, want substring %q", err, tc.wantMsg)
+			}
+		})
+	}
+}
+
 // TestValidate_SuiteTimeoutInvalid proves an unparsable suite.timeout is a
 // load-time validation error (exit 2) naming the field (#17).
 func TestValidate_SuiteTimeoutInvalid(t *testing.T) {

--- a/internal/loader/fuzz_test.go
+++ b/internal/loader/fuzz_test.go
@@ -17,6 +17,10 @@ func FuzzLoadBytes(f *testing.F) {
 		"version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps:\n      - run: {command: echo}",
 		"version: \"1\"\nsuite: {name: x}\nscenarios:\n  - name: a\n    steps:\n      - run: {command: echo}\n        assert: {exit_code: 0}",
 		"version: \"1\"\nsuite: {name: x}\nrunners:\n  d: {type: db, dsn: \"sqlite::memory:\"}\nscenarios:\n  - name: a\n    steps: [{query: {runner: d, sql: SELECT 1}}, {assert: {rows: {empty: false}}}]",
+		// stdin sources (#18): inline scalar, file mapping, base64 mapping.
+		"version: \"1\"\nsuite: {name: x}\nscenarios:\n  - name: a\n    steps: [{run: {command: cat, stdin: \"inline\"}}]",
+		"version: \"1\"\nsuite: {name: x}\nscenarios:\n  - name: a\n    steps: [{run: {command: cat, stdin: {file: in.txt}}}]",
+		"version: \"1\"\nsuite: {name: x}\nscenarios:\n  - name: a\n    steps: [{run: {command: cat, stdin: {base64: AAEC/w==}}}]",
 	}
 	for _, s := range seeds {
 		f.Add([]byte(s))

--- a/internal/loader/validate.go
+++ b/internal/loader/validate.go
@@ -1,6 +1,7 @@
 package loader
 
 import (
+	"encoding/base64"
 	"fmt"
 	"maps"
 	"regexp"
@@ -94,6 +95,9 @@ func validateDefaults(add func(string, ...any), d *spec.Defaults) {
 		if r.Retry != nil {
 			add("defaults.run.retry is not supported (retry is per-step)")
 		}
+		if !r.Stdin.IsZero() {
+			add("defaults.run.stdin is not supported (stdin is per-step input data, like command)")
+		}
 		if r.Timeout != "" {
 			if _, err := time.ParseDuration(r.Timeout); err != nil {
 				add("defaults.run.timeout %q is not a valid duration (e.g. \"30s\")", r.Timeout)
@@ -110,6 +114,29 @@ func validateDefaults(add func(string, ...any), d *spec.Defaults) {
 		}
 		validateHermeticEnv(add, "defaults.service", sv.ClearEnv, sv.PassEnv)
 		validateReady(add, "defaults.service", sv.Ready)
+	}
+}
+
+// validateStdin checks a run step's stdin source (#18): the mapping form must
+// set exactly one of file/base64, and a base64 payload must decode — at load
+// time, so a typo fails with a positioned message instead of mid-run.
+func validateStdin(add func(string, ...any), where string, s spec.Stdin) {
+	if s.IsMapping() {
+		set := 0
+		if s.File != "" {
+			set++
+		}
+		if s.Base64 != "" {
+			set++
+		}
+		if set != 1 {
+			add("%s.stdin must set exactly one of file/base64 (or be a plain string for inline text)", where)
+		}
+	}
+	if s.Base64 != "" {
+		if _, err := base64.StdEncoding.DecodeString(s.Base64); err != nil {
+			add("%s.stdin.base64 is not valid base64: %v", where, err)
+		}
 	}
 }
 
@@ -263,6 +290,7 @@ func validateSuiteBlock(add func(string, ...any), where string, steps []spec.Ste
 				add("%s.run.command is required", sw)
 			}
 			validateHermeticEnv(add, sw+".run", st.Run.ClearEnv, st.Run.PassEnv)
+			validateStdin(add, sw+".run", st.Run.Stdin)
 			validateRetry(add, sw+".run", st.Run.Retry)
 		case spec.StepStore:
 			validateStore(add, sw, st.Store)
@@ -404,6 +432,7 @@ func validateStep(add func(string, ...any), where string, st *spec.Step, runners
 			}
 		}
 		validateHermeticEnv(add, where+".run", st.Run.ClearEnv, st.Run.PassEnv)
+		validateStdin(add, where+".run", st.Run.Stdin)
 		validateRetry(add, where+".run", st.Run.Retry)
 	case spec.StepAssert:
 		validateAssert(add, where, st.Assert)

--- a/internal/manifest/scenario.go
+++ b/internal/manifest/scenario.go
@@ -107,7 +107,7 @@ func buildStep(index int, step *spec.Step, vars map[string]bool) Step {
 		if r.Retry != nil {
 			st.Retry = &Retry{Times: r.Retry.Times, Interval: r.Retry.Interval}
 		}
-		collectVars(vars, r.Command, r.Cwd, r.Stdin)
+		collectVars(vars, r.Command, r.Cwd, r.Stdin.Inline, r.Stdin.File)
 		for _, v := range r.Env {
 			collectVars(vars, v)
 		}

--- a/internal/runner/cmd/cmd.go
+++ b/internal/runner/cmd/cmd.go
@@ -4,9 +4,12 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -58,8 +61,12 @@ func (r *Runner) Run(ctx context.Context, run *spec.Run, workdir string) (*runne
 	// otherwise block until it exits on its own. WaitDelay is a portable backstop
 	// that force-closes the pipes if a stray child still lingers.
 	configureCancellation(cmd)
-	if run.Stdin != "" {
-		cmd.Stdin = strings.NewReader(run.Stdin)
+	stdin, err := stdinReader(run, workdir)
+	if err != nil {
+		return nil, err
+	}
+	if stdin != nil {
+		cmd.Stdin = stdin
 	}
 
 	var stdout, stderr strings.Builder
@@ -115,6 +122,38 @@ func (r *Runner) Run(ctx context.Context, run *spec.Run, workdir string) (*runne
 		return nil, fmt.Errorf("failed to execute %q: %w", run.Command, runErr)
 	}
 	return res, nil
+}
+
+// stdinReader builds the reader fed to the command's standard input (#18):
+// inline text verbatim, a workdir-confined file's bytes, or decoded base64
+// for binary input. It returns nil when no stdin was authored (the child
+// inherits no stdin, exec's default). The one-of shape and the base64 payload
+// are validated at load time; the file read stays a runtime concern because
+// the file typically comes from an earlier fixture or run step.
+func stdinReader(run *spec.Run, workdir string) (io.Reader, error) {
+	s := run.Stdin
+	switch {
+	case s.File != "":
+		abs, err := security.ResolveWorkdirPath("run.stdin.file", workdir, s.File)
+		if err != nil {
+			return nil, err
+		}
+		data, err := os.ReadFile(abs) //nolint:gosec // confined to the scenario workdir above
+		if err != nil {
+			return nil, fmt.Errorf("run.stdin.file: %w", err)
+		}
+		return bytes.NewReader(data), nil
+	case s.Base64 != "":
+		data, err := base64.StdEncoding.DecodeString(s.Base64)
+		if err != nil {
+			// Unreachable for loader-validated specs; kept for direct API users.
+			return nil, fmt.Errorf("run.stdin.base64: %w", err)
+		}
+		return bytes.NewReader(data), nil
+	case s.Inline != "":
+		return strings.NewReader(s.Inline), nil
+	}
+	return nil, nil
 }
 
 // writeRedirects writes the captured stdout/stderr to the workdir-relative files

--- a/internal/runner/cmd/cmd_test.go
+++ b/internal/runner/cmd/cmd_test.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -233,13 +235,83 @@ func TestRun_ClearEnvEndToEnd(t *testing.T) {
 	}
 }
 
+// TestRun_StdinFromFile proves stdin: {file: ...} feeds a workdir file's bytes
+// to the child (#18).
+func TestRun_StdinFromFile(t *testing.T) {
+	t.Parallel()
+	wd := t.TempDir()
+	if err := os.WriteFile(filepath.Join(wd, "in.txt"), []byte("piped\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	r := New()
+	res, err := r.Run(context.Background(), &spec.Run{
+		Command: argvCommand("cat", "findstr piped"),
+		Stdin:   spec.Stdin{File: "in.txt"},
+	}, wd)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got := strings.TrimSpace(string(res.Stdout)); got != "piped" {
+		t.Errorf("stdout = %q, want piped", got)
+	}
+}
+
+// TestRun_StdinFileConfinedToWorkdir proves the stdin file path may not escape
+// the scenario workdir (#18).
+func TestRun_StdinFileConfinedToWorkdir(t *testing.T) {
+	t.Parallel()
+	r := New()
+	_, err := r.Run(context.Background(), &spec.Run{
+		Command: argvCommand("cat", "findstr x"),
+		Stdin:   spec.Stdin{File: "../escape.txt"},
+	}, t.TempDir())
+	if err == nil {
+		t.Fatal("expected a workdir-confinement error, got nil")
+	}
+}
+
+// TestRun_StdinFileMissing proves a missing stdin file is a named execution
+// error instead of a silent empty stdin (#18).
+func TestRun_StdinFileMissing(t *testing.T) {
+	t.Parallel()
+	r := New()
+	_, err := r.Run(context.Background(), &spec.Run{
+		Command: argvCommand("cat", "findstr x"),
+		Stdin:   spec.Stdin{File: "nope.txt"},
+	}, t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "run.stdin.file") {
+		t.Fatalf("error = %v, want it to name run.stdin.file", err)
+	}
+}
+
+// TestRun_StdinBase64Binary proves base64 stdin delivers the decoded bytes
+// exactly, including NUL and non-UTF8 bytes (#18).
+func TestRun_StdinBase64Binary(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("cat-based byte-exact check is POSIX-only; loader/schema cover Windows")
+	}
+	want := []byte{0x00, 0x01, 0x02, 0xff}
+	r := New()
+	res, err := r.Run(context.Background(), &spec.Run{
+		Command: "cat",
+		Stdin:   spec.Stdin{Base64: base64.StdEncoding.EncodeToString(want)},
+	}, t.TempDir())
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !bytes.Equal(res.Stdout, want) {
+		t.Errorf("stdout = %x, want %x (byte-exact binary delivery)", res.Stdout, want)
+	}
+}
+
 func TestRun_Stdin(t *testing.T) {
 	t.Parallel()
 	r := New()
 	// cat / findstr both copy the matching stdin lines to stdout.
 	res, err := r.Run(context.Background(), &spec.Run{
 		Command: argvCommand("cat", "findstr piped"),
-		Stdin:   "piped\n",
+		Stdin:   spec.Stdin{Inline: "piped\n"},
 	}, t.TempDir())
 	if err != nil {
 		t.Fatalf("Run() error = %v", err)

--- a/internal/spec/describe.go
+++ b/internal/spec/describe.go
@@ -109,7 +109,7 @@ func SecurityNotes(sc *Scenario) []string {
 			if NetworkCommand.MatchString(step.Run.Command) {
 				add("network access: " + step.Run.Command)
 			}
-			addEnvRefs(step.Run.Command, step.Run.Stdin)
+			addEnvRefs(step.Run.Command, step.Run.Stdin.Inline, step.Run.Stdin.File)
 			addEnvRefs(envValues(step.Run.Env)...)
 		case StepHTTP:
 			add("network access: HTTP request")

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -412,7 +412,10 @@ type Run struct {
 	// (#16). Only meaningful with ClearEnv (the loader rejects it otherwise);
 	// unset host variables are skipped, not an error.
 	PassEnv []string `yaml:"pass_env,omitempty"`
-	Stdin   string   `yaml:"stdin,omitempty"`
+	// Stdin feeds the command's standard input: a scalar string (inline
+	// text), {file: path} (workdir-relative, expanded and confined), or
+	// {base64: data} for binary bytes (#18).
+	Stdin Stdin `yaml:"stdin,omitempty"`
 	// StdoutTo / StderrTo redirect the command's captured stdout / stderr to a
 	// workdir-relative file (create/truncate), so a `shell: false` step can write
 	// output to a file without borrowing the shell's `>` operator. The streams are
@@ -669,6 +672,67 @@ type ImageAssert struct {
 	// for SimilarTo. It defaults to 0 (an exact pixel match); lossy formats need a
 	// small tolerance such as 0.02.
 	MaxDiff *float64 `yaml:"max_diff,omitempty"`
+}
+
+// Stdin is a run step's standard-input source (#18). It accepts either the
+// historical scalar string (inline text) or a mapping with exactly one of
+// `file` (a workdir-relative, ${name}-expanded, workdir-confined path whose
+// bytes are fed to the child) or `base64` (binary bytes, validated at load
+// time; no ${name} expansion, mirroring fixture.base64). The loader enforces
+// the one-of rule.
+type Stdin struct {
+	// Inline is the scalar form, fed to stdin verbatim.
+	Inline string
+	// File names a workdir-relative file whose bytes become stdin.
+	File string
+	// Base64 carries binary stdin as base64.
+	Base64 string
+
+	// mapped records that the author used the mapping form, so the validator
+	// can reject an empty mapping ({}), which is otherwise indistinguishable
+	// from "no stdin".
+	mapped bool
+}
+
+// IsZero reports whether no stdin was authored at all.
+func (s Stdin) IsZero() bool {
+	return s.Inline == "" && s.File == "" && s.Base64 == "" && !s.mapped
+}
+
+// IsMapping reports whether the author used the {file/base64} mapping form.
+func (s Stdin) IsMapping() bool { return s.mapped }
+
+// UnmarshalYAML decodes stdin as a scalar string or a {file}/{base64} mapping.
+// It uses the interface-based decoder so escapes like "\x1b" in the inline
+// form are resolved by goccy's parser, matching the historical behavior.
+// Unknown mapping keys are rejected here (a custom unmarshaler bypasses the
+// loader's strict-decode), with the accepted shapes spelled out.
+func (s *Stdin) UnmarshalYAML(unmarshal func(any) error) error {
+	var one string
+	if err := unmarshal(&one); err == nil {
+		s.Inline = one
+		return nil
+	}
+	var raw map[string]any
+	if err := unmarshal(&raw); err != nil {
+		return fmt.Errorf("stdin must be a string, {file: path}, or {base64: data}")
+	}
+	s.mapped = true
+	for k, v := range raw {
+		str, ok := v.(string)
+		if !ok {
+			return fmt.Errorf("stdin.%s must be a string", k)
+		}
+		switch k {
+		case "file":
+			s.File = str
+		case "base64":
+			s.Base64 = str
+		default:
+			return fmt.Errorf("stdin: unknown key %q (accepted: file, base64)", k)
+		}
+	}
+	return nil
 }
 
 // ExitCode accepts either a bare integer or {not: <int>}.

--- a/schema/atago.schema.json
+++ b/schema/atago.schema.json
@@ -89,8 +89,7 @@
             "timeout": { "type": "string" },
             "env": { "type": "object", "additionalProperties": { "type": "string" } },
             "clear_env": { "type": "boolean", "description": "Start the child from an empty environment instead of inheriting the host environment (#16). On Windows a small system-critical set (SystemRoot, SystemDrive, TEMP, TMP, PATHEXT) is always retained." },
-            "pass_env": { "type": "array", "items": { "type": "string", "minLength": 1 }, "description": "Host variables copied into the cleared environment (#16). Requires clear_env: true; unset host variables are skipped." },
-            "stdin": { "type": "string" }
+            "pass_env": { "type": "array", "items": { "type": "string", "minLength": 1 }, "description": "Host variables copied into the cleared environment (#16). Requires clear_env: true; unset host variables are skipped." }
           }
         },
         "scenario": {
@@ -438,7 +437,24 @@
         "env": { "type": "object", "additionalProperties": { "type": "string" } },
         "clear_env": { "type": "boolean", "description": "Start the child from an empty environment instead of inheriting the host environment (#16). On Windows a small system-critical set (SystemRoot, SystemDrive, TEMP, TMP, PATHEXT) is always retained." },
         "pass_env": { "type": "array", "items": { "type": "string", "minLength": 1 }, "description": "Host variables copied into the cleared environment (#16). Requires clear_env: true; unset host variables are skipped." },
-        "stdin": { "type": "string" },
+        "stdin": {
+          "description": "Standard input for the command (#18): a plain string (inline text), {file: path} (workdir-relative, path-confined), or {base64: data} for binary bytes.",
+          "oneOf": [
+            { "type": "string" },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["file"],
+              "properties": { "file": { "type": "string", "minLength": 1 } }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["base64"],
+              "properties": { "base64": { "type": "string" } }
+            }
+          ]
+        },
         "stdout_to": { "type": "string", "minLength": 1, "description": "Write the command's captured stdout to this workdir-relative file (create/truncate), without needing shell redirection." },
         "stderr_to": { "type": "string", "minLength": 1, "description": "Write the command's captured stderr to this workdir-relative file (create/truncate), without needing shell redirection." },
         "retry": { "$ref": "#/$defs/retry" }

--- a/schema_test.go
+++ b/schema_test.go
@@ -155,6 +155,23 @@ scenarios:
 	}
 }
 
+// TestSchema_AcceptsStdinSources confirms the three stdin shapes (#18) are
+// accepted.
+func TestSchema_AcceptsStdinSources(t *testing.T) {
+	s := loadSchema(t)
+	src := `version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps:
+      - run: {command: cat, stdin: "inline"}
+      - run: {command: cat, stdin: {file: in.txt}}
+      - run: {command: cat, stdin: {base64: AAEC/w==}}`
+	if err := s.Validate(yamlToAny(t, []byte(src))); err != nil {
+		t.Errorf("schema rejected valid stdin sources:\n%v", err)
+	}
+}
+
 // TestSchema_RejectsInvalid confirms the schema actually catches bad specs.
 func TestSchema_RejectsInvalid(t *testing.T) {
 	s := loadSchema(t)
@@ -244,6 +261,26 @@ suite: {name: x, timeout: 30}
 scenarios:
   - name: a
     steps: [{run: {command: echo}}]`,
+		// Issue #18: the stdin mapping form sets exactly one of file/base64.
+		"stdin with both file and base64": `version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps: [{run: {command: cat, stdin: {file: in.txt, base64: AAEC}}}]`,
+		// Issue #18: unknown stdin keys are rejected.
+		"stdin with unknown key": `version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps: [{run: {command: cat, stdin: {fil: in.txt}}}]`,
+		// Issue #18: defaults.run.stdin is per-step input data.
+		"defaults run stdin": `version: "1"
+suite: {name: x}
+defaults:
+  run: {stdin: shared}
+scenarios:
+  - name: a
+    steps: [{run: {command: cat}}]`,
 	}
 	for name, src := range bad {
 		t.Run(name, func(t *testing.T) {

--- a/test/e2e/atago/stdin_sources.atago.yaml
+++ b/test/e2e/atago/stdin_sources.atago.yaml
@@ -1,0 +1,113 @@
+version: "1"
+
+suite:
+  name: atago self-hosting / stdin sources (file + base64)
+
+# Exercises #18: stdin: {file: ...} pipes a workdir file into the child,
+# stdin: {base64: ...} delivers binary bytes exactly, and the malformed
+# shapes fail at load time with positioned messages. The byte-count probes
+# are POSIX (`wc -c`), so those scenarios skip on Windows; the load-error
+# scenarios run everywhere.
+scenarios:
+  - name: base64 stdin delivers the exact byte count
+    skip:
+      os: windows
+    steps:
+      # AAEC/w== is the four bytes 00 01 02 ff; wc -c must see all four.
+      - run:
+          shell: true
+          command: wc -c
+          stdin:
+            base64: AAEC/w==
+      - assert:
+          exit_code: 0
+          stdout:
+            matches: "^\\s*4\\s*$"
+
+  - name: stdin file is expanded and read from the workdir
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: payload.txt
+          content: "from-a-file"
+      # ${workdir} proves the path is ${name}-expanded before the confinement
+      # check; an absolute path inside the workdir is allowed.
+      - run:
+          command: cat
+          stdin:
+            file: ${workdir}/payload.txt
+      - assert:
+          exit_code: 0
+          stdout:
+            equals: from-a-file
+
+  - name: a stdin file outside the workdir is rejected at runtime
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: escape.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: escape
+            scenarios:
+              - name: tries to read outside the workdir
+                steps:
+                  - run:
+                      command: cat
+                      stdin:
+                        file: ../outside.txt
+      - run:
+          command: ${atago} run escape.atago.yaml
+      - assert:
+          exit_code: { not: 0 }
+      - assert:
+          stdout:
+            contains: "run.stdin.file"
+
+  - name: stdin with both file and base64 is a load-time error
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: bad
+            scenarios:
+              - name: both sources
+                steps:
+                  - run:
+                      command: cat
+                      stdin:
+                        file: in.txt
+                        base64: AAEC
+      - run:
+          command: ${atago} run bad.atago.yaml
+      - assert:
+          exit_code: 2
+          stderr:
+            contains: "exactly one of file/base64"
+
+  - name: invalid base64 stdin is a load-time error
+    steps:
+      - fixture:
+          file: badb64.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: badb64
+            scenarios:
+              - name: bad payload
+                steps:
+                  - run:
+                      command: cat
+                      stdin:
+                        base64: "not!!base64"
+      - run:
+          command: ${atago} run badb64.atago.yaml
+      - assert:
+          exit_code: 2
+          stderr:
+            contains: "not valid base64"

--- a/test/e2e/thirdparty/jq/jq.atago.yaml
+++ b/test/e2e/thirdparty/jq/jq.atago.yaml
@@ -25,9 +25,16 @@ scenarios:
 
   - name: sort-keys output is deterministic and exact
     steps:
+      # stdin can come from a workdir file (#18) instead of an inline string —
+      # the natural shape for large documents produced by fixtures or earlier
+      # steps.
+      - fixture:
+          file: input.json
+          content: '{"b":2,"a":1}'
       - run:
           command: jq -c --sort-keys .
-          stdin: '{"b":2,"a":1}'
+          stdin:
+            file: input.json
       - assert:
           exit_code: 0
           stdout:


### PR DESCRIPTION
## Summary

This PR extends `run.stdin` beyond an inline string (#18): `stdin: {file: path}` feeds a workdir file's bytes to the child, and `stdin: {base64: data}` delivers binary stdin — the input shapes filter-style CLIs (jq, sort, iconv, pandoc) need. The historical scalar form keeps working unchanged.

## Changes

- `internal/spec`: `Run.Stdin` becomes a polymorphic `Stdin` type (scalar → `Inline`, mapping → `File`/`Base64`) with a custom unmarshaler that rejects unknown mapping keys with the accepted shapes spelled out (a custom unmarshaler bypasses the loader's strict decode, so the key check lives here).
- `internal/runner/cmd`: `stdinReader` composes the input — inline verbatim, file bytes via `security.ResolveWorkdirPath` (same confinement as `stdout_to`; `../` and outside-absolute paths rejected at runtime), decoded base64 for binary.
- `internal/loader`: the mapping form must set exactly one of file/base64 and base64 must decode — both load-time errors with positions (exit 2); `defaults.run.stdin` is now rejected (per-step input data, same category as `command`) and its merge removed.
- `internal/engine`: `${name}` expansion applies to the inline text and the file path, deliberately NOT to base64 (binary must stay byte-exact, mirroring `fixture.base64`).
- `explain` notes "stdin from file ..." / "binary stdin (base64)"; `doc` previews name the file or the base64 size instead of dumping bytes; manifest/security walkers cover the new fields.
- `schema/atago.schema.json`: `run.stdin` is now a oneOf (string | {file} | {base64}); `defaults.run.stdin` removed.
- New `examples/stdin.atago.yaml` (hermetic, registered), README Examples row, CHANGELOG Added + Changed entries.
- Tests: cmd unit tests (file source, confinement, missing-file naming, byte-exact binary via cat), loader one-of/bad-base64/unknown-key/defaults-rejection cases, three new fuzz seeds, schema accept/reject cases, self-hosted E2E `test/e2e/atago/stdin_sources.atago.yaml` (`wc -c` proves the exact byte count; POSIX scenarios skip on Windows, the load-error scenarios run everywhere), and the jq third-party sort-keys scenario now exercises `stdin: {file: ...}`.

## Design Decisions

- The file read stays a runtime concern (not load-time) because the input typically comes from an earlier fixture or run step in the same scenario.
- `defaults.run.stdin` removal is a documented behavior change: sharing one stdin payload across steps was input data masquerading as configuration.

Closes #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for stdin inputs from inline text, a workdir-relative file, or base64-encoded data.
  * Updated examples and docs to show the new stdin options.

* **Bug Fixes**
  * Improved validation for invalid stdin configurations, including conflicting input sources and malformed base64.
  * Ensured file-based stdin stays confined to the scenario workdir.

* **Changes**
  * Removed support for configuring stdin through shared defaults; stdin must now be set on each step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->