### PR TITLE
feat(engine): add signal step for graceful-shutdown testing of managed services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project follows [Semantic Versioning](https://semver.org/).
   (`SystemRoot`, `SystemDrive`, `TEMP`, `TMP`, `PATHEXT`) is always retained.
   `pass_env` without `clear_env: true` is a load-time error (exit 2).
   See `examples/hermetic_env.atago.yaml`.
+- `signal:` step (#23): send a named POSIX signal (TERM, INT, HUP, USR1,
+  USR2, KILL) to a managed service's whole process group — scenario services
+  and suite services both — for declarative graceful-shutdown and
+  SIGHUP-reload testing. Handle-based targeting makes it race-free under
+  `--parallel`, unlike `kill`/`killall` shell hacks. An optional
+  `wait: {timeout: 5s}` blocks until the process exits and fails the step
+  with a named message when it does not. POSIX-only (Windows reports a clear
+  execution error, like pty). See `examples/signal.atago.yaml`.
 - `exit_code: {in: [0, 2]}` (#19): assert the exit code against a set of
   accepted values — the contract shape of grep (0/1) or
   `terraform plan -detailed-exitcode` (0/2). Exactly one of the bare-int /

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Every feature has a commented, runnable spec under [examples/](examples/). The e
 | [retry](examples/retry.atago.yaml) | polling a command until an assertion passes |
 | [snapshot](examples/snapshot.atago.yaml) | golden-file testing with normalized output |
 | [services](examples/services.atago.yaml) | background servers: readiness probes, `ready.store`, teardown |
+| [signal](examples/signal.atago.yaml) | `signal:` steps deliver SIGTERM/SIGHUP/... to a managed service's process group for graceful-shutdown and reload testing (POSIX-only) |
 | [defaults](examples/defaults.atago.yaml) | sharing `shell`/`env`/`service` fragments across scenarios |
 | [suite_setup](examples/suite_setup.atago.yaml) | once-per-suite bootstrap: ordered setup steps, suite-wide `service:` steps, `${suitedir}`, suite env, always-run suite teardown |
 | [select_skip_only](examples/select_skip_only.atago.yaml) | tags, and gating scenarios by OS, env var, or a probe command |

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -2858,8 +2858,9 @@ _skipped on windows_
 for i in 1 2 3 4 5 6 7 8 9 10; do [ -f reload.log ] && break; sleep 0.1; done; cat reload.log
 ```
 #### Then
-- exit code is `0`
-- stdout contains `reloaded`
+- after `for i in 1 2 3 4 5 6 7 8 9 10; do [ -f reload.log ] && break; sleep 0.1; done; cat reload.log`:
+  - exit code is `0`
+  - stdout contains `reloaded`
 ### Scenario: a wait timeout on a TERM-ignoring service fails with the documented message
 _skipped on windows_
 #### Given

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-46 suites · 157 scenarios
+47 suites · 161 scenarios
 ## Contents
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 3 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
@@ -164,6 +164,11 @@
 - [atago self-hosting / harness shell is not shadowed by the program PATH](#atago-self-hosting--harness-shell-is-not-shadowed-by-the-program-path) — 2 scenarios
   - [a PATH-resident fake sh does not hijack shell:true](#scenario-a-path-resident-fake-sh-does-not-hijack-shelltrue)
   - [ATAGO_SHELL overrides the shell used for shell:true](#scenario-atago_shell-overrides-the-shell-used-for-shelltrue)
+- [atago self-hosting / signal step (graceful shutdown)](#atago-self-hosting--signal-step-graceful-shutdown) — 4 scenarios
+  - [SIGTERM reaches the trap handler and wait observes the exit](#scenario-sigterm-reaches-the-trap-handler-and-wait-observes-the-exit)
+  - [SIGHUP triggers a reload without stopping the service](#scenario-sighup-triggers-a-reload-without-stopping-the-service)
+  - [a wait timeout on a TERM-ignoring service fails with the documented message](#scenario-a-wait-timeout-on-a-term-ignoring-service-fails-with-the-documented-message)
+  - [an unknown target service is a load-time error listing declared names](#scenario-an-unknown-target-service-is-a-load-time-error-listing-declared-names)
 - [atago self-hosting / skip-only command predicate](#atago-self-hosting--skip-only-command-predicate) — 3 scenarios
   - [skip command that succeeds skips the scenario](#scenario-skip-command-that-succeeds-skips-the-scenario)
   - [only command that fails skips the scenario](#scenario-only-command-that-fails-skips-the-scenario)
@@ -2831,6 +2836,87 @@ printf '%s\n' ok
 ```
 #### Then
 - stdout equals an exact value
+## atago self-hosting / signal step (graceful shutdown)
+Source: `test/e2e/atago/signal.atago.yaml`
+### Scenario: SIGTERM reaches the trap handler and wait observes the exit
+_skipped on windows_
+#### Given
+- Background service `server` is started: `trap 'echo graceful shutdown complete > server.log; exit 0' TERM; echo booted; while true; do sleep 0.1; done`.
+#### When
+```shell
+# send SIGTERM to service server and wait up to 5s for exit
+```
+#### Then
+- file `server.log` contains `graceful shutdown complete`
+### Scenario: SIGHUP triggers a reload without stopping the service
+_skipped on windows_
+#### Given
+- Background service `reloader` is started: `trap 'echo reloaded >> reload.log' HUP; echo booted; while true; do sleep 0.1; done`.
+#### When
+```shell
+# send SIGHUP to service reloader
+for i in 1 2 3 4 5 6 7 8 9 10; do [ -f reload.log ] && break; sleep 0.1; done; cat reload.log
+```
+#### Then
+- exit code is `0`
+- stdout contains `reloaded`
+### Scenario: a wait timeout on a TERM-ignoring service fails with the documented message
+_skipped on windows_
+#### Given
+- Fixture file `stubborn.atago.yaml` is created.
+#### Inputs
+_Fixture `stubborn.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: stubborn
+scenarios:
+  - name: never exits on TERM
+    services:
+      - name: stubborn
+        shell: true
+        command: "trap '' TERM; echo booted; while true; do sleep 0.2; done"
+        ready: {log: booted, timeout: 10s}
+    steps:
+      - signal:
+          service: stubborn
+          signal: TERM
+          wait:
+            timeout: 300ms
+```
+#### When
+```shell
+${atago} run stubborn.atago.yaml
+```
+#### Then
+- exit code is not `0`
+- stdout contains `did not exit within 300ms after SIGTERM`
+### Scenario: an unknown target service is a load-time error listing declared names
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: bad
+scenarios:
+  - name: wrong name
+    services:
+      - name: web
+        command: ./web
+    steps:
+      - signal:
+          service: cache
+          signal: TERM
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `not a declared service (declared: web)`
 ## atago self-hosting / skip-only command predicate
 Source: `test/e2e/atago/skip_command.atago.yaml`
 ### Scenario: skip command that succeeds skips the scenario

--- a/examples/signal.atago.yaml
+++ b/examples/signal.atago.yaml
@@ -1,0 +1,60 @@
+version: "1"
+
+# Signal steps (#23). `signal:` sends a named POSIX signal (TERM, INT, HUP,
+# USR1, USR2, KILL — optional SIG prefix accepted) to a service atago itself
+# started, targeting its whole process group. Because the target is a handle,
+# not a process name, delivery is race-free under --parallel — the reason
+# this exists instead of `kill`/`killall` shell hacks.
+#
+# `wait:` optionally blocks until the process exits (default timeout 5s); a
+# still-running process fails the step with "service X did not exit within
+# ... after SIGTERM". Signals are POSIX-only, so these scenarios skip on
+# Windows. Runs green as-is on Linux/macOS: atago run examples/signal.atago.yaml
+
+suite:
+  name: signal steps
+
+scenarios:
+  - name: a server shuts down gracefully on SIGTERM
+    skip:
+      os: windows
+    services:
+      # The classic graceful-shutdown shape: a trap handler cleans up, writes
+      # evidence, and exits 0.
+      - name: server
+        shell: true
+        command: "trap 'echo graceful shutdown complete > server.log; exit 0' TERM; echo booted; while true; do sleep 0.1; done"
+        ready:
+          log: booted
+    steps:
+      - signal:
+          service: server        # must name a declared scenario/suite service
+          signal: TERM
+          wait:
+            timeout: 5s          # fail loudly if it never exits
+      - assert:
+          file:
+            path: server.log
+            contains: "graceful shutdown complete"
+
+  - name: SIGHUP reloads configuration without a restart
+    skip:
+      os: windows
+    services:
+      - name: daemon
+        shell: true
+        command: "trap 'echo config reloaded >> daemon.log' HUP; echo booted; while true; do sleep 0.1; done"
+        ready:
+          log: booted
+    steps:
+      # No wait: the daemon handles the signal and keeps serving.
+      - signal:
+          service: daemon
+          signal: HUP
+      - run:
+          shell: true
+          command: "for i in 1 2 3 4 5 6 7 8 9 10; do [ -f daemon.log ] && break; sleep 0.1; done; cat daemon.log"
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: config reloaded

--- a/examples_test.go
+++ b/examples_test.go
@@ -34,6 +34,7 @@ var exampleSpecs = map[string]bool{ // path -> hermetic (run, not just validate)
 	"examples/select_skip_only.atago.yaml":    true,
 	"examples/services.atago.yaml":            true,
 	"examples/shell_and_redirect.atago.yaml":  true,
+	"examples/signal.atago.yaml":              true,
 	"examples/snapshot.atago.yaml":            true,
 	"examples/ssh.atago.yaml":                 false,
 	"examples/stdin.atago.yaml":               true,

--- a/internal/docgen/docgen.go
+++ b/internal/docgen/docgen.go
@@ -263,6 +263,18 @@ func commands(steps []spec.Step, expand func(string) string) []string {
 			if step.Store != nil {
 				out = append(out, fmt.Sprintf("# capture ${%s} from %s", step.Store.Name, storeSourceLabel(step.Store)))
 			}
+		case spec.StepSignal:
+			if step.Signal != nil {
+				line := fmt.Sprintf("# send SIG%s to service %s", spec.NormalizeSignalName(step.Signal.Signal), expand(step.Signal.Service))
+				if step.Signal.Wait != nil {
+					timeout := step.Signal.Wait.Timeout
+					if timeout == "" {
+						timeout = "5s"
+					}
+					line += fmt.Sprintf(" and wait up to %s for exit", timeout)
+				}
+				out = append(out, line)
+			}
 		}
 	}
 	return out
@@ -322,7 +334,7 @@ func thenGroups(sc *spec.Scenario, expand func(string) string) []thenGroup {
 	for i := range sc.Steps {
 		step := &sc.Steps[i]
 		switch step.Kind() {
-		case spec.StepRun, spec.StepHTTP, spec.StepQuery, spec.StepGRPC, spec.StepCDP:
+		case spec.StepRun, spec.StepHTTP, spec.StepQuery, spec.StepGRPC, spec.StepCDP, spec.StepSignal:
 			actionIdx, actionLbl = i, actionLabel(step, expand)
 		case spec.StepAssert:
 			if len(groups) == 0 || groups[len(groups)-1].actionIdx != actionIdx {
@@ -351,6 +363,8 @@ func actionLabel(step *spec.Step, expand func(string) string) string {
 		return "gRPC " + step.GRPC.Method
 	case spec.StepCDP:
 		return "the browser flow"
+	case spec.StepSignal:
+		return "SIG" + spec.NormalizeSignalName(step.Signal.Signal) + " to " + expand(step.Signal.Service)
 	default:
 		return ""
 	}

--- a/internal/docgen/docgen.go
+++ b/internal/docgen/docgen.go
@@ -379,10 +379,12 @@ func writeThen(md *markdown.Markdown, sc *spec.Scenario, expand func(string) str
 	if len(groups) == 0 {
 		return
 	}
+	// Keep this action set in sync with thenGroups: a drift flattens grouped
+	// bullets (or vice versa) for scenarios mixing the two step kinds.
 	actions := 0
 	for i := range sc.Steps {
 		switch sc.Steps[i].Kind() {
-		case spec.StepRun, spec.StepHTTP, spec.StepQuery, spec.StepGRPC, spec.StepCDP:
+		case spec.StepRun, spec.StepHTTP, spec.StepQuery, spec.StepGRPC, spec.StepCDP, spec.StepSignal:
 			actions++
 		}
 	}

--- a/internal/docgen/docgen_test.go
+++ b/internal/docgen/docgen_test.go
@@ -203,6 +203,56 @@ scenarios:
 	}
 }
 
+// TestGenerate_SignalGroupsThenBullets proves a signal step is an action for
+// Then-grouping (#23): a run + signal scenario (each with asserts) renders two
+// "after ...:" groups instead of one flattened list — the writeThen counter
+// and thenGroups must agree on what counts as an action.
+func TestGenerate_SignalGroupsThenBullets(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: sig
+scenarios:
+  - name: shutdown flow
+    services:
+      - name: server
+        command: ./server
+    steps:
+      - run:
+          command: ./client warmup
+      - assert:
+          exit_code: 0
+      - signal:
+          service: server
+          signal: TERM
+          wait:
+            timeout: 5s
+      - assert:
+          file:
+            path: server.log
+            contains: done
+`
+	s, err := loader.LoadBytes("sig.atago.yaml", []byte(src))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	var b bytes.Buffer
+	if err := Generate(&b, []Source{{Path: "sig.atago.yaml", Spec: s}}); err != nil {
+		t.Fatal(err)
+	}
+	out := b.String()
+	for _, w := range []string{
+		"# send SIGTERM to service server and wait up to 5s for exit",
+		"after `./client warmup`:",
+		"after `SIGTERM to server`:",
+	} {
+		if !strings.Contains(out, w) {
+			t.Errorf("doc output missing %q\n--- got ---\n%s", w, out)
+		}
+	}
+}
+
 // TestGenerate_MixedRunners verifies doc generation reaches parity with the
 // supported step kinds: background services, HTTP/query/gRPC/CDP steps all
 // appear in the narrative instead of only run steps (issue #41).

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -160,6 +160,7 @@ func (e *Engine) Run(ctx context.Context, s *spec.Spec, specPath string) *SuiteR
 		}
 		rc.suiteVars = suiteRT.vars
 		rc.suiteEnv = suiteRT.env
+		rc.suiteServices = suiteRT.services
 		defer func() {
 			// Deferred after suiteRT.stop ⇒ runs before it, so teardown can
 			// still reach the suite services.
@@ -333,6 +334,10 @@ type runConfig struct {
 	// and can name it in the timeout-kill hint.
 	suiteTimeout       string
 	defaultsRunTimeout string
+	// suiteServices are the suite-wide background processes started by
+	// suite.setup service steps (#7), threaded here so a scenario's `signal:`
+	// step (#23) can target them by name alongside its own services.
+	suiteServices []*servicerunner.Proc
 }
 
 func (e *Engine) runScenario(ctx context.Context, scenarioIdx int, sc *spec.Scenario, rc runConfig) ScenarioResult {
@@ -579,6 +584,15 @@ func (e *Engine) runScenario(ctx context.Context, scenarioIdx int, sc *spec.Scen
 			}
 			current = r
 			sr.Run = maskResult(masker, r)
+		case spec.StepSignal:
+			// Handle-based signaling (#23): the target is a service atago
+			// itself started (scenario services first, then suite services),
+			// so delivery is race-free under --parallel, unlike name-based
+			// kill/killall shell hacks.
+			if err := runSignal(step.Signal, st, services, rc.suiteServices); err != nil {
+				sr.ErrMsg = err.Error()
+				status = StatusError
+			}
 		default:
 			sr.ErrMsg = "step has no recognized action"
 			status = StatusError

--- a/internal/engine/signal.go
+++ b/internal/engine/signal.go
@@ -1,0 +1,70 @@
+package engine
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	servicerunner "github.com/nao1215/atago/internal/runner/service"
+	"github.com/nao1215/atago/internal/spec"
+	"github.com/nao1215/atago/internal/store"
+)
+
+// defaultSignalWait bounds `signal.wait` when no timeout is authored (#23).
+const defaultSignalWait = 5 * time.Second
+
+// runSignal executes a signal step (#23): resolve the target service by name
+// (scenario services first, then suite services), deliver the named POSIX
+// signal to its process group, and — when wait is set — block until the
+// process exits or the timeout elapses. The service name is ${name}-expanded
+// so matrix instances can target parameterized services; the signal name is
+// normalized (an optional SIG prefix, any case) to match the loader's rule.
+func runSignal(sg *spec.Signal, st *store.Store, scenarioServices, suiteServices []*servicerunner.Proc) error {
+	name := st.Expand(sg.Service)
+	proc := findServiceProc(name, scenarioServices, suiteServices)
+	if proc == nil {
+		return fmt.Errorf("signal step targets unknown service %q (no scenario or suite service with that name is running)", name)
+	}
+	sigName := spec.NormalizeSignalName(sg.Signal)
+	if err := proc.Signal(sigName); err != nil {
+		return fmt.Errorf("signal step: %w", err)
+	}
+	if sg.Wait == nil {
+		return nil
+	}
+	timeout := defaultSignalWait
+	if sg.Wait.Timeout != "" {
+		d, err := time.ParseDuration(sg.Wait.Timeout) // validated at load time
+		if err == nil {
+			timeout = d
+		}
+	}
+	if !proc.WaitExit(timeout) {
+		return fmt.Errorf("service %q did not exit within %s after SIG%s", name, timeout, sigName)
+	}
+	return nil
+}
+
+// findServiceProc resolves a service name against the scenario's own services
+// first, then the suite-wide ones, mirroring the store's scenario-over-suite
+// precedence.
+func findServiceProc(name string, scenarioServices, suiteServices []*servicerunner.Proc) *servicerunner.Proc {
+	for _, p := range scenarioServices {
+		if p.Name() == name {
+			return p
+		}
+	}
+	for _, p := range suiteServices {
+		if p.Name() == name {
+			return p
+		}
+	}
+	return nil
+}
+
+// signalNames is the accepted signal set (#23), shared with the loader's
+// validation message.
+var signalNames = []string{"TERM", "INT", "HUP", "USR1", "USR2", "KILL"}
+
+// SignalNameList renders the accepted signal names for error messages.
+func SignalNameList() string { return strings.Join(signalNames, ", ") }

--- a/internal/engine/signal_test.go
+++ b/internal/engine/signal_test.go
@@ -1,0 +1,118 @@
+package engine
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestEngine_SignalGracefulShutdown proves the full #23 flow: a trap-based
+// service receives SIGTERM from a signal step, the wait observes its exit,
+// and the marker file it wrote is assertable — all race-free under the
+// default parallelism because the target is atago's own service handle.
+func TestEngine_SignalGracefulShutdown(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("signal steps are POSIX-only")
+	}
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: s
+scenarios:
+  - name: graceful shutdown on SIGTERM
+    services:
+      - name: server
+        shell: true
+        command: "trap 'echo graceful shutdown complete > server.log; exit 0' TERM; echo ready; while true; do sleep 0.1; done"
+        ready: {log: ready, timeout: 5s}
+    steps:
+      - signal:
+          service: server
+          signal: TERM
+          wait:
+            timeout: 5s
+      - assert:
+          file:
+            path: server.log
+            contains: "graceful shutdown complete"
+`)
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed: %+v", res.Status, res.Scenarios)
+	}
+}
+
+// TestEngine_SignalWaitTimeoutFails proves a TERM-ignoring service fails the
+// step with the documented message when wait elapses (#23).
+func TestEngine_SignalWaitTimeoutFails(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("signal steps are POSIX-only")
+	}
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: s
+scenarios:
+  - name: stubborn service outlives the wait
+    services:
+      - name: stubborn
+        shell: true
+        command: "trap '' TERM; echo ready; while true; do sleep 0.2; done"
+        ready: {log: ready, timeout: 5s}
+    steps:
+      - signal:
+          service: stubborn
+          signal: TERM
+          wait:
+            timeout: 300ms
+`)
+	if res.Status != StatusError {
+		t.Fatalf("status = %s, want error: %+v", res.Status, res.Scenarios)
+	}
+	var msg string
+	for _, sc := range res.Scenarios {
+		for _, st := range sc.Steps {
+			if st.ErrMsg != "" {
+				msg = st.ErrMsg
+			}
+		}
+	}
+	if !strings.Contains(msg, `service "stubborn" did not exit within 300ms after SIGTERM`) {
+		t.Errorf("ErrMsg = %q, want the documented did-not-exit message", msg)
+	}
+}
+
+// TestEngine_SignalSuiteService proves a scenario's signal step can target a
+// suite-wide service started by suite.setup (#23).
+func TestEngine_SignalSuiteService(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("signal steps are POSIX-only")
+	}
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: s
+  setup:
+    - service:
+        name: shared
+        shell: true
+        command: "trap 'exit 0' TERM; echo ready; while true; do sleep 0.1; done"
+        ready: {log: ready, timeout: 5s}
+scenarios:
+  - name: signal the suite service
+    steps:
+      - signal:
+          service: shared
+          signal: TERM
+          wait:
+            timeout: 5s
+      - run: {shell: true, command: echo done}
+      - assert:
+          exit_code: 0
+`)
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed: %+v", res.Status, res.Scenarios)
+	}
+}

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -173,6 +173,11 @@ func explainScenario(b *strings.Builder, sc *spec.Scenario) {
 					}
 				}
 			}
