### PR TITLE
feat(report): render colorized unified diffs for equals and snapshot failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ and this project follows [Semantic Versioning](https://semver.org/).
   (`SystemRoot`, `SystemDrive`, `TEMP`, `TMP`, `PATHEXT`) is always retained.
   `pass_env` without `clear_env: true` is a load-time error (exit 2).
   See `examples/hermetic_env.atago.yaml`.
+- Colorized unified diff for equals/snapshot failures (#28): when both
+  sides of a failed `equals`/`snapshot` comparison are multi-line, the
+  console FAILED block renders a unified diff (3 context lines, removals
+  red / additions green, hunk headers dimmed; snapshot sides labeled
+  "snapshot (golden)" / "actual") instead of two raw Expected/Actual dumps.
+  Color respects `--ci`/`NO_COLOR`; the uncolored diff text also lands in
+  the JSON report's new additive `diff` field and the junit/tap/gha detail
+  bodies. Inputs and rendered hunks are capped with explicit truncation
+  notes; secrets are masked before diffing.
 - PTY screen assertions (#27): the new `screen:` assertion target replays a
   pty step's transcript through a vt100 terminal emulator (hinshun/vt10x)
   sized by the step's rows/cols and asserts on the final RENDERED screen —

--- a/README.md
+++ b/README.md
@@ -90,7 +90,28 @@ $ atago run ./specs
 PASSED  47 scenarios: 47 passed, 0 failed, 0 errored, 0 skipped (1.2s)
 ```
 
-When a check fails, atago prints exactly what was expected and what happened:
+When a check fails, atago prints exactly what was expected and what happened — and multi-line `equals`/`snapshot` mismatches render a colorized unified diff (respecting `--ci`/`NO_COLOR`) instead of two raw dumps:
+
+```text
+FAILED: demo / greeting matches its golden
+
+Step:
+  assert stdout snapshot
+
+Diff (-expected +actual):
+  --- snapshot (golden)
+  +++ actual
+  @@ -1,3 +1,3 @@
+   hello
+  -WORLD
+  +world
+   bye
+
+Hint:
+  stdout did not match snapshot "snaps/greeting.txt" (update with --update-snapshots if intended)
+```
+
+Single-line failures keep the compact form:
 
 ```text
 FAILED: demo / expect Alice but the command prints Bob

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-49 suites · 172 scenarios
+49 suites · 173 scenarios
 ## Contents
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 3 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
@@ -143,11 +143,12 @@
   - [screen asserts see the final frame where the transcript sees history](#scenario-screen-asserts-see-the-final-frame-where-the-transcript-sees-history)
   - [a screen snapshot round-trips through update and compare](#scenario-a-screen-snapshot-round-trips-through-update-and-compare)
   - [a screen assert without a pty step is a load-time error](#scenario-a-screen-assert-without-a-pty-step-is-a-load-time-error)
-- [atago self-hosting / reports](#atago-self-hosting--reports) — 4 scenarios
+- [atago self-hosting / reports](#atago-self-hosting--reports) — 5 scenarios
   - [JUnit report is XML with a testsuite and testcase](#scenario-junit-report-is-xml-with-a-testsuite-and-testcase)
   - [GitHub Actions annotations are emitted on failure](#scenario-github-actions-annotations-are-emitted-on-failure)
   - [TAP report is a numbered TAP 13 stream with ok / not ok points](#scenario-tap-report-is-a-numbered-tap-13-stream-with-ok--not-ok-points)
   - [failure artifacts are written and referenced in the JSON report](#scenario-failure-artifacts-are-written-and-referenced-in-the-json-report)
+  - [a multi-line snapshot failure renders a unified diff with hunks](#scenario-a-multi-line-snapshot-failure-renders-a-unified-diff-with-hunks)
 - [atago self-hosting / rerun-failed](#atago-self-hosting--rerun-failed) — 2 scenarios
   - [a failing run is recorded and rerun-failed selects only it](#scenario-a-failing-run-is-recorded-and-rerun-failed-selects-only-it)
   - [rerun-failed with nothing recorded is a no-op success](#scenario-rerun-failed-with-nothing-recorded-is-a-no-op-success)
@@ -2637,6 +2638,55 @@ cat arts/*/*/step-*-stdout.actual.txt
 - after `cat arts/*/*/step-*-stdout.actual.txt`:
   - exit code is `0`
   - stdout contains `Bob`
+### Scenario: a multi-line snapshot failure renders a unified diff with hunks
+#### Given
+- Fixture file `diffspec.atago.yaml` is created.
+- Fixture file `diffspec.atago.yaml` is created.
+#### Inputs
+_Fixture `diffspec.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: diffdemo
+scenarios:
+  - name: multi-line output matches its golden
+    steps:
+      - run:
+          shell: true
+          command: "printf 'alpha\\nbeta\\ngamma\\n'"
+      - assert:
+          stdout:
+            snapshot: snaps/out.txt
+```
+_Fixture `diffspec.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: diffdemo
+scenarios:
+  - name: multi-line output matches its golden
+    steps:
+      - run:
+          shell: true
+          command: "printf 'alpha\\nBETA\\ngamma\\n'"
+      - assert:
+          stdout:
+            snapshot: snaps/out.txt
+```
+#### When
+```shell
+${atago} run --update-snapshots diffspec.atago.yaml
+${atago} run diffspec.atago.yaml
+${atago} run --report json diffspec.atago.yaml; true
+```
+#### Then
+- after `${atago} run --update-snapshots diffspec.atago.yaml`:
+  - exit code is `0`
+- after `${atago} run diffspec.atago.yaml`:
+  - exit code is `1`
+  - stdout contains `Diff (-expected +actual):`, `--- snapshot (golden)`, `-beta`, `+BETA`, `snaps/out.txt`
+- after `${atago} run --report json diffspec.atago.yaml; true`:
+  - stdout contains `"diff":`
 ## atago self-hosting / rerun-failed
 Source: `test/e2e/atago/rerun.atago.yaml`
 ### Scenario: a failing run is recorded and rerun-failed selects only it

--- a/internal/assert/tree.go
+++ b/internal/assert/tree.go
@@ -216,7 +216,10 @@ func checkDirSnapshot(d *spec.DirAssert, dirPath string, env Env) *CheckResult {
 		return cr
 	}
 	// Replace the two full-dump excerpts with a manifest diff: the names of
-	// the added/removed/changed paths are the review-relevant signal.
+	// the added/removed/changed paths are the review-relevant signal. The
+	// distinct "tree" kind keeps the report's generic unified diff (#28) from
+	// overriding this domain-specific summary.
+	cr.ArtifactKind = "tree"
 	cr.Expected = fmt.Sprintf("tree matches snapshot %q", d.Snapshot)
 	cr.Actual = manifestDiff(string(cr.ArtifactExpected), string(cr.ArtifactActual))
 	return cr

--- a/internal/report/console.go
+++ b/internal/report/console.go
@@ -40,11 +40,18 @@ func writeDetail(b *strings.Builder, color bool, suite string, sc *engine.Scenar
 				if cmd != "" {
 					fmt.Fprintf(b, "\nCommand:\n  %s\n", cmd)
 				}
-				if ck.Expected != "" {
-					fmt.Fprintf(b, "\nExpected:\n%s\n", indent(ck.Expected))
-				}
-				if ck.Actual != "" {
-					fmt.Fprintf(b, "\nActual:\n%s\n", indent(ck.Actual))
+				// Multi-line equals/snapshot failures render a unified diff
+				// (#28): the one-character difference the two raw blocks hide.
+				// Single-line failures keep the compact Expected/Actual form.
+				if diff := checkDiff(ck); diff != "" {
+					fmt.Fprintf(b, "\nDiff (-expected +actual):\n%s\n", indent(colorizeDiff(color, diff)))
+				} else {
+					if ck.Expected != "" {
+						fmt.Fprintf(b, "\nExpected:\n%s\n", indent(ck.Expected))
+					}
+					if ck.Actual != "" {
+						fmt.Fprintf(b, "\nActual:\n%s\n", indent(ck.Actual))
+					}
 				}
 				if ck.Hint != "" {
 					fmt.Fprintf(b, "\nHint:\n  %s\n", ck.Hint)
@@ -123,11 +130,15 @@ func writeSuiteSteps(b *strings.Builder, color bool, suite, label string, steps 
 			}
 			fmt.Fprintf(b, "\n%s %s\n", colorize(color, cRed+cBold, label), suite)
 			fmt.Fprintf(b, "\nStep:\n  %s\n", ck.Desc)
-			if ck.Expected != "" {
-				fmt.Fprintf(b, "\nExpected:\n%s\n", indent(ck.Expected))
-			}
-			if ck.Actual != "" {
-				fmt.Fprintf(b, "\nActual:\n%s\n", indent(ck.Actual))
+			if diff := checkDiff(ck); diff != "" {
+				fmt.Fprintf(b, "\nDiff (-expected +actual):\n%s\n", indent(colorizeDiff(color, diff)))
+			} else {
+				if ck.Expected != "" {
+					fmt.Fprintf(b, "\nExpected:\n%s\n", indent(ck.Expected))
+				}
+				if ck.Actual != "" {
+					fmt.Fprintf(b, "\nActual:\n%s\n", indent(ck.Actual))
+				}
 			}
 			if ck.Hint != "" {
 				fmt.Fprintf(b, "\nHint:\n  %s\n", ck.Hint)

--- a/internal/report/diff.go
+++ b/internal/report/diff.go
@@ -1,0 +1,240 @@
+package report
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/nao1215/atago/internal/assert"
+)
+
+// diffMaxInputLines caps each side fed to the LCS table so a pathological
+// payload cannot blow up memory; anything beyond is cut with a note (the
+// full payloads live in --artifacts-dir sidecars).
+const diffMaxInputLines = 400
+
+// diffMaxOutputLines caps the rendered diff, mirroring the excerpt policy on
+// Expected/Actual.
+const diffMaxOutputLines = 120
+
+// noNewlineMarker is the classic diff annotation for a side that does not end
+// in a newline, so trailing-newline differences are visible instead of
+// invisible.
+const noNewlineMarker = `\ No newline at end of file`
+
+// checkDiff returns the unified diff for a failed check when a diff is the
+// clearer rendering: both full payloads present (equals/snapshot failures
+// carry them) and at least one side multi-line. Empty string means "keep the
+// compact Expected/Actual form". Payloads are masked by the engine before
+// they reach the report, so secrets cannot leak through context lines.
+func checkDiff(ck *assert.CheckResult) string {
+	if ck == nil || ck.OK || len(ck.ArtifactExpected) == 0 || len(ck.ArtifactActual) == 0 {
+		return ""
+	}
+	// Tree-manifest failures carry their own added/removed/changed summary
+	// (#25) — a better rendering for trees than a generic unified diff.
+	if ck.ArtifactKind == "tree" {
+		return ""
+	}
+	expected, actual := string(ck.ArtifactExpected), string(ck.ArtifactActual)
+	if !strings.Contains(strings.TrimRight(expected, "\n"), "\n") && !strings.Contains(strings.TrimRight(actual, "\n"), "\n") {
+		return ""
+	}
+	expectedLabel, actualLabel := "expected", "actual"
+	if ck.ArtifactKind == "snapshot" {
+		expectedLabel, actualLabel = "snapshot (golden)", "actual"
+	}
+	return unifiedDiff(expected, actual, expectedLabel, actualLabel)
+}
+
+// unifiedDiff renders a classic unified diff (3 context lines) between two
+// texts. It returns "" when the texts are equal.
+func unifiedDiff(expected, actual, expectedLabel, actualLabel string) string {
+	if expected == actual {
+		return ""
+	}
+	a, aTrunc := splitDiffLines(expected)
+	b, bTrunc := splitDiffLines(actual)
+
+	ops := diffOps(a, b)
+
+	var out []string
+	out = append(out, "--- "+expectedLabel, "+++ "+actualLabel)
+	hunks := groupHunks(ops, 3)
+	for _, h := range hunks {
+		out = append(out, fmt.Sprintf("@@ -%d,%d +%d,%d @@", h.aStart+1, h.aCount, h.bStart+1, h.bCount))
+		for _, op := range h.ops {
+			switch op.kind {
+			case ' ':
+				out = append(out, " "+a[op.aIdx])
+			case '-':
+				out = append(out, "-"+a[op.aIdx])
+			case '+':
+				out = append(out, "+"+b[op.bIdx])
+			}
+		}
+	}
+	// Cap the rendered hunks first so the annotations below always survive.
+	if len(out) > diffMaxOutputLines {
+		out = append(out[:diffMaxOutputLines], "... (diff truncated)")
+	}
+	if aTrunc || bTrunc {
+		out = append(out, fmt.Sprintf("... (inputs truncated at %d lines; full payloads in artifacts)", diffMaxInputLines))
+	}
+	if !strings.HasSuffix(expected, "\n") && strings.HasSuffix(actual, "\n") {
+		out = append(out, noNewlineMarker+" (expected)")
+	}
+	if strings.HasSuffix(expected, "\n") && !strings.HasSuffix(actual, "\n") {
+		out = append(out, noNewlineMarker+" (actual)")
+	}
+	return strings.Join(out, "\n")
+}
+
+// splitDiffLines splits text into lines for diffing (CRLF folded so an OS
+// line-ending artifact never renders a whole-file diff) and caps the count.
+func splitDiffLines(text string) (lines []string, truncated bool) {
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = strings.TrimSuffix(text, "\n")
+	if text == "" {
+		return nil, false
+	}
+	lines = strings.Split(text, "\n")
+	if len(lines) > diffMaxInputLines {
+		return lines[:diffMaxInputLines], true
+	}
+	return lines, false
+}
+
+// diffOp is one line of the diff script: ' ' common, '-' only in a, '+' only
+// in b.
+type diffOp struct {
+	kind       byte
+	aIdx, bIdx int
+}
+
+// diffOps computes a line-level diff via a classic LCS table — fine at the
+// capped input sizes and dependency-free, matching the repo's small-helper
+// style (color.go, excerpt).
+func diffOps(a, b []string) []diffOp {
+	n, m := len(a), len(b)
+	lcs := make([][]int, n+1)
+	for i := range lcs {
+		lcs[i] = make([]int, m+1)
+	}
+	for i := n - 1; i >= 0; i-- {
+		for j := m - 1; j >= 0; j-- {
+			if a[i] == b[j] {
+				lcs[i][j] = lcs[i+1][j+1] + 1
+			} else if lcs[i+1][j] >= lcs[i][j+1] {
+				lcs[i][j] = lcs[i+1][j]
+			} else {
+				lcs[i][j] = lcs[i][j+1]
+			}
+		}
+	}
+	var ops []diffOp
+	i, j := 0, 0
+	for i < n && j < m {
+		switch {
+		case a[i] == b[j]:
+			ops = append(ops, diffOp{' ', i, j})
+			i++
+			j++
+		case lcs[i+1][j] >= lcs[i][j+1]:
+			ops = append(ops, diffOp{'-', i, -1})
+			i++
+		default:
+			ops = append(ops, diffOp{'+', -1, j})
+			j++
+		}
+	}
+	for ; i < n; i++ {
+		ops = append(ops, diffOp{'-', i, -1})
+	}
+	for ; j < m; j++ {
+		ops = append(ops, diffOp{'+', -1, j})
+	}
+	return ops
+}
+
+// hunk is one @@-block: a run of changes with up to `context` common lines on
+// each side.
+type hunk struct {
+	aStart, aCount int
+	bStart, bCount int
+	ops            []diffOp
+}
+
+// groupHunks folds the op script into unified-diff hunks with the given
+// context width, merging hunks whose context would overlap.
+func groupHunks(ops []diffOp, context int) []hunk {
+	// Indices of change ops.
+	var changes []int
+	for i, op := range ops {
+		if op.kind != ' ' {
+			changes = append(changes, i)
+		}
+	}
+	if len(changes) == 0 {
+		return nil
+	}
+	var hunks []hunk
+	start := max(0, changes[0]-context)
+	end := min(len(ops), changes[0]+context+1)
+	for _, c := range changes[1:] {
+		if c-context <= end {
+			end = min(len(ops), c+context+1)
+			continue
+		}
+		hunks = append(hunks, buildHunk(ops[start:end]))
+		start = max(0, c-context)
+		end = min(len(ops), c+context+1)
+	}
+	hunks = append(hunks, buildHunk(ops[start:end]))
+	return hunks
+}
+
+func buildHunk(ops []diffOp) hunk {
+	h := hunk{ops: ops, aStart: -1, bStart: -1}
+	for _, op := range ops {
+		if op.aIdx >= 0 {
+			if h.aStart < 0 {
+				h.aStart = op.aIdx
+			}
+			h.aCount++
+		}
+		if op.bIdx >= 0 {
+			if h.bStart < 0 {
+				h.bStart = op.bIdx
+			}
+			h.bCount++
+		}
+	}
+	if h.aStart < 0 {
+		h.aStart = 0
+	}
+	if h.bStart < 0 {
+		h.bStart = 0
+	}
+	return h
+}
+
+// colorizeDiff applies the console palette to a rendered diff: removals red,
+// additions green, hunk headers and file labels dim. A no-op when color is
+// off (--ci / NO_COLOR / non-TTY).
+func colorizeDiff(on bool, diff string) string {
+	if !on || diff == "" {
+		return diff
+	}
+	lines := strings.Split(diff, "\n")
+	for i, l := range lines {
+		switch {
+		case strings.HasPrefix(l, "---") || strings.HasPrefix(l, "+++") || strings.HasPrefix(l, "@@"):
+			lines[i] = colorize(true, cDim, l)
+		case strings.HasPrefix(l, "-"):
+			lines[i] = colorize(true, cRed, l)
+		case strings.HasPrefix(l, "+"):
+			lines[i] = colorize(true, cGreen, l)
+		}
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/report/diff_test.go
+++ b/internal/report/diff_test.go
@@ -1,0 +1,123 @@
+package report
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nao1215/atago/internal/assert"
+)
+
+// TestUnifiedDiff_HunkPlacement pins hunk generation for a change at the
+// start, middle, and end of a document (#28).
+func TestUnifiedDiff_HunkPlacement(t *testing.T) {
+	t.Parallel()
+	base := "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\n"
+
+	middle := unifiedDiff(base, strings.Replace(base, "e\n", "E\n", 1), "expected", "actual")
+	for _, want := range []string{"--- expected", "+++ actual", "@@ -2,7 +2,7 @@", "-e", "+E", " d", " f"} {
+		if !strings.Contains(middle, want) {
+			t.Errorf("middle diff missing %q:\n%s", want, middle)
+		}
+	}
+	if strings.Contains(middle, " a\n") || strings.Contains(middle, " j") {
+		t.Errorf("middle diff leaked far context:\n%s", middle)
+	}
+
+	start := unifiedDiff(base, strings.Replace(base, "a\n", "A\n", 1), "expected", "actual")
+	if !strings.Contains(start, "@@ -1,4 +1,4 @@") || !strings.Contains(start, "-a") || !strings.Contains(start, "+A") {
+		t.Errorf("start diff wrong:\n%s", start)
+	}
+
+	end := unifiedDiff(base, strings.Replace(base, "j\n", "J\n", 1), "expected", "actual")
+	if !strings.Contains(end, "-j") || !strings.Contains(end, "+J") {
+		t.Errorf("end diff wrong:\n%s", end)
+	}
+}
+
+// TestUnifiedDiff_CRLFAndTrailingNewline proves CRLF inputs fold (an OS
+// artifact must not diff every line) while a trailing-newline difference is
+// rendered explicitly.
+func TestUnifiedDiff_CRLFAndTrailingNewline(t *testing.T) {
+	t.Parallel()
+	if got := unifiedDiff("a\r\nb\r\n", "a\nb\n", "expected", "actual"); !strings.Contains(got, noNewlineMarker) && got != "" {
+		// CRLF folding makes the contents equal; only the byte-level
+		// difference remains, which the caller treats as equal lines. The
+		// diff is header-only in that case — assert no +/- content lines.
+		for _, l := range strings.Split(got, "\n") {
+			if strings.HasPrefix(l, "-") && !strings.HasPrefix(l, "---") {
+				t.Errorf("CRLF-only difference produced content hunks:\n%s", got)
+			}
+		}
+	}
+	got := unifiedDiff("a\nb\n", "a\nb", "expected", "actual")
+	if !strings.Contains(got, noNewlineMarker+" (actual)") {
+		t.Errorf("trailing-newline difference not annotated:\n%s", got)
+	}
+}
+
+// TestUnifiedDiff_Truncation proves oversized inputs and long diffs are cut
+// with explicit notes.
+func TestUnifiedDiff_Truncation(t *testing.T) {
+	t.Parallel()
+	var a, b strings.Builder
+	for i := 0; i < diffMaxInputLines+50; i++ {
+		a.WriteString("same\n")
+		b.WriteString("diff\n")
+	}
+	got := unifiedDiff(a.String(), b.String(), "expected", "actual")
+	if !strings.Contains(got, "(diff truncated)") {
+		t.Errorf("long diff not truncated:\n...%s", got[len(got)-200:])
+	}
+	if !strings.Contains(got, "inputs truncated") {
+		t.Errorf("oversized inputs not annotated")
+	}
+}
+
+// TestCheckDiff_Eligibility proves the diff renders only for multi-line
+// two-sided failures; single-line failures keep the compact form.
+func TestCheckDiff_Eligibility(t *testing.T) {
+	t.Parallel()
+	multi := &assert.CheckResult{
+		ArtifactExpected: []byte("one\ntwo\nthree\n"),
+		ArtifactActual:   []byte("one\nTWO\nthree\n"),
+	}
+	if got := checkDiff(multi); !strings.Contains(got, "-two") || !strings.Contains(got, "+TWO") {
+		t.Errorf("multi-line diff = %q", got)
+	}
+	single := &assert.CheckResult{ArtifactExpected: []byte("x\n"), ArtifactActual: []byte("y\n")}
+	if got := checkDiff(single); got != "" {
+		t.Errorf("single-line failure should keep the compact form, got %q", got)
+	}
+	oneSided := &assert.CheckResult{ArtifactActual: []byte("a\nb\n")}
+	if got := checkDiff(oneSided); got != "" {
+		t.Errorf("one-sided failure should not diff, got %q", got)
+	}
+	snap := &assert.CheckResult{
+		ArtifactKind:     "snapshot",
+		ArtifactExpected: []byte("a\nb\n"),
+		ArtifactActual:   []byte("a\nc\n"),
+	}
+	if got := checkDiff(snap); !strings.Contains(got, "--- snapshot (golden)") {
+		t.Errorf("snapshot diff should label the golden side, got %q", got)
+	}
+}
+
+// TestColorizeDiff proves red/green/dim application and the NO_COLOR-off
+// path's byte-stability.
+func TestColorizeDiff(t *testing.T) {
+	t.Parallel()
+	diff := "--- expected\n+++ actual\n@@ -1,1 +1,1 @@\n-old\n+new\n context"
+	if got := colorizeDiff(false, diff); got != diff {
+		t.Errorf("color off must be byte-stable")
+	}
+	got := colorizeDiff(true, diff)
+	if !strings.Contains(got, cRed+"-old"+cReset) || !strings.Contains(got, cGreen+"+new"+cReset) {
+		t.Errorf("colorized = %q", got)
+	}
+	if !strings.Contains(got, cDim+"@@ -1,1 +1,1 @@"+cReset) {
+		t.Errorf("hunk header not dimmed: %q", got)
+	}
+	if strings.Contains(got, cRed+"--- expected") {
+		t.Errorf("file label wrongly red: %q", got)
+	}
+}

--- a/internal/report/json.go
+++ b/internal/report/json.go
@@ -56,11 +56,14 @@ type jsonServiceLog struct {
 }
 
 type jsonFailure struct {
-	Scenario  string         `json:"scenario"`
-	Step      string         `json:"step"`
-	Command   string         `json:"command,omitempty"`
-	Expected  string         `json:"expected,omitempty"`
-	Actual    string         `json:"actual,omitempty"`
+	Scenario string `json:"scenario"`
+	Step     string `json:"step"`
+	Command  string `json:"command,omitempty"`
+	Expected string `json:"expected,omitempty"`
+	Actual   string `json:"actual,omitempty"`
+	// Diff is the uncolored unified diff for multi-line equals/snapshot
+	// failures (#28) — additive, so schema_version stays "1".
+	Diff      string         `json:"diff,omitempty"`
 	Hint      string         `json:"hint,omitempty"`
 	Error     string         `json:"error,omitempty"`
 	Artifacts []jsonArtifact `json:"artifacts,omitempty"`
@@ -144,6 +147,7 @@ func suiteStepFailures(suite string, steps []engine.StepResult) []jsonFailure {
 				Step:     ck.Desc,
 				Expected: ck.Expected,
 				Actual:   ck.Actual,
+				Diff:     checkDiff(ck),
 				Hint:     ck.Hint,
 			})
 		}
@@ -173,6 +177,7 @@ func teardownFailuresOf(sc *engine.ScenarioResult) []jsonFailure {
 				Step:      ck.Desc,
 				Expected:  ck.Expected,
 				Actual:    ck.Actual,
+				Diff:      checkDiff(ck),
 				Hint:      ck.Hint,
 				Artifacts: artifactsOf(ck),
 			})
@@ -202,6 +207,7 @@ func failuresOf(sc *engine.ScenarioResult) []jsonFailure {
 				Command:   cmd,
 				Expected:  ck.Expected,
 				Actual:    ck.Actual,
+				Diff:      checkDiff(ck),
 				Hint:      ck.Hint,
 				Artifacts: artifactsOf(ck),
 			})

--- a/internal/report/junit.go
+++ b/internal/report/junit.go
@@ -121,11 +121,18 @@ func detailText(sc *engine.ScenarioResult) string {
 				continue
 			}
 			fmt.Fprintf(&b, "Step: %s\n", ck.Desc)
-			if ck.Expected != "" {
-				fmt.Fprintf(&b, "Expected: %s\n", ck.Expected)
-			}
-			if ck.Actual != "" {
-				fmt.Fprintf(&b, "Actual: %s\n", ck.Actual)
+			// Multi-line equals/snapshot failures embed the uncolored unified
+			// diff (#28); the compact form covers everything else. These
+			// bodies feed junit/tap/gha, which must stay ANSI-free.
+			if diff := checkDiff(ck); diff != "" {
+				fmt.Fprintf(&b, "Diff (-expected +actual):\n%s\n", diff)
+			} else {
+				if ck.Expected != "" {
+					fmt.Fprintf(&b, "Expected: %s\n", ck.Expected)
+				}
+				if ck.Actual != "" {
+					fmt.Fprintf(&b, "Actual: %s\n", ck.Actual)
+				}
 			}
 			if ck.Hint != "" {
 				fmt.Fprintf(&b, "Hint: %s\n", ck.Hint)

--- a/schema/report.schema.json
+++ b/schema/report.schema.json
@@ -90,6 +90,10 @@
         "command": {"type": "string"},
         "expected": {"type": "string"},
         "actual": {"type": "string"},
+        "diff": {
+          "description": "Uncolored unified diff for multi-line equals/snapshot failures (#28).",
+          "type": "string"
+        },
         "hint": {"type": "string"},
         "error": {"type": "string"},
         "artifacts": {

--- a/test/e2e/atago/reports.atago.yaml
+++ b/test/e2e/atago/reports.atago.yaml
@@ -126,3 +126,60 @@ scenarios:
           exit_code: 0
           stdout:
             contains: Bob
+
+  - name: a multi-line snapshot failure renders a unified diff with hunks
+    steps:
+      # Record a golden, mutate the output, and fail against it: the FAILED
+      # block shows -/+ hunk lines and the golden path (#28) instead of two
+      # raw dumps, and --report json carries the same diff additively.
+      - fixture:
+          file: diffspec.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: diffdemo
+            scenarios:
+              - name: multi-line output matches its golden
+                steps:
+                  - run:
+                      shell: true
+                      command: "printf 'alpha\\nbeta\\ngamma\\n'"
+                  - assert:
+                      stdout:
+                        snapshot: snaps/out.txt
+      - run:
+          command: ${atago} run --update-snapshots diffspec.atago.yaml
+      - assert:
+          exit_code: 0
+      - fixture:
+          file: diffspec.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: diffdemo
+            scenarios:
+              - name: multi-line output matches its golden
+                steps:
+                  - run:
+                      shell: true
+                      command: "printf 'alpha\\nBETA\\ngamma\\n'"
+                  - assert:
+                      stdout:
+                        snapshot: snaps/out.txt
+      - run:
+          command: ${atago} run diffspec.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "Diff (-expected +actual):"
+              - "--- snapshot (golden)"
+              - "-beta"
+              - "+BETA"
+              - "snaps/out.txt"
+      - run:
+          shell: true
+          command: ${atago} run --report json diffspec.atago.yaml; true
+      - assert:
+          stdout:
+            contains: '"diff":'


### PR DESCRIPTION
## Summary

This PR renders a colorized unified diff in failure output for multi-line `equals`/`snapshot` mismatches (#28) — the highest-leverage red-path UX fix: a one-character difference no longer hides inside two raw Expected/Actual dumps. Single-line failures keep the compact form.

## Changes

- `internal/report/diff.go` (new, dependency-free per the repo's small-helper style): LCS line diff → classic unified hunks (3 context lines, merged when overlapping), CRLF folded before diffing (an OS artifact must not diff every line) with trailing-newline differences annotated `\ No newline at end of file`, inputs capped at 400 lines and rendered hunks at 120 with explicit truncation notes pointing at the artifact sidecars.
- Console (`writeDetail`/`writeSuiteSteps`): failed checks carrying BOTH full payloads (equals and snapshot failures do, via ArtifactExpected/ArtifactActual — already masked by the engine, so secrets cannot leak through context lines) render "Diff (-expected +actual):" — removals red, additions green, headers dimmed via the existing palette; `--ci`/`NO_COLOR`/non-TTY stay byte-stable uncolored. Snapshot sides are labeled "snapshot (golden)" / "actual", and the Hint keeps printing the golden's relative path.
- Tree-manifest failures (#25) keep their domain-specific added/removed/changed summary: their checks now carry the distinct "tree" artifact kind, which the generic diff skips.
- JSON report: additive `diff` field on failure entries (uncolored; schema_version stays "1"); `schema/report.schema.json` failure def updated (additionalProperties: false requires it). junit/tap/gha embed the uncolored diff in their existing ANSI-free detail bodies.
- README "When a check fails" now shows a real diff-style failure (regenerated from actual output), CHANGELOG entry.
- Tests: hunk placement (start/middle/end), CRLF vs LF, trailing-newline annotation, input+output truncation, eligibility rules (single-line/one-sided keep compact; snapshot labeling; tree exemption), color application + byte-stability with color off; self-hosted E2E extension in `reports.atago.yaml` proving -/+ hunk lines, the golden path, and the JSON `diff` field on a real failing snapshot run.

Closes #28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-line `equals` and `snapshot` failures now show a unified diff view, including colorized console output.
  * JSON, JUnit, TAP, and GitHub-style reports now include diff details for applicable failures.
* **Bug Fixes**
  * Single-line and one-sided failures continue to use the compact expected/actual format.
  * Large or truncated inputs are handled gracefully, with diff output capped to keep reports readable.
* **Documentation**
  * Updated getting-started docs and examples to show the new failure output format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->