### PR TITLE
feat(pty): add named keys to send steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project follows [Semantic Versioning](https://semver.org/).
   (`SystemRoot`, `SystemDrive`, `TEMP`, `TMP`, `PATHEXT`) is always retained.
   `pass_env` without `clear_env: true` is a load-time error (exit 2).
   See `examples/hermetic_env.atago.yaml`.
+- PTY named keys (#26): `send: {key: enter}` presses a named key instead of
+  embedding raw escape bytes — enter, tab, esc, space, backspace, delete,
+  the arrows, home/end, pageup/pagedown, f1-f12, and ctrl-a..ctrl-z (mapped
+  to standard xterm sequences; `{key: ctrl-d}` is the readable alias for the
+  empty-send EOF rule). Unknown names are load-time errors listing the
+  vocabulary; explain renders the keys symbolically.
 - Recursive dir assertions and directory-tree snapshots (#25):
   `dir.recursive: true` makes `contains`/`not_contains` accept nested
   relative paths and `count`/`min_count`/`max_count` (files only) / `glob`

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Every feature has a commented, runnable spec under [examples/](examples/). The e
 | [stdin](examples/stdin.atago.yaml) | stdin sources: inline text, `stdin: {file: ...}` from a workdir file, and binary input via `stdin: {base64: ...}` |
 | [matrix](examples/matrix.atago.yaml) | one template scenario expanded per parameter row |
 | [mock_server](examples/mock_server.atago.yaml) | test API-client CLIs offline: `mock_servers` serve canned routes, record every request, and `mock:` asserts what the client actually sent |
-| [pty](examples/pty.atago.yaml) | interactive testing in a real pseudo-terminal: expect/send sessions, TTY-detection (POSIX-only) |
+| [pty](examples/pty.atago.yaml) | interactive testing in a real pseudo-terminal: expect/send sessions, named keys (`send: {key: enter}`), TTY-detection (POSIX-only) |
 | [retry](examples/retry.atago.yaml) | polling a command until an assertion passes |
 | [snapshot](examples/snapshot.atago.yaml) | golden-file testing with normalized output |
 | [dir_tree](examples/dir_tree.atago.yaml) | recursive dir assertions and directory-tree snapshots: pin a generator's whole output tree with one golden manifest |

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-49 suites · 167 scenarios
+49 suites · 169 scenarios
 ## Contents
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 3 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
@@ -135,9 +135,11 @@
 - [atago self-hosting / pdf assertion](#atago-self-hosting--pdf-assertion) — 2 scenarios
   - [pdf assertions cover page count, metadata, and text](#scenario-pdf-assertions-cover-page-count-metadata-and-text)
   - [a non-pdf file fails the pdf target](#scenario-a-non-pdf-file-fails-the-pdf-target)
-- [atago self-hosting / pty](#atago-self-hosting--pty) — 2 scenarios
+- [atago self-hosting / pty](#atago-self-hosting--pty) — 4 scenarios
   - [a pty step sees a terminal where a run step sees a pipe](#scenario-a-pty-step-sees-a-terminal-where-a-run-step-sees-a-pipe)
   - [a never-matching expect fails with the pattern in the block](#scenario-a-never-matching-expect-fails-with-the-pattern-in-the-block)
+  - [named keys transmit their documented bytes and ctrl-c aborts](#scenario-named-keys-transmit-their-documented-bytes-and-ctrl-c-aborts)
+  - [an unknown key name is a load-time error listing the vocabulary](#scenario-an-unknown-key-name-is-a-load-time-error-listing-the-vocabulary)
 - [atago self-hosting / reports](#atago-self-hosting--reports) — 4 scenarios
   - [JUnit report is XML with a testsuite and testcase](#scenario-junit-report-is-xml-with-a-testsuite-and-testcase)
   - [GitHub Actions annotations are emitted on failure](#scenario-github-actions-annotations-are-emitted-on-failure)
@@ -2414,6 +2416,41 @@ ${atago} run bad.atago.yaml
 #### Then
 - exit code is `1`
 - stdout contains `pty expect /prompt-that-never-comes/`, `never appeared in the terminal transcript`
+### Scenario: named keys transmit their documented bytes and ctrl-c aborts
+_skipped on windows_
+#### When
+```shell
+# interactive (pty): cat -v
+# interactive (pty): trap 'exit 130' INT; echo waiting; while true; do sleep 0.1; done
+```
+#### Then
+- exit code is `0`
+- stdout contains `^[[B`
+- exit code is `130`
+### Scenario: an unknown key name is a load-time error listing the vocabulary
+#### Given
+- Fixture file `badkey.atago.yaml` is created.
+#### Inputs
+_Fixture `badkey.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: inner
+scenarios:
+  - name: typo'd key
+    steps:
+      - pty:
+          command: cat
+          session:
+            - send: { key: entr }
+```
+#### When
+```shell
+${atago} run badkey.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `not a supported key (supported: enter, tab`
 ## atago self-hosting / reports
 Source: `test/e2e/atago/reports.atago.yaml`
 ### Scenario: JUnit report is XML with a testsuite and testcase

--- a/examples/pty.atago.yaml
+++ b/examples/pty.atago.yaml
@@ -47,3 +47,26 @@ scenarios:
           exit_code: 0
           stdout:
             contains: hello interactive world
+
+  - name: named keys keep sessions readable
+    skip:
+      os: windows
+    steps:
+      # {key: <name>} presses a named key (#26) instead of embedding raw
+      # \x1b escape bytes: enter, tab, esc, space, backspace, delete, the
+      # arrows, home/end, pageup/pagedown, f1-f12, and ctrl-a..ctrl-z.
+      # {key: ctrl-d} is the readable alias for the empty-send EOF rule.
+      # `cat -v` renders control bytes visibly, so the down arrow it received
+      # shows up as ^[[B in the transcript.
+      - pty:
+          command: cat -v
+          timeout: 10s
+          session:
+            - send: { key: down }
+            - send: { key: enter }
+            - expect: '\^\[\[B'
+            - send: { key: ctrl-d }
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "^[[B"

--- a/internal/engine/pty.go
+++ b/internal/engine/pty.go
@@ -32,8 +32,14 @@ func (e *Engine) runPTY(ctx context.Context, p *spec.PTY, st *store.Store, scena
 		for i, a := range p.Session {
 			na := spec.PTYAction{Expect: st.Expand(a.Expect)}
 			if a.Send != nil {
-				sent := st.Expand(*a.Send)
-				na.Send = &sent
+				cs := *a.Send
+				// Only verbatim text gets ${name} expansion; named keys are
+				// fixed byte sequences (#26).
+				if cs.Text != nil {
+					txt := st.Expand(*cs.Text)
+					cs.Text = &txt
+				}
+				na.Send = &cs
 			}
 			c.Session[i] = na
 		}

--- a/internal/engine/pty_test.go
+++ b/internal/engine/pty_test.go
@@ -184,3 +184,43 @@ scenarios:
 		t.Fatalf("status = %s, want passed: %+v", res.Status, res.Scenarios)
 	}
 }
+
+// TestEngine_PTY_NamedKeys proves named keys transmit their documented xterm
+// bytes (#26): `cat -v` renders the down arrow it received as ^[[B, ctrl-d
+// ends the stream, and a trap-based shell observes ctrl-c as SIGINT.
+func TestEngine_PTY_NamedKeys(t *testing.T) {
+	skipOnWindows(t)
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: s
+scenarios:
+  - name: cat -v shows the arrow bytes and ctrl-d ends input
+    steps:
+      - pty:
+          command: cat -v
+          session:
+            - send: { key: down }
+            - send: { key: enter }
+            - expect: '\^\[\[B'
+            - send: { key: ctrl-d }
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "^[[B"
+  - name: ctrl-c delivers SIGINT
+    steps:
+      - pty:
+          shell: true
+          command: "trap 'exit 130' INT; echo waiting; while true; do sleep 0.1; done"
+          session:
+            - expect: waiting
+            - send: { key: ctrl-c }
+      - assert:
+          exit_code: 130
+`)
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed: %+v", res.Status, res.Scenarios)
+	}
+}

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -149,11 +149,20 @@ func explainScenario(b *strings.Builder, sc *spec.Scenario) {
 				for _, v := range step.PTY.Env {
 					collectVars(vars, v)
 				}
+				var keys []string
 				for _, a := range step.PTY.Session {
 					collectVars(vars, a.Expect)
 					if a.Send != nil {
-						collectVars(vars, *a.Send)
+						if a.Send.Text != nil {
+							collectVars(vars, *a.Send.Text)
+						}
+						if a.Send.Key != "" {
+							keys = append(keys, a.Send.Key)
+						}
 					}
+				}
+				if len(keys) > 0 {
+					commands[len(commands)-1] += "  [keys: " + strings.Join(keys, ", ") + "]"
 				}
 			}
 		case spec.StepCDP:

--- a/internal/loader/defaults_test.go
+++ b/internal/loader/defaults_test.go
@@ -463,6 +463,50 @@ scenarios:
 	}
 }
 
+// TestValidate_PTYNamedKeys proves the #26 rules: an unknown key name lists
+// the vocabulary, malformed send mappings fail, and a valid key loads.
+func TestValidate_PTYNamedKeys(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name, send, wantMsg string
+	}{
+		{"unknown key lists vocabulary", "{key: entr}", "not a supported key (supported: enter, tab"},
+		{"unknown mapping field", "{kye: enter}", "unknown key"},
+		{"valid named key", "{key: ctrl-c}", ""},
+		{"valid scalar still works", `"hello"`, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			src := `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: s
+    steps:
+      - pty:
+          command: cat
+          session:
+            - send: ` + tc.send + `
+`
+			_, err := LoadBytes("sample.atago.yaml", []byte(src))
+			if tc.wantMsg == "" {
+				if err != nil {
+					t.Fatalf("LoadBytes() error = %v, want clean load", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("LoadBytes() = nil error, want a pty send validation error")
+			}
+			if !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Errorf("error = %q, want substring %q", err, tc.wantMsg)
+			}
+		})
+	}
+}
+
 // TestValidate_DirTreeRules proves the #25 combination rules: snapshot is
 // exclusive with the matcher family, ignore needs recursive/snapshot, bad
 // ignore globs fail, and bare recursive needs a matcher.

--- a/internal/loader/validate.go
+++ b/internal/loader/validate.go
@@ -686,6 +686,12 @@ func validatePTY(add func(string, ...any), where string, p *spec.PTY) {
 			if _, err := regexp.Compile(a.Expect); err != nil {
 				add("%s.expect %q is not a valid regexp: %v", aw, a.Expect, err)
 			}
+		case hasSend:
+			// A named key must be in the vocabulary (#26); a typo'd key would
+			// otherwise silently send nothing.
+			if a.Send.Key != "" && !spec.ValidPTYKey(a.Send.Key) {
+				add("%s.send.key %q is not a supported key (supported: %s)", aw, a.Send.Key, spec.PTYKeyNames())
+			}
 		}
 	}
 }

--- a/internal/manifest/scenario.go
+++ b/internal/manifest/scenario.go
@@ -207,8 +207,8 @@ func buildStep(index int, step *spec.Step, vars map[string]bool) Step {
 			collectVars(vars, v)
 		}
 		for _, a := range pt.Session {
-			if a.Send != nil {
-				collectVars(vars, *a.Send)
+			if a.Send != nil && a.Send.Text != nil {
+				collectVars(vars, *a.Send.Text)
 			}
 			collectVars(vars, a.Expect)
 		}

--- a/internal/runner/ptyrun/ptyrun_unix.go
+++ b/internal/runner/ptyrun/ptyrun_unix.go
@@ -188,14 +188,10 @@ func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runne
 			continue
 		}
 		if a.Send != nil {
-			if *a.Send == "" {
-				// EOF: ^D. Terminals deliver it as VEOF on an empty input line.
-				if _, werr := master.Write([]byte{0x04}); werr != nil {
-					return failHard(fmt.Errorf("pty: send EOF: %w", werr))
-				}
-				continue
-			}
-			if _, werr := master.Write([]byte(*a.Send)); werr != nil {
+			// Bytes resolves named keys to their xterm sequences and keeps the
+			// historical rule that an empty verbatim send transmits EOF (^D,
+			// delivered as VEOF on an empty input line) (#26).
+			if _, werr := master.Write(a.Send.Bytes()); werr != nil {
 				return failHard(fmt.Errorf("pty: send: %w", werr))
 			}
 		}

--- a/internal/spec/ptysend_test.go
+++ b/internal/spec/ptysend_test.go
@@ -1,0 +1,68 @@
+package spec
+
+import (
+	"testing"
+)
+
+// TestPTYKeySequences_GoldenTable pins the exact bytes each named key
+// transmits (#26) — the documented contract TUI specs rely on.
+func TestPTYKeySequences_GoldenTable(t *testing.T) {
+	t.Parallel()
+	want := map[string]string{
+		"enter":     "\r",
+		"tab":       "\t",
+		"esc":       "\x1b",
+		"space":     " ",
+		"backspace": "\x7f",
+		"delete":    "\x1b[3~",
+		"up":        "\x1b[A",
+		"down":      "\x1b[B",
+		"right":     "\x1b[C",
+		"left":      "\x1b[D",
+		"home":      "\x1b[H",
+		"end":       "\x1b[F",
+		"pageup":    "\x1b[5~",
+		"pagedown":  "\x1b[6~",
+		"f1":        "\x1bOP",
+		"f4":        "\x1bOS",
+		"f5":        "\x1b[15~",
+		"f12":       "\x1b[24~",
+		"ctrl-a":    "\x01",
+		"ctrl-c":    "\x03",
+		"ctrl-d":    "\x04",
+		"ctrl-z":    "\x1a",
+	}
+	for name, bytes := range want {
+		got := (&PTYSend{Key: name}).Bytes()
+		if string(got) != bytes {
+			t.Errorf("key %s = %q, want %q", name, got, bytes)
+		}
+	}
+	// The whole vocabulary is valid; a typo is not.
+	for name := range want {
+		if !ValidPTYKey(name) {
+			t.Errorf("ValidPTYKey(%s) = false", name)
+		}
+	}
+	if ValidPTYKey("entr") {
+		t.Error("ValidPTYKey(entr) = true, want false")
+	}
+}
+
+// TestPTYSend_TextAndEOF proves the scalar form and the historical
+// empty-string EOF rule survive the polymorphic type.
+func TestPTYSend_TextAndEOF(t *testing.T) {
+	t.Parallel()
+	if got := SendText("hello\n").Bytes(); string(got) != "hello\n" {
+		t.Errorf("text bytes = %q", got)
+	}
+	if got := SendText("").Bytes(); string(got) != "\x04" {
+		t.Errorf("empty send = %q, want ^D", got)
+	}
+	if got := SendText("").Label(); got != "send EOF (^D)" {
+		t.Errorf("label = %q", got)
+	}
+	if got := (&PTYSend{Key: "enter"}).Label(); got != "press enter" {
+		t.Errorf("label = %q", got)
+	}
+}

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -609,9 +609,136 @@ type PTYAction struct {
 	// expect fails the step (reported like an assertion) when the session
 	// timeout elapses.
 	Expect string `yaml:"expect,omitempty"`
-	// Send writes this string to the terminal verbatim (include "\n" to press
-	// enter). The empty string sends EOF (^D). ${name} expansion applies.
-	Send *string `yaml:"send,omitempty"`
+	// Send writes to the terminal: a scalar string verbatim (the empty string
+	// sends EOF/^D; ${name} expansion applies) or {key: <name>} for a named
+	// key (#26) — enter, tab, esc, arrows, f1-f12, ctrl-a..ctrl-z — so
+	// sessions stay readable instead of embedding \x1b escapes.
+	Send *PTYSend `yaml:"send,omitempty"`
+}
+
+// PTYSend is the polymorphic pty send payload (#26): exactly one of Text
+// (scalar form) or Key (mapping form) is set.
+type PTYSend struct {
+	// Text is sent verbatim; the empty string transmits EOF (^D).
+	Text *string
+	// Key is a named key, normalized to lower case.
+	Key string
+}
+
+// SendText is sugar for authoring the scalar form in Go literals (tests).
+func SendText(s string) *PTYSend { return &PTYSend{Text: &s} }
+
+// UnmarshalYAML decodes send as a scalar string or a {key: name} mapping,
+// rejecting unknown mapping keys (a custom unmarshaler bypasses the loader's
+// strict decode).
+func (p *PTYSend) UnmarshalYAML(unmarshal func(any) error) error {
+	var one string
+	if err := unmarshal(&one); err == nil {
+		p.Text = &one
+		return nil
+	}
+	var raw map[string]any
+	if err := unmarshal(&raw); err != nil {
+		return fmt.Errorf("send must be a string or {key: <name>} (e.g. {key: enter})")
+	}
+	for k, v := range raw {
+		if k != "key" {
+			return fmt.Errorf("send: unknown key %q (accepted: key)", k)
+		}
+		str, ok := v.(string)
+		if !ok {
+			return fmt.Errorf("send.key must be a string")
+		}
+		p.Key = strings.ToLower(strings.TrimSpace(str))
+	}
+	if p.Key == "" {
+		return fmt.Errorf("send: {key: <name>} requires a key name (e.g. enter, tab, ctrl-c)")
+	}
+	return nil
+}
+
+// ptyKeySequences maps each named key (#26) to the xterm byte sequence it
+// transmits. Documented bytes: enter=\r, tab=\t, esc=\x1b, space=" ",
+// backspace=\x7f (DEL, the modern erase), delete=\x1b[3~, arrows
+// up/down/right/left=\x1b[A/B/C/D, home=\x1b[H, end=\x1b[F,
+// pageup=\x1b[5~, pagedown=\x1b[6~, f1-f4=\x1bOP..\x1bOS,
+// f5..f12=\x1b[15~,[17~..[21~,[23~,[24~, ctrl-a..ctrl-z=0x01..0x1a
+// (ctrl-d is therefore the readable alias for the empty-send EOF rule).
+var ptyKeySequences = func() map[string]string {
+	m := map[string]string{
+		"enter":     "\r",
+		"tab":       "\t",
+		"esc":       "\x1b",
+		"space":     " ",
+		"backspace": "\x7f",
+		"delete":    "\x1b[3~",
+		"up":        "\x1b[A",
+		"down":      "\x1b[B",
+		"right":     "\x1b[C",
+		"left":      "\x1b[D",
+		"home":      "\x1b[H",
+		"end":       "\x1b[F",
+		"pageup":    "\x1b[5~",
+		"pagedown":  "\x1b[6~",
+		"f1":        "\x1bOP",
+		"f2":        "\x1bOQ",
+		"f3":        "\x1bOR",
+		"f4":        "\x1bOS",
+		"f5":        "\x1b[15~",
+		"f6":        "\x1b[17~",
+		"f7":        "\x1b[18~",
+		"f8":        "\x1b[19~",
+		"f9":        "\x1b[20~",
+		"f10":       "\x1b[21~",
+		"f11":       "\x1b[23~",
+		"f12":       "\x1b[24~",
+	}
+	for c := byte('a'); c <= 'z'; c++ {
+		m["ctrl-"+string(c)] = string([]byte{c - 'a' + 1})
+	}
+	return m
+}()
+
+// ValidPTYKey reports whether name is in the named-key vocabulary (#26).
+func ValidPTYKey(name string) bool {
+	_, ok := ptyKeySequences[strings.ToLower(strings.TrimSpace(name))]
+	return ok
+}
+
+// PTYKeyNames lists the vocabulary for error messages, compactly.
+func PTYKeyNames() string {
+	return "enter, tab, esc, space, backspace, delete, up, down, left, right, home, end, pageup, pagedown, f1-f12, ctrl-a..ctrl-z"
+}
+
+// Bytes resolves the send payload to the bytes written to the terminal: the
+// named key's xterm sequence, the verbatim text, or 0x04 (VEOF, ^D) for the
+// historical empty-string EOF rule.
+func (p *PTYSend) Bytes() []byte {
+	if p.Key != "" {
+		return []byte(ptyKeySequences[p.Key])
+	}
+	if p.Text != nil && *p.Text == "" {
+		return []byte{0x04}
+	}
+	if p.Text != nil {
+		return []byte(*p.Text)
+	}
+	return nil
+}
+
+// Label renders the send symbolically for explain/doc (#26): "press Enter"
+// for keys, a quoted excerpt for text, "EOF (^D)" for the empty string.
+func (p *PTYSend) Label() string {
+	switch {
+	case p.Key != "":
+		return "press " + p.Key
+	case p.Text != nil && *p.Text == "":
+		return "send EOF (^D)"
+	case p.Text != nil:
+		return fmt.Sprintf("type %q", *p.Text)
+	default:
+		return "send"
+	}
 }
 
 // HTTP issues an HTTP request (post-MVP).

--- a/schema/atago.schema.json
+++ b/schema/atago.schema.json
@@ -503,10 +503,22 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "description": "Exactly one of expect (wait until the transcript matches the regexp) or send (write to the terminal; \"\" sends EOF/^D).",
+            "description": "Exactly one of expect (wait until the transcript matches the regexp) or send (write to the terminal; \"\" sends EOF/^D; {key: enter} presses a named key, #26).",
             "properties": {
               "expect": { "type": "string" },
-              "send": { "type": "string" }
+              "send": {
+                "oneOf": [
+                  { "type": "string" },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["key"],
+                    "properties": {
+                      "key": { "type": "string", "minLength": 1, "description": "Named key: enter, tab, esc, space, backspace, delete, arrows, home/end, pageup/pagedown, f1-f12, ctrl-a..ctrl-z." }
+                    }
+                  }
+                ]
+              }
             }
           }
         }

--- a/test/e2e/atago/pty.atago.yaml
+++ b/test/e2e/atago/pty.atago.yaml
@@ -59,3 +59,54 @@ scenarios:
             contains:
               - "pty expect /prompt-that-never-comes/"
               - "never appeared in the terminal transcript"
+
+  - name: named keys transmit their documented bytes and ctrl-c aborts
+    skip:
+      os: windows
+    steps:
+      # An arrow key received by `cat -v` renders as ^[[B — proof the named
+      # key (#26) transmitted the real xterm sequence.
+      - pty:
+          command: cat -v
+          timeout: 10s
+          session:
+            - send: { key: down }
+            - send: { key: enter }
+            - expect: '\^\[\[B'
+            - send: { key: ctrl-d }
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "^[[B"
+      # ctrl-c delivers a real SIGINT to the foreground process group.
+      - pty:
+          shell: true
+          command: "trap 'exit 130' INT; echo waiting; while true; do sleep 0.1; done"
+          timeout: 10s
+          session:
+            - expect: waiting
+            - send: { key: ctrl-c }
+      - assert:
+          exit_code: 130
+
+  - name: an unknown key name is a load-time error listing the vocabulary
+    steps:
+      - fixture:
+          file: badkey.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: inner
+            scenarios:
+              - name: typo'd key
+                steps:
+                  - pty:
+                      command: cat
+                      session:
+                        - send: { key: entr }
+      - run:
+          command: ${atago} run badkey.atago.yaml
+      - assert:
+          exit_code: 2
+          stderr:
+            contains: 'not a supported key (supported: enter, tab'


### PR DESCRIPTION
## Summary

This PR adds named keys to pty sessions (#26): `send: {key: enter}` presses a key by name instead of embedding `\x1b[B`-style escapes in YAML — the exact friction the fzf specs (#20) documented. Sessions stay readable and self-documenting.

## Changes

- `internal/spec`: `PTYAction.Send` becomes the polymorphic `PTYSend` (scalar → verbatim `Text`, mapping → `Key`), with the key table documented byte-for-byte on `ptyKeySequences` — enter=\r, tab=\t, esc=\x1b, space, backspace=\x7f, delete=\x1b[3~, arrows \x1b[A-D, home/end \x1b[H/F, pageup/pagedown \x1b[5~/6~, f1-f4 \x1bOP..OS, f5-f12 \x1b[15~..[24~, ctrl-a..ctrl-z 0x01..0x1a. `{key: ctrl-d}` is therefore the readable alias for the historical empty-send EOF rule, which is unchanged. `Bytes()` resolves the payload; `Label()` renders it symbolically.
- `internal/runner/ptyrun`: the send path writes `Send.Bytes()` — named keys and the EOF rule resolve in one place.
- `internal/engine`: ${name} expansion applies to verbatim text only (keys are fixed byte sequences).
- `internal/loader`: unknown key names are load-time errors LISTING the vocabulary; malformed `send:` mappings (unknown field, non-string key) are rejected by the unmarshaler.
- `explain` appends "[keys: down, enter, ctrl-c]" to the pty line; manifest var collection reads the text form only; JSON schema `send` becomes a oneOf (string | {key}).
- Tests: a golden table pinning every documented byte sequence + vocabulary membership; engine round-trips (`cat -v` renders a received down arrow as `^[[B`; ctrl-c delivers SIGINT to a trap-based shell asserting exit 130); loader vocabulary/shape cases; extended `examples/pty.atago.yaml` and `test/e2e/atago/pty.atago.yaml` (named-key round-trip, ctrl-c abort, unknown-key load error).

Closes #26