### PR TITLE
feat(engine): add declarative mock http servers with recorded-request asserts

### DIFF
--- a/.github/workflows/e2e-cross.yml
+++ b/.github/workflows/e2e-cross.yml
@@ -63,6 +63,7 @@ jobs:
               ./test/e2e/atago/rerun.atago.yaml
               ./test/e2e/atago/db.atago.yaml
               ./test/e2e/atago/http.atago.yaml
+              ./test/e2e/atago/mock_server.atago.yaml
               ./test/e2e/atago/grpc.atago.yaml
               ./test/e2e/atago/ssh.atago.yaml
               ./test/e2e/atago/cdp.atago.yaml

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -118,6 +118,7 @@ jobs:
           ./test/e2e/atago/rerun.atago.yaml
           ./test/e2e/atago/db.atago.yaml
           ./test/e2e/atago/http.atago.yaml
+          ./test/e2e/atago/mock_server.atago.yaml
           ./test/e2e/atago/grpc.atago.yaml
           ./test/e2e/atago/ssh.atago.yaml
           ./test/e2e/atago/cdp.atago.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ and this project follows [Semantic Versioning](https://semver.org/).
   (`SystemRoot`, `SystemDrive`, `TEMP`, `TMP`, `PATHEXT`) is always retained.
   `pass_env` without `clear_env: true` is a load-time error (exit 2).
   See `examples/hermetic_env.atago.yaml`.
+- Mock HTTP servers (#24): `mock_servers:` (scenario level) and
+  suite.setup `mock_server:` steps start declarative stub HTTP servers on
+  ephemeral loopback ports — canned routes matched on exact method+path
+  (`json` / `body` / `body_file` payloads, optional `status`, `header`,
+  `delay`), every incoming request recorded (unmatched ones answer 404 and
+  stay visible). `${<name>.url}` / `${<name>.port}` are seeded into the
+  store, and the new `mock:` assertion target checks what the CLI under test
+  actually sent: request `count`, plus `header` / `body` matchers applied to
+  the last matching request. Header matchers (http and mock) also gain
+  `matches:` for regexp checks ("^Bearer "). Cross-platform (pure Go).
+  Scaffold with `atago init --template mock`; see
+  `examples/mock_server.atago.yaml`.
 - `signal:` step (#23): send a named POSIX signal (TERM, INT, HUP, USR1,
   USR2, KILL) to a managed service's whole process group — scenario services
   and suite services both — for declarative graceful-shutdown and

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ cli       run a command; assert exit code/stdout/stderr (runs as-is)
 db        run SQL; assert on rows via bundled SQLite (runs as-is)
 grpc      call a unary gRPC method via server reflection (edit target first)
 http      call an HTTP API; assert status and JSON body (edit base_url first)
+mock      stub an HTTP API offline and assert what the client sent (needs curl on PATH)
 services  test against a background server: readiness, retry, teardown (runs as-is)
 ssh       run a command on a remote host over SSH (edit host/user first)
 ```
@@ -140,6 +141,7 @@ Every feature has a commented, runnable spec under [examples/](examples/). The e
 | [timeouts](examples/timeouts.atago.yaml) | the built-in 60s default step timeout, `suite.timeout`, per-step overrides, and the `timeout: "0"` escape hatch |
 | [stdin](examples/stdin.atago.yaml) | stdin sources: inline text, `stdin: {file: ...}` from a workdir file, and binary input via `stdin: {base64: ...}` |
 | [matrix](examples/matrix.atago.yaml) | one template scenario expanded per parameter row |
+| [mock_server](examples/mock_server.atago.yaml) | test API-client CLIs offline: `mock_servers` serve canned routes, record every request, and `mock:` asserts what the client actually sent |
 | [pty](examples/pty.atago.yaml) | interactive testing in a real pseudo-terminal: expect/send sessions, TTY-detection (POSIX-only) |
 | [retry](examples/retry.atago.yaml) | polling a command until an assertion passes |
 | [snapshot](examples/snapshot.atago.yaml) | golden-file testing with normalized output |
@@ -156,6 +158,10 @@ Every feature has a commented, runnable spec under [examples/](examples/). The e
 | [browser](examples/browser.atago.yaml) | headless-Chrome flows and screenshots |
 
 Selection flags compose with any spec: `--filter NAME`, `--tag T`, `--skip-tag T`, `--parallel N` (default: the number of CPUs — scenarios are isolated, so runs are concurrent out of the box), `--fail-fast`, and `--rerun-failed` (rerun only what failed last time). While authoring a spec, `--verbose` traces every scenario — the expanded command, exit code, captured stdout/stderr, and each assertion's verdict — for passing scenarios too, so you never have to break an assertion just to see what a command printed.
+
+## Test API-client CLIs offline
+
+Tools that talk to an API — gh-style CLIs, cloud CLIs, webhook senders, anything with an `--endpoint` flag — are testable without the real service: `mock_servers:` starts a stub HTTP server on an ephemeral loopback port, serves canned routes, and records every request, and the `mock:` assertion target then checks what your CLI actually sent (request count, auth header, JSON body). `${<name>.url}` carries the address into your command; unmatched requests answer 404 and stay visible in failures. See [examples/mock_server.atago.yaml](examples/mock_server.atago.yaml) or scaffold one with `atago init --template mock`.
 
 ## Use it in CI
 

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-47 suites · 161 scenarios
+48 suites · 164 scenarios
 ## Contents
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 3 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
@@ -116,6 +116,10 @@
 - [atago self-hosting / matrix scenarios](#atago-self-hosting--matrix-scenarios) — 2 scenarios
   - [matrix expands into one scenario per row](#scenario-matrix-expands-into-one-scenario-per-row)
   - [matrix without a templated name gets a deterministic suffix](#scenario-matrix-without-a-templated-name-gets-a-deterministic-suffix)
+- [atago self-hosting / mock http server (offline API-client testing)](#atago-self-hosting--mock-http-server-offline-api-client-testing) — 3 scenarios
+  - [count, header, and body-json asserts pass against a real client](#scenario-count-header-and-body-json-asserts-pass-against-a-real-client)
+  - [a failing count summarizes the recorded requests](#scenario-a-failing-count-summarizes-the-recorded-requests)
+  - [an unknown mock name in an assert is a load-time error](#scenario-an-unknown-mock-name-in-an-assert-is-a-load-time-error)
 - [atago self-hosting / not_equals matcher](#atago-self-hosting--not_equals-matcher) — 4 scenarios
   - [not_equals passes when stdout differs from the given text](#scenario-not_equals-passes-when-stdout-differs-from-the-given-text)
   - [not_equals is trailing-newline tolerant like equals](#scenario-not_equals-is-trailing-newline-tolerant-like-equals)
@@ -2001,6 +2005,103 @@ ${atago} run --report junit suffix.atago.yaml
 #### Then
 - exit code is `0`
 - stdout contains `name="row [n=1]"`, `name="row [n=2]"`
+## atago self-hosting / mock http server (offline API-client testing)
+Source: `test/e2e/atago/mock_server.atago.yaml`
+### Scenario: count, header, and body-json asserts pass against a real client
+#### Given
+- Stub HTTP server `api` serves 1 canned route(s) at `${api.url}` and records every request (#24).
+- Fixture file `client.atago.yaml` is created.
+#### Inputs
+_Fixture `client.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: client
+runners:
+  api:
+    type: http
+    base_url: ${api.url}
+scenarios:
+  - name: post a report
+    steps:
+      - http:
+          runner: api
+          method: POST
+          path: /v1/reports
+          header: { Authorization: "Bearer tok-123" }
+          json: { title: "report" }
+      - assert:
+          status: 201
+```
+#### When
+```shell
+${atago} run client.atago.yaml
+```
+#### Then
+- exit code is `0`
+- mock `api` received `POST /v1/reports` exactly 1 time(s)
+### Scenario: a failing count summarizes the recorded requests
+#### Given
+- Stub HTTP server `stub` serves 1 canned route(s) at `${stub.url}` and records every request (#24).
+- Fixture file `outer.atago.yaml` is created.
+#### Inputs
+_Fixture `outer.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: outer
+runners:
+  api:
+    type: http
+    base_url: ${stub.url}
+scenarios:
+  - name: wrong path then failing count
+    mock_servers:
+      - name: inner
+        routes:
+          - method: GET
+            path: /right
+    steps:
+      - http:
+          runner: api
+          method: GET
+          path: /wrong
+      - assert:
+… (truncated, 6 more lines)
+```
+#### When
+```shell
+${atago} run outer.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `1 request for /right`, `0 matching of 0 recorded`
+### Scenario: an unknown mock name in an assert is a load-time error
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: bad
+scenarios:
+  - name: wrong name
+    mock_servers:
+      - name: api
+        routes: [{method: GET, path: /}]
+    steps:
+      - run: {command: echo hi}
+      - assert:
+          mock: {name: apo, count: 1}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `not a declared mock server (declared: api)`
 ## atago self-hosting / not_equals matcher
 Source: `test/e2e/atago/not_equals.atago.yaml`
 ### Scenario: not_equals passes when stdout differs from the given text

--- a/examples/mock_server.atago.yaml
+++ b/examples/mock_server.atago.yaml
@@ -1,0 +1,100 @@
+version: "1"
+
+# Mock HTTP servers (#24): test API-client CLIs OFFLINE. `mock_servers:`
+# starts a stub HTTP server on an ephemeral loopback port before the steps
+# run, serves canned routes (matched on exact method + path; the query string
+# is excluded), and RECORDS every incoming request — including unmatched ones,
+# which answer 404. `${<name>.url}` / `${<name>.port}` are seeded into the
+# store, and the `mock:` assertion target checks what the client actually
+# sent: request count, and header/body matchers applied to the last matching
+# request. Response bodies come from `json:` (inline document), `body:`
+# (inline text), or `body_file:` (spec-relative file); `delay:` slows a route
+# down for retry testing.
+#
+# The client here is stock curl; single-quoted shell args are POSIX, so these
+# scenarios skip on Windows (the engine itself is pure Go and cross-platform —
+# see test/e2e/atago/mock_server.atago.yaml for an http-runner-driven variant).
+# Runs green as-is on Linux/macOS: atago run examples/mock_server.atago.yaml
+
+suite:
+  name: mock http server
+
+scenarios:
+  - name: the CLI posts a report and the mock records exactly what was sent
+    skip:
+      os: windows
+    mock_servers:
+      - name: api
+        routes:
+          - method: POST
+            path: /v1/reports
+            status: 201
+            json: { id: "r-1", ok: true }
+    steps:
+      - run:
+          shell: true
+          command: >-
+            curl -sf -X POST -H 'Authorization: Bearer tok-123'
+            -d '{"title":"report"}' ${api.url}/v1/reports
+      - assert:
+          exit_code: 0
+          stdout:
+            json: { path: "$.id", equals: "r-1" }
+      # The headline assertion: what did the CLI actually send?
+      - assert:
+          mock:
+            name: api
+            path: /v1/reports
+            method: POST
+            count: 1
+            header: { name: Authorization, matches: "^Bearer " }
+            body:
+              json: { path: "$.title", equals: "report" }
+
+  - name: an unmatched path answers 404 and is still recorded
+    skip:
+      os: windows
+    mock_servers:
+      - name: stub
+        routes:
+          - method: GET
+            path: /right
+            body: found
+    steps:
+      # curl without -f: the 404 response body is still printed, exit 0.
+      - run:
+          shell: true
+          command: curl -s ${stub.url}/wrong
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: no route for GET /wrong
+      # Without count, the mock assert requires at least one matching request.
+      - assert:
+          mock:
+            name: stub
+            path: /wrong
+            method: GET
+
+  - name: a delayed route exercises client retry loops
+    skip:
+      os: windows
+    mock_servers:
+      - name: slow
+        routes:
+          - method: GET
+            path: /ping
+            delay: 200ms
+            body: pong
+    steps:
+      - run:
+          shell: true
+          command: curl -s ${slow.url}/ping
+          retry:
+            times: 3
+            interval: 100ms
+            until:
+              stdout:
+                contains: pong
+      - assert:
+          exit_code: 0

--- a/examples_test.go
+++ b/examples_test.go
@@ -28,6 +28,7 @@ var exampleSpecs = map[string]bool{ // path -> hermetic (run, not just validate)
 	"examples/image_and_pdf.atago.yaml":       true,
 	"examples/json_and_yaml.atago.yaml":       true,
 	"examples/matrix.atago.yaml":              true,
+	"examples/mock_server.atago.yaml":         true,
 	"examples/pty.atago.yaml":                 true,
 	"examples/retry.atago.yaml":               true,
 	"examples/run_and_assert.atago.yaml":      true,

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/nao1215/atago/internal/runner"
+	"github.com/nao1215/atago/internal/runner/mock"
 	"github.com/nao1215/atago/internal/spec"
 )
 
@@ -88,6 +89,10 @@ type Env struct {
 	// snapshot is written or compared, so a real credential is never committed to
 	// a golden file (issue #11).
 	Secrets func([]byte) []byte
+	// MockRecords, when set, resolves a mock server's recorded requests by
+	// name for the `mock:` assertion target (#24). Nil in contexts with no
+	// mock servers (retry `until` asserts, direct API use).
+	MockRecords func(name string) ([]mock.Record, bool)
 }
 
 func pass(desc string) *CheckResult { return &CheckResult{OK: true, Desc: desc} }
@@ -164,6 +169,8 @@ func checkTarget(a *spec.Assert, target spec.AssertTarget, res *runner.Result, e
 		return checkDir(a.Dir, env)
 	case spec.AssertPDF:
 		return checkPDF(a.PDF, env)
+	case spec.AssertMock:
+		return checkMock(a.Mock, env)
 	default:
 		return &CheckResult{Desc: string(target), Hint: "assertion target not supported yet"}
 	}

--- a/internal/assert/http.go
+++ b/internal/assert/http.go
@@ -2,6 +2,7 @@ package assert
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/nao1215/atago/internal/runner"
@@ -32,7 +33,13 @@ func checkHeader(h *spec.HeaderMatch, res *runner.Result) *CheckResult {
 	if res == nil || !res.IsHTTP {
 		return &CheckResult{Desc: "assert header", Hint: "no HTTP request has run in this scenario yet"}
 	}
-	got := res.Header.Get(h.Name)
+	return checkHeaderValue(h, res.Header.Get(h.Name), "response")
+}
+
+// checkHeaderValue matches one header value; kind names the header's origin
+// ("response" for the http target, "recorded request" for the mock target,
+// #24) so failure hints read naturally in both contexts.
+func checkHeaderValue(h *spec.HeaderMatch, got, kind string) *CheckResult {
 	switch {
 	case h.Equals != nil:
 		desc := fmt.Sprintf("assert header %q equals %q", h.Name, *h.Equals)
@@ -43,7 +50,7 @@ func checkHeader(h *spec.HeaderMatch, res *runner.Result) *CheckResult {
 			Desc:     desc,
 			Expected: fmt.Sprintf("%s: %s", h.Name, *h.Equals),
 			Actual:   fmt.Sprintf("%s: %s", h.Name, got),
-			Hint:     fmt.Sprintf("response header %q did not equal the expected value", h.Name),
+			Hint:     fmt.Sprintf("%s header %q did not equal the expected value", kind, h.Name),
 		}
 	case h.Contains != nil:
 		desc := fmt.Sprintf("assert header %q contains %q", h.Name, *h.Contains)
@@ -54,10 +61,25 @@ func checkHeader(h *spec.HeaderMatch, res *runner.Result) *CheckResult {
 			Desc:     desc,
 			Expected: fmt.Sprintf("%s containing %q", h.Name, *h.Contains),
 			Actual:   fmt.Sprintf("%s: %s", h.Name, got),
-			Hint:     fmt.Sprintf("response header %q did not contain the substring", h.Name),
+			Hint:     fmt.Sprintf("%s header %q did not contain the substring", kind, h.Name),
+		}
+	case h.Matches != nil:
+		desc := fmt.Sprintf("assert header %q matches /%s/", h.Name, *h.Matches)
+		re, err := regexp.Compile(*h.Matches)
+		if err != nil {
+			return &CheckResult{Desc: desc, Hint: fmt.Sprintf("invalid regexp: %v", err)}
+		}
+		if re.MatchString(got) {
+			return pass(desc)
+		}
+		return &CheckResult{
+			Desc:     desc,
+			Expected: fmt.Sprintf("%s matching /%s/", h.Name, *h.Matches),
+			Actual:   fmt.Sprintf("%s: %s", h.Name, got),
+			Hint:     fmt.Sprintf("%s header %q did not match the pattern", kind, h.Name),
 		}
 	default:
-		return &CheckResult{Desc: "assert header", Hint: "header assertion must set contains or equals"}
+		return &CheckResult{Desc: "assert header", Hint: "header assertion must set contains, equals, or matches"}
 	}
 }
 

--- a/internal/assert/mock.go
+++ b/internal/assert/mock.go
@@ -1,0 +1,112 @@
+package assert
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/nao1215/atago/internal/runner/mock"
+	"github.com/nao1215/atago/internal/spec"
+)
+
+// checkMock evaluates a `mock:` assertion (#24) against the requests a mock
+// server recorded: filter by the optional path/method, pin the exact Count
+// (or require at least one match without it), then apply the header/body
+// matchers to the LAST matching request.
+func checkMock(m *spec.MockAssert, env Env) *CheckResult {
+	desc := fmt.Sprintf("assert mock %q", m.Name)
+	if env.MockRecords == nil {
+		return &CheckResult{Desc: desc, Hint: "mock assertions are not available in this context"}
+	}
+	records, ok := env.MockRecords(m.Name)
+	if !ok {
+		return &CheckResult{Desc: desc, Hint: fmt.Sprintf("no mock server named %q is running", m.Name)}
+	}
+
+	var matched []mock.Record
+	for _, r := range records {
+		if m.Path != "" && r.Path != m.Path {
+			continue
+		}
+		if m.Method != "" && !strings.EqualFold(r.Method, m.Method) {
+			continue
+		}
+		matched = append(matched, r)
+	}
+
+	filter := mockFilterLabel(m)
+	if m.Count != nil {
+		desc := fmt.Sprintf("assert mock %q received %d %s", m.Name, *m.Count, plural("request", *m.Count))
+		if len(matched) != *m.Count {
+			return &CheckResult{
+				Desc:     desc,
+				Expected: fmt.Sprintf("%d %s %s", *m.Count, plural("request", *m.Count), filter),
+				Actual:   fmt.Sprintf("%d matching of %d recorded:\n%s", len(matched), len(records), summarizeRecords(records)),
+				Hint:     "the CLI under test did not send the expected number of matching requests",
+			}
+		}
+	} else if len(matched) == 0 {
+		return &CheckResult{
+			Desc:     desc,
+			Expected: "at least one request " + filter,
+			Actual:   fmt.Sprintf("0 matching of %d recorded:\n%s", len(records), summarizeRecords(records)),
+			Hint:     "the CLI under test never sent a matching request",
+		}
+	}
+
+	if m.Header != nil || m.Body != nil {
+		if len(matched) == 0 {
+			// Count: 0 with matchers is contradictory; the validator rejects it,
+			// but stay safe for direct API users.
+			return &CheckResult{Desc: desc, Hint: "header/body matchers need at least one matching request"}
+		}
+		last := matched[len(matched)-1]
+		if m.Header != nil {
+			if cr := checkHeaderValue(m.Header, last.Header.Get(m.Header.Name), "recorded request"); !cr.OK {
+				return cr
+			}
+		}
+		if m.Body != nil {
+			if cr := checkStream("mock request body", m.Body, last.Body, true, env); !cr.OK {
+				return cr
+			}
+		}
+	}
+	if m.Count != nil {
+		return pass(fmt.Sprintf("assert mock %q received %d %s", m.Name, *m.Count, plural("request", *m.Count)))
+	}
+	return pass(desc + " received a matching request")
+}
+
+// mockFilterLabel names the path/method filter for Expected lines.
+func mockFilterLabel(m *spec.MockAssert) string {
+	switch {
+	case m.Method != "" && m.Path != "":
+		return fmt.Sprintf("for %s %s", strings.ToUpper(m.Method), m.Path)
+	case m.Path != "":
+		return "for " + m.Path
+	case m.Method != "":
+		return "for " + strings.ToUpper(m.Method)
+	default:
+		return "(any route)"
+	}
+}
+
+// summarizeRecords renders the recorded requests one per line so a failing
+// count shows what the CLI actually sent.
+func summarizeRecords(records []mock.Record) string {
+	if len(records) == 0 {
+		return "  (no requests recorded)"
+	}
+	var b strings.Builder
+	for i, r := range records {
+		fmt.Fprintf(&b, "  %d: %s %s -> %d\n", i+1, r.Method, r.Path, r.Status)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func plural(word string, n int) string {
+	if n == 1 {
+		return word
+	}
+	return word + "s"
+}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -263,6 +263,54 @@ scenarios:
             contains: pong
 `
 
+const mockTemplate = `version: "1"
+
+# Test an API-client CLI OFFLINE (#24): the mock server serves canned routes
+# on an ephemeral loopback port and records every request, so you can assert
+# what your CLI actually sent. Runs as-is with curl on PATH:
+#   atago run mock.atago.yaml
+# For your own CLI: replace the curl command with e.g.
+#   mycli push --endpoint ${api.url} report.txt
+
+suite:
+  name: mock-example
+
+scenarios:
+  - name: the client posts a report and the mock records it
+    mock_servers:
+      - name: api
+        routes:
+          - method: POST
+            path: /v1/reports
+            status: 201
+            json: { id: "r-1", ok: true }
+          - method: GET
+            path: /v1/reports/r-1
+            json: { id: "r-1", title: "report" }
+    steps:
+      # ${api.url} is the mock's base URL, seeded before steps run.
+      - run:
+          shell: true
+          command: >-
+            curl -sf -X POST -H 'Authorization: Bearer tok-123'
+            -d '{"title":"report"}' ${api.url}/v1/reports
+      - assert:
+          exit_code: 0
+          stdout:
+            json: { path: "$.id", equals: "r-1" }
+      # Assert what the CLI actually sent: exactly one POST, with the auth
+      # header and the JSON body it was supposed to carry.
+      - assert:
+          mock:
+            name: api
+            path: /v1/reports
+            method: POST
+            count: 1
+            header: { name: Authorization, matches: "^Bearer " }
+            body:
+              json: { path: "$.title", equals: "report" }
+`
+
 // initTemplate pairs a scaffold with the one-line summary shown by
 // --list-templates, so a user can pick a starting point without opening the
 // generated file first.
@@ -304,6 +352,10 @@ var initTemplates = map[string]initTemplate{
 	"services": {
 		body: servicesTemplate,
 		desc: "test against a background server: readiness, retry, teardown (runs as-is)",
+	},
+	"mock": {
+		body: mockTemplate,
+		desc: "stub an HTTP API offline and assert what the client sent (needs curl on PATH)",
 	},
 }
 

--- a/internal/docgen/describe.go
+++ b/internal/docgen/describe.go
@@ -54,6 +54,18 @@ func describeTarget(a *spec.Assert, target spec.AssertTarget) string {
 			return fmt.Sprintf("exit code is %s", markdown.Code(fmt.Sprint(*a.ExitCode.Equals)))
 		}
 		return "exit code is checked"
+	case spec.AssertMock:
+		m := a.Mock
+		desc := "mock " + markdown.Code(m.Name) + " received"
+		if m.Method != "" || m.Path != "" {
+			desc += " " + markdown.Code(strings.TrimSpace(strings.ToUpper(m.Method)+" "+m.Path))
+		} else {
+			desc += " a request"
+		}
+		if m.Count != nil {
+			desc += fmt.Sprintf(" exactly %d time(s)", *m.Count)
+		}
+		return desc
 	case spec.AssertStdout:
 		return "stdout " + describeStream(a.Stdout)
 	case spec.AssertStderr:

--- a/internal/docgen/docgen.go
+++ b/internal/docgen/docgen.go
@@ -197,6 +197,10 @@ func givenBullets(sc *spec.Scenario, expand func(string) string) []string {
 		svc := &sc.Services[i]
 		out = append(out, fmt.Sprintf("Background service `%s` is started: `%s`.", svc.Name, expand(svc.Command)))
 	}
+	for i := range sc.MockServers {
+		ms := &sc.MockServers[i]
+		out = append(out, fmt.Sprintf("Stub HTTP server `%s` serves %d canned route(s) at `${%s.url}` and records every request (#24).", ms.Name, len(ms.Routes), ms.Name))
+	}
 	for i := range sc.Steps {
 		step := &sc.Steps[i]
 		switch step.Kind() {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -21,6 +21,7 @@ import (
 	runnercmd "github.com/nao1215/atago/internal/runner/cmd"
 	dbrunner "github.com/nao1215/atago/internal/runner/db"
 	grpcrunner "github.com/nao1215/atago/internal/runner/grpc"
+	mockrunner "github.com/nao1215/atago/internal/runner/mock"
 	servicerunner "github.com/nao1215/atago/internal/runner/service"
 	sshrunner "github.com/nao1215/atago/internal/runner/ssh"
 	"github.com/nao1215/atago/internal/security"
@@ -161,6 +162,7 @@ func (e *Engine) Run(ctx context.Context, s *spec.Spec, specPath string) *SuiteR
 		rc.suiteVars = suiteRT.vars
 		rc.suiteEnv = suiteRT.env
 		rc.suiteServices = suiteRT.services
+		rc.suiteMocks = suiteRT.mocks
 		defer func() {
 			// Deferred after suiteRT.stop ⇒ runs before it, so teardown can
 			// still reach the suite services.
@@ -338,6 +340,9 @@ type runConfig struct {
 	// suite.setup service steps (#7), threaded here so a scenario's `signal:`
 	// step (#23) can target them by name alongside its own services.
 	suiteServices []*servicerunner.Proc
+	// suiteMocks are the suite-wide stub HTTP servers (#24), threaded here so
+	// scenario `mock:` asserts can read their recorded requests.
+	suiteMocks []*mockrunner.Server
 }
 
 func (e *Engine) runScenario(ctx context.Context, scenarioIdx int, sc *spec.Scenario, rc runConfig) ScenarioResult {
@@ -398,6 +403,29 @@ func (e *Engine) runScenario(ctx context.Context, scenarioIdx int, sc *spec.Scen
 			_ = c.Close()
 		}
 	}()
+	// Mock servers (#24) start before the leading fixtures and services, so
+	// fixture contents and service commands/env can reference ${<mock>.url}. Each binds an ephemeral loopback port and seeds
+	// ${<name>.url} / ${<name>.port} into the store; they stop LIFO with the
+	// scenario.
+	var mocks []*mockrunner.Server
+	defer func() {
+		for i := len(mocks) - 1; i >= 0; i-- {
+			mocks[i].Stop()
+		}
+	}()
+	for i := range sc.MockServers {
+		ms, err := mockrunner.Start(ctx, &sc.MockServers[i], specDir)
+		if err != nil {
+			out.Status = StatusError
+			out.Steps = append(out.Steps, StepResult{Kind: spec.StepNone, Setup: true, ErrMsg: masker.Mask(err.Error())})
+			out.Duration = time.Since(start)
+			return out
+		}
+		mocks = append(mocks, ms)
+		st.Set(ms.Name()+".url", ms.URL())
+		st.Set(ms.Name()+".port", ms.Port())
+	}
+
 	// Leading fixture steps — the uninterrupted prefix of steps that are all
 	// fixtures — are applied BEFORE services start, so a background server can
 	// consume authored input (its config file, seed data) the way a real daemon
@@ -453,6 +481,23 @@ func (e *Engine) runScenario(ctx context.Context, scenarioIdx int, sc *spec.Scen
 	}
 
 	var current *runner.Result
+
+	// mockRecords resolves a mock server's recorded requests for the `mock:`
+	// assertion target (#24): the scenario's own mocks first, then suite-wide
+	// ones, mirroring the store's scenario-over-suite precedence.
+	mockRecords := func(name string) ([]mockrunner.Record, bool) {
+		for _, m := range mocks {
+			if m.Name() == name {
+				return m.Records(), true
+			}
+		}
+		for _, m := range rc.suiteMocks {
+			if m.Name() == name {
+				return m.Records(), true
+			}
+		}
+		return nil, false
+	}
 
 	// execStep runs one step and returns its result, its status contribution
 	// (passed/failed/error), and whether it breached the security policy. It is
@@ -513,6 +558,7 @@ func (e *Engine) runScenario(ctx context.Context, scenarioIdx int, sc *spec.Scen
 				SpecDir:         specDir,
 				UpdateSnapshots: e.UpdateSnapshots,
 				Secrets:         masker.MaskBytes,
+				MockRecords:     mockRecords,
 			})
 			e.recordChecks(masker, crs, rc.specPath, sc.Name, scenarioIdx, i)
 			sr.Checks = crs

--- a/internal/engine/mock_test.go
+++ b/internal/engine/mock_test.go
@@ -1,0 +1,144 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestEngine_MockServerRoundTrip proves the full #24 flow with the http
+// runner as the client: routes answer canned JSON, ${name.url} seeds the
+// store, and mock asserts check count/header/body of what was sent.
+func TestEngine_MockServerRoundTrip(t *testing.T) {
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: s
+runners:
+  api:
+    type: http
+    base_url: ${api.url}
+scenarios:
+  - name: client posts a report
+    mock_servers:
+      - name: api
+        routes:
+          - method: POST
+            path: /v1/reports
+            status: 201
+            json: { id: "r-1", ok: true }
+    steps:
+      - http:
+          runner: api
+          method: POST
+          path: /v1/reports
+          header: { Authorization: "Bearer tok-123" }
+          json: { title: "report" }
+      - assert:
+          status: 201
+          body:
+            json: { path: "$.id", equals: "r-1" }
+      - assert:
+          mock:
+            name: api
+            path: /v1/reports
+            method: POST
+            count: 1
+            header: { name: Authorization, matches: "^Bearer " }
+            body:
+              json: { path: "$.title", equals: "report" }
+`)
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed: %+v", res.Status, res.Scenarios)
+	}
+}
+
+// TestEngine_MockUnmatchedRecordedAs404 proves an unmatched request answers
+// 404 and is still recorded, and a failing count summarizes what was sent.
+func TestEngine_MockUnmatchedRecordedAs404(t *testing.T) {
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: s
+runners:
+  api:
+    type: http
+    base_url: ${stub.url}
+scenarios:
+  - name: typo'd path is visible in the failure
+    mock_servers:
+      - name: stub
+        routes:
+          - method: GET
+            path: /right
+    steps:
+      - http:
+          runner: api
+          method: GET
+          path: /wrong
+      - assert:
+          status: 404
+      - assert:
+          mock:
+            name: stub
+            path: /right
+            count: 1
+`)
+	if res.Status != StatusFailed {
+		t.Fatalf("status = %s, want failed: %+v", res.Status, res.Scenarios)
+	}
+	var actual string
+	for _, sc := range res.Scenarios {
+		for _, st := range sc.Steps {
+			for _, c := range st.Checks {
+				if c != nil && !c.OK {
+					actual = c.Actual
+				}
+			}
+		}
+	}
+	if !strings.Contains(actual, "GET /wrong -> 404") {
+		t.Errorf("failing count Actual = %q, want the recorded-request summary", actual)
+	}
+}
+
+// TestEngine_SuiteMockServer proves a suite.setup mock_server seeds every
+// scenario with its URL and is assertable from scenario steps.
+func TestEngine_SuiteMockServer(t *testing.T) {
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: s
+  setup:
+    - mock_server:
+        name: shared
+        routes:
+          - method: GET
+            path: /ping
+            body: pong
+runners:
+  api:
+    type: http
+    base_url: ${shared.url}
+scenarios:
+  - name: scenario hits the suite-wide mock
+    steps:
+      - http:
+          runner: api
+          method: GET
+          path: /ping
+      - assert:
+          status: 200
+          body: { equals: pong }
+      - assert:
+          mock:
+            name: shared
+            path: /ping
+            method: GET
+`)
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed: %+v", res.Status, res.Scenarios)
+	}
+}