+		case spec.StepSignal:
+			if step.Signal != nil {
+				commands = append(commands, describeSignal(step.Signal))
+				collectVars(vars, step.Signal.Service)
+			}
 		}
 	}
 
@@ -202,6 +207,9 @@ func explainScenario(b *strings.Builder, sc *spec.Scenario) {
 			teardown = append(teardown, describeAsserts(step.Assert)...)
 		case spec.StepStore:
 			teardown = append(teardown, "store "+step.Store.Name)
+		case spec.StepSignal:
+			teardown = append(teardown, describeSignal(step.Signal))
+			collectVars(vars, step.Signal.Service)
 		}
 	}
 
@@ -261,6 +269,19 @@ func describeCDP(c *spec.CDP) string {
 		acts = append(acts, spec.CDPActionLabel(a))
 	}
 	return fmt.Sprintf("CDP via %s: %s", c.Runner, strings.Join(acts, " → "))
+}
+
+// describeSignal renders a one-line summary of a signal step (#23).
+func describeSignal(sg *spec.Signal) string {
+	desc := "send SIG" + spec.NormalizeSignalName(sg.Signal) + " to service " + sg.Service
+	if sg.Wait != nil {
+		timeout := sg.Wait.Timeout
+		if timeout == "" {
+			timeout = "5s"
+		}
+		desc += "  [wait up to " + timeout + " for exit]"
+	}
+	return desc
 }
 
 func describeFixture(f *spec.Fixture) string {

--- a/internal/loader/defaults_test.go
+++ b/internal/loader/defaults_test.go
@@ -463,6 +463,114 @@ scenarios:
 	}
 }
 
