### PR TITLE
feat(assert): add exit_code in-set matcher for accepted exit code sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project follows [Semantic Versioning](https://semver.org/).
   (`SystemRoot`, `SystemDrive`, `TEMP`, `TMP`, `PATHEXT`) is always retained.
   `pass_env` without `clear_env: true` is a load-time error (exit 2).
   See `examples/hermetic_env.atago.yaml`.
+- `exit_code: {in: [0, 2]}` (#19): assert the exit code against a set of
+  accepted values — the contract shape of grep (0/1) or
+  `terraform plan -detailed-exitcode` (0/2). Exactly one of the bare-int /
+  `not` / `in` forms per assert; an empty or duplicated set is a load-time
+  error. Failure output lists the accepted codes, and a timeout kill keeps
+  its timeout hint.
 - stdin sources (#18): `run.stdin` now also accepts `{file: path}` (a
   workdir-relative, `${name}`-expanded, path-confined file whose bytes are fed
   to the child) and `{base64: data}` (binary stdin, validated at load time; no

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Every feature has a commented, runnable spec under [examples/](examples/). The e
 
 | Example | Shows |
 |---------|-------|
-| [run_and_assert](examples/run_and_assert.atago.yaml) | exit code, stdout/stderr matchers (`contains`, `equals`, `matches`/`not_matches`, lists, `line`), multi-target asserts |
+| [run_and_assert](examples/run_and_assert.atago.yaml) | exit code (exact, `not`, `in: [0, 2]` sets), stdout/stderr matchers (`contains`, `equals`, `matches`/`not_matches`, lists, `line`), multi-target asserts |
 | [shell_and_redirect](examples/shell_and_redirect.atago.yaml) | `shell: true` vs direct argv execution, `stdout_to`/`stderr_to` redirects |
 | [json_and_yaml](examples/json_and_yaml.atago.yaml) | JSONPath assertions, numeric bounds (`gt`/`lte`), the `yaml` matcher |
 | [files_and_fixtures](examples/files_and_fixtures.atago.yaml) | input fixtures (text and base64), `file` and `dir` assertions |

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-45 suites · 153 scenarios
+46 suites · 157 scenarios
 ## Contents
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 3 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
@@ -47,6 +47,11 @@
   - [file not_contains passes when the substring is absent](#scenario-file-not_contains-passes-when-the-substring-is-absent)
   - [not_contains fails when the substring is present](#scenario-not_contains-fails-when-the-substring-is-present)
   - [a shell metacharacter without shell is a load-time error](#scenario-a-shell-metacharacter-without-shell-is-a-load-time-error)
+- [atago self-hosting / exit_code in-set matcher](#atago-self-hosting--exit_code-in-set-matcher) — 4 scenarios
+  - [a listed exit code passes](#scenario-a-listed-exit-code-passes)
+  - [an unlisted exit code fails and the output lists the set](#scenario-an-unlisted-exit-code-fails-and-the-output-lists-the-set)
+  - [mixing not and in is a load-time error](#scenario-mixing-not-and-in-is-a-load-time-error)
+  - [an empty in list is a load-time error](#scenario-an-empty-in-list-is-a-load-time-error)
 - [atago self-hosting / explain](#atago-self-hosting--explain) — 1 scenario
   - [explain summarizes a spec without running it](#scenario-explain-summarizes-a-spec-without-running-it)
 - [atago self-hosting / fixture from (copy committed testdata)](#atago-self-hosting--fixture-from-copy-committed-testdata) — 2 scenarios
@@ -950,6 +955,94 @@ ${atago} run bad.atago.yaml
 #### Then
 - exit code is `2`
 - stderr contains `shell is not enabled`, `shell: true`, `stdout_to`
+## atago self-hosting / exit_code in-set matcher
+Source: `test/e2e/atago/exit_code_in.atago.yaml`
+### Scenario: a listed exit code passes
+#### When
+```shell
+exit 2
+```
+#### Then
+- exit code is one of `0`, `2`
+### Scenario: an unlisted exit code fails and the output lists the set
+#### Given
+- Fixture file `inner.atago.yaml` is created.
+#### Inputs
+_Fixture `inner.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: inner
+scenarios:
+  - name: exit 2 is not in the accepted set
+    steps:
+      - run:
+          shell: true
+          command: exit 2
+      - assert:
+          exit_code:
+            in: [0, 1]
+```
+#### When
+```shell
+${atago} run inner.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `exit code in [0, 1]`
+### Scenario: mixing not and in is a load-time error
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: bad
+scenarios:
+  - name: both forms
+    steps:
+      - run:
+          shell: true
+          command: exit 0
+      - assert:
+          exit_code:
+            not: 1
+            in: [0, 2]
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `exactly one of`
+### Scenario: an empty in list is a load-time error
+#### Given
+- Fixture file `empty.atago.yaml` is created.
+#### Inputs
+_Fixture `empty.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: empty
+scenarios:
+  - name: empty set
+    steps:
+      - run:
+          shell: true
+          command: exit 0
+      - assert:
+          exit_code:
+            in: []
+```
+#### When
+```shell
+${atago} run empty.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `at least one accepted exit code`
 ## atago self-hosting / explain
 Source: `test/e2e/atago/explain.atago.yaml`
 ### Scenario: explain summarizes a spec without running it

--- a/examples/run_and_assert.atago.yaml
+++ b/examples/run_and_assert.atago.yaml
@@ -60,3 +60,15 @@ scenarios:
           stdout:
             line: 1
             equals: first
+
+  - name: exit code sets match a documented contract
+    steps:
+      # Real CLIs define exit-code SETS as their contract: grep exits 0 or 1
+      # without error, terraform plan -detailed-exitcode exits 0 (clean) or 2
+      # (changes). `in:` asserts membership in the accepted set (#19).
+      - run:
+          shell: true
+          command: exit 2
+      - assert:
+          exit_code:
+            in: [0, 2]

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -5,11 +5,24 @@ package assert
 
 import (
 	"fmt"
+	"slices"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/nao1215/atago/internal/runner"
 	"github.com/nao1215/atago/internal/spec"
 )
+
+// intList renders an accepted exit-code set as "[0, 2]" for descriptions and
+// failure output (#19).
+func intList(ns []int) string {
+	parts := make([]string, len(ns))
+	for i, n := range ns {
+		parts[i] = strconv.Itoa(n)
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}
 
 // CheckResult is the structured outcome of one assertion.
 type CheckResult struct {
@@ -176,27 +189,42 @@ func checkExitCode(e *spec.ExitCode, res *runner.Result) *CheckResult {
 	if res.TimedOut {
 		actual = fmt.Sprintf("exit code %d (the command timed out after %s and was killed)", res.ExitCode, res.Duration.Round(time.Millisecond))
 	}
+	// timeoutHint replaces the mismatch hint when the command was killed by a
+	// timeout, naming the level that supplied it (step/runner/defaults/suite/
+	// built-in, #17) so the user knows which knob to adjust.
+	timeoutHint := func(fallback string) string {
+		if !res.TimedOut {
+			return fallback
+		}
+		source := res.TimeoutSource
+		if source == "" {
+			source = "run.timeout"
+		}
+		return fmt.Sprintf("the command hit its %s after %s and was killed before exiting", source, res.Duration.Round(time.Millisecond))
+	}
 	switch {
 	case e.Equals != nil:
 		desc := fmt.Sprintf("assert exit_code is %d", *e.Equals)
 		if res.ExitCode == *e.Equals {
 			return pass(desc)
 		}
-		hint := fmt.Sprintf("expected exit code %d but the command exited with %d", *e.Equals, res.ExitCode)
-		if res.TimedOut {
-			// Name the level that supplied the timeout (step/runner/defaults/
-			// suite/built-in, #17) so the user knows which knob to adjust.
-			source := res.TimeoutSource
-			if source == "" {
-				source = "run.timeout"
-			}
-			hint = fmt.Sprintf("the command hit its %s after %s and was killed before exiting", source, res.Duration.Round(time.Millisecond))
-		}
 		return &CheckResult{
 			Desc:     desc,
 			Expected: fmt.Sprintf("exit code %d", *e.Equals),
 			Actual:   actual,
-			Hint:     hint,
+			Hint:     timeoutHint(fmt.Sprintf("expected exit code %d but the command exited with %d", *e.Equals, res.ExitCode)),
+		}
+	case len(e.In) > 0:
+		set := intList(e.In)
+		desc := fmt.Sprintf("assert exit_code in %s", set)
+		if slices.Contains(e.In, res.ExitCode) {
+			return pass(desc)
+		}
+		return &CheckResult{
+			Desc:     desc,
+			Expected: fmt.Sprintf("exit code in %s", set),
+			Actual:   actual,
+			Hint:     timeoutHint(fmt.Sprintf("expected the exit code to be one of %s but the command exited with %d", set, res.ExitCode)),
 		}
 	case e.Not != nil:
 		desc := fmt.Sprintf("assert exit_code is not %d", *e.Not)
@@ -210,6 +238,6 @@ func checkExitCode(e *spec.ExitCode, res *runner.Result) *CheckResult {
 			Hint:     fmt.Sprintf("expected any exit code except %d", *e.Not),
 		}
 	default:
-		return &CheckResult{Desc: "assert exit_code", Hint: "exit_code must be an int or {not: int}"}
+		return &CheckResult{Desc: "assert exit_code", Hint: "exit_code must be an int, {not: int}, or {in: [int, ...]}"}
 	}
 }

--- a/internal/assert/assert_test.go
+++ b/internal/assert/assert_test.go
@@ -58,6 +58,44 @@ func TestCheck_ExitCode_TimedOut(t *testing.T) {
 	}
 }
 
+// TestCheck_ExitCode_In proves membership in the accepted set (#19): a listed
+// code passes, an unlisted one fails with the set spelled out.
+func TestCheck_ExitCode_In(t *testing.T) {
+	t.Parallel()
+	in := &spec.ExitCode{In: []int{0, 2}}
+	if got := Check(&spec.Assert{ExitCode: in}, &runner.Result{ExitCode: 2}, Env{}); !got.OK {
+		t.Errorf("exit code 2 against in [0, 2]: OK = false, want pass: %+v", got)
+	}
+	got := Check(&spec.Assert{ExitCode: in}, &runner.Result{ExitCode: 1}, Env{})
+	if got.OK {
+		t.Fatal("exit code 1 against in [0, 2]: OK = true, want failure")
+	}
+	if !strings.Contains(got.Expected, "exit code in [0, 2]") {
+		t.Errorf("Expected = %q, want it to list the accepted set", got.Expected)
+	}
+	if !strings.Contains(got.Hint, "[0, 2]") {
+		t.Errorf("Hint = %q, want it to list the accepted set", got.Hint)
+	}
+}
+
+// TestCheck_ExitCode_InTimedOut proves a timeout kill keeps the timeout hint
+// under the in matcher instead of presenting the synthetic -1 as a plain
+// mismatch (#19).
+func TestCheck_ExitCode_InTimedOut(t *testing.T) {
+	t.Parallel()
+	res := &runner.Result{ExitCode: -1, TimedOut: true, Duration: 200 * time.Millisecond}
+	got := Check(&spec.Assert{ExitCode: &spec.ExitCode{In: []int{0, 2}}}, res, Env{})
+	if got.OK {
+		t.Fatal("OK = true, want a failure for a timed-out command")
+	}
+	if !strings.Contains(got.Actual, "timed out after 200ms") {
+		t.Errorf("Actual = %q, want it to mention the timeout", got.Actual)
+	}
+	if !strings.Contains(got.Hint, "run.timeout") {
+		t.Errorf("Hint = %q, want the timeout hint, not a bare mismatch", got.Hint)
+	}
+}
+
 // TestCheck_ExitCode_TimedOutNamesSource proves the hint names the level that
 // supplied the timeout when the engine's resolver recorded one (#17).
 func TestCheck_ExitCode_TimedOutNamesSource(t *testing.T) {

--- a/internal/docgen/describe.go
+++ b/internal/docgen/describe.go
@@ -43,6 +43,13 @@ func describeTarget(a *spec.Assert, target spec.AssertTarget) string {
 		if a.ExitCode.Not != nil {
 			return fmt.Sprintf("exit code is not %s", markdown.Code(fmt.Sprint(*a.ExitCode.Not)))
 		}
+		if len(a.ExitCode.In) > 0 {
+			codes := make([]string, len(a.ExitCode.In))
+			for i, n := range a.ExitCode.In {
+				codes[i] = markdown.Code(fmt.Sprint(n))
+			}
+			return "exit code is one of " + strings.Join(codes, ", ")
+		}
 		if a.ExitCode.Equals != nil {
 			return fmt.Sprintf("exit code is %s", markdown.Code(fmt.Sprint(*a.ExitCode.Equals)))
 		}

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/nao1215/atago/internal/spec"
@@ -321,6 +322,9 @@ func describeTarget(a *spec.Assert, target spec.AssertTarget) string {
 		if a.ExitCode.Not != nil {
 			return fmt.Sprintf("exit code is not %d", *a.ExitCode.Not)
 		}
+		if len(a.ExitCode.In) > 0 {
+			return "exit code in " + intList(a.ExitCode.In)
+		}
 		if a.ExitCode.Equals != nil {
 			return fmt.Sprintf("exit code is %d", *a.ExitCode.Equals)
 		}
@@ -566,6 +570,15 @@ func writeList(b *strings.Builder, title string, items []string) {
 	for _, it := range items {
 		fmt.Fprintf(b, "    - %s\n", it)
 	}
+}
+
+// intList renders an accepted exit-code set as "[0, 2]" (#19).
+func intList(ns []int) string {
+	parts := make([]string, len(ns))
+	for i, n := range ns {
+		parts[i] = strconv.Itoa(n)
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
 }
 
 func toSet(m map[string]string) map[string]bool {

--- a/internal/loader/defaults_test.go
+++ b/internal/loader/defaults_test.go
@@ -376,6 +376,93 @@ scenarios:
 	}
 }
 
+// TestValidate_ExitCodeIn proves the exit_code in-set rules (#19): one-of
+// violations, an empty set, duplicate values, and non-int entries all fail at
+// load time.
+func TestValidate_ExitCodeIn(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name, src, wantMsg string
+	}{
+		{
+			name: "not and in together",
+			src: `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: s
+    steps:
+      - run:
+          command: echo hi
+      - assert:
+          exit_code: {not: 1, in: [0, 2]}
+`,
+			wantMsg: "exactly one of",
+		},
+		{
+			name: "empty in list",
+			src: `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: s
+    steps:
+      - run:
+          command: echo hi
+      - assert:
+          exit_code: {in: []}
+`,
+			wantMsg: "at least one accepted exit code",
+		},
+		{
+			name: "duplicate values",
+			src: `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: s
+    steps:
+      - run:
+          command: echo hi
+      - assert:
+          exit_code: {in: [0, 2, 0]}
+`,
+			wantMsg: "more than once",
+		},
+		{
+			name: "non-int entry",
+			src: `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: s
+    steps:
+      - run:
+          command: echo hi
+      - assert:
+          exit_code: {in: [0, ok]}
+`,
+			wantMsg: "exit_code",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := LoadBytes("sample.atago.yaml", []byte(tc.src))
+			if err == nil {
+				t.Fatal("LoadBytes() = nil error, want an exit_code validation error")
+			}
+			if !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Errorf("error = %q, want substring %q", err, tc.wantMsg)
+			}
+		})
+	}
+}
+
 // TestValidate_SuiteTimeoutInvalid proves an unparsable suite.timeout is a
 // load-time validation error (exit 2) naming the field (#17).
 func TestValidate_SuiteTimeoutInvalid(t *testing.T) {

--- a/internal/loader/validate.go
+++ b/internal/loader/validate.go
@@ -117,6 +117,42 @@ func validateDefaults(add func(string, ...any), d *spec.Defaults) {
 	}
 }
 
+// validateExitCode checks the exit_code assertion (#19): exactly one of the
+// bare-int / {not} / {in} forms, and an `in` set that is non-empty with unique
+// values — a duplicated code is authoring confusion, not a wider contract.
+func validateExitCode(add func(string, ...any), where string, e *spec.ExitCode) {
+	set := 0
+	if e.Equals != nil {
+		set++
+	}
+	if e.Not != nil {
+		set++
+	}
+	if e.In != nil {
+		set++
+	}
+	if set == 0 {
+		add("%s must be an int, {not: int}, or {in: [int, ...]}", where)
+		return
+	}
+	if set > 1 {
+		add("%s: set exactly one of a bare int, not, or in", where)
+		return
+	}
+	if e.In != nil {
+		if len(e.In) == 0 {
+			add("%s.in must list at least one accepted exit code", where)
+		}
+		seen := make(map[int]bool, len(e.In))
+		for _, n := range e.In {
+			if seen[n] {
+				add("%s.in lists %d more than once", where, n)
+			}
+			seen[n] = true
+		}
+	}
+}
+
 // validateStdin checks a run step's stdin source (#18): the mapping form must
 // set exactly one of file/base64, and a base64 payload must decode — at load
 // time, so a typo fails with a positioned message instead of mid-run.
@@ -676,7 +712,9 @@ func validateAssert(add func(string, ...any), where string, a *spec.Assert) {
 func validateAssertTarget(add func(string, ...any), where string, a *spec.Assert, target spec.AssertTarget) {
 	switch target {
 	case spec.AssertExitCode:
-		// exit_code shape already enforced by ExitCode.UnmarshalYAML.
+		// Scalar/mapping shape enforced by ExitCode.UnmarshalYAML; the one-of
+		// rule and the `in` set contents are semantic checks (#19).
+		validateExitCode(add, where+".assert.exit_code", a.ExitCode)
 	case spec.AssertStdout:
 		validateStream(add, where+".assert.stdout", a.Stdout)
 	case spec.AssertStderr:

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -735,28 +735,34 @@ func (s *Stdin) UnmarshalYAML(unmarshal func(any) error) error {
 	return nil
 }
 
-// ExitCode accepts either a bare integer or {not: <int>}.
+// ExitCode accepts a bare integer, {not: <int>}, or {in: [<int>, ...]} (#19).
+// The `in` set is the contract shape real CLIs document (grep's 0/1,
+// terraform plan -detailed-exitcode's 0/2): membership in an accepted set.
 type ExitCode struct {
 	Equals *int
 	Not    *int
+	In     []int
 }
 
-// UnmarshalYAML decodes exit_code as a scalar int or a {not: int} map. Anything
-// else gets a purpose-built error: the generic decoder message ("string was
-// used where mapping is expected", positioned at the sub-node) reads like an
-// internal failure, and a spec author needs to know the two accepted shapes.
+// UnmarshalYAML decodes exit_code as a scalar int, a {not: int} map, or an
+// {in: [int, ...]} map. Anything else gets a purpose-built error: the generic
+// decoder message ("string was used where mapping is expected", positioned at
+// the sub-node) reads like an internal failure, and a spec author needs to
+// know the accepted shapes.
 func (e *ExitCode) UnmarshalYAML(b []byte) error {
 	if n, err := strconv.Atoi(trimYAMLScalar(string(b))); err == nil {
 		e.Equals = &n
 		return nil
 	}
 	var m struct {
-		Not *int `yaml:"not"`
+		Not *int  `yaml:"not"`
+		In  []int `yaml:"in"`
 	}
 	if err := yaml.Unmarshal(b, &m); err != nil {
-		return fmt.Errorf("exit_code must be an integer (exit_code: 0) or a negation (exit_code: {not: 0}), got %q", strings.TrimSpace(string(b)))
+		return fmt.Errorf("exit_code must be an integer (exit_code: 0), a negation (exit_code: {not: 0}), or a set (exit_code: {in: [0, 2]}), got %q", strings.TrimSpace(string(b)))
 	}
 	e.Not = m.Not
+	e.In = m.In
 	return nil
 }
 

--- a/schema/atago.schema.json
+++ b/schema/atago.schema.json
@@ -620,6 +620,20 @@
           "required": ["not"],
           "additionalProperties": false,
           "properties": { "not": { "type": "integer" } }
+        },
+        {
+          "type": "object",
+          "required": ["in"],
+          "additionalProperties": false,
+          "properties": {
+            "in": {
+              "description": "The exit code must be one of these values (#19) — the contract shape of grep (0/1) or terraform plan -detailed-exitcode (0/2).",
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": { "type": "integer" }
+            }
+          }
         }
       ]
     },

--- a/schema_test.go
+++ b/schema_test.go
@@ -172,6 +172,22 @@ scenarios:
 	}
 }
 
+// TestSchema_AcceptsExitCodeIn confirms exit_code: {in: [...]} (#19) is
+// accepted.
+func TestSchema_AcceptsExitCodeIn(t *testing.T) {
+	s := loadSchema(t)
+	src := `version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps:
+      - run: {command: echo}
+      - assert: {exit_code: {in: [0, 2]}}`
+	if err := s.Validate(yamlToAny(t, []byte(src))); err != nil {
+		t.Errorf("schema rejected valid exit_code in-set:\n%v", err)
+	}
+}
+
 // TestSchema_RejectsInvalid confirms the schema actually catches bad specs.
 func TestSchema_RejectsInvalid(t *testing.T) {
 	s := loadSchema(t)
@@ -281,6 +297,22 @@ defaults:
 scenarios:
   - name: a
     steps: [{run: {command: cat}}]`,
+		// Issue #19: an empty in list is rejected (minItems 1).
+		"exit_code in empty list": `version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps:
+      - run: {command: echo}
+      - assert: {exit_code: {in: []}}`,
+		// Issue #19: not and in cannot be combined (oneOf shapes).
+		"exit_code not and in mixed": `version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps:
+      - run: {command: echo}
+      - assert: {exit_code: {not: 1, in: [0]}}`,
 	}
 	for name, src := range bad {
 		t.Run(name, func(t *testing.T) {

--- a/test/e2e/atago/exit_code_in.atago.yaml
+++ b/test/e2e/atago/exit_code_in.atago.yaml
@@ -1,0 +1,91 @@
+version: "1"
+
+suite:
+  name: atago self-hosting / exit_code in-set matcher
+
+# Exercises #19: `exit_code: {in: [...]}` passes when the exit code is any of
+# the listed values, fails with the set spelled out otherwise, and the
+# malformed shapes are load-time errors. `exit 2` under shell: true works in
+# both sh and cmd.exe, so these scenarios run on every OS.
+scenarios:
+  - name: a listed exit code passes
+    steps:
+      - run:
+          shell: true
+          command: exit 2
+      - assert:
+          exit_code:
+            in: [0, 2]
+
+  - name: an unlisted exit code fails and the output lists the set
+    steps:
+      - fixture:
+          file: inner.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: inner
+            scenarios:
+              - name: exit 2 is not in the accepted set
+                steps:
+                  - run:
+                      shell: true
+                      command: exit 2
+                  - assert:
+                      exit_code:
+                        in: [0, 1]
+      - run:
+          command: ${atago} run inner.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains: "exit code in [0, 1]"
+
+  - name: mixing not and in is a load-time error
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: bad
+            scenarios:
+              - name: both forms
+                steps:
+                  - run:
+                      shell: true
+                      command: exit 0
+                  - assert:
+                      exit_code:
+                        not: 1
+                        in: [0, 2]
+      - run:
+          command: ${atago} run bad.atago.yaml
+      - assert:
+          exit_code: 2
+          stderr:
+            contains: "exactly one of"
+
+  - name: an empty in list is a load-time error
+    steps:
+      - fixture:
+          file: empty.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: empty
+            scenarios:
+              - name: empty set
+                steps:
+                  - run:
+                      shell: true
+                      command: exit 0
+                  - assert:
+                      exit_code:
+                        in: []
+      - run:
+          command: ${atago} run empty.atago.yaml
+      - assert:
+          exit_code: 2
+          stderr:
+            contains: "at least one accepted exit code"


### PR DESCRIPTION
## Summary

This PR adds an `in:` form to the `exit_code` assertion (#19): `exit_code: {in: [0, 2]}` passes when the exit code is any of the listed values — the contract shape real CLIs document (grep's 0/1, `terraform plan -detailed-exitcode`'s 0/2).

## Changes

- `internal/spec`: `ExitCode` gains `In []int`; the unmarshaler accepts the third shape and its error message now spells out all three accepted forms.
- `internal/assert`: membership check with `Expected: exit code in [0, 2]` and a hint listing the set; the timeout-kill hint (naming the level that supplied the timeout, #17) is factored into a shared helper so `equals` and `in` both keep it when the exit code is the synthetic -1.
- `internal/loader`: `validateExitCode` enforces exactly one of bare-int / `not` / `in`, a non-empty set, and unique values — all load-time errors (exit 2) with positions. This also upgrades the previously runtime-only "exit_code: {}" shape error to load time.
- `explain` renders "exit code in [0, 2]", `doc` renders "exit code is one of \`0\`, \`2\`".
- `schema/atago.schema.json`: the exitCode oneOf gains the `{in: [...]}` object (minItems 1, uniqueItems).
- `examples/run_and_assert.atago.yaml` gains an exit-code-set scenario (cross-platform: `exit 2` under `shell: true` works in sh and cmd.exe); README row updated; CHANGELOG entry.
- Tests: assert membership pass/fail + timed-out interaction, loader one-of/empty/duplicate/non-int cases, schema accept/reject cases, and self-hosted E2E `test/e2e/atago/exit_code_in.atago.yaml` (runs on every OS) proving the FAILED block lists the set and the malformed shapes exit 2.

Closes #19