--- a/internal/engine/suite.go
+++ b/internal/engine/suite.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nao1215/atago/internal/assert"
 	"github.com/nao1215/atago/internal/fixture"
 	"github.com/nao1215/atago/internal/runner"
+	mockrunner "github.com/nao1215/atago/internal/runner/mock"
 	servicerunner "github.com/nao1215/atago/internal/runner/service"
 	sshrunner "github.com/nao1215/atago/internal/runner/ssh"
 	"github.com/nao1215/atago/internal/spec"
@@ -28,6 +29,10 @@ type suiteRuntime struct {
 	dir      string
 	st       *store.Store
 	services []*servicerunner.Proc
+	// mocks are the suite-wide stub HTTP servers started by suite.setup
+	// mock_server steps (#24); their ${<name>.url}/${<name>.port} vars flow to
+	// every scenario, and scenario `mock:` asserts can read their records.
+	mocks    []*mockrunner.Server
 	env      map[string]string // raw suite.env; expanded per use
 	vars     map[string]string // seeded into every scenario store
 	sshConns map[string]*sshrunner.Runner
@@ -46,6 +51,9 @@ func (rt *suiteRuntime) set(name, value string) {
 func (rt *suiteRuntime) stop() {
 	for i := len(rt.services) - 1; i >= 0; i-- {
 		rt.services[i].Stop()
+	}
+	for i := len(rt.mocks) - 1; i >= 0; i-- {
+		rt.mocks[i].Stop()
 	}
 	for _, c := range rt.sshConns {
 		_ = c.Close()
@@ -137,6 +145,14 @@ func (e *Engine) runSuiteSteps(ctx context.Context, steps []spec.Step, rt *suite
 				SpecDir:         rc.specDir,
 				UpdateSnapshots: e.UpdateSnapshots,
 				Secrets:         rc.masker.MaskBytes,
+				MockRecords: func(name string) ([]mockrunner.Record, bool) {
+					for _, m := range rt.mocks {
+						if m.Name() == name {
+							return m.Records(), true
+						}
+					}
+					return nil, false
+				},
 			})
 			sr.Checks = crs
 			if !assert.AllOK(crs) {
@@ -155,6 +171,16 @@ func (e *Engine) runSuiteSteps(ctx context.Context, steps []spec.Step, rt *suite
 			if step.Service.Ready != nil && step.Service.Ready.Store != "" {
 				rt.set(step.Service.Ready.Store, captured)
 			}
+		case spec.StepMockServer:
+			ms, err := mockrunner.Start(ctx, step.MockServer, rc.specDir)
+			if err != nil {
+				sr.ErrMsg = err.Error()
+				failed = true
+				break
+			}
+			rt.mocks = append(rt.mocks, ms)
+			rt.set(ms.Name()+".url", ms.URL())
+			rt.set(ms.Name()+".port", ms.Port())
 		default:
 			sr.ErrMsg = fmt.Sprintf("%s steps are not allowed at suite level", step.Kind())
 			failed = true

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -61,6 +61,8 @@ func explainSuiteBlock(b *strings.Builder, label string, steps []spec.Step) {
 			fmt.Fprintf(b, "  - %s\n", describeRun(step.Run))
 		case spec.StepService:
 			fmt.Fprintf(b, "  - start suite service %q: %s\n", step.Service.Name, step.Service.Command)
+		case spec.StepMockServer:
+			fmt.Fprintf(b, "  - %s\n", describeMockServer(step.MockServer))
 		case spec.StepFixture:
 			fmt.Fprintf(b, "  - %s\n", describeFixture(step.Fixture))
 		case spec.StepStore:
@@ -96,6 +98,9 @@ func explainScenario(b *strings.Builder, sc *spec.Scenario) {
 		if svc.Ready != nil && svc.Ready.Store != "" {
 			stores = append(stores, svc.Ready.Store)
 		}
+	}
+	for i := range sc.MockServers {
+		services = append(services, describeMockServer(&sc.MockServers[i]))
 	}
 
 	for i := range sc.Steps {
@@ -271,6 +276,11 @@ func describeCDP(c *spec.CDP) string {
 	return fmt.Sprintf("CDP via %s: %s", c.Runner, strings.Join(acts, " → "))
 }
 
+// describeMockServer renders a one-line summary of a stub HTTP server (#24).
+func describeMockServer(ms *spec.MockServer) string {
+	return fmt.Sprintf("mock server %s: %d canned route(s), serves ${%s.url}", ms.Name, len(ms.Routes), ms.Name)
+}
+
 // describeSignal renders a one-line summary of a signal step (#23).
 func describeSignal(sg *spec.Signal) string {
 	desc := "send SIG" + spec.NormalizeSignalName(sg.Signal) + " to service " + sg.Service
@@ -280,6 +290,20 @@ func describeSignal(sg *spec.Signal) string {
 			timeout = "5s"
 		}
 		desc += "  [wait up to " + timeout + " for exit]"
+	}
+	return desc
+}
+
+// describeMockAssert renders a one-line summary of a mock assertion (#24).
+func describeMockAssert(m *spec.MockAssert) string {
+	desc := "mock " + m.Name
+	if m.Method != "" || m.Path != "" {
+		desc += " received " + strings.TrimSpace(strings.ToUpper(m.Method)+" "+m.Path)
+	} else {
+		desc += " received a request"
+	}
+	if m.Count != nil {
+		desc += fmt.Sprintf(" x%d", *m.Count)
 	}
 	return desc
 }
@@ -350,6 +374,8 @@ func describeTarget(a *spec.Assert, target spec.AssertTarget) string {
 			return fmt.Sprintf("exit code is %d", *a.ExitCode.Equals)
 		}
 		return "exit code"
+	case spec.AssertMock:
+		return describeMockAssert(a.Mock)
 	case spec.AssertStdout:
 		return "stdout " + describeStream(a.Stdout)
 	case spec.AssertStderr:

--- a/internal/loader/defaults_test.go
+++ b/internal/loader/defaults_test.go
@@ -463,6 +463,147 @@ scenarios:
 	}
 }
 
+// TestValidate_MockServers proves the mock-server rules (#24): duplicate
+// names, route payload one-of, unknown mock names in asserts (listing the
+// declared ones), and count-0-with-matchers contradictions all fail at load.
+func TestValidate_MockServers(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name, src, wantMsg string
+	}{
+		{
+			name: "duplicate mock names",
+			src: `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: s
+    mock_servers:
+      - name: api
+        routes: [{method: GET, path: /}]
+      - name: api
+        routes: [{method: GET, path: /}]
+    steps:
+      - run: {command: echo hi}
+`,
+			wantMsg: `duplicate mock server name "api"`,
+		},
+		{
+			name: "route with two payload sources",
+			src: `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: s
+    mock_servers:
+      - name: api
+        routes:
+          - method: GET
+            path: /
+            body: inline
+            body_file: canned.json
+    steps:
+      - run: {command: echo hi}
+`,
+			wantMsg: "at most one of json/body/body_file",
+		},
+		{
+			name: "unknown mock name in assert lists declared",
+			src: `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: s
+    mock_servers:
+      - name: api
+        routes: [{method: GET, path: /}]
+    steps:
+      - run: {command: echo hi}
+      - assert:
+          mock: {name: apo, count: 1}
+`,
+			wantMsg: `"apo" is not a declared mock server (declared: api)`,
+		},
+		{
+			name: "count zero with body matcher",
+			src: `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: s
+    mock_servers:
+      - name: api
+        routes: [{method: GET, path: /}]
+    steps:
+      - run: {command: echo hi}
+      - assert:
+          mock:
+            name: api
+            count: 0
+            body: {contains: x}
+`,
+			wantMsg: "count: 0 cannot be combined",
+		},
+		{
+			name: "relative route path",
+			src: `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: s
+    mock_servers:
+      - name: api
+        routes: [{method: GET, path: v1/x}]
+    steps:
+      - run: {command: echo hi}
+`,
+			wantMsg: `must start with "/"`,
+		},
+		{
+			name: "suite mock is a legal assert target",
+			src: `
+version: "1"
+suite:
+  name: sample
+  setup:
+    - mock_server:
+        name: shared
+        routes: [{method: GET, path: /}]
+scenarios:
+  - name: s
+    steps:
+      - run: {command: echo hi}
+      - assert:
+          mock: {name: shared, count: 0}
+`,
+			wantMsg: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := LoadBytes("sample.atago.yaml", []byte(tc.src))
+			if tc.wantMsg == "" {
+				if err != nil {
+					t.Fatalf("LoadBytes() error = %v, want clean load", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("LoadBytes() = nil error, want a mock validation error")
+			}
+			if !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Errorf("error = %q, want substring %q", err, tc.wantMsg)
+			}
+		})
+	}
+}
+
 // TestValidate_SignalStep proves the signal-step rules (#23): the target must
 // be a declared service (with the declared names listed), the signal name
 // must be in the accepted set, and wait.timeout must parse.

--- a/internal/loader/validate.go
+++ b/internal/loader/validate.go
@@ -39,11 +39,16 @@ func validate(s *spec.Spec) []string {
 	validateSuiteBlock(add, "suite.setup", s.Suite.Setup, s.Runners, true)
 	validateSuiteBlock(add, "suite.teardown", s.Suite.Teardown, s.Runners, false)
 
-	// Suite services are legal signal targets from any scenario (#23).
+	// Suite services are legal signal targets from any scenario (#23), and
+	// suite mock servers are legal mock-assert targets (#24).
 	suiteServiceNames := map[string]bool{}
+	suiteMockNames := map[string]bool{}
 	for i := range s.Suite.Setup {
 		if svc := s.Suite.Setup[i].Service; svc != nil && svc.Name != "" {
 			suiteServiceNames[svc.Name] = true
+		}
+		if ms := s.Suite.Setup[i].MockServer; ms != nil && ms.Name != "" {
+			suiteMockNames[ms.Name] = true
 		}
 	}
 
@@ -69,18 +74,78 @@ func validate(s *spec.Spec) []string {
 				serviceNames[sc.Services[j].Name] = true
 			}
 		}
+		mockNames := maps.Clone(suiteMockNames)
+		validateMockServers(add, where, sc.MockServers, mockNames)
 		if len(sc.Steps) == 0 {
 			add("%s: steps must contain at least one step", where)
 			continue
 		}
 		for j := range sc.Steps {
-			validateStep(add, fmt.Sprintf("%s.steps[%d]", where, j), &sc.Steps[j], s.Runners, serviceNames)
+			validateStep(add, fmt.Sprintf("%s.steps[%d]", where, j), &sc.Steps[j], s.Runners, serviceNames, mockNames)
 		}
 		for j := range sc.Teardown {
-			validateStep(add, fmt.Sprintf("%s.teardown[%d]", where, j), &sc.Teardown[j], s.Runners, serviceNames)
+			validateStep(add, fmt.Sprintf("%s.teardown[%d]", where, j), &sc.Teardown[j], s.Runners, serviceNames, mockNames)
 		}
 	}
 	return errs
+}
+
+// validateMockServers checks a scenario's mock_servers block (#24) and adds
+// every declared name to mockNames (which arrives pre-seeded with the
+// suite-wide mock names).
+func validateMockServers(add func(string, ...any), where string, servers []spec.MockServer, mockNames map[string]bool) {
+	for i := range servers {
+		ms := &servers[i]
+		mw := fmt.Sprintf("%s.mock_servers[%d]", where, i)
+		if ms.Name == "" {
+			add("%s.name is required", mw)
+		} else {
+			if mockNames[ms.Name] {
+				add("%s: duplicate mock server name %q", where, ms.Name)
+			}
+			mockNames[ms.Name] = true
+			mw = fmt.Sprintf("%s mock server %q", where, ms.Name)
+		}
+		validateMockRoutes(add, mw, ms.Routes)
+	}
+}
+
+// validateMockRoutes checks each canned route (#24): method+path required, at
+// most one payload source, sane status, parseable delay.
+func validateMockRoutes(add func(string, ...any), where string, routes []spec.MockRoute) {
+	for i := range routes {
+		rt := &routes[i]
+		rw := fmt.Sprintf("%s.routes[%d]", where, i)
+		if rt.Method == "" {
+			add("%s.method is required", rw)
+		}
+		if rt.Path == "" {
+			add("%s.path is required", rw)
+		} else if !strings.HasPrefix(rt.Path, "/") {
+			add("%s.path %q must start with \"/\"", rw, rt.Path)
+		}
+		payloads := 0
+		if rt.JSON != nil {
+			payloads++
+		}
+		if rt.Body != "" {
+			payloads++
+		}
+		if rt.BodyFile != "" {
+			payloads++
+		}
+		if payloads > 1 {
+			add("%s: set at most one of json/body/body_file", rw)
+		}
+		if rt.Status != 0 && (rt.Status < 100 || rt.Status > 599) {
+			add("%s.status %d is not a valid HTTP status", rw, rt.Status)
+		}
+		if rt.Delay != "" {
+			if _, err := time.ParseDuration(rt.Delay); err != nil {
+				add("%s.delay %q is not a valid duration (e.g. \"500ms\")", rw, rt.Delay)
+			}
+		}
+	}
 }
 
 // validateDefaults checks the top-level `defaults:` block (ADR-0039). The merge only
@@ -318,6 +383,7 @@ func validateServices(add func(string, ...any), where string, services []spec.Se
 // rejected with a pointer to where they belong.
 func validateSuiteBlock(add func(string, ...any), where string, steps []spec.Step, runners map[string]spec.Runner, allowService bool) {
 	seenService := map[string]bool{}
+	seenMock := map[string]bool{}
 	for i := range steps {
 		st := &steps[i]
 		sw := fmt.Sprintf("%s[%d]", where, i)
@@ -345,7 +411,7 @@ func validateSuiteBlock(add func(string, ...any), where string, steps []spec.Ste
 		case spec.StepStore:
 			validateStore(add, sw, st.Store)
 		case spec.StepAssert:
-			validateAssert(add, sw, st.Assert)
+			validateAssert(add, sw, st.Assert, nil)
 		case spec.StepService:
 			if !allowService {
 				add("%s: service steps are only allowed in suite.setup", sw)
@@ -364,6 +430,22 @@ func validateSuiteBlock(add func(string, ...any), where string, steps []spec.Ste
 			}
 			validateHermeticEnv(add, sw+".service", svc.ClearEnv, svc.PassEnv)
 			validateReady(add, sw+".service", svc.Ready)
+		case spec.StepMockServer:
+			// Mock servers follow the service rule (#24): setup-only, so the
+			// position in the sequence controls ordering.
+			if !allowService {
+				add("%s: mock_server steps are only allowed in suite.setup", sw)
+				continue
+			}
+			ms := st.MockServer
+			if ms.Name == "" {
+				add("%s.mock_server.name is required", sw)
+			} else if seenMock[ms.Name] {
+				add("%s: duplicate suite mock server name %q", where, ms.Name)
+			} else {
+				seenMock[ms.Name] = true
+			}
+			validateMockRoutes(add, sw+".mock_server", ms.Routes)
 		default:
 			add("%s: %s steps are per-scenario (they need a scenario workdir and runners); move it into a scenario", sw, st.Kind())
 		}
@@ -446,7 +528,7 @@ func validateRunnerRef(add func(string, ...any), where, stepKind, name string, r
 	}
 }
 
-func validateStep(add func(string, ...any), where string, st *spec.Step, runners map[string]spec.Runner, serviceNames map[string]bool) {
+func validateStep(add func(string, ...any), where string, st *spec.Step, runners map[string]spec.Runner, serviceNames, mockNames map[string]bool) {
 	keys := st.SetKeys()
 	switch len(keys) {
 	case 0:
@@ -485,7 +567,7 @@ func validateStep(add func(string, ...any), where string, st *spec.Step, runners
 		validateStdin(add, where+".run", st.Run.Stdin)
 		validateRetry(add, where+".run", st.Run.Retry)
 	case spec.StepAssert:
-		validateAssert(add, where, st.Assert)
+		validateAssert(add, where, st.Assert, mockNames)
 	case spec.StepHTTP:
 		validateRunnerRef(add, where, "http", st.HTTP.Runner, runners)
 		if st.HTTP.Method == "" {
@@ -742,7 +824,7 @@ func validateFixture(add func(string, ...any), where string, f *spec.Fixture) {
 	}
 }
 
-func validateAssert(add func(string, ...any), where string, a *spec.Assert) {
+func validateAssert(add func(string, ...any), where string, a *spec.Assert, mockNames map[string]bool) {
 	targets := a.SetTargets()
 	if len(targets) == 0 {
 		add("%s.assert: must set at least one assertion target (got none)", where)
@@ -751,12 +833,12 @@ func validateAssert(add func(string, ...any), where string, a *spec.Assert) {
 	// Each set target is an independent check and all must hold, so validate every
 	// one of them (an assert may combine, e.g., exit_code + stdout + file).
 	for _, t := range targets {
-		validateAssertTarget(add, where, a, t)
+		validateAssertTarget(add, where, a, t, mockNames)
 	}
 }
 
 // validateAssertTarget checks the shape of a single assertion target family.
-func validateAssertTarget(add func(string, ...any), where string, a *spec.Assert, target spec.AssertTarget) {
+func validateAssertTarget(add func(string, ...any), where string, a *spec.Assert, target spec.AssertTarget, mockNames map[string]bool) {
 	switch target {
 	case spec.AssertExitCode:
 		// Scalar/mapping shape enforced by ExitCode.UnmarshalYAML; the one-of
@@ -782,6 +864,8 @@ func validateAssertTarget(add func(string, ...any), where string, a *spec.Assert
 		validateImage(add, where+".assert.image", a.Image)
 	case spec.AssertDir:
 		validateDir(add, where+".assert.dir", a.Dir)
+	case spec.AssertMock:
+		validateMockAssert(add, where+".assert.mock", a.Mock, mockNames)
 	case spec.AssertPDF:
 		validatePDF(add, where+".assert.pdf", a.PDF)
 	case spec.AssertGRPCStatus:
@@ -924,6 +1008,37 @@ func shellMetachar(cmd string) string {
 	return ""
 }
 
+// validateMockAssert checks a `mock:` assertion (#24): a declared server
+// name (listed on a miss, mirroring the unknown-runner message), a sane
+// count, and well-formed header/body matchers. A nil mockNames (retry.until)
+// skips the declared-name check.
+func validateMockAssert(add func(string, ...any), where string, m *spec.MockAssert, mockNames map[string]bool) {
+	switch {
+	case m.Name == "":
+		add("%s.name is required (the mock server whose recorded requests to check)", where)
+	case mockNames != nil && !mockNames[m.Name]:
+		declared := "none"
+		if len(mockNames) > 0 {
+			declared = strings.Join(slices.Sorted(maps.Keys(mockNames)), ", ")
+		}
+		add("%s.name %q is not a declared mock server (declared: %s)", where, m.Name, declared)
+	}
+	if m.Count != nil {
+		if *m.Count < 0 {
+			add("%s.count must be >= 0 (got %d)", where, *m.Count)
+		}
+		if *m.Count == 0 && (m.Header != nil || m.Body != nil) {
+			add("%s: count: 0 cannot be combined with header/body matchers (there is no request to match)", where)
+		}
+	}
+	if m.Header != nil {
+		validateHeaderMatch(add, where+".header", m.Header)
+	}
+	if m.Body != nil {
+		validateStream(add, where+".body", m.Body)
+	}
+}
+
 func validateHeaderMatch(add func(string, ...any), where string, h *spec.HeaderMatch) {
 	if h.Name == "" {
 		add("%s.name is required", where)
@@ -935,12 +1050,18 @@ func validateHeaderMatch(add func(string, ...any), where string, h *spec.HeaderM
 	if h.Equals != nil {
 		n++
 	}
+	if h.Matches != nil {
+		n++
+		if _, err := regexp.Compile(*h.Matches); err != nil {
+			add("%s.matches %q is not a valid regexp: %v", where, *h.Matches, err)
+		}
+	}
 	switch n {
 	case 0:
-		add("%s: must set one of contains/equals", where)
+		add("%s: must set one of contains/equals/matches", where)
 	case 1:
 	default:
-		add("%s: must set exactly one of contains/equals", where)
+		add("%s: must set exactly one of contains/equals/matches", where)
 	}
 }
 
@@ -1117,7 +1238,7 @@ func validateRetry(add func(string, ...any), where string, r *spec.Retry) {
 		add("%s.retry.until is required", where)
 		return
 	}
-	validateAssert(add, where+".retry.until", r.Until)
+	validateAssert(add, where+".retry.until", r.Until, nil)
 }
 
 func validateJSON(add func(string, ...any), where string, j *spec.JSONAssert) {

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -121,7 +121,9 @@ type Scenario struct {
 	Only     *Condition        `json:"only,omitempty"`
 	Skip     *Condition        `json:"skip,omitempty"`
 	Services []Service         `json:"services,omitempty"`
-	Steps    []Step            `json:"steps"`
+	// MockServers summarizes the scenario's stub HTTP servers (#24).
+	MockServers []MockServer `json:"mock_servers,omitempty"`
+	Steps       []Step       `json:"steps"`
 	// Teardown lists steps that always run after Steps (pass, fail, error, or
 	// interrupt), sharing the scenario's variable store. Their failures never
 	// change the scenario's verdict.
@@ -139,6 +141,13 @@ type Condition struct {
 	OS      string `json:"os,omitempty"`
 	Env     string `json:"env,omitempty"`
 	Command string `json:"command,omitempty"`
+}
+
+// MockServer summarizes a stub HTTP server (#24).
+type MockServer struct {
+	Name string `json:"name"`
+	// Routes is the number of canned routes.
+	Routes int `json:"routes"`
 }
 
 // Service summarizes a background service.

--- a/internal/manifest/scenario.go
+++ b/internal/manifest/scenario.go
@@ -33,6 +33,9 @@ func buildScenario(sc *spec.Scenario, src SourceLocator) Scenario {
 			collectVars(vars, v)
 		}
 	}
+	for i := range sc.MockServers {
+		out.MockServers = append(out.MockServers, MockServer{Name: sc.MockServers[i].Name, Routes: len(sc.MockServers[i].Routes)})
+	}
 
 	for i := range sc.Steps {
 		step := &sc.Steps[i]
@@ -173,6 +176,11 @@ func buildStep(index int, step *spec.Step, vars map[string]bool) Step {
 				collectVars(vars, a.Download.Click, a.Download.Dir)
 			}
 		}
+
+	case spec.StepMockServer:
+		ms := step.MockServer
+		st.Target = ms.Name
+		st.Action = fmt.Sprintf("start suite mock server %s (%d routes)", ms.Name, len(ms.Routes))
 
 	case spec.StepSignal:
 		sg := step.Signal

--- a/internal/runner/mock/mock.go
+++ b/internal/runner/mock/mock.go
@@ -1,0 +1,191 @@
+// Package mock implements the declarative stub HTTP server behind
+// `mock_servers:` (#24): canned routes served on an ephemeral loopback port,
+// with every incoming request recorded for the `mock:` assertion target — so
+// API-client CLIs (gh-style tools, cloud CLIs, webhook senders) are testable
+// fully offline.
+package mock
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/nao1215/atago/internal/security"
+	"github.com/nao1215/atago/internal/spec"
+)
+
+// maxRecordedBody caps a recorded request body so a runaway client cannot
+// exhaust memory; the response is unaffected.
+const maxRecordedBody = 8 << 20 // 8 MiB
+
+// Record is one incoming request as the mock server observed it.
+type Record struct {
+	Method string
+	Path   string
+	Header http.Header
+	Body   []byte
+	// Status is the response status the mock answered with (404 for an
+	// unmatched request — recorded so asserts can catch typo'd paths).
+	Status int
+}
+
+// Server is a running mock server.
+type Server struct {
+	name    string
+	specDir string
+	routes  []spec.MockRoute
+	lis     net.Listener
+	srv     *http.Server
+
+	mu      sync.Mutex
+	records []Record
+}
+
+// Start launches the mock server on an ephemeral 127.0.0.1 port. The returned
+// server is ready to accept connections when Start returns (the listener
+// binds synchronously); ctx only scopes the bind itself.
+func Start(ctx context.Context, ms *spec.MockServer, specDir string) (*Server, error) {
+	lis, err := (&net.ListenConfig{}).Listen(ctx, "tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("mock server %q: listen: %w", ms.Name, err)
+	}
+	s := &Server{name: ms.Name, specDir: specDir, routes: ms.Routes, lis: lis}
+	s.srv = &http.Server{Handler: s, ReadHeaderTimeout: 10 * time.Second}
+	go func() { _ = s.srv.Serve(lis) }()
+	return s, nil
+}
+
+// Name identifies the server in diagnostics and asserts.
+func (s *Server) Name() string { return s.name }
+
+// URL is the base URL clients hit, seeded as ${<name>.url}.
+func (s *Server) URL() string { return "http://" + s.lis.Addr().String() }
+
+// Port is the bound port, seeded as ${<name>.port}.
+func (s *Server) Port() string {
+	_, port, _ := net.SplitHostPort(s.lis.Addr().String())
+	return port
+}
+
+// Stop shuts the listener down. Recorded requests remain readable.
+func (s *Server) Stop() {
+	if s == nil || s.srv == nil {
+		return
+	}
+	_ = s.srv.Close()
+}
+
+// Records returns a snapshot of every request observed so far, in arrival
+// order.
+func (s *Server) Records() []Record {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]Record, len(s.records))
+	copy(out, s.records)
+	return out
+}
+
+// RequestLog renders the recorded requests as one line each — the durable
+// artifact written next to service logs when a scenario fails.
+func (s *Server) RequestLog() string {
+	var b strings.Builder
+	for i, r := range s.Records() {
+		fmt.Fprintf(&b, "%d: %s %s -> %d (%d body bytes)\n", i+1, r.Method, r.Path, r.Status, len(r.Body))
+	}
+	return b.String()
+}
+
+// ServeHTTP matches the request against the routes (exact method+path, query
+// string excluded), answers the canned response, and records the request —
+// an unmatched request answers 404 and is still recorded.
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(io.LimitReader(r.Body, maxRecordedBody))
+	rec := Record{Method: r.Method, Path: r.URL.Path, Header: r.Header.Clone(), Body: body}
+
+	route := s.match(r.Method, r.URL.Path)
+	if route == nil {
+		rec.Status = http.StatusNotFound
+		s.record(rec)
+		http.Error(w, fmt.Sprintf("mock server %q has no route for %s %s", s.name, r.Method, r.URL.Path), http.StatusNotFound)
+		return
+	}
+
+	if route.Delay != "" {
+		if d, err := time.ParseDuration(route.Delay); err == nil { // validated at load time
+			time.Sleep(d)
+		}
+	}
+
+	status := route.Status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	payload, contentType, err := routePayload(route, s.specDir)
+	if err != nil {
+		rec.Status = http.StatusInternalServerError
+		s.record(rec)
+		http.Error(w, fmt.Sprintf("mock server %q: %v", s.name, err), http.StatusInternalServerError)
+		return
+	}
+	rec.Status = status
+	s.record(rec)
+
+	if contentType != "" {
+		w.Header().Set("Content-Type", contentType)
+	}
+	for k, v := range route.Header {
+		w.Header().Set(k, v)
+	}
+	w.WriteHeader(status)
+	_, _ = w.Write(payload)
+}
+
+// match returns the first route with the request's exact method and path.
+func (s *Server) match(method, path string) *spec.MockRoute {
+	for i := range s.routes {
+		rt := &s.routes[i]
+		if strings.EqualFold(rt.Method, method) && rt.Path == path {
+			return rt
+		}
+	}
+	return nil
+}
+
+// routePayload builds the response body: inline JSON (marshaled), inline
+// text, or a spec-relative file read at request time (confined to the spec
+// directory like snapshot goldens).
+func routePayload(rt *spec.MockRoute, specDir string) (body []byte, contentType string, err error) {
+	switch {
+	case rt.JSON != nil:
+		b, err := json.Marshal(rt.JSON)
+		if err != nil {
+			return nil, "", fmt.Errorf("route %s %s: marshal json: %w", rt.Method, rt.Path, err)
+		}
+		return b, "application/json", nil
+	case rt.BodyFile != "":
+		abs, err := security.ResolveSpecPath("mock route body_file", specDir, rt.BodyFile)
+		if err != nil {
+			return nil, "", err
+		}
+		b, err := os.ReadFile(abs) //nolint:gosec // confined to the spec directory above
+		if err != nil {
+			return nil, "", fmt.Errorf("route %s %s: %w", rt.Method, rt.Path, err)
+		}
+		return b, "", nil
+	default:
+		return []byte(rt.Body), "", nil
+	}
+}
+
+func (s *Server) record(r Record) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.records = append(s.records, r)
+}

--- a/internal/runner/mock/mock_test.go
+++ b/internal/runner/mock/mock_test.go
@@ -1,0 +1,175 @@
+package mock
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nao1215/atago/internal/spec"
+)
+
+func startTest(t *testing.T, ms *spec.MockServer, specDir string) *Server {
+	t.Helper()
+	s, err := Start(context.Background(), ms, specDir)
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(s.Stop)
+	return s
+}
+
+// do issues one request and returns the status, headers, and drained body —
+// the response never escapes the helper, so closing stays in one place.
+func do(t *testing.T, method, url string, body io.Reader) (int, http.Header, []byte) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), method, url, body)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, url, err)
+	}
+	defer func() {
+		if err := res.Body.Close(); err != nil {
+			t.Errorf("close body: %v", err)
+		}
+	}()
+	b, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return res.StatusCode, res.Header, b
+}
+
+// TestServe_RouteMatchingAndRecording proves exact method+path matching,
+// canned JSON responses, 404-with-recording for unmatched requests, and
+// ephemeral-port URL/Port reporting (#24).
+func TestServe_RouteMatchingAndRecording(t *testing.T) {
+	t.Parallel()
+	s := startTest(t, &spec.MockServer{
+		Name: "api",
+		Routes: []spec.MockRoute{
+			{Method: http.MethodPost, Path: "/v1/reports", Status: http.StatusCreated, JSON: map[string]any{"id": "r-1", "ok": true}},
+			{Method: http.MethodGet, Path: "/v1/reports/r-1", Body: "plain"},
+		},
+	}, t.TempDir())
+
+	if s.URL() == "" || s.Port() == "" {
+		t.Fatalf("URL/Port empty: %q %q", s.URL(), s.Port())
+	}
+
+	// The query string is excluded from matching.
+	status, header, body := do(t, http.MethodPost, s.URL()+"/v1/reports?ignored=1", strings.NewReader(`{"title":"report"}`))
+	if status != http.StatusCreated {
+		t.Errorf("status = %d, want 201", status)
+	}
+	if !bytes.Contains(body, []byte(`"id":"r-1"`)) {
+		t.Errorf("body = %s, want the canned json", body)
+	}
+	if ct := header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("content-type = %q, want application/json", ct)
+	}
+
+	status2, _, _ := do(t, http.MethodGet, s.URL()+"/nope", nil)
+	if status2 != http.StatusNotFound {
+		t.Errorf("unmatched status = %d, want 404", status2)
+	}
+
+	recs := s.Records()
+	if len(recs) != 2 {
+		t.Fatalf("records = %d, want 2 (unmatched requests are recorded too)", len(recs))
+	}
+	if recs[0].Method != http.MethodPost || recs[0].Path != "/v1/reports" || recs[0].Status != http.StatusCreated {
+		t.Errorf("record[0] = %+v, want POST /v1/reports 201", recs[0])
+	}
+	if !bytes.Contains(recs[0].Body, []byte("report")) {
+		t.Errorf("record[0].Body = %s, want the request payload", recs[0].Body)
+	}
+	if recs[1].Status != http.StatusNotFound {
+		t.Errorf("record[1].Status = %d, want 404", recs[1].Status)
+	}
+}
+
+// TestServe_BodyFileConfined proves body_file reads a spec-relative file at
+// request time and rejects escapes from the spec directory.
+func TestServe_BodyFileConfined(t *testing.T) {
+	t.Parallel()
+	specDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(specDir, "canned.json"), []byte(`{"from":"file"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s := startTest(t, &spec.MockServer{
+		Name: "api",
+		Routes: []spec.MockRoute{
+			{Method: http.MethodGet, Path: "/ok", BodyFile: "canned.json"},
+			{Method: http.MethodGet, Path: "/escape", BodyFile: "../outside.txt"},
+		},
+	}, specDir)
+
+	status, _, body := do(t, http.MethodGet, s.URL()+"/ok", nil)
+	if status != http.StatusOK || !bytes.Contains(body, []byte("from")) {
+		t.Errorf("status/body = %d/%s, want 200 with file content", status, body)
+	}
+
+	status2, _, _ := do(t, http.MethodGet, s.URL()+"/escape", nil)
+	if status2 != http.StatusInternalServerError {
+		t.Errorf("escape status = %d, want 500 (spec-dir confinement)", status2)
+	}
+}
+
+// TestServe_DelayAndHeaders proves the per-route delay and extra response
+// headers.
+func TestServe_DelayAndHeaders(t *testing.T) {
+	t.Parallel()
+	s := startTest(t, &spec.MockServer{
+		Name: "slow",
+		Routes: []spec.MockRoute{
+			{Method: http.MethodGet, Path: "/", Delay: "100ms", Header: map[string]string{"X-Mock": "yes"}},
+		},
+	}, t.TempDir())
+	start := time.Now()
+	_, header, _ := do(t, http.MethodGet, s.URL()+"/", nil)
+	if elapsed := time.Since(start); elapsed < 100*time.Millisecond {
+		t.Errorf("elapsed = %s, want >= 100ms (route delay)", elapsed)
+	}
+	if header.Get("X-Mock") != "yes" {
+		t.Errorf("X-Mock header missing")
+	}
+}
+
+// TestRecords_ThreadSafe proves concurrent clients record without races
+// (run with -race in CI).
+func TestRecords_ThreadSafe(t *testing.T) {
+	t.Parallel()
+	s := startTest(t, &spec.MockServer{
+		Name:   "busy",
+		Routes: []spec.MockRoute{{Method: http.MethodGet, Path: "/"}},
+	}, t.TempDir())
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Go(func() {
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, s.URL()+"/", nil)
+			if err != nil {
+				return
+			}
+			res, err := http.DefaultClient.Do(req)
+			if err != nil {
+				return
+			}
+			_, _ = io.Copy(io.Discard, res.Body)
+			_ = res.Body.Close()
+		})
+	}
+	wg.Wait()
+	if got := len(s.Records()); got != 20 {
+		t.Errorf("records = %d, want 20", got)
+	}
+}

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -164,7 +164,14 @@ type Scenario struct {
 	// CLI that talks to a peer (a TCP client, an API consumer) by standing up that
 	// peer for the duration of the scenario.
 	Services []Service `yaml:"services,omitempty"`
-	Steps    []Step    `yaml:"steps"`
+	// MockServers are declarative stub HTTP servers (#24): each serves canned
+	// routes on an ephemeral loopback port, records every incoming request
+	// for the `mock:` assertion target, and seeds ${<name>.url} /
+	// ${<name>.port} into the store before steps run — so an API-client CLI
+	// can be tested fully offline. Lifecycle mirrors services: started before
+	// steps, stopped LIFO at scenario end.
+	MockServers []MockServer `yaml:"mock_servers,omitempty"`
+	Steps       []Step       `yaml:"steps"`
 	// Teardown steps always run after Steps — whether the scenario passed,
 	// failed, errored, or was interrupted — and share its variable store, so a
 	// resource id captured with `store` flows into the cleanup request. They
@@ -206,6 +213,63 @@ type Service struct {
 	// Ready declares how to wait until the service is accepting work before the
 	// steps run. When omitted, the steps start as soon as the process is spawned.
 	Ready *Ready `yaml:"ready,omitempty"`
+}
+
+// MockServer is a declarative stub HTTP server (#24). It listens on
+// 127.0.0.1 with an ephemeral port, serves Routes matched on exact
+// method+path, and records every incoming request (matched or not — an
+// unmatched request answers 404 and is still recorded) for the `mock:`
+// assertion target.
+type MockServer struct {
+	// Name identifies the server for ${<name>.url} seeding and mock asserts;
+	// unique per scenario (and among suite-wide mock servers).
+	Name string `yaml:"name"`
+	// Routes are the canned responses, matched top-down on exact method+path
+	// (query string excluded; deliberately no patterns).
+	Routes []MockRoute `yaml:"routes,omitempty"`
+}
+
+// MockRoute is one canned response (#24). At most one of JSON/Body/BodyFile
+// supplies the payload; Status defaults to 200.
+type MockRoute struct {
+	// Method is the HTTP method to match (case-insensitive).
+	Method string `yaml:"method"`
+	// Path is the exact request path to match (query string excluded).
+	Path string `yaml:"path"`
+	// Status is the response status (default 200).
+	Status int `yaml:"status,omitempty"`
+	// JSON is an inline response document, marshaled with
+	// Content-Type: application/json.
+	JSON any `yaml:"json,omitempty"`
+	// Body is an inline text response body.
+	Body string `yaml:"body,omitempty"`
+	// BodyFile reads the response body from a spec-relative file (confined to
+	// the spec directory, like snapshot goldens), read at request time.
+	BodyFile string `yaml:"body_file,omitempty"`
+	// Header sets extra response headers.
+	Header map[string]string `yaml:"header,omitempty"`
+	// Delay sleeps this Go duration before responding — for retry testing.
+	Delay string `yaml:"delay,omitempty"`
+}
+
+// MockAssert checks what the CLI under test actually sent to a mock server
+// (#24). Records are filtered by the optional Path/Method, then Count pins
+// the exact number of matching requests (without Count, at least one must
+// exist); Header and Body apply to the LAST matching request.
+type MockAssert struct {
+	// Name references a declared mock server.
+	Name string `yaml:"name"`
+	// Path filters recorded requests by exact path.
+	Path string `yaml:"path,omitempty"`
+	// Method filters recorded requests by method (case-insensitive).
+	Method string `yaml:"method,omitempty"`
+	// Count asserts the exact number of matching requests.
+	Count *int `yaml:"count,omitempty"`
+	// Header matches a header of the last matching request.
+	Header *HeaderMatch `yaml:"header,omitempty"`
+	// Body matches the body of the last matching request with the stream
+	// matchers (json path, contains, ...).
+	Body *StreamAssert `yaml:"body,omitempty"`
 }
 
 // Ready is a service readiness probe (ADR-0031). Exactly one of File/Port/Log/
@@ -268,6 +332,11 @@ type Step struct {
 	// loader accepts the step everywhere and the engine reports a clear error
 	// on Windows.
 	Signal *Signal `yaml:"signal,omitempty"`
+	// MockServer starts a suite-wide stub HTTP server (#24). Like `service:`
+	// it is valid only inside suite.setup, so its position in the sequence
+	// controls ordering; its recorded requests and ${<name>.url} seed every
+	// scenario.
+	MockServer *MockServer `yaml:"mock_server,omitempty"`
 }
 
 // Signal targets a declared service (scenario or suite) by name and delivers
@@ -634,6 +703,11 @@ type Assert struct {
 	// surface for generated PDFs — page count, Info metadata fields, and extracted
 	// text — without depending on a specific layout engine.
 	PDF *PDFAssert `yaml:"pdf,omitempty"`
+
+	// Mock is the mock-server assertion target (#24): what the CLI under test
+	// actually sent to a declared mock server — request count, and header/body
+	// matchers applied to the last matching recorded request.
+	Mock *MockAssert `yaml:"mock,omitempty"`
 }
 
 // PDFAssert checks a generated PDF file (#73). Like ImageAssert/DirAssert, every
@@ -889,11 +963,15 @@ type JSONAssert struct {
 	Lte     *float64 `yaml:"lte,omitempty"`
 }
 
-// HeaderMatch checks an HTTP response header (post-MVP).
+// HeaderMatch checks an HTTP header (response headers on the `header` target,
+// recorded request headers on the `mock` target). Exactly one matcher.
 type HeaderMatch struct {
 	Name     string  `yaml:"name"`
 	Contains *string `yaml:"contains,omitempty"`
 	Equals   *string `yaml:"equals,omitempty"`
+	// Matches applies a regexp — the natural shape for auth headers
+	// ("^Bearer ") (#24).
+	Matches *string `yaml:"matches,omitempty"`
 }
 
 // Store captures a value into the variable store (post-MVP).

--- a/internal/spec/step.go
+++ b/internal/spec/step.go
@@ -4,18 +4,19 @@ package spec
 type StepKind string
 
 const (
-	StepNone    StepKind = ""
-	StepFixture StepKind = "fixture"
-	StepRun     StepKind = "run"
-	StepHTTP    StepKind = "http"
-	StepQuery   StepKind = "query"
-	StepGRPC    StepKind = "grpc"
-	StepCDP     StepKind = "cdp"
-	StepAssert  StepKind = "assert"
-	StepStore   StepKind = "store"
-	StepService StepKind = "service"
-	StepPTY     StepKind = "pty"
-	StepSignal  StepKind = "signal"
+	StepNone       StepKind = ""
+	StepFixture    StepKind = "fixture"
+	StepRun        StepKind = "run"
+	StepHTTP       StepKind = "http"
+	StepQuery      StepKind = "query"
+	StepGRPC       StepKind = "grpc"
+	StepCDP        StepKind = "cdp"
+	StepAssert     StepKind = "assert"
+	StepStore      StepKind = "store"
+	StepService    StepKind = "service"
+	StepPTY        StepKind = "pty"
+	StepSignal     StepKind = "signal"
+	StepMockServer StepKind = "mock_server"
 )
 
 // SetKeys returns the action keys that are present on the step. A valid step has
@@ -55,6 +56,9 @@ func (s *Step) SetKeys() []StepKind {
 	if s.Signal != nil {
 		keys = append(keys, StepSignal)
 	}
+	if s.MockServer != nil {
+		keys = append(keys, StepMockServer)
+	}
 	return keys
 }
 
@@ -86,6 +90,7 @@ const (
 	AssertImage      AssertTarget = "image"
 	AssertDir        AssertTarget = "dir"
 	AssertPDF        AssertTarget = "pdf"
+	AssertMock       AssertTarget = "mock"
 )
 
 // SetTargets returns the assertion target families present. A valid assert has
@@ -133,6 +138,9 @@ func (a *Assert) SetTargets() []AssertTarget {
 	}
 	if a.PDF != nil {
 		t = append(t, AssertPDF)
+	}
+	if a.Mock != nil {
+		t = append(t, AssertMock)
 	}
 	return t
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -14,7 +14,9 @@ import (
 // `$${name}` — the match is a literal escape that renders as `${name}` without
 // expansion. A bare `$$` not followed by `{name}` (a shell PID, a doubled
 // currency sign) does not match and is left untouched.
-var varRef = regexp.MustCompile(`(\$?)\$\{((?:env:)?[a-zA-Z_][a-zA-Z0-9_]*)\}`)
+// Dotted segments (${api.url}) exist for namespaced built-ins like the mock
+// server's url/port seeds (#24); a name never starts or ends with a dot.
+var varRef = regexp.MustCompile(`(\$?)\$\{((?:env:)?[a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z0-9_]+)*)\}`)
 
 // envPrefix marks a reference resolved from the host environment instead of
 // the scenario store: `${env:HOME}` expands to os.Getenv("HOME"). It exists

--- a/schema/atago.schema.json
+++ b/schema/atago.schema.json
@@ -230,6 +230,11 @@
           "type": "array",
           "items": { "$ref": "#/$defs/service" }
         },
+        "mock_servers": {
+          "description": "Declarative stub HTTP servers (#24): canned routes on an ephemeral loopback port, every request recorded for the mock: assertion target; ${<name>.url} / ${<name>.port} are seeded before steps run.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/mockServer" }
+        },
         "steps": {
           "type": "array",
           "minItems": 1,
@@ -283,7 +288,8 @@
         { "required": ["store"] },
         { "required": ["service"] },
         { "required": ["pty"] },
-        { "required": ["signal"] }
+        { "required": ["signal"] },
+        { "required": ["mock_server"] }
       ],
       "properties": {
         "fixture": { "$ref": "#/$defs/fixture" },
@@ -297,6 +303,10 @@
           "description": "Starts a suite-wide background process at this point in the sequence. Valid only inside suite.setup; the loader rejects it anywhere else."
         },
         "signal": { "$ref": "#/$defs/signal" },
+        "mock_server": {
+          "$ref": "#/$defs/mockServer",
+          "description": "Starts a suite-wide stub HTTP server at this point in the sequence (#24). Valid only inside suite.setup."
+        },
         "pty": { "$ref": "#/$defs/pty" },
         "assert": { "$ref": "#/$defs/assert" },
         "store": { "$ref": "#/$defs/store" }
@@ -502,6 +512,49 @@
         }
       }
     },
+    "mockServer": {
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "description": "A declarative stub HTTP server (#24): routes match on exact method+path (query string excluded); an unmatched request answers 404 and is still recorded.",
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "routes": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/mockRoute" }
+        }
+      }
+    },
+    "mockRoute": {
+      "type": "object",
+      "required": ["method", "path"],
+      "additionalProperties": false,
+      "description": "One canned response. At most one of json/body/body_file supplies the payload; status defaults to 200.",
+      "properties": {
+        "method": { "type": "string", "minLength": 1 },
+        "path": { "type": "string", "pattern": "^/" },
+        "status": { "type": "integer", "minimum": 100, "maximum": 599 },
+        "json": {},
+        "body": { "type": "string" },
+        "body_file": { "type": "string", "minLength": 1, "description": "Spec-relative response body file, confined to the spec directory." },
+        "header": { "type": "object", "additionalProperties": { "type": "string" } },
+        "delay": { "type": "string", "description": "Go duration to sleep before responding - for retry testing." }
+      }
+    },
+    "mockAssert": {
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "description": "Checks what the CLI under test sent to a mock server (#24): filter by path/method, pin the exact count (or require at least one match), and match header/body of the LAST matching request.",
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "path": { "type": "string" },
+        "method": { "type": "string" },
+        "count": { "type": "integer", "minimum": 0 },
+        "header": { "$ref": "#/$defs/headerMatch" },
+        "body": { "$ref": "#/$defs/stream" }
+      }
+    },
     "signal": {
       "type": "object",
       "required": ["service", "signal"],
@@ -582,7 +635,8 @@
         { "required": ["value"] },
         { "required": ["image"] },
         { "required": ["dir"] },
-        { "required": ["pdf"] }
+        { "required": ["pdf"] },
+        { "required": ["mock"] }
       ],
       "properties": {
         "exit_code": { "$ref": "#/$defs/exitCode" },
@@ -598,7 +652,8 @@
         "value": { "$ref": "#/$defs/stream" },
         "image": { "$ref": "#/$defs/image" },
         "dir": { "$ref": "#/$defs/dir" },
-        "pdf": { "$ref": "#/$defs/pdf" }
+        "pdf": { "$ref": "#/$defs/pdf" },
+        "mock": { "$ref": "#/$defs/mockAssert" }
       }
     },
     "pdf": {
@@ -767,12 +822,14 @@
       "additionalProperties": false,
       "oneOf": [
         { "required": ["contains"] },
-        { "required": ["equals"] }
+        { "required": ["equals"] },
+        { "required": ["matches"] }
       ],
       "properties": {
         "name": { "type": "string" },
         "contains": { "type": "string" },
-        "equals": { "type": "string" }
+        "equals": { "type": "string" },
+        "matches": { "type": "string", "description": "Regexp the header value must match - the natural shape for auth headers (^Bearer )." }
       }
     },
     "store": {

--- a/schema/manifest.schema.json
+++ b/schema/manifest.schema.json
@@ -179,6 +179,19 @@
             "$ref": "#/$defs/service"
           }
         },
+        "mock_servers": {
+          "description": "Stub HTTP servers declared by the scenario (#24).",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "routes"],
+            "properties": {
+              "name": { "type": "string" },
+              "routes": { "type": "integer" }
+            }
+          }
+        },
         "steps": {
           "type": "array",
           "items": {

--- a/schema_test.go
+++ b/schema_test.go
@@ -205,6 +205,45 @@ scenarios:
 	}
 }
 
+// TestSchema_AcceptsMockServers confirms mock_servers, the suite mock_server
+// step, and the mock assert target (#24) are accepted.
+func TestSchema_AcceptsMockServers(t *testing.T) {
+	s := loadSchema(t)
+	src := `version: "1"
+suite:
+  name: x
+  setup:
+    - mock_server:
+        name: shared
+        routes: [{method: GET, path: /ping, body: pong}]
+scenarios:
+  - name: a
+    mock_servers:
+      - name: api
+        routes:
+          - method: POST
+            path: /v1/reports
+            status: 201
+            json: { id: "r-1" }
+          - method: GET
+            path: /file
+            body_file: canned.json
+            delay: 200ms
+    steps:
+      - run: {command: echo hi}
+      - assert:
+          mock:
+            name: api
+            path: /v1/reports
+            method: POST
+            count: 1
+            header: { name: Authorization, matches: "^Bearer " }
+            body: { contains: report }`
+	if err := s.Validate(yamlToAny(t, []byte(src))); err != nil {
+		t.Errorf("schema rejected valid mock-server spec:\n%v", err)
+	}
+}
+
 // TestSchema_RejectsInvalid confirms the schema actually catches bad specs.
 func TestSchema_RejectsInvalid(t *testing.T) {
 	s := loadSchema(t)

--- a/test/e2e/atago/mock_server.atago.yaml
+++ b/test/e2e/atago/mock_server.atago.yaml
@@ -1,0 +1,127 @@
+version: "1"
+
+suite:
+  name: atago self-hosting / mock http server (offline API-client testing)
+
+# Exercises #24: mock_servers serve canned routes, record every request, and
+# the mock: assertion target checks what the client sent. The client here is
+# an INNER atago http runner (pure Go), so every scenario runs on Windows too
+# — this spec is in the Windows E2E allowlist on purpose.
+scenarios:
+  - name: count, header, and body-json asserts pass against a real client
+    mock_servers:
+      - name: api
+        routes:
+          - method: POST
+            path: /v1/reports
+            status: 201
+            json: { id: "r-1", ok: true }
+    steps:
+      - fixture:
+          file: client.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: client
+            runners:
+              api:
+                type: http
+                base_url: ${api.url}
+            scenarios:
+              - name: post a report
+                steps:
+                  - http:
+                      runner: api
+                      method: POST
+                      path: /v1/reports
+                      header: { Authorization: "Bearer tok-123" }
+                      json: { title: "report" }
+                  - assert:
+                      status: 201
+      - run:
+          command: ${atago} run client.atago.yaml
+      - assert:
+          exit_code: 0
+      - assert:
+          mock:
+            name: api
+            path: /v1/reports
+            method: POST
+            count: 1
+            header: { name: Authorization, matches: "^Bearer " }
+            body:
+              json: { path: "$.title", equals: "report" }
+
+  - name: a failing count summarizes the recorded requests
+    mock_servers:
+      - name: stub
+        routes:
+          - method: GET
+            path: /right
+            body: found
+    steps:
+      - fixture:
+          file: outer.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: outer
+            runners:
+              api:
+                type: http
+                base_url: ${stub.url}
+            scenarios:
+              - name: wrong path then failing count
+                mock_servers:
+                  - name: inner
+                    routes:
+                      - method: GET
+                        path: /right
+                steps:
+                  - http:
+                      runner: api
+                      method: GET
+                      path: /wrong
+                  - assert:
+                      status: 404
+                  - assert:
+                      mock:
+                        name: inner
+                        path: /right
+                        count: 1
+      # The inner spec asserts against ITS mock (zero matching requests: the
+      # http step above hit the OUTER stub), so the run fails and the block
+      # summarizes what was recorded. ${stub.url} interpolates the outer
+      # mock's URL into the inner spec via the fixture.
+      - run:
+          command: ${atago} run outer.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "1 request for /right"
+              - "0 matching of 0 recorded"
+
+  - name: an unknown mock name in an assert is a load-time error
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: bad
+            scenarios:
+              - name: wrong name
+                mock_servers:
+                  - name: api
+                    routes: [{method: GET, path: /}]
+                steps:
+                  - run: {command: echo hi}
+                  - assert:
+                      mock: {name: apo, count: 1}
+      - run:
+          command: ${atago} run bad.atago.yaml
+      - assert:
+          exit_code: 2
+          stderr:
+            contains: 'not a declared mock server (declared: api)'


### PR DESCRIPTION
## Summary

This PR adds the mock HTTP server (#24), a headline differentiator: atago plays the SERVER to test CLI clients offline. `mock_servers:` (scenario level) and suite.setup `mock_server:` steps serve canned routes on ephemeral loopback ports and record every incoming request; the new `mock:` assertion target then checks what the CLI under test actually sent — count, auth header, JSON body.

## Changes

- `internal/runner/mock` (new): pure-Go stub server — exact method+path matching (query string excluded), `json`/`body`/`body_file` payloads (`body_file` is spec-dir-confined like snapshot goldens, read at request time), optional `status`/`header`/`delay` (retry testing), 404-and-still-recorded for unmatched requests, 8 MiB recorded-body cap, mutex-guarded records (race-tested).
- `internal/engine`: scenario mocks start BEFORE the leading fixtures and services — so fixture contents and service commands can reference `${<name>.url}` — and stop LIFO; `${<name>.url}` / `${<name>.port}` seed the store; suite mocks live in suiteRuntime, seed suite vars, and are threaded through runConfig so scenario asserts can read them.
- `internal/assert`: `mock:` target — path/method filter, exact `count` (or at-least-one without it), header/body matchers on the LAST matching request; a failing count summarizes every recorded request ("1: GET /wrong -> 404"). `HeaderMatch` gains `matches:` (regexp, "^Bearer ") for both the http `header` target and mock asserts, via a shared `checkHeaderValue`.
- `internal/store`: ${name} references now accept dotted segments (`${api.url}`) — a strict superset of the old grammar.
- `internal/loader`: duplicate mock names (scenario and suite), route payload one-of, non-"/" paths, bad status/delay, unknown `mock.name` in asserts (LISTING declared names), `count: 0` + matchers contradiction, and header-match regexp compile — all exit 2 with positions. `mock_server` steps are suite.setup-only, like `service`.
- Surfaces: JSON schema (`mockServer`/`mockRoute`/`mockAssert` defs, headerMatch `matches`), `explain` (mocks listed under services, mock asserts described), `doc` (Given bullet + assert rendering), manifest (scenario `mock_servers` summary, suite step action, manifest schema), and `atago init --template mock`.
- Docs: new `examples/mock_server.atago.yaml` (curl-driven; POSIX quoting, skips on Windows), a README "Test API-client CLIs offline" section + Examples row + template list, CHANGELOG entry.
- Tests: mock runner unit tests (matching/recording/confinement/delay/thread-safety, -race), engine round-trip + failing-count-summary + suite-mock tests (http-runner client, cross-platform), loader cases, schema accept case, and self-hosted E2E `test/e2e/atago/mock_server.atago.yaml` — pure-Go clients, added to BOTH Windows E2E allowlists (e2e.yml, e2e-cross.yml).

## Design Decisions

- v1 keeps routes fully declarative: exact method+path, no patterns; matchers apply to the last matching request (documented in the spec comments).
- `${env:NAME}`-style interpolation happens where it always did (fixtures, commands, runners); mock ROUTE definitions are served verbatim.
- Recorded bodies flow through the existing recordChecks masking on their way into reports.

Closes #24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added offline HTTP mocking for scenarios and setup steps, including request recording, canned responses, request-count checks, and header/body matching.
  * Added regex support for header matching.
  * Added a new starter template and example for testing API clients without external network access.

* **Bug Fixes**
  * Unmatched mock routes now return 404 and are included in request summaries, making failures easier to diagnose.
  * Validation now catches invalid mock server definitions and undeclared mock assertions earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->