+// TestValidate_SignalStep proves the signal-step rules (#23): the target must
+// be a declared service (with the declared names listed), the signal name
+// must be in the accepted set, and wait.timeout must parse.
+func TestValidate_SignalStep(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name, src, wantMsg string
+	}{
+		{
+			name: "unknown service lists declared names",
+			src: `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: s
+    services:
+      - name: web
+        command: ./web
+      - name: db
+        command: ./db
+    steps:
+      - signal:
+          service: cache
+          signal: TERM
+`,
+			wantMsg: `signal.service "cache" is not a declared service (declared: db, web)`,
+		},
+		{
+			name: "invalid signal name",
+			src: `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: s
+    services:
+      - name: web
+        command: ./web
+    steps:
+      - signal:
+          service: web
+          signal: STOP
+`,
+			wantMsg: "not an accepted signal",
+		},
+		{
+			name: "bad wait timeout",
+			src: `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: s
+    services:
+      - name: web
+        command: ./web
+    steps:
+      - signal:
+          service: web
+          signal: TERM
+          wait:
+            timeout: soon
+`,
+			wantMsg: "signal.wait.timeout",
+		},
+		{
+			name: "suite service is a legal target",
+			src: `
+version: "1"
+suite:
+  name: sample
+  setup:
+    - service:
+        name: shared
+        command: ./shared
+scenarios:
+  - name: s
+    steps:
+      - signal:
+          service: shared
+          signal: SIGHUP
+      - run:
+          command: echo ok
+`,
+			wantMsg: "", // loads cleanly
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := LoadBytes("sample.atago.yaml", []byte(tc.src))
+			if tc.wantMsg == "" {
+				if err != nil {
+					t.Fatalf("LoadBytes() error = %v, want clean load", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("LoadBytes() = nil error, want a signal validation error")
+			}
+			if !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Errorf("error = %q, want substring %q", err, tc.wantMsg)
+			}
+		})
+	}
+}
+
 // TestValidate_SuiteTimeoutInvalid proves an unparsable suite.timeout is a
 // load-time validation error (exit 2) naming the field (#17).
 func TestValidate_SuiteTimeoutInvalid(t *testing.T) {

--- a/internal/loader/validate.go
+++ b/internal/loader/validate.go
@@ -39,6 +39,14 @@ func validate(s *spec.Spec) []string {
 	validateSuiteBlock(add, "suite.setup", s.Suite.Setup, s.Runners, true)
 	validateSuiteBlock(add, "suite.teardown", s.Suite.Teardown, s.Runners, false)
 
+	// Suite services are legal signal targets from any scenario (#23).
+	suiteServiceNames := map[string]bool{}
+	for i := range s.Suite.Setup {
+		if svc := s.Suite.Setup[i].Service; svc != nil && svc.Name != "" {
+			suiteServiceNames[svc.Name] = true
+		}
+	}
+
 	seen := make(map[string]bool, len(s.Scenarios))
 	for i := range s.Scenarios {
 		sc := &s.Scenarios[i]
@@ -55,15 +63,21 @@ func validate(s *spec.Spec) []string {
 		validateCondition(add, where, "skip", sc.Skip)
 		validateCondition(add, where, "only", sc.Only)
 		validateServices(add, where, sc.Services)
+		serviceNames := maps.Clone(suiteServiceNames)
+		for j := range sc.Services {
+			if sc.Services[j].Name != "" {
+				serviceNames[sc.Services[j].Name] = true
+			}
+		}
 		if len(sc.Steps) == 0 {
 			add("%s: steps must contain at least one step", where)
 			continue
 		}
 		for j := range sc.Steps {
-			validateStep(add, fmt.Sprintf("%s.steps[%d]", where, j), &sc.Steps[j], s.Runners)
+			validateStep(add, fmt.Sprintf("%s.steps[%d]", where, j), &sc.Steps[j], s.Runners, serviceNames)
 		}
 		for j := range sc.Teardown {
-			validateStep(add, fmt.Sprintf("%s.teardown[%d]", where, j), &sc.Teardown[j], s.Runners)
+			validateStep(add, fmt.Sprintf("%s.teardown[%d]", where, j), &sc.Teardown[j], s.Runners, serviceNames)
 		}
 	}
 	return errs
@@ -432,11 +446,11 @@ func validateRunnerRef(add func(string, ...any), where, stepKind, name string, r
 	}
 }
 
-func validateStep(add func(string, ...any), where string, st *spec.Step, runners map[string]spec.Runner) {
+func validateStep(add func(string, ...any), where string, st *spec.Step, runners map[string]spec.Runner, serviceNames map[string]bool) {
 	keys := st.SetKeys()
 	switch len(keys) {
 	case 0:
-		add("%s: step must set exactly one of fixture/run/http/query/grpc/cdp/assert/store (got none)", where)
+		add("%s: step must set exactly one of fixture/run/http/query/grpc/cdp/assert/store/pty/signal (got none)", where)
 		return
 	case 1:
 	default:
@@ -518,6 +532,39 @@ func validateStep(add func(string, ...any), where string, st *spec.Step, runners
 		add("%s: service steps are only allowed in suite.setup (scenario-scoped peers go under the scenario's services: list)", where)
 	case spec.StepPTY:
 		validatePTY(add, where, st.PTY)
+	case spec.StepSignal:
+		validateSignal(add, where, st.Signal, serviceNames)
+	}
+}
+
+// validateSignal checks a signal step (#23): a declared target service, an
+// accepted signal name, and a parseable wait timeout. A ${name}-referencing
+// target is resolved at run time and skips the declared-name check.
+func validateSignal(add func(string, ...any), where string, sg *spec.Signal, serviceNames map[string]bool) {
+	switch {
+	case sg.Service == "":
+		add("%s.signal.service is required (the scenario or suite service to signal)", where)
+	case !strings.Contains(sg.Service, "${") && !serviceNames[sg.Service]:
+		declared := "none"
+		if len(serviceNames) > 0 {
+			declared = strings.Join(slices.Sorted(maps.Keys(serviceNames)), ", ")
+		}
+		add("%s.signal.service %q is not a declared service (declared: %s)", where, sg.Service, declared)
+	}
+	switch {
+	case sg.Signal == "":
+		add("%s.signal.signal is required (TERM, INT, HUP, USR1, USR2, or KILL)", where)
+	case !spec.ValidSignalName(sg.Signal):
+		add("%s.signal.signal %q is not an accepted signal (TERM, INT, HUP, USR1, USR2, or KILL, with an optional SIG prefix)", where, sg.Signal)
+	}
+	if sg.Wait != nil && sg.Wait.Timeout != "" {
+		d, err := time.ParseDuration(sg.Wait.Timeout)
+		switch {
+		case err != nil:
+			add("%s.signal.wait.timeout %q is not a valid duration (e.g. \"5s\")", where, sg.Wait.Timeout)
+		case d <= 0:
+			add("%s.signal.wait.timeout must be positive (got %q); omit it for the 5s default", where, sg.Wait.Timeout)
+		}
 	}
 }
 

--- a/internal/manifest/scenario.go
+++ b/internal/manifest/scenario.go
@@ -174,6 +174,19 @@ func buildStep(index int, step *spec.Step, vars map[string]bool) Step {
 			}
 		}
 
+	case spec.StepSignal:
+		sg := step.Signal
+		st.Target = sg.Service
+		st.Action = "signal SIG" + spec.NormalizeSignalName(sg.Signal) + " to service " + sg.Service
+		if sg.Wait != nil {
+			timeout := sg.Wait.Timeout
+			if timeout == "" {
+				timeout = "5s"
+			}
+			st.Action += ", wait up to " + timeout + " for exit"
+		}
+		collectVars(vars, sg.Service)
+
 	case spec.StepPTY:
 		pt := step.PTY
 		st.Command = pt.Command

--- a/internal/runner/service/process_unix.go
+++ b/internal/runner/service/process_unix.go
@@ -4,6 +4,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
 	"syscall"
 	"time"
@@ -28,6 +29,28 @@ func newProcessCmd(ctx context.Context, name string, args []string) *processCmd 
 
 func (p *processCmd) terminate() { _ = signalGroup(p.cmd, syscall.SIGTERM) }
 func (p *processCmd) kill()      { _ = signalGroup(p.cmd, syscall.SIGKILL) }
+
+// namedSignals maps the signal names a `signal:` step accepts (#23) to their
+// POSIX numbers. The loader validates against the same set, so an unknown
+// name here means the spec bypassed validation.
+var namedSignals = map[string]syscall.Signal{
+	"TERM": syscall.SIGTERM,
+	"INT":  syscall.SIGINT,
+	"HUP":  syscall.SIGHUP,
+	"USR1": syscall.SIGUSR1,
+	"USR2": syscall.SIGUSR2,
+	"KILL": syscall.SIGKILL,
+}
+
+// signalByName delivers the named signal to the whole process group (#23),
+// consistent with terminate/kill.
+func (p *processCmd) signalByName(name string) error {
+	sig, ok := namedSignals[name]
+	if !ok {
+		return fmt.Errorf("unknown signal %q (accepted: TERM, INT, HUP, USR1, USR2, KILL)", name)
+	}
+	return signalGroup(p.cmd, sig)
+}
 
 // signalGroup sends sig to the command's process group, falling back to the
 // leader process if the group id cannot be resolved.

--- a/internal/runner/service/process_windows.go
+++ b/internal/runner/service/process_windows.go
@@ -4,6 +4,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"os/exec"
 	"time"
 )
@@ -30,4 +31,11 @@ func (p *processCmd) kill() {
 	if p.cmd.Process != nil {
 		_ = p.cmd.Process.Kill()
 	}
+}
+
+// signalByName rejects signal steps on Windows (#23): there are no POSIX
+// signals to deliver. Mirrors the pty runner's Windows contract — the loader
+// accepts the step everywhere, execution reports a clear error.
+func (p *processCmd) signalByName(string) error {
+	return errors.New("signal steps are not supported on Windows (POSIX-only; gate the scenario with `skip: {os: windows}`)")
 }

--- a/internal/runner/service/service.go
+++ b/internal/runner/service/service.go
@@ -113,6 +113,38 @@ func (p *Proc) Stop() {
 	}
 }
 
+// Signal delivers the named POSIX signal (TERM, INT, HUP, USR1, USR2, KILL)
+// to the service's whole process group (#23), consistent with the teardown
+// kill semantics. Signaling a service that already exited is an error naming
+// the service — a graceful-shutdown spec that signals a dead process is
+// asserting against nothing.
+func (p *Proc) Signal(name string) error {
+	if p == nil || p.c == nil {
+		return fmt.Errorf("service is not running")
+	}
+	select {
+	case <-p.done:
+		return fmt.Errorf("service %q already exited", p.name)
+	default:
+	}
+	return p.c.signalByName(name)
+}
+
+// WaitExit blocks until the service's process exits or timeout elapses,
+// reporting whether it exited (#23). The exit is observed through the same
+// done channel Stop uses, so a later teardown Stop is a clean no-op.
+func (p *Proc) WaitExit(timeout time.Duration) bool {
+	if p == nil || p.c == nil {
+		return true
+	}
+	select {
+	case <-p.done:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
+
 // waitReady blocks until the readiness probe passes or its timeout elapses. A
 // nil probe means "ready as soon as it is spawned".
 func (p *Proc) waitReady(ctx context.Context, r *spec.Ready, workdir string) (string, error) {

--- a/internal/runner/service/signal_test.go
+++ b/internal/runner/service/signal_test.go
@@ -1,0 +1,143 @@
+package service
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nao1215/atago/internal/spec"
+)
+
+// TestSignal_TrapReceivesTERM proves a named signal reaches the service: a
+// trap handler writes a marker and exits, and WaitExit observes the exit so
+// a later Stop is a clean no-op (#23).
+func TestSignal_TrapReceivesTERM(t *testing.T) {
+	skipWindows(t)
+	wd := t.TempDir()
+	svc := &spec.Service{
+		Name:    "graceful",
+		Shell:   spec.Bool(true),
+		Command: `trap 'echo graceful-shutdown > marker.txt; exit 0' TERM; echo ready; while true; do sleep 0.1; done`,
+		Ready:   &spec.Ready{Log: "ready", Timeout: "5s"},
+	}
+	p, _, err := Start(context.Background(), svc, wd)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer p.Stop()
+	if err := p.Signal("TERM"); err != nil {
+		t.Fatalf("Signal(TERM) error = %v", err)
+	}
+	if !p.WaitExit(5 * time.Second) {
+		t.Fatal("service did not exit within 5s after SIGTERM")
+	}
+	b, err := os.ReadFile(filepath.Join(wd, "marker.txt"))
+	if err != nil {
+		t.Fatalf("marker not written by the trap handler: %v", err)
+	}
+	if !strings.Contains(string(b), "graceful-shutdown") {
+		t.Errorf("marker = %q, want graceful-shutdown", b)
+	}
+	p.Stop() // double-teardown safety after a signaled exit
+}
+
+// TestSignal_GroupDelivery proves the signal reaches backgrounded children,
+// not just the shell leader (#23).
+func TestSignal_GroupDelivery(t *testing.T) {
+	skipWindows(t)
+	wd := t.TempDir()
+	svc := &spec.Service{
+		Name:  "family",
+		Shell: spec.Bool(true),
+		// The backgrounded child writes its own marker when TERM arrives —
+		// it only can if the signal went to the whole group.
+		Command: `( trap 'echo child-got-term > child.txt; exit 0' TERM; while true; do sleep 0.1; done ) & echo ready; wait`,
+		Ready:   &spec.Ready{Log: "ready", Timeout: "5s"},
+	}
+	p, _, err := Start(context.Background(), svc, wd)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer p.Stop()
+	if err := p.Signal("TERM"); err != nil {
+		t.Fatalf("Signal(TERM) error = %v", err)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if b, err := os.ReadFile(filepath.Join(wd, "child.txt")); err == nil && strings.Contains(string(b), "child-got-term") {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("backgrounded child never saw SIGTERM (group delivery broken)")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// TestSignal_KILLStopsATermIgnorer proves the KILL path works where TERM is
+// trapped and ignored (#23).
+func TestSignal_KILLStopsATermIgnorer(t *testing.T) {
+	skipWindows(t)
+	wd := t.TempDir()
+	svc := &spec.Service{
+		Name:    "stubborn",
+		Shell:   spec.Bool(true),
+		Command: `trap '' TERM; echo ready; while true; do sleep 0.2; done`,
+		Ready:   &spec.Ready{Log: "ready", Timeout: "5s"},
+	}
+	p, _, err := Start(context.Background(), svc, wd)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer p.Stop()
+	if err := p.Signal("TERM"); err != nil {
+		t.Fatalf("Signal(TERM) error = %v", err)
+	}
+	if p.WaitExit(300 * time.Millisecond) {
+		t.Fatal("TERM-ignoring service exited on TERM; the fixture is broken")
+	}
+	if err := p.Signal("KILL"); err != nil {
+		t.Fatalf("Signal(KILL) error = %v", err)
+	}
+	if !p.WaitExit(5 * time.Second) {
+		t.Fatal("service did not exit within 5s after SIGKILL")
+	}
+}
+
+// TestSignal_AlreadyExited proves signaling a dead service is a named error,
+// not a stray ESRCH (#23).
+func TestSignal_AlreadyExited(t *testing.T) {
+	skipWindows(t)
+	wd := t.TempDir()
+	svc := &spec.Service{Name: "gone", Shell: spec.Bool(true), Command: "echo bye"}
+	p, _, err := Start(context.Background(), svc, wd)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if !p.WaitExit(5 * time.Second) {
+		t.Fatal("echo service did not exit")
+	}
+	err = p.Signal("TERM")
+	if err == nil || !strings.Contains(err.Error(), `service "gone" already exited`) {
+		t.Errorf("Signal on exited service = %v, want an already-exited error naming the service", err)
+	}
+}
+
+// TestSignal_UnknownName proves an unmapped signal name errors with the
+// accepted set (defense in depth behind the loader's validation).
+func TestSignal_UnknownName(t *testing.T) {
+	skipWindows(t)
+	wd := t.TempDir()
+	svc := &spec.Service{Name: "s", Shell: spec.Bool(true), Command: sleepCmd(5)}
+	p, _, err := Start(context.Background(), svc, wd)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer p.Stop()
+	if err := p.Signal("WINCH"); err == nil || !strings.Contains(err.Error(), "accepted") {
+		t.Errorf("Signal(WINCH) = %v, want an unknown-signal error listing the accepted set", err)
+	}
+}

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -262,7 +262,51 @@ type Step struct {
 	// or present an interactive prompt. POSIX-only for now; the loader accepts
 	// the step everywhere and the engine reports a clear error on Windows.
 	PTY *PTY `yaml:"pty,omitempty"`
+	// Signal sends a named POSIX signal to a managed service (#23) — the
+	// race-free, handle-based alternative to `kill`/`killall` shell hacks for
+	// graceful-shutdown and signal-handling tests. POSIX-only like pty: the
+	// loader accepts the step everywhere and the engine reports a clear error
+	// on Windows.
+	Signal *Signal `yaml:"signal,omitempty"`
 }
+
+// Signal targets a declared service (scenario or suite) by name and delivers
+// a POSIX signal to its whole process group (#23), consistent with the
+// teardown kill semantics. Wait optionally blocks until the process exits.
+type Signal struct {
+	// Service names the target: a service declared in the scenario's
+	// services: list or started by a suite.setup service: step. Unknown names
+	// are a load-time error listing the declared services.
+	Service string `yaml:"service"`
+	// Signal is the POSIX signal name: TERM, INT, HUP, USR1, USR2, or KILL
+	// (an optional SIG prefix is accepted).
+	Signal string `yaml:"signal"`
+	// Wait, when set, blocks until the signaled process exits or the timeout
+	// elapses; a still-running process fails the step with a clear message.
+	Wait *SignalWait `yaml:"wait,omitempty"`
+}
+
+// SignalWait bounds the wait for a signaled service's exit (#23).
+type SignalWait struct {
+	// Timeout is a Go duration (default "5s").
+	Timeout string `yaml:"timeout,omitempty"`
+}
+
+// validSignalNames is the accepted `signal:` set (#23): the portable
+// process-control signals. Anything more exotic (STOP/CONT/real-time) is out
+// of scope for declarative CLI testing.
+var validSignalNames = map[string]bool{
+	"TERM": true, "INT": true, "HUP": true, "USR1": true, "USR2": true, "KILL": true,
+}
+
+// NormalizeSignalName upper-cases a signal name and strips an optional SIG
+// prefix, so `term`, `TERM`, and `SIGTERM` all mean SIGTERM (#23).
+func NormalizeSignalName(name string) string {
+	return strings.TrimPrefix(strings.ToUpper(strings.TrimSpace(name)), "SIG")
+}
+
+// ValidSignalName reports whether the (normalized) signal name is accepted.
+func ValidSignalName(name string) bool { return validSignalNames[NormalizeSignalName(name)] }
 
 // Query runs a SQL statement through a named db runner (ADR-0026). The result
 // rows (for a SELECT) are captured as JSON for the `rows` assertion target and

--- a/internal/spec/step.go
+++ b/internal/spec/step.go
@@ -15,6 +15,7 @@ const (
 	StepStore   StepKind = "store"
 	StepService StepKind = "service"
 	StepPTY     StepKind = "pty"
+	StepSignal  StepKind = "signal"
 )
 
 // SetKeys returns the action keys that are present on the step. A valid step has
@@ -50,6 +51,9 @@ func (s *Step) SetKeys() []StepKind {
 	}
 	if s.PTY != nil {
 		keys = append(keys, StepPTY)
+	}
+	if s.Signal != nil {
+		keys = append(keys, StepSignal)
 	}
 	return keys
 }

--- a/schema/atago.schema.json
+++ b/schema/atago.schema.json
@@ -282,7 +282,8 @@
         { "required": ["assert"] },
         { "required": ["store"] },
         { "required": ["service"] },
-        { "required": ["pty"] }
+        { "required": ["pty"] },
+        { "required": ["signal"] }
       ],
       "properties": {
         "fixture": { "$ref": "#/$defs/fixture" },
@@ -295,6 +296,7 @@
           "$ref": "#/$defs/service",
           "description": "Starts a suite-wide background process at this point in the sequence. Valid only inside suite.setup; the loader rejects it anywhere else."
         },
+        "signal": { "$ref": "#/$defs/signal" },
         "pty": { "$ref": "#/$defs/pty" },
         "assert": { "$ref": "#/$defs/assert" },
         "store": { "$ref": "#/$defs/store" }
@@ -496,6 +498,24 @@
               "expect": { "type": "string" },
               "send": { "type": "string" }
             }
+          }
+        }
+      }
+    },
+    "signal": {
+      "type": "object",
+      "required": ["service", "signal"],
+      "additionalProperties": false,
+      "description": "Sends a named POSIX signal to a managed service's process group (#23) - the race-free alternative to kill/killall for graceful-shutdown tests. POSIX-only at runtime; Windows reports a clear execution error.",
+      "properties": {
+        "service": { "type": "string", "minLength": 1, "description": "A service declared in the scenario's services: list or started by a suite.setup service: step." },
+        "signal": { "type": "string", "minLength": 1, "description": "TERM, INT, HUP, USR1, USR2, or KILL (optional SIG prefix accepted)." },
+        "wait": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Block until the signaled process exits; a still-running process fails the step.",
+          "properties": {
+            "timeout": { "type": "string", "description": "Go duration bounding the wait (default 5s)." }
           }
         }
       }

