### PR TITLE
fix(assert): parse tree-manifest diffs by line grammar and render dir ignore in docs

### DIFF
--- a/internal/assert/tree.go
+++ b/internal/assert/tree.go
@@ -226,17 +226,31 @@ func checkDirSnapshot(d *spec.DirAssert, dirPath string, env Env) *CheckResult {
 // lists. A path present in both with a different line (hash or kind) counts
 // as changed.
 func manifestDiff(expected, actual string) string {
+	// Parse by the known line grammar (dir/file/link), not a whitespace
+	// split: relative paths may contain spaces.
 	parse := func(text string) map[string]string {
 		m := map[string]string{}
 		for _, line := range strings.Split(strings.TrimRight(text, "\n"), "\n") {
-			if line == "" {
+			var p string
+			switch {
+			case strings.HasPrefix(line, "dir "):
+				p = strings.TrimPrefix(line, "dir ")
+			case strings.HasPrefix(line, "file "):
+				rest := strings.TrimPrefix(line, "file ")
+				if i := strings.LastIndex(rest, " sha256:"); i >= 0 {
+					rest = rest[:i]
+				}
+				p = rest
+			case strings.HasPrefix(line, "link "):
+				rest := strings.TrimPrefix(line, "link ")
+				if i := strings.Index(rest, " -> "); i >= 0 {
+					rest = rest[:i]
+				}
+				p = rest
+			default:
 				continue
 			}
-			fields := strings.Fields(line)
-			if len(fields) < 2 {
-				continue
-			}
-			m[fields[1]] = line
+			m[p] = line
 		}
 		return m
 	}

--- a/internal/assert/tree_test.go
+++ b/internal/assert/tree_test.go
@@ -115,6 +115,24 @@ func TestCheckDir_RecursiveMatchers(t *testing.T) {
 	}
 }
 
+// TestManifestDiff_PathsWithSpaces proves the diff parser follows the line
+// grammar instead of splitting on whitespace, so spaced filenames survive.
+func TestManifestDiff_PathsWithSpaces(t *testing.T) {
+	t.Parallel()
+	expected := "file My File.txt sha256:aaa\nlink my link -> some target\n"
+	actual := "file My File.txt sha256:bbb\ndir new dir\n"
+	got := manifestDiff(expected, actual)
+	for _, want := range []string{
+		"changed: My File.txt",
+		"added:   dir new dir",
+		"removed: link my link -> some target",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("diff = %q, want %q", got, want)
+		}
+	}
+}
+
 // TestCheckDir_SnapshotRoundTrip proves record → green compare → mutation
 // diff naming exactly the changed path (#25).
 func TestCheckDir_SnapshotRoundTrip(t *testing.T) {

--- a/internal/docgen/describe.go
+++ b/internal/docgen/describe.go
@@ -205,6 +205,9 @@ func dirConstraints(d *spec.DirAssert) []string {
 	if d.Recursive {
 		parts = append(parts, "(recursive)")
 	}
+	if len(d.Ignore) > 0 {
+		parts = append(parts, "ignoring "+strings.Join(d.Ignore, ", "))
+	}
 	return parts
 }
 


### PR DESCRIPTION
## Summary

Two follow-ups to #25 (PR #50) from CodeRabbit's review: the tree-manifest failure diff mis-parsed relative paths containing spaces (it split on whitespace; now it follows the dir/file/link line grammar, with a regression test covering spaced file, link, and dir names), and `atago doc` omitted the `dir.ignore` list that `atago explain` already renders.

Both were review findings on the merged PR #50; no behavior change beyond failure diagnostics and doc output.