### PR TITLE
feat(assert): add recursive dir assertions and directory-tree snapshots

### DIFF
--- a/.github/workflows/e2e-cross.yml
+++ b/.github/workflows/e2e-cross.yml
@@ -64,6 +64,7 @@ jobs:
               ./test/e2e/atago/db.atago.yaml
               ./test/e2e/atago/http.atago.yaml
               ./test/e2e/atago/mock_server.atago.yaml
+              ./test/e2e/atago/dir_tree.atago.yaml
               ./test/e2e/atago/grpc.atago.yaml
               ./test/e2e/atago/ssh.atago.yaml
               ./test/e2e/atago/cdp.atago.yaml

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -119,6 +119,7 @@ jobs:
           ./test/e2e/atago/db.atago.yaml
           ./test/e2e/atago/http.atago.yaml
           ./test/e2e/atago/mock_server.atago.yaml
+          ./test/e2e/atago/dir_tree.atago.yaml
           ./test/e2e/atago/grpc.atago.yaml
           ./test/e2e/atago/ssh.atago.yaml
           ./test/e2e/atago/cdp.atago.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ and this project follows [Semantic Versioning](https://semver.org/).
   (`SystemRoot`, `SystemDrive`, `TEMP`, `TMP`, `PATHEXT`) is always retained.
   `pass_env` without `clear_env: true` is a load-time error (exit 2).
   See `examples/hermetic_env.atago.yaml`.
+- Recursive dir assertions and directory-tree snapshots (#25):
+  `dir.recursive: true` makes `contains`/`not_contains` accept nested
+  relative paths and `count`/`min_count`/`max_count` (files only) / `glob`
+  walk the whole tree; `dir.snapshot:` pins the tree against a golden
+  manifest (`dir <path>` / `file <path> sha256:<hash>` /
+  `link <path> -> <target>`, sorted, /-separated, byte-exact hashes — CRLF
+  differences ARE differences) refreshed with `--update-snapshots`, with a
+  failure diff naming exactly the added/removed/changed paths;
+  `dir.ignore:` glob patterns (`*.log`, `.git/**`) filter both. See
+  `examples/dir_tree.atago.yaml`.
 - Mock HTTP servers (#24): `mock_servers:` (scenario level) and
   suite.setup `mock_server:` steps start declarative stub HTTP servers on
   ephemeral loopback ports — canned routes matched on exact method+path

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Every feature has a commented, runnable spec under [examples/](examples/). The e
 | [pty](examples/pty.atago.yaml) | interactive testing in a real pseudo-terminal: expect/send sessions, TTY-detection (POSIX-only) |
 | [retry](examples/retry.atago.yaml) | polling a command until an assertion passes |
 | [snapshot](examples/snapshot.atago.yaml) | golden-file testing with normalized output |
+| [dir_tree](examples/dir_tree.atago.yaml) | recursive dir assertions and directory-tree snapshots: pin a generator's whole output tree with one golden manifest |
 | [services](examples/services.atago.yaml) | background servers: readiness probes, `ready.store`, teardown |
 | [signal](examples/signal.atago.yaml) | `signal:` steps deliver SIGTERM/SIGHUP/... to a managed service's process group for graceful-shutdown and reload testing (POSIX-only) |
 | [defaults](examples/defaults.atago.yaml) | sharing `shell`/`env`/`service` fragments across scenarios |

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-48 suites · 164 scenarios
+49 suites · 167 scenarios
 ## Contents
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 3 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
@@ -31,6 +31,10 @@
 - [atago self-hosting / dir assertion](#atago-self-hosting--dir-assertion) — 2 scenarios
   - [directory/tree assertions cover a multi-file generator](#scenario-directorytree-assertions-cover-a-multi-file-generator)
   - [a missing directory can be asserted absent](#scenario-a-missing-directory-can-be-asserted-absent)
+- [atago self-hosting / recursive dir asserts + tree snapshots](#atago-self-hosting--recursive-dir-asserts--tree-snapshots) — 3 scenarios
+  - [record, compare green, then a mutation names the changed paths](#scenario-record-compare-green-then-a-mutation-names-the-changed-paths)
+  - [recursive matchers and ignore globs walk the tree](#scenario-recursive-matchers-and-ignore-globs-walk-the-tree)
+  - [combining snapshot with matchers is a load-time error](#scenario-combining-snapshot-with-matchers-is-a-load-time-error)
 - [atago self-hosting / doc](#atago-self-hosting--doc) — 5 scenarios
   - [doc generates Markdown to a file](#scenario-doc-generates-markdown-to-a-file)
   - [doc writes Markdown to stdout without --out](#scenario-doc-writes-markdown-to-stdout-without---out)
@@ -675,6 +679,116 @@ mkdir -p site/assets && printf '<html>' > site/index.html && printf '<html>' > s
 ### Scenario: a missing directory can be asserted absent
 #### Then
 - dir `never-created` does not exist
+## atago self-hosting / recursive dir asserts + tree snapshots
+Source: `test/e2e/atago/dir_tree.atago.yaml`
+### Scenario: record, compare green, then a mutation names the changed paths
+#### Given
+- Fixture file `inner.atago.yaml` is created.
+- Fixture file `inner_mutated.atago.yaml` is created.
+#### Inputs
+_Fixture `inner.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: inner
+scenarios:
+  - name: tree matches its golden
+    steps:
+      - fixture:
+          file: site/hugo.toml
+          content: "baseURL = 'x'\n"
+      - fixture:
+          file: site/content/posts/hello.md
+          content: "# hello\n"
+      - assert:
+          dir:
+            path: site
+            snapshot: snapshots/site_tree.txt
+```
+_Fixture `inner_mutated.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: inner
+scenarios:
+  - name: tree matches its golden
+    steps:
+      - fixture:
+          file: site/hugo.toml
+          content: "baseURL = 'x'\n"
+      - fixture:
+          file: site/content/posts/hello.md
+          content: "# CHANGED\n"
+      - fixture:
+          file: site/extra.txt
+          content: "new\n"
+      - assert:
+          dir:
+            path: site
+            snapshot: snapshots/site_tree.txt
+```
+#### When
+```shell
+${atago} run --update-snapshots inner.atago.yaml
+${atago} run inner.atago.yaml
+${atago} run inner_mutated.atago.yaml
+```
+#### Then
+- after `${atago} run --update-snapshots inner.atago.yaml`:
+  - exit code is `0`
+  - file `snapshots/site_tree.txt` contains `dir content`, `file hugo.toml sha256:`
+- after `${atago} run inner.atago.yaml`:
+  - exit code is `0`
+- after `${atago} run inner_mutated.atago.yaml`:
+  - exit code is `1`
+  - stdout contains `added:   file extra.txt`, `changed: content/posts/hello.md`
+### Scenario: recursive matchers and ignore globs walk the tree
+#### Given
+- Fixture file `out/a/deep/nested.md` is created.
+- Fixture file `out/top.txt` is created.
+- Fixture file `out/noise.log` is created.
+#### Inputs
+_Fixture `out/a/deep/nested.md`:_
+```text
+nested
+```
+_Fixture `out/top.txt`:_
+```text
+top
+```
+_Fixture `out/noise.log`:_
+```text
+noise
+```
+#### Then
+- dir `out` contains `a/deep/nested.md`, has 2 entries, matches glob `*.md`, (recursive)
+- dir `out` does not contain `a/deep/missing.md`, (recursive)
+### Scenario: combining snapshot with matchers is a load-time error
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: bad
+scenarios:
+  - name: over-specified
+    steps:
+      - run: {command: echo hi}
+      - assert:
+          dir:
+            path: out
+            snapshot: tree.txt
+            contains: [a.txt]
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `snapshot cannot be combined`
 ## atago self-hosting / doc
 Source: `test/e2e/atago/doc.atago.yaml`
 ### Scenario: doc generates Markdown to a file

--- a/examples/dir_tree.atago.yaml
+++ b/examples/dir_tree.atago.yaml
@@ -1,0 +1,68 @@
+version: "1"
+
+# Recursive dir assertions and directory-tree snapshots (#25) — for CLIs whose
+# primary output IS a tree (project generators, scaffolders, archive
+# extractors, backup tools).
+#
+#   recursive: true   makes contains/not_contains take slash-separated
+#                     relative paths anywhere in the tree, count/min/max count
+#                     FILES across the whole walk, and glob match relative
+#                     paths (or basenames for patterns without "/").
+#   snapshot:         pins the WHOLE tree against a committed golden manifest:
+#                     one line per entry — `dir <path>`,
+#                     `file <path> sha256:<hash>`, `link <path> -> <target>`.
+#                     File content is hashed byte-exact (CRLF differences ARE
+#                     differences). Refresh with:
+#                       atago snapshot update examples/dir_tree.atago.yaml
+#   ignore:           glob patterns excluded from the walk and the manifest
+#                     ("*.log", ".git/**" prunes the subtree).
+#
+# Runs green as-is on every OS (pure Go): atago run examples/dir_tree.atago.yaml
+
+suite:
+  name: dir tree
+
+scenarios:
+  - name: a scaffolded tree is pinned by one snapshot line
+    steps:
+      - fixture:
+          file: site/hugo.toml
+          content: "baseURL = 'https://example.org/'\n"
+      - fixture:
+          file: site/content/posts/hello.md
+          content: "# hello\n"
+      - fixture:
+          file: site/debug.log
+          content: "noise that must not churn the golden\n"
+      # One line replaces a whole ladder of per-level dir asserts.
+      - assert:
+          dir:
+            path: site
+            snapshot: snapshots/site_tree.txt
+            ignore: ["*.log"]
+
+  - name: recursive matchers walk the whole tree
+    steps:
+      - fixture:
+          file: out/a/deep/nested.md
+          content: "nested\n"
+      - fixture:
+          file: out/top.txt
+          content: "top\n"
+      - assert:
+          dir:
+            path: out
+            recursive: true
+            contains: [a/deep/nested.md, top.txt]
+      # Counts see FILES only (directories are structure, not output).
+      - assert:
+          dir:
+            path: out
+            recursive: true
+            count: 2
+      # A "/"-less glob matches basenames at any depth.
+      - assert:
+          dir:
+            path: out
+            recursive: true
+            glob: "*.md"

--- a/examples/snapshots/site_tree.txt
+++ b/examples/snapshots/site_tree.txt
@@ -1,0 +1,4 @@
+dir content
+dir content/posts
+file content/posts/hello.md sha256:9e8b62f81ea5c66fa06ee53da032751386b37702153070c0e14dd1d316282fa7
+file hugo.toml sha256:a3ee5004ca17c908e6b261b344cd061808b2a3df8b983189eb387046b02b3946

--- a/examples_test.go
+++ b/examples_test.go
@@ -21,6 +21,7 @@ var exampleSpecs = map[string]bool{ // path -> hermetic (run, not just validate)
 	"examples/browser.atago.yaml":             false,
 	"examples/db.atago.yaml":                  true,
 	"examples/defaults.atago.yaml":            true,
+	"examples/dir_tree.atago.yaml":            true,
 	"examples/files_and_fixtures.atago.yaml":  true,
 	"examples/grpc.atago.yaml":                false,
 	"examples/hermetic_env.atago.yaml":        true,

--- a/internal/assert/dir.go
+++ b/internal/assert/dir.go
@@ -43,6 +43,19 @@ func checkDir(d *spec.DirAssert, env Env) *CheckResult {
 		}
 	}
 
+	// Tree snapshot (#25): the golden manifest covers the whole walk; the
+	// loader guarantees it is not combined with the matcher family.
+	if d.Snapshot != "" {
+		return checkDirSnapshot(d, dirPath, env)
+	}
+	// Recursive mode (#25): the matcher family applies to the whole walk.
+	if d.Recursive {
+		if cr := checkDirRecursive(d, dirPath); cr != nil {
+			return cr
+		}
+		return pass(fmt.Sprintf("assert dir %q (recursive)", d.Path))
+	}
+
 	if cr := checkDirChildren(d, dirPath); cr != nil {
 		return cr
 	}

--- a/internal/assert/tree.go
+++ b/internal/assert/tree.go
@@ -1,0 +1,277 @@
+package assert
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/nao1215/atago/internal/spec"
+)
+
+// treeEntry is one filesystem object in a walked tree (#25).
+type treeEntry struct {
+	rel    string // /-separated path relative to the asserted directory
+	kind   string // "dir", "file", or "link"
+	hash   string // sha256 of the raw bytes, files only
+	target string // symlink target, links only
+}
+
+// manifestLine renders the entry's snapshot-manifest line.
+func (e treeEntry) manifestLine() string {
+	switch e.kind {
+	case "file":
+		return "file " + e.rel + " sha256:" + e.hash
+	case "link":
+		return "link " + e.rel + " -> " + e.target
+	default:
+		return "dir " + e.rel
+	}
+}
+
+// walkTree walks dirPath depth-first and returns every entry (root excluded)
+// with /-separated relative paths, sorted, so manifests are deterministic
+// across platforms. Symlinks are recorded, never traversed; an ignored
+// directory prunes its whole subtree.
+func walkTree(dirPath string, ignore []string) ([]treeEntry, error) {
+	var out []treeEntry
+	err := filepath.WalkDir(dirPath, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if p == dirPath {
+			return nil
+		}
+		rel := filepath.ToSlash(strings.TrimPrefix(p, dirPath+string(filepath.Separator)))
+		if ignoredPath(rel, ignore) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		switch {
+		case d.Type()&fs.ModeSymlink != 0:
+			target, lerr := os.Readlink(p)
+			if lerr != nil {
+				return lerr
+			}
+			out = append(out, treeEntry{rel: rel, kind: "link", target: filepath.ToSlash(target)})
+		case d.IsDir():
+			out = append(out, treeEntry{rel: rel, kind: "dir"})
+		default:
+			h, herr := hashFile(p)
+			if herr != nil {
+				return herr
+			}
+			out = append(out, treeEntry{rel: rel, kind: "file", hash: h})
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].rel < out[j].rel })
+	return out, nil
+}
+
+// hashFile streams the file's raw bytes into sha256 — byte-exact by design,
+// so CRLF differences ARE differences (documented on DirAssert.Snapshot).
+func hashFile(p string) (string, error) {
+	f, err := os.Open(p) //nolint:gosec // confined under the asserted workdir directory
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }() // read-only handle
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// ignoredPath reports whether rel matches any ignore glob (#25): a "<dir>/**"
+// pattern prunes the subtree, a pattern without "/" also matches basenames at
+// any depth, and everything else is path.Match on the whole relative path.
+// Invalid patterns are rejected at load time.
+func ignoredPath(rel string, ignore []string) bool {
+	for _, pat := range ignore {
+		if prefix, found := strings.CutSuffix(pat, "/**"); found {
+			if rel == prefix || strings.HasPrefix(rel, prefix+"/") {
+				return true
+			}
+			continue
+		}
+		if ok, _ := path.Match(pat, rel); ok {
+			return true
+		}
+		if !strings.Contains(pat, "/") {
+			if ok, _ := path.Match(pat, path.Base(rel)); ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// checkDirRecursive evaluates the recursive matcher family over the walked
+// tree (#25): contains/not_contains against relative paths, counts over files
+// only, glob against each relative path (or basename for /-less patterns).
+func checkDirRecursive(d *spec.DirAssert, dirPath string) *CheckResult {
+	entries, err := walkTree(dirPath, d.Ignore)
+	if err != nil {
+		return &CheckResult{Desc: fmt.Sprintf("assert dir %q recursive", d.Path), Hint: fmt.Sprintf("could not walk %q: %v", d.Path, err)}
+	}
+	present := make(map[string]bool, len(entries))
+	files := 0
+	for _, e := range entries {
+		present[e.rel] = true
+		if e.kind == "file" {
+			files++
+		}
+	}
+
+	for _, child := range d.Contains {
+		if !present[path.Clean(filepath.ToSlash(child))] {
+			return &CheckResult{
+				Desc:     fmt.Sprintf("assert dir %q contains %q", d.Path, child),
+				Expected: fmt.Sprintf("path %q present in the tree", child),
+				Actual:   "missing",
+				Hint:     fmt.Sprintf("expected %q to exist under %q (recursive)", child, d.Path),
+			}
+		}
+	}
+	for _, child := range d.NotContains {
+		if present[path.Clean(filepath.ToSlash(child))] {
+			return &CheckResult{
+				Desc:     fmt.Sprintf("assert dir %q does not contain %q", d.Path, child),
+				Expected: fmt.Sprintf("path %q absent from the tree", child),
+				Actual:   "present",
+				Hint:     fmt.Sprintf("expected %q not to exist under %q (recursive)", child, d.Path),
+			}
+		}
+	}
+
+	if d.Count != nil && files != *d.Count {
+		return dirCountFailure(d, files, fmt.Sprintf("exactly %d files in the tree", *d.Count))
+	}
+	if d.MinCount != nil && files < *d.MinCount {
+		return dirCountFailure(d, files, fmt.Sprintf("at least %d files in the tree", *d.MinCount))
+	}
+	if d.MaxCount != nil && files > *d.MaxCount {
+		return dirCountFailure(d, files, fmt.Sprintf("at most %d files in the tree", *d.MaxCount))
+	}
+
+	if d.Glob != "" {
+		matched := false
+		for _, e := range entries {
+			if ok, _ := path.Match(d.Glob, e.rel); ok {
+				matched = true
+				break
+			}
+			if !strings.Contains(d.Glob, "/") {
+				if ok, _ := path.Match(d.Glob, path.Base(e.rel)); ok {
+					matched = true
+					break
+				}
+			}
+		}
+		if !matched {
+			return &CheckResult{
+				Desc:     fmt.Sprintf("assert dir %q glob %q", d.Path, d.Glob),
+				Expected: fmt.Sprintf("at least one tree entry matching %q", d.Glob),
+				Actual:   fmt.Sprintf("no match among %d entries", len(entries)),
+				Hint:     fmt.Sprintf("no entry under %q matched glob %q (recursive)", d.Path, d.Glob),
+			}
+		}
+	}
+	return nil
+}
+
+// checkDirSnapshot compares (or updates) the tree's golden manifest (#25).
+// On mismatch the failure shows an added/removed/changed summary instead of
+// two full manifests; the full texts still flow to --artifacts-dir.
+func checkDirSnapshot(d *spec.DirAssert, dirPath string, env Env) *CheckResult {
+	entries, err := walkTree(dirPath, d.Ignore)
+	if err != nil {
+		return &CheckResult{Desc: fmt.Sprintf("assert dir %q snapshot", d.Path), Hint: fmt.Sprintf("could not walk %q: %v", d.Path, err)}
+	}
+	lines := make([]string, len(entries))
+	for i, e := range entries {
+		lines[i] = e.manifestLine()
+	}
+	manifest := strings.Join(lines, "\n")
+	if manifest != "" {
+		manifest += "\n"
+	}
+
+	desc := fmt.Sprintf("assert dir %q snapshot %q", d.Path, d.Snapshot)
+	cr := checkSnapshot(desc, "tree of "+d.Path, d.Snapshot, []byte(manifest), env)
+	if cr.OK || cr.ArtifactKind == "" {
+		return cr
+	}
+	// Replace the two full-dump excerpts with a manifest diff: the names of
+	// the added/removed/changed paths are the review-relevant signal.
+	cr.Expected = fmt.Sprintf("tree matches snapshot %q", d.Snapshot)
+	cr.Actual = manifestDiff(string(cr.ArtifactExpected), string(cr.ArtifactActual))
+	return cr
+}
+
+// manifestDiff summarizes two tree manifests as added/removed/changed path
+// lists. A path present in both with a different line (hash or kind) counts
+// as changed.
+func manifestDiff(expected, actual string) string {
+	parse := func(text string) map[string]string {
+		m := map[string]string{}
+		for _, line := range strings.Split(strings.TrimRight(text, "\n"), "\n") {
+			if line == "" {
+				continue
+			}
+			fields := strings.Fields(line)
+			if len(fields) < 2 {
+				continue
+			}
+			m[fields[1]] = line
+		}
+		return m
+	}
+	want, got := parse(expected), parse(actual)
+
+	var added, removed, changed []string
+	for p, line := range got {
+		wline, ok := want[p]
+		switch {
+		case !ok:
+			added = append(added, line)
+		case wline != line:
+			changed = append(changed, p)
+		}
+	}
+	for p, line := range want {
+		if _, ok := got[p]; !ok {
+			removed = append(removed, line)
+		}
+	}
+	sort.Strings(added)
+	sort.Strings(removed)
+	sort.Strings(changed)
+
+	var b strings.Builder
+	writeGroup := func(label string, items []string) {
+		for _, it := range items {
+			fmt.Fprintf(&b, "%s %s\n", label, it)
+		}
+	}
+	writeGroup("added:  ", added)
+	writeGroup("removed:", removed)
+	writeGroup("changed:", changed)
+	if b.Len() == 0 {
+		return "(manifests differ only in ordering or trailing whitespace)"
+	}
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/internal/assert/tree_test.go
+++ b/internal/assert/tree_test.go
@@ -1,0 +1,154 @@
+package assert
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/atago/internal/spec"
+)
+
+// seedTree builds a small deterministic tree for the walk/snapshot tests.
+func seedTree(t *testing.T) string {
+	t.Helper()
+	wd := t.TempDir()
+	mustWrite := func(rel, content string) {
+		t.Helper()
+		p := filepath.Join(wd, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite("site/content/posts/hello.md", "hello\n")
+	mustWrite("site/hugo.toml", "baseURL = 'x'\n")
+	mustWrite("site/debug.log", "noise\n")
+	mustWrite("site/.git/config", "gitstuff\n")
+	return wd
+}
+
+// TestWalkTree_DeterministicAndIgnored proves ordering, /-separated paths,
+// basename globs, and subtree pruning (#25).
+func TestWalkTree_DeterministicAndIgnored(t *testing.T) {
+	t.Parallel()
+	wd := seedTree(t)
+	entries, err := walkTree(filepath.Join(wd, "site"), []string{"*.log", ".git/**"})
+	if err != nil {
+		t.Fatalf("walkTree: %v", err)
+	}
+	var rels []string
+	for _, e := range entries {
+		rels = append(rels, e.kind+" "+e.rel)
+	}
+	got := strings.Join(rels, "\n")
+	want := strings.Join([]string{
+		"dir content",
+		"dir content/posts",
+		"file content/posts/hello.md",
+		"file hugo.toml",
+	}, "\n")
+	if got != want {
+		t.Errorf("walk = \n%s\nwant\n%s", got, want)
+	}
+}
+
+// TestWalkTree_SymlinkRecordedNotTraversed proves symlinks appear as `link`
+// entries with their target and their subtree is never walked (#25).
+func TestWalkTree_SymlinkRecordedNotTraversed(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation needs privileges on Windows")
+	}
+	wd := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(wd, "real"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wd, "real", "f.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("real", filepath.Join(wd, "alias")); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := walkTree(wd, nil)
+	if err != nil {
+		t.Fatalf("walkTree: %v", err)
+	}
+	var lines []string
+	for _, e := range entries {
+		lines = append(lines, e.manifestLine())
+	}
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "link alias -> real") {
+		t.Errorf("manifest missing the link entry:\n%s", joined)
+	}
+	if strings.Contains(joined, "alias/f.txt") {
+		t.Errorf("symlink was traversed:\n%s", joined)
+	}
+}
+
+// TestCheckDir_RecursiveMatchers proves nested contains, file-only counts,
+// and deep globs (#25).
+func TestCheckDir_RecursiveMatchers(t *testing.T) {
+	t.Parallel()
+	wd := seedTree(t)
+	env := Env{Workdir: wd}
+
+	pass := &spec.DirAssert{
+		Path:      "site",
+		Recursive: true,
+		Ignore:    []string{"*.log", ".git/**"},
+		Contains:  []string{"content/posts/hello.md"},
+		Count:     intp(2), // hello.md + hugo.toml; dirs and ignored files excluded
+		Glob:      "*.md",
+	}
+	if cr := checkDir(pass, env); !cr.OK {
+		t.Fatalf("recursive matchers failed: %+v", cr)
+	}
+
+	fail := &spec.DirAssert{Path: "site", Recursive: true, Contains: []string{"content/missing.md"}}
+	if cr := checkDir(fail, env); cr.OK {
+		t.Fatal("missing nested path passed")
+	}
+}
+
+// TestCheckDir_SnapshotRoundTrip proves record → green compare → mutation
+// diff naming exactly the changed path (#25).
+func TestCheckDir_SnapshotRoundTrip(t *testing.T) {
+	t.Parallel()
+	wd := seedTree(t)
+	specDir := t.TempDir()
+	d := &spec.DirAssert{Path: "site", Snapshot: "site_tree", Ignore: []string{"*.log", ".git/**"}}
+
+	// Record.
+	if cr := checkDir(d, Env{Workdir: wd, SpecDir: specDir, UpdateSnapshots: true}); !cr.OK {
+		t.Fatalf("update failed: %+v", cr)
+	}
+	// Green compare.
+	if cr := checkDir(d, Env{Workdir: wd, SpecDir: specDir}); !cr.OK {
+		t.Fatalf("compare after update failed: %+v", cr)
+	}
+	// Mutate one file and add another: the diff names exactly those paths.
+	if err := os.WriteFile(filepath.Join(wd, "site", "hugo.toml"), []byte("changed"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wd, "site", "new.txt"), []byte("n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cr := checkDir(d, Env{Workdir: wd, SpecDir: specDir})
+	if cr.OK {
+		t.Fatal("mutated tree still matched the snapshot")
+	}
+	if !strings.Contains(cr.Actual, "changed: hugo.toml") {
+		t.Errorf("Actual = %q, want changed: hugo.toml", cr.Actual)
+	}
+	if !strings.Contains(cr.Actual, "added:   file new.txt") {
+		t.Errorf("Actual = %q, want the added file named", cr.Actual)
+	}
+	if strings.Contains(cr.Actual, "hello.md") {
+		t.Errorf("Actual = %q, must not name unchanged paths", cr.Actual)
+	}
+}

--- a/internal/docgen/describe.go
+++ b/internal/docgen/describe.go
@@ -199,6 +199,12 @@ func dirConstraints(d *spec.DirAssert) []string {
 	if d.Glob != "" {
 		parts = append(parts, "matches glob "+markdown.Code(d.Glob))
 	}
+	if d.Snapshot != "" {
+		parts = append(parts, "tree matches snapshot "+markdown.Code(d.Snapshot))
+	}
+	if d.Recursive {
+		parts = append(parts, "(recursive)")
+	}
 	return parts
 }
 

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -494,6 +494,15 @@ func describeDir(d *spec.DirAssert) string {
 	if d.Glob != "" {
 		parts = append(parts, "matches glob "+d.Glob)
 	}
+	if d.Snapshot != "" {
+		parts = append(parts, "tree matches snapshot "+d.Snapshot)
+	}
+	if d.Recursive {
+		parts = append(parts, "(recursive)")
+	}
+	if len(d.Ignore) > 0 {
+		parts = append(parts, "ignoring "+strings.Join(d.Ignore, ", "))
+	}
 	if len(parts) == 0 {
 		return fmt.Sprintf("%q is checked", d.Path)
 	}

--- a/internal/loader/defaults_test.go
+++ b/internal/loader/defaults_test.go
@@ -463,6 +463,52 @@ scenarios:
 	}
 }
 
+// TestValidate_DirTreeRules proves the #25 combination rules: snapshot is
+// exclusive with the matcher family, ignore needs recursive/snapshot, bad
+// ignore globs fail, and bare recursive needs a matcher.
+func TestValidate_DirTreeRules(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name, dir, wantMsg string
+	}{
+		{"snapshot with contains", "{path: out, snapshot: t.txt, contains: [a]}", "snapshot cannot be combined"},
+		{"snapshot with recursive", "{path: out, snapshot: t.txt, recursive: true}", "recursive is implied by snapshot"},
+		{"ignore without recursive", "{path: out, contains: [a], ignore: ['*.log']}", "ignore only applies to recursive or snapshot"},
+		{"bare recursive", "{path: out, recursive: true}", "recursive needs at least one of"},
+		{"invalid ignore glob", "{path: out, snapshot: t.txt, ignore: ['[']}", "not a valid glob"},
+		{"snapshot alone is valid", "{path: out, snapshot: t.txt, ignore: ['*.log']}", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			src := `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: s
+    steps:
+      - run: {command: echo hi}
+      - assert:
+          dir: ` + tc.dir + `
+`
+			_, err := LoadBytes("sample.atago.yaml", []byte(src))
+			if tc.wantMsg == "" {
+				if err != nil {
+					t.Fatalf("LoadBytes() error = %v, want clean load", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("LoadBytes() = nil error, want a dir validation error")
+			}
+			if !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Errorf("error = %q, want substring %q", err, tc.wantMsg)
+			}
+		})
+	}
+}
+
 // TestValidate_MockServers proves the mock-server rules (#24): duplicate
 // names, route payload one-of, unknown mock names in asserts (listing the
 // declared ones), and count-0-with-matchers contradictions all fail at load.

--- a/internal/loader/validate.go
+++ b/internal/loader/validate.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"maps"
+	"path"
 	"regexp"
 	"slices"
 	"strconv"
@@ -945,8 +946,32 @@ func validateDir(add func(string, ...any), where string, d *spec.DirAssert) {
 	if d.MinCount != nil && d.MaxCount != nil && *d.MinCount > *d.MaxCount {
 		add("%s: min_count %d exceeds max_count %d", where, *d.MinCount, *d.MaxCount)
 	}
-	if n == 0 {
-		add("%s: must set at least one of exists/contains/not_contains/count/min_count/max_count/glob", where)
+	// Tree snapshot rules (#25): the golden manifest IS the whole assertion,
+	// so it composes only with ignore; the matcher family needs recursive or
+	// the historical single-level semantics.
+	if d.Snapshot != "" {
+		if n > 0 || d.Exists != nil {
+			add("%s: snapshot cannot be combined with the matcher family (exists/contains/not_contains/count/glob) — the manifest already pins the whole tree", where)
+		}
+		if d.Recursive {
+			add("%s: recursive is implied by snapshot; drop it", where)
+		}
+	} else {
+		if d.Recursive && n == 0 {
+			add("%s: recursive needs at least one of contains/not_contains/count/min_count/max_count/glob", where)
+		}
+		if len(d.Ignore) > 0 && !d.Recursive {
+			add("%s: ignore only applies to recursive or snapshot assertions", where)
+		}
+	}
+	for _, pat := range d.Ignore {
+		trimmed := strings.TrimSuffix(pat, "/**")
+		if _, err := path.Match(trimmed, "probe"); err != nil {
+			add("%s.ignore %q is not a valid glob: %v", where, pat, err)
+		}
+	}
+	if n == 0 && d.Snapshot == "" {
+		add("%s: must set at least one of exists/contains/not_contains/count/min_count/max_count/glob/snapshot", where)
 	}
 }
 

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -756,6 +756,22 @@ type DirAssert struct {
 	// Glob asserts that at least one direct entry matches this shell glob pattern
 	// (filepath.Match semantics, e.g. "*.html").
 	Glob string `yaml:"glob,omitempty"`
+	// Recursive makes Contains/NotContains accept slash-separated relative
+	// paths anywhere in the tree, and Count/MinCount/MaxCount/Glob apply to
+	// the whole walk (counts see FILES only; Glob matches each entry's
+	// relative path, or its basename for patterns without "/") (#25).
+	Recursive bool `yaml:"recursive,omitempty"`
+	// Snapshot compares the whole tree against a golden manifest (#25):
+	// sorted /-separated relative paths, one line per entry — `dir <path>`,
+	// `file <path> sha256:<hash>` (hashed byte-exact: CRLF is NOT normalized
+	// inside file content), or `link <path> -> <target>` (not traversed).
+	// No mode/mtime (not portable). Refresh with --update-snapshots.
+	Snapshot string `yaml:"snapshot,omitempty"`
+	// Ignore lists glob patterns excluded from the recursive walk and the
+	// snapshot manifest ("*.log", ".git/**"). A pattern without "/" also
+	// matches basenames at any depth; a "<dir>/**" pattern prunes the whole
+	// subtree.
+	Ignore []string `yaml:"ignore,omitempty"`
 }
 
 // ImageAssert checks a generated image file (ADR-0030). Unlike the one-of

--- a/schema/atago.schema.json
+++ b/schema/atago.schema.json
@@ -684,7 +684,10 @@
         "count": { "type": "integer", "minimum": 0 },
         "min_count": { "type": "integer", "minimum": 0 },
         "max_count": { "type": "integer", "minimum": 0 },
-        "glob": { "type": "string" }
+        "glob": { "type": "string" },
+        "recursive": { "type": "boolean", "description": "Apply contains/not_contains/count/glob to the whole tree (#25): counts see files only; glob matches relative paths, or basenames for patterns without /." },
+        "snapshot": { "type": "string", "description": "Golden tree manifest (#25): sorted relative paths, one line per entry (dir/file sha256/link). Composes only with ignore; refresh with --update-snapshots." },
+        "ignore": { "type": "array", "items": { "type": "string" }, "description": "Glob patterns excluded from the recursive walk and the snapshot manifest (*.log, .git/**)." }
       }
     },
     "exitCode": {

--- a/test/e2e/atago/dir_tree.atago.yaml
+++ b/test/e2e/atago/dir_tree.atago.yaml
@@ -1,0 +1,129 @@
+version: "1"
+
+suite:
+  name: atago self-hosting / recursive dir asserts + tree snapshots
+
+# Exercises #25 end-to-end through an inner atago run: recording a tree
+# manifest with --update-snapshots, a green compare, a failing compare whose
+# FAILED block names exactly the added/removed/changed paths, and the
+# recursive matcher family. Pure Go and fixture-driven, so every scenario
+# runs on all three OSes.
+scenarios:
+  - name: record, compare green, then a mutation names the changed paths
+    steps:
+      - fixture:
+          file: inner.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: inner
+            scenarios:
+              - name: tree matches its golden
+                steps:
+                  - fixture:
+                      file: site/hugo.toml
+                      content: "baseURL = 'x'\n"
+                  - fixture:
+                      file: site/content/posts/hello.md
+                      content: "# hello\n"
+                  - assert:
+                      dir:
+                        path: site
+                        snapshot: snapshots/site_tree.txt
+      # 1. Record the golden.
+      - run:
+          command: ${atago} run --update-snapshots inner.atago.yaml
+      - assert:
+          exit_code: 0
+      - assert:
+          file:
+            path: snapshots/site_tree.txt
+            contains:
+              - "dir content"
+              - "file hugo.toml sha256:"
+      # 2. Compare green.
+      - run:
+          command: ${atago} run inner.atago.yaml
+      - assert:
+          exit_code: 0
+      # 3. Mutate the inner spec's tree (an extra fixture) and compare again:
+      #    the failure names the added path, not two full manifests.
+      - fixture:
+          file: inner_mutated.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: inner
+            scenarios:
+              - name: tree matches its golden
+                steps:
+                  - fixture:
+                      file: site/hugo.toml
+                      content: "baseURL = 'x'\n"
+                  - fixture:
+                      file: site/content/posts/hello.md
+                      content: "# CHANGED\n"
+                  - fixture:
+                      file: site/extra.txt
+                      content: "new\n"
+                  - assert:
+                      dir:
+                        path: site
+                        snapshot: snapshots/site_tree.txt
+      - run:
+          command: ${atago} run inner_mutated.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "added:   file extra.txt"
+              - "changed: content/posts/hello.md"
+
+  - name: recursive matchers and ignore globs walk the tree
+    steps:
+      - fixture:
+          file: out/a/deep/nested.md
+          content: "nested\n"
+      - fixture:
+          file: out/top.txt
+          content: "top\n"
+      - fixture:
+          file: out/noise.log
+          content: "noise\n"
+      - assert:
+          dir:
+            path: out
+            recursive: true
+            ignore: ["*.log"]
+            contains: [a/deep/nested.md]
+            count: 2
+            glob: "*.md"
+      - assert:
+          dir:
+            path: out
+            recursive: true
+            not_contains: [a/deep/missing.md]
+
+  - name: combining snapshot with matchers is a load-time error
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: bad
+            scenarios:
+              - name: over-specified
+                steps:
+                  - run: {command: echo hi}
+                  - assert:
+                      dir:
+                        path: out
+                        snapshot: tree.txt
+                        contains: [a.txt]
+      - run:
+          command: ${atago} run bad.atago.yaml
+      - assert:
+          exit_code: 2
+          stderr:
+            contains: "snapshot cannot be combined"


### PR DESCRIPTION
## Summary

This PR makes `dir` assertions recursive (opt-in) and adds directory-tree snapshots (#25): a golden manifest of an entire tree — sorted /-separated relative paths, one line per entry (`dir <path>`, `file <path> sha256:<hash>`, `link <path> -> <target>`) — compared through the existing snapshot machinery. "The generator produces exactly this layout" becomes one line, refreshed with `--update-snapshots`.

## Changes

- `internal/spec`: `DirAssert` gains `recursive`, `snapshot`, `ignore` with semantics documented on the fields (counts see FILES only; a "/"-less glob also matches basenames; `<dir>/**` prunes the subtree; hashes are byte-exact so CRLF differences ARE differences; no mode/mtime — not portable).
- `internal/assert/tree.go` (new): deterministic walker (sorted, /-separated, symlinks recorded as `link p -> target` and never traversed, ignored dirs pruned), streaming sha256, recursive matcher family, and the tree-snapshot check whose failure output is an added/removed/changed summary (full manifests still flow to `--artifacts-dir`); manifests reuse `snapshot.Compare`/`Update`, so `atago snapshot update` just works.
- `internal/loader`: combination rules — `snapshot` composes only with `ignore` (the manifest already pins the whole tree), `recursive` is implied by (and rejected next to) `snapshot`, `ignore` needs recursive/snapshot, bare `recursive` needs a matcher, and every ignore glob must compile — all exit 2.
- Surfaces: JSON schema dir def, `explain`/`doc` render "tree matches snapshot X", "(recursive)", and the ignore list.
- Docs: new `examples/dir_tree.atago.yaml` + committed golden `examples/snapshots/site_tree.txt` (hermetic, registered), README Examples row, CHANGELOG entry.
- Tests: walker determinism + ignore/prune semantics, symlink record-not-traverse, recursive matchers (nested contains, files-only count, deep glob), snapshot round-trip (record → green → mutation diff naming exactly the changed/added paths), loader combination-rule table, and self-hosted E2E `test/e2e/atago/dir_tree.atago.yaml` (record/compare/mutate through an inner atago run; pure Go — added to BOTH Windows E2E allowlists).

## Design Decisions

- The failure diff names paths (`added: file extra.txt`, `changed: content/posts/hello.md`) instead of dumping two manifests — the review-relevant signal for trees.
- Ignore globs are deliberately simple: `path.Match` on the relative path, basename matching for "/"-less patterns, and `<dir>/**` prefix pruning — no full doublestar engine.

Closes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recursive directory assertions and tree snapshot support.
  * Introduced directory ignore patterns, full-tree matching, and snapshot comparisons for directory contents.
  * Expanded end-to-end coverage with new directory-tree scenarios.

* **Documentation**
  * Updated changelog, README, and examples to cover the new directory tree behavior.
  * Improved generated descriptions and validation guidance for directory assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->