--- a/schema_test.go
+++ b/schema_test.go
@@ -188,6 +188,23 @@ scenarios:
 	}
 }
 
+// TestSchema_AcceptsSignalStep confirms the signal step (#23) is accepted.
+func TestSchema_AcceptsSignalStep(t *testing.T) {
+	s := loadSchema(t)
+	src := `version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    services:
+      - {name: srv, command: ./srv}
+    steps:
+      - signal: {service: srv, signal: TERM, wait: {timeout: 5s}}
+      - signal: {service: srv, signal: KILL}`
+	if err := s.Validate(yamlToAny(t, []byte(src))); err != nil {
+		t.Errorf("schema rejected valid signal steps:\n%v", err)
+	}
+}
+
 // TestSchema_RejectsInvalid confirms the schema actually catches bad specs.
 func TestSchema_RejectsInvalid(t *testing.T) {
 	s := loadSchema(t)

--- a/test/e2e/atago/signal.atago.yaml
+++ b/test/e2e/atago/signal.atago.yaml
@@ -1,0 +1,109 @@
+version: "1"
+
+suite:
+  name: atago self-hosting / signal step (graceful shutdown)
+
+# Exercises #23: `signal:` delivers a named POSIX signal to a service atago
+# itself started, so delivery is race-free under the default --parallel —
+# unlike name-based kill/killall shell hacks, it can never cross a scenario
+# boundary. POSIX-only, so every scenario skips on Windows.
+scenarios:
+  - name: SIGTERM reaches the trap handler and wait observes the exit
+    skip:
+      os: windows
+    services:
+      - name: server
+        shell: true
+        command: "trap 'echo graceful shutdown complete > server.log; exit 0' TERM; echo booted; while true; do sleep 0.1; done"
+        ready:
+          log: booted
+          timeout: 10s
+    steps:
+      - signal:
+          service: server
+          signal: TERM
+          wait:
+            timeout: 5s
+      - assert:
+          file:
+            path: server.log
+            contains: "graceful shutdown complete"
+
+  - name: SIGHUP triggers a reload without stopping the service
+    skip:
+      os: windows
+    services:
+      - name: reloader
+        shell: true
+        command: "trap 'echo reloaded >> reload.log' HUP; echo booted; while true; do sleep 0.1; done"
+        ready:
+          log: booted
+          timeout: 10s
+    steps:
+      # No wait: the service keeps running after handling the signal.
+      - signal:
+          service: reloader
+          signal: HUP
+      - run:
+          shell: true
+          command: "for i in 1 2 3 4 5 6 7 8 9 10; do [ -f reload.log ] && break; sleep 0.1; done; cat reload.log"
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: reloaded
+
+  - name: a wait timeout on a TERM-ignoring service fails with the documented message
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: stubborn.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: stubborn
+            scenarios:
+              - name: never exits on TERM
+                services:
+                  - name: stubborn
+                    shell: true
+                    command: "trap '' TERM; echo booted; while true; do sleep 0.2; done"
+                    ready: {log: booted, timeout: 10s}
+                steps:
+                  - signal:
+                      service: stubborn
+                      signal: TERM
+                      wait:
+                        timeout: 300ms
+      - run:
+          command: ${atago} run stubborn.atago.yaml
+          timeout: 30s
+      - assert:
+          exit_code: { not: 0 }
+      - assert:
+          stdout:
+            contains: 'did not exit within 300ms after SIGTERM'
+
+  - name: an unknown target service is a load-time error listing declared names
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: bad
+            scenarios:
+              - name: wrong name
+                services:
+                  - name: web
+                    command: ./web
+                steps:
+                  - signal:
+                      service: cache
+                      signal: TERM
+      - run:
+          command: ${atago} run bad.atago.yaml
+      - assert:
+          exit_code: 2
+          stderr:
+            contains: 'not a declared service (declared: web)'


### PR DESCRIPTION
## Summary

This PR adds the `signal:` step (#23): deliver a named POSIX signal (TERM, INT, HUP, USR1, USR2, KILL) to an atago-managed service's whole process group, with an optional `wait: {timeout}` that blocks until the process exits. Handle-based targeting makes signal testing race-free under `--parallel` — the reason the mimixbox dogfood suite had to pin `--parallel 1` for its name-based kills.

## Changes

- `internal/spec`: `Signal`/`SignalWait` types, `Step.Signal` field, `StepSignal` kind, and shared `NormalizeSignalName`/`ValidSignalName` helpers (optional SIG prefix, any case).
- `internal/runner/service`: `Proc.Signal(name)` reuses the existing `signalGroup` primitive (SIGTERM-teardown semantics: `syscall.Kill(-pgid, sig)` with a leader fallback); `Proc.WaitExit(timeout)` observes the same done channel Stop uses, so a later teardown Stop is a clean no-op after a signaled exit. Signaling an already-exited service is a named error, not a stray ESRCH. Windows `signalByName` reports the same clear POSIX-only error pattern as pty.
- `internal/engine`: `StepSignal` case in the step executor — resolves the target among scenario services first, then suite services (newly threaded through `runConfig.suiteServices`), ${name}-expands the target, and turns a wait timeout into "service X did not exit within 5s after SIGTERM".
- `internal/loader`: unknown target service is a load-time error LISTING the declared scenario+suite service names (mirroring the unknown-runner message); invalid signal names and unparseable/negative `wait.timeout` are load errors too; the one-of step message now includes pty/signal.
- `explain` ("send SIGTERM to service server [wait up to 5s for exit]"), `doc` command lines + Then-group labels, manifest action/target, JSON schema `signal` def.
- New `examples/signal.atago.yaml` (hermetic, registered; graceful SIGTERM + SIGHUP-reload), README Examples row, CHANGELOG entry.
- Tests: service-level (trap receives TERM + marker, process-group delivery to backgrounded children, KILL vs a TERM-ignorer, already-exited error, unknown-name error), engine-level (full graceful-shutdown flow, wait-timeout failure message, suite-service targeting), loader validation cases, schema accept case, and self-hosted E2E `test/e2e/atago/signal.atago.yaml` (SIGTERM shutdown, SIGHUP reload without exit, wait-timeout FAILED block, unknown-service load error) — green under the default `--parallel 8` (166 scenarios).

## Design Decisions

- Signaling an already-exited service errors (a graceful-shutdown spec signaling a dead process is asserting against nothing) instead of silently no-opping.
- The mimixbox `--parallel 1` unpin is deliberately NOT in this PR: its kill-family scenarios test mimixbox's OWN killall/pkill applets, which are inherently name-based; migrating them is the follow-up the issue allows.

Closes #23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `signal` step for sending POSIX signals to running services, with optional waiting for exit.
  * Added support for graceful shutdown and reload testing scenarios, including suite-level service targeting.

* **Bug Fixes**
  * Clear errors now appear for unknown services, invalid signal names, and signal waits that time out.
  * Windows now reports that signal steps are unsupported, with guidance to skip them on that OS.

* **Documentation**
  * Updated the changelog, README examples, and behavior docs with the new signal-step workflows and scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->