### PR TITLE
feat(cli): add atago record to generate a spec skeleton from an observed run

### DIFF
--- a/.github/workflows/e2e-cross.yml
+++ b/.github/workflows/e2e-cross.yml
@@ -65,6 +65,7 @@ jobs:
               ./test/e2e/atago/http.atago.yaml
               ./test/e2e/atago/mock_server.atago.yaml
               ./test/e2e/atago/dir_tree.atago.yaml
+              ./test/e2e/atago/record.atago.yaml
               ./test/e2e/atago/grpc.atago.yaml
               ./test/e2e/atago/ssh.atago.yaml
               ./test/e2e/atago/cdp.atago.yaml

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -120,6 +120,7 @@ jobs:
           ./test/e2e/atago/http.atago.yaml
           ./test/e2e/atago/mock_server.atago.yaml
           ./test/e2e/atago/dir_tree.atago.yaml
+          ./test/e2e/atago/record.atago.yaml
           ./test/e2e/atago/grpc.atago.yaml
           ./test/e2e/atago/ssh.atago.yaml
           ./test/e2e/atago/cdp.atago.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ and this project follows [Semantic Versioning](https://semver.org/).
   (`SystemRoot`, `SystemDrive`, `TEMP`, `TMP`, `PATHEXT`) is always retained.
   `pass_env` without `clear_env: true` is a load-time error (exit 2).
   See `examples/hermetic_env.atago.yaml`.
+- `atago record -- <command>` (#30): run a command once in a scratch
+  directory and generate a ready-to-edit spec skeleton from what it observed
+  — exact exit code, the first non-empty stdout line as a `contains`
+  matcher, `stderr: {empty: true}` when stderr was silent, and created
+  files as `exists` asserts (capped at 10 with a note). `--out`/`--force`
+  mirror `init`; `--shell` records shell command lines; `--snapshot` writes
+  a stdout golden instead. The generated spec is validated in-process
+  before it is written. Interactive (pty) and HTTP recording are explicit
+  non-goals for now.
 - Flaky-test tooling (#29): `--repeat N` runs each selected scenario N times
   (fresh workdir per iteration, sequential per scenario) to detect
   flakiness — any failing iteration fails the run and the console reports

--- a/README.md
+++ b/README.md
@@ -132,6 +132,20 @@ Hint:
   the substring "Alice" was not present in stdout
 ```
 
+Already have a working command? `atago record -- <command>` runs it once in a scratch directory and generates a spec from what it observed — exit code, first output line, created files — so you start from *your* tool's behavior instead of a blank file:
+
+```shell
+$ atago record --out mytool.atago.yaml -- mytool convert input.txt
+recorded: exit 0, 2 stdout line(s), 1 file(s) created
+wrote mytool.atago.yaml
+$ atago run mytool.atago.yaml
+.
+
+PASSED  1 scenario: 1 passed, 0 failed, 0 errored, 0 skipped (12ms)
+```
+
+The generated matchers are deliberately conservative (a skeleton to tighten, not a brittle golden); `--snapshot` records a stdout golden instead, and `--shell` records shell-style command lines.
+
 `atago init --template <name>` scaffolds a starter for the other runner families; `atago init --list-templates` describes each one and says whether it runs as-is or what to edit first:
 
 ```shell

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-50 suites · 176 scenarios
+51 suites · 181 scenarios
 ## Contents
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 3 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
@@ -147,6 +147,12 @@
   - [screen asserts see the final frame where the transcript sees history](#scenario-screen-asserts-see-the-final-frame-where-the-transcript-sees-history)
   - [a screen snapshot round-trips through update and compare](#scenario-a-screen-snapshot-round-trips-through-update-and-compare)
   - [a screen assert without a pty step is a load-time error](#scenario-a-screen-assert-without-a-pty-step-is-a-load-time-error)
+- [atago self-hosting / record (spec skeleton from an observed run)](#atago-self-hosting--record-spec-skeleton-from-an-observed-run) — 5 scenarios
+  - [record then run round-trips green](#scenario-record-then-run-round-trips-green)
+  - [refusing to overwrite without --force](#scenario-refusing-to-overwrite-without---force)
+  - [created files become exists asserts (shell mode)](#scenario-created-files-become-exists-asserts-shell-mode)
+  - [snapshot mode writes a golden the run then matches](#scenario-snapshot-mode-writes-a-golden-the-run-then-matches)
+  - [no command is a usage error](#scenario-no-command-is-a-usage-error)
 - [atago self-hosting / reports](#atago-self-hosting--reports) — 5 scenarios
   - [JUnit report is XML with a testsuite and testcase](#scenario-junit-report-is-xml-with-a-testsuite-and-testcase)
   - [GitHub Actions annotations are emitted on failure](#scenario-github-actions-annotations-are-emitted-on-failure)
@@ -2629,6 +2635,80 @@ ${atago} run bad.atago.yaml
 #### Then
 - exit code is `2`
 - stderr contains `requires a preceding pty step`
+## atago self-hosting / record (spec skeleton from an observed run)
+Source: `test/e2e/atago/record.atago.yaml`
+### Scenario: record then run round-trips green
+#### When
+```shell
+${atago} record --out recorded.atago.yaml -- ${atago} version
+${atago} run recorded.atago.yaml
+```
+#### Then
+- after `${atago} record --out recorded.atago.yaml -- ${atago} version`:
+  - exit code is `0`
+  - stderr contains `wrote recorded.atago.yaml`
+  - file `recorded.atago.yaml` contains `contains: atago`
+- after `${atago} run recorded.atago.yaml`:
+  - exit code is `0`
+  - stdout contains `1 passed`
+### Scenario: refusing to overwrite without --force
+#### Given
+- Fixture file `existing.atago.yaml` is created.
+#### Inputs
+_Fixture `existing.atago.yaml`:_
+```text
+precious
+```
+#### When
+```shell
+${atago} record --out existing.atago.yaml -- ${atago} version
+${atago} record --force --out existing.atago.yaml -- ${atago} version
+```
+#### Then
+- after `${atago} record --out existing.atago.yaml -- ${atago} version`:
+  - exit code is `3`
+  - stderr contains `use --force to overwrite`
+  - file `existing.atago.yaml` contains `precious`
+- after `${atago} record --force --out existing.atago.yaml -- ${atago} version`:
+  - exit code is `0`
+  - file `existing.atago.yaml` contains `exit_code: 0`
+### Scenario: created files become exists asserts (shell mode)
+_skipped on windows_
+#### When
+```shell
+${atago} record --shell --out gen.atago.yaml -- 'echo made > out.txt; echo done'
+${atago} run gen.atago.yaml
+```
+#### Then
+- after `${atago} record --shell --out gen.atago.yaml -- 'echo made > out.txt; echo done'`:
+  - exit code is `0`
+  - file `gen.atago.yaml` contains `path: out.txt`
+  - file `gen.atago.yaml` contains `shell: true`
+- after `${atago} run gen.atago.yaml`:
+  - exit code is `0`
+### Scenario: snapshot mode writes a golden the run then matches
+_skipped on windows_
+#### When
+```shell
+${atago} record --snapshot --out snapdemo.atago.yaml -- echo stable output
+${atago} run snapdemo.atago.yaml
+```
+#### Then
+- after `${atago} record --snapshot --out snapdemo.atago.yaml -- echo stable output`:
+  - exit code is `0`
+  - file `snapdemo.atago.yaml` contains `snapshot: snapshots/snapdemo.stdout.txt`
+  - file `snapshots/snapdemo.stdout.txt` contains `stable output`
+- after `${atago} run snapdemo.atago.yaml`:
+  - exit code is `0`
+  - stdout contains `1 passed`
+### Scenario: no command is a usage error
+#### When
+```shell
+${atago} record
+```
+#### Then
+- exit code is `3`
+- stderr contains `no command given`
 ## atago self-hosting / reports
 Source: `test/e2e/atago/reports.atago.yaml`
 ### Scenario: JUnit report is XML with a testsuite and testcase

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -33,6 +33,8 @@ func Main(args []string, stdout, stderr io.Writer) int {
 		return runCmd(rest, stdout, stderr)
 	case "init":
 		return initCmd(rest, stdout, stderr)
+	case "record":
+		return recordCmd(rest, stdout, stderr)
 	case "explain":
 		return explainCmd(rest, stdout, stderr)
 	case "doc":
@@ -70,7 +72,8 @@ Usage:
 
 Commands:
   run         Run spec files and assert behavior
-  init        Scaffold a starter spec file (--template browser|cli|db|grpc|http|services|ssh)
+  init        Scaffold a starter spec file (--template browser|cli|db|grpc|http|mock|services|ssh)
+  record      Generate a spec skeleton from one observed command run (record -- <cmd>)
   list        List suites, scenarios, tags, and generated artifacts (--json)
   explain     Describe what a spec does without running it
   doc         Generate Markdown documentation from specs

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -19,6 +19,7 @@ var subcommandNames = []string{
 	"init",
 	"list",
 	"manifest",
+	"record",
 	"run",
 	"snapshot",
 	"version",

--- a/internal/cli/record.go
+++ b/internal/cli/record.go
@@ -1,0 +1,177 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/nao1215/atago/internal/record"
+	runnercmd "github.com/nao1215/atago/internal/runner/cmd"
+	"github.com/nao1215/atago/internal/snapshot"
+	"github.com/nao1215/atago/internal/spec"
+)
+
+// recordCmd implements `atago record -- <command> [args...]` (#30): run the
+// command once in a fresh scratch dir (never the user's cwd), observe its
+// exit code, streams, and created files, and emit a ready-to-edit spec
+// skeleton with conservative matchers.
+func recordCmd(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("atago record", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	out := fs.String("out", "", "write the generated spec to this file (default: stdout)")
+	force := fs.Bool("force", false, "overwrite --out if it already exists")
+	shell := fs.Bool("shell", false, "record the command line verbatim with shell: true")
+	snap := fs.Bool("snapshot", false, "assert stdout against a snapshot golden (requires --out; the golden is written next to it)")
+	fs.Usage = func() {
+		fmt.Fprint(stderr, `Usage: atago record [--out FILE] [--force] [--shell] [--snapshot] -- <command> [args...]
+
+Runs the command once in a scratch directory and prints a spec skeleton
+derived from what it observed: exit code, first stdout line, empty stderr,
+and created files. Interactive (pty) and HTTP recording are non-goals for
+now — write those steps by hand.
+`)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return ExitOK
+		}
+		return ExitConfig
+	}
+	cmdArgs := fs.Args()
+	if len(cmdArgs) == 0 {
+		fmt.Fprintln(stderr, "atago record: no command given (usage: atago record [flags] -- <command> [args...])")
+		return ExitConfig
+	}
+	if *snap && *out == "" {
+		fmt.Fprintln(stderr, "atago record: --snapshot needs --out (the golden is written next to the spec)")
+		return ExitConfig
+	}
+
+	command := strings.Join(cmdArgs, " ")
+	workdir, err := os.MkdirTemp("", "atago-record-")
+	if err != nil {
+		fmt.Fprintf(stderr, "atago record: could not create scratch dir: %v\n", err)
+		return ExitExec
+	}
+	defer func() { _ = os.RemoveAll(workdir) }() // best-effort scratch cleanup
+
+	run := &spec.Run{Command: command}
+	if *shell {
+		run.Shell = spec.Bool(true)
+	}
+	res, err := runnercmd.New().Run(context.Background(), run, workdir)
+	if err != nil {
+		fmt.Fprintf(stderr, "atago record: %v\n", err)
+		return ExitExec
+	}
+
+	created, err := listFiles(workdir)
+	if err != nil {
+		fmt.Fprintf(stderr, "atago record: could not inspect the scratch dir: %v\n", err)
+		return ExitExec
+	}
+
+	obs := record.Observation{
+		Command:      command,
+		Shell:        *shell,
+		ExitCode:     res.ExitCode,
+		Stdout:       res.Stdout,
+		Stderr:       res.Stderr,
+		CreatedFiles: created,
+	}
+	opts := record.Options{SuiteName: suiteNameFor(cmdArgs[0])}
+	if *snap {
+		opts.Snapshot = true
+		opts.SnapshotPath = "snapshots/" + strings.TrimSuffix(filepath.Base(*out), ".atago.yaml") + ".stdout.txt"
+	}
+	generated, err := record.Generate(obs, opts)
+	if err != nil {
+		fmt.Fprintf(stderr, "atago record: %v\n", err)
+		return ExitInternal
+	}
+
+	fmt.Fprintf(stderr, "recorded: exit %d, %d stdout line(s), %d file(s) created\n",
+		res.ExitCode, countLines(res.Stdout), len(created))
+
+	if *out == "" {
+		fmt.Fprint(stdout, string(generated))
+		return ExitOK
+	}
+	if _, err := os.Stat(*out); err == nil && !*force {
+		fmt.Fprintf(stderr, "atago record: %q already exists (use --force to overwrite)\n", *out)
+		return ExitConfig
+	}
+	if dir := filepath.Dir(*out); dir != "." {
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			fmt.Fprintf(stderr, "atago record: %v\n", err)
+			return ExitExec
+		}
+	}
+	if *snap {
+		golden := filepath.Join(filepath.Dir(*out), filepath.FromSlash(opts.SnapshotPath))
+		if err := snapshot.Update(golden, res.Stdout, snapshot.Options{Workdir: workdir}); err != nil {
+			fmt.Fprintf(stderr, "atago record: could not write snapshot golden: %v\n", err)
+			return ExitExec
+		}
+		fmt.Fprintf(stderr, "wrote %s\n", golden)
+	}
+	if err := os.WriteFile(*out, generated, 0o644); err != nil { //nolint:gosec // a spec file the user asked for
+		fmt.Fprintf(stderr, "atago record: %v\n", err)
+		return ExitExec
+	}
+	fmt.Fprintf(stderr, "wrote %s\n", *out)
+	return ExitOK
+}
+
+// listFiles walks the scratch dir and returns every file as a sorted,
+// /-separated relative path — the created-files diff (the dir starts empty).
+func listFiles(root string) ([]string, error) {
+	var out []string
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, rerr := filepath.Rel(root, p)
+		if rerr != nil {
+			return rerr
+		}
+		out = append(out, filepath.ToSlash(rel))
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// suiteNameFor derives a suite name from the command's base name.
+func suiteNameFor(argv0 string) string {
+	name := filepath.Base(filepath.FromSlash(argv0))
+	name = strings.TrimSuffix(name, ".exe")
+	if name == "" || name == "." {
+		return "recorded"
+	}
+	return name
+}
+
+func countLines(stream []byte) int {
+	n := 0
+	for _, l := range strings.Split(string(stream), "\n") {
+		if strings.TrimSpace(l) != "" {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/cli/testdata/completion/bash.txt
+++ b/internal/cli/testdata/completion/bash.txt
@@ -7,7 +7,7 @@ _atago() {
         cur="${COMP_WORDS[COMP_CWORD]}"
         prev="${COMP_WORDS[COMP_CWORD-1]}"
     }
-    local commands="completion doc explain help init list manifest run snapshot version"
+    local commands="completion doc explain help init list manifest record run snapshot version"
     local run_flags="--artifacts-dir --ci --fail-fast --filter --parallel --repeat --report --rerun-failed --retry-failed --skip-tag --tag --update-snapshots --verbose"
     if [ "${COMP_CWORD}" -eq 1 ]; then
         COMPREPLY=( $(compgen -W "${commands}" -- "${cur}") )

--- a/internal/cli/testdata/completion/fish.txt
+++ b/internal/cli/testdata/completion/fish.txt
@@ -8,6 +8,7 @@ complete -c atago -n '__fish_use_subcommand' -a help
 complete -c atago -n '__fish_use_subcommand' -a init
 complete -c atago -n '__fish_use_subcommand' -a list
 complete -c atago -n '__fish_use_subcommand' -a manifest
+complete -c atago -n '__fish_use_subcommand' -a record
 complete -c atago -n '__fish_use_subcommand' -a run
 complete -c atago -n '__fish_use_subcommand' -a snapshot
 complete -c atago -n '__fish_use_subcommand' -a version

--- a/internal/cli/testdata/completion/powershell.txt
+++ b/internal/cli/testdata/completion/powershell.txt
@@ -2,7 +2,7 @@
 # Install: atago completion powershell | Out-String | Invoke-Expression
 Register-ArgumentCompleter -Native -CommandName atago -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
-    $commands = @('completion', 'doc', 'explain', 'help', 'init', 'list', 'manifest', 'run', 'snapshot', 'version')
+    $commands = @('completion', 'doc', 'explain', 'help', 'init', 'list', 'manifest', 'record', 'run', 'snapshot', 'version')
     $runFlags = @('--artifacts-dir', '--ci', '--fail-fast', '--filter', '--parallel', '--repeat', '--report', '--rerun-failed', '--retry-failed', '--skip-tag', '--tag', '--update-snapshots', '--verbose')
     $tokens = $commandAst.CommandElements
     if ($tokens.Count -le 2) {

--- a/internal/cli/testdata/completion/zsh.txt
+++ b/internal/cli/testdata/completion/zsh.txt
@@ -3,7 +3,7 @@
 # Install: atago completion zsh > "${fpath[1]}/_atago"
 _atago() {
     local -a commands run_flags
-    commands=(completion doc explain help init list manifest run snapshot version)
+    commands=(completion doc explain help init list manifest record run snapshot version)
     run_flags=(--artifacts-dir --ci --fail-fast --filter --parallel --repeat --report --rerun-failed --retry-failed --skip-tag --tag --update-snapshots --verbose)
     if (( CURRENT == 2 )); then
         compadd -- ${commands}

--- a/internal/engine/attempts.go
+++ b/internal/engine/attempts.go
@@ -35,7 +35,7 @@ func (e *Engine) runRepeated(ctx context.Context, idx int, sc *spec.Scenario, rc
 
 	for i := 0; i < e.Repeat; i++ {
 		if ctx.Err() != nil && i > 0 {
-			break // cancelled mid-repeat: report what actually ran
+			break // canceled mid-repeat: report what actually ran
 		}
 		run := e.runScenario(ctx, idx, sc, rc)
 		iterations = append(iterations, run.Status)

--- a/internal/record/record.go
+++ b/internal/record/record.go
@@ -1,0 +1,124 @@
+// Package record generates a ready-to-edit spec skeleton from one observed
+// command run (#30) — the answer to the blank-YAML problem. It is
+// deliberately a skeleton generator with conservative matchers the author
+// then tightens, not a brittle exact-golden recorder.
+package record
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/goccy/go-yaml"
+	"github.com/nao1215/atago/internal/loader"
+)
+
+// maxFileAsserts caps the generated file.exists asserts so a command that
+// explodes a tree does not produce an unreadable spec; the rest is noted in a
+// comment.
+const maxFileAsserts = 10
+
+// Observation is what one command run produced.
+type Observation struct {
+	// Command is the recorded command line, verbatim.
+	Command string
+	// Shell marks the run as shell-executed (`--shell`).
+	Shell bool
+	// ExitCode is the observed exit code.
+	ExitCode int
+	// Stdout / Stderr are the captured streams.
+	Stdout []byte
+	Stderr []byte
+	// CreatedFiles lists workdir-relative /-separated files the command
+	// created, sorted.
+	CreatedFiles []string
+}
+
+// Options tunes generation.
+type Options struct {
+	// SuiteName names the suite (default: first command token's base name).
+	SuiteName string
+	// Snapshot switches the stdout assert to a snapshot matcher referencing
+	// SnapshotPath (spec-relative).
+	Snapshot     bool
+	SnapshotPath string
+}
+
+// Generate renders the spec skeleton and proves it loads cleanly — a
+// generated spec that fails validation is an internal bug, never the user's
+// problem.
+func Generate(obs Observation, opts Options) ([]byte, error) {
+	var b strings.Builder
+	b.WriteString("version: \"1\"\n\n")
+	b.WriteString("# Recorded by `atago record` — a starting point, not a verdict:\n")
+	b.WriteString("# tighten the matchers to pin the behavior you actually care about.\n")
+	fmt.Fprintf(&b, "suite:\n  name: %s\n\n", yamlScalar(opts.SuiteName))
+	b.WriteString("scenarios:\n")
+	fmt.Fprintf(&b, "  - name: %s # TODO: describe the behavior\n", yamlScalar(obs.Command))
+	b.WriteString("    steps:\n")
+	b.WriteString("      - run:\n")
+	if obs.Shell {
+		b.WriteString("          shell: true\n")
+	}
+	fmt.Fprintf(&b, "          command: %s\n", yamlScalar(obs.Command))
+	b.WriteString("      - assert:\n")
+	fmt.Fprintf(&b, "          exit_code: %d\n", obs.ExitCode)
+
+	switch {
+	case opts.Snapshot:
+		b.WriteString("      - assert:\n")
+		b.WriteString("          stdout:\n")
+		fmt.Fprintf(&b, "            snapshot: %s\n", yamlScalar(opts.SnapshotPath))
+	case firstLine(obs.Stdout) != "":
+		b.WriteString("      - assert:\n")
+		b.WriteString("          stdout:\n")
+		fmt.Fprintf(&b, "            contains: %s # first non-empty line, trimmed\n", yamlScalar(firstLine(obs.Stdout)))
+	}
+	if len(obs.Stderr) == 0 {
+		b.WriteString("      - assert:\n")
+		b.WriteString("          stderr:\n")
+		b.WriteString("            empty: true\n")
+	}
+
+	files := obs.CreatedFiles
+	capped := false
+	if len(files) > maxFileAsserts {
+		files = files[:maxFileAsserts]
+		capped = true
+	}
+	for _, f := range files {
+		b.WriteString("      - assert:\n")
+		b.WriteString("          file:\n")
+		fmt.Fprintf(&b, "            path: %s\n", yamlScalar(f))
+		b.WriteString("            exists: true\n")
+	}
+	if capped {
+		fmt.Fprintf(&b, "      # ... and %d more created files not asserted here\n", len(obs.CreatedFiles)-maxFileAsserts)
+	}
+
+	out := []byte(b.String())
+	if _, err := loader.LoadBytes("recorded.atago.yaml", out); err != nil {
+		return nil, fmt.Errorf("generated spec does not validate (this is an atago bug, please report it): %w", err)
+	}
+	return out, nil
+}
+
+// firstLine returns the first non-empty line, trimmed.
+func firstLine(stream []byte) string {
+	for _, l := range strings.Split(string(stream), "\n") {
+		if t := strings.TrimSpace(l); t != "" {
+			return t
+		}
+	}
+	return ""
+}
+
+// yamlScalar renders an arbitrary string as one safe inline YAML scalar,
+// delegating quoting decisions to the YAML library so recorded commands and
+// output can never break the document structure.
+func yamlScalar(s string) string {
+	out, err := yaml.Marshal(s)
+	if err != nil {
+		return fmt.Sprintf("%q", s)
+	}
+	return strings.TrimRight(string(out), "\n")
+}

--- a/internal/record/record_test.go
+++ b/internal/record/record_test.go
@@ -1,0 +1,122 @@
+package record
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/atago/internal/loader"
+)
+
+// TestGenerate_Skeleton pins the conservative matcher policy (#30): exact
+// exit code, first non-empty stdout line as contains, stderr empty only when
+// it was, created files as exists asserts.
+func TestGenerate_Skeleton(t *testing.T) {
+	t.Parallel()
+	out, err := Generate(Observation{
+		Command:      "mytool convert input.txt",
+		ExitCode:     0,
+		Stdout:       []byte("\nconverted 3 records\ndetails follow\n"),
+		Stderr:       nil,
+		CreatedFiles: []string{"output.json"},
+	}, Options{SuiteName: "mytool"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"suite:\n  name: mytool",
+		"# TODO: describe the behavior",
+		"command: mytool convert input.txt",
+		"exit_code: 0",
+		"contains: converted 3 records",
+		"empty: true",
+		"path: output.json",
+		"exists: true",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("generated spec missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestGenerate_EdgeShapes proves generation stays valid across observed
+// shapes: empty output, non-zero exit, noisy stderr, shell mode, file cap,
+// and hostile strings that must not break YAML structure.
+func TestGenerate_EdgeShapes(t *testing.T) {
+	t.Parallel()
+	files := make([]string, 15)
+	for i := range files {
+		files[i] = fmt.Sprintf("out/f%02d.txt", i)
+	}
+	cases := []struct {
+		name string
+		obs  Observation
+		want []string
+	}{
+		{
+			name: "empty output nonzero exit",
+			obs:  Observation{Command: "false", ExitCode: 1},
+			want: []string{"exit_code: 1", "empty: true"},
+		},
+		{
+			name: "noisy stderr drops the empty assert",
+			obs:  Observation{Command: "tool", ExitCode: 0, Stderr: []byte("warn\n")},
+			want: []string{"exit_code: 0"},
+		},
+		{
+			name: "shell mode",
+			obs:  Observation{Command: "echo a | grep a", Shell: true, ExitCode: 0, Stdout: []byte("a\n")},
+			want: []string{"shell: true", "command: echo a | grep a"},
+		},
+		{
+			name: "file cap notes the rest",
+			obs:  Observation{Command: "gen", ExitCode: 0, CreatedFiles: files},
+			want: []string{"path: out/f09.txt", "and 5 more created files"},
+		},
+		{
+			name: "hostile strings stay one scalar",
+			obs:  Observation{Command: `tool --msg "a: b # c"`, ExitCode: 0, Stdout: []byte("line: with { yaml } chars\n")},
+			want: []string{"exit_code: 0"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out, err := Generate(tc.obs, Options{SuiteName: "s"})
+			if err != nil {
+				t.Fatalf("Generate: %v", err)
+			}
+			if _, lerr := loader.LoadBytes("g.atago.yaml", out); lerr != nil {
+				t.Fatalf("generated spec does not load: %v\n%s", lerr, out)
+			}
+			for _, w := range tc.want {
+				if !strings.Contains(string(out), w) {
+					t.Errorf("missing %q:\n%s", w, out)
+				}
+			}
+			if strings.Contains(string(out), "out/f10.txt") {
+				t.Errorf("file cap leaked an 11th assert:\n%s", out)
+			}
+		})
+	}
+}
+
+// TestGenerate_Snapshot proves --snapshot switches stdout to the snapshot
+// matcher referencing the given golden path.
+func TestGenerate_Snapshot(t *testing.T) {
+	t.Parallel()
+	out, err := Generate(
+		Observation{Command: "tool", ExitCode: 0, Stdout: []byte("big output\n")},
+		Options{SuiteName: "s", Snapshot: true, SnapshotPath: "snapshots/tool.stdout.txt"},
+	)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if !strings.Contains(string(out), "snapshot: snapshots/tool.stdout.txt") {
+		t.Errorf("snapshot matcher missing:\n%s", out)
+	}
+	if strings.Contains(string(out), "contains:") {
+		t.Errorf("snapshot mode must replace the contains matcher:\n%s", out)
+	}
+}

--- a/test/e2e/atago/record.atago.yaml
+++ b/test/e2e/atago/record.atago.yaml
@@ -1,0 +1,104 @@
+version: "1"
+
+suite:
+  name: atago self-hosting / record (spec skeleton from an observed run)
+
+# Exercises #30: the record → run round-trip is the core acceptance test —
+# a spec generated from an observed command must pass when run. The echo
+# scenarios run on every OS (this spec is in the Windows E2E allowlist);
+# the shell-redirect scenario is POSIX.
+scenarios:
+  - name: record then run round-trips green
+    steps:
+      # `${atago} version` is the one command guaranteed present on every OS.
+      - run:
+          command: ${atago} record --out recorded.atago.yaml -- ${atago} version
+      - assert:
+          exit_code: 0
+          stderr:
+            contains: "wrote recorded.atago.yaml"
+      - assert:
+          file:
+            path: recorded.atago.yaml
+            contains: "contains: atago"
+      - run:
+          command: ${atago} run recorded.atago.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "1 passed"
+
+  - name: refusing to overwrite without --force
+    steps:
+      - fixture:
+          file: existing.atago.yaml
+          content: "precious"
+      - run:
+          command: ${atago} record --out existing.atago.yaml -- ${atago} version
+      - assert:
+          exit_code: 3
+          stderr:
+            contains: "use --force to overwrite"
+      - assert:
+          file:
+            path: existing.atago.yaml
+            contains: precious
+      - run:
+          command: ${atago} record --force --out existing.atago.yaml -- ${atago} version
+      - assert:
+          exit_code: 0
+          file:
+            path: existing.atago.yaml
+            contains: "exit_code: 0"
+
+  - name: created files become exists asserts (shell mode)
+    skip:
+      os: windows
+    steps:
+      - run:
+          shell: true
+          command: "${atago} record --shell --out gen.atago.yaml -- 'echo made > out.txt; echo done'"
+      - assert:
+          exit_code: 0
+          file:
+            path: gen.atago.yaml
+            contains: "path: out.txt"
+      - assert:
+          file:
+            path: gen.atago.yaml
+            contains: "shell: true"
+      - run:
+          command: ${atago} run gen.atago.yaml
+      - assert:
+          exit_code: 0
+
+  - name: snapshot mode writes a golden the run then matches
+    skip:
+      os: windows
+    steps:
+      - run:
+          command: ${atago} record --snapshot --out snapdemo.atago.yaml -- echo stable output
+      - assert:
+          exit_code: 0
+          file:
+            path: snapdemo.atago.yaml
+            contains: "snapshot: snapshots/snapdemo.stdout.txt"
+      - assert:
+          file:
+            path: snapshots/snapdemo.stdout.txt
+            contains: stable output
+      - run:
+          command: ${atago} run snapdemo.atago.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "1 passed"
+
+  - name: no command is a usage error
+    steps:
+      - run:
+          command: ${atago} record
+      - assert:
+          exit_code: 3
+          stderr:
+            contains: "no command given"


### PR DESCRIPTION
## Summary

This PR adds `atago record -- <command> [args...]` (#30): run a command once in a fresh scratch directory (never the user's cwd), observe its exit code, streams, and created files, and emit a ready-to-edit spec skeleton — the answer to the blank-YAML adoption hurdle. Deliberately a conservative skeleton generator, not a brittle exact-golden recorder.

## Changes

- `internal/record` (new): generation with the documented v1 matcher policy — exact `exit_code`, first non-empty stdout line as `contains`, `stderr: {empty: true}` only when stderr was silent, created files as `exists` asserts capped at 10 with a comment noting the rest, `--snapshot` switching stdout to a `snapshot:` matcher. Every generated spec is validated through the real loader before it leaves the function (a validation failure is exit 5 — an atago bug, never the user's). Arbitrary strings are marshaled through the YAML library so hostile commands/output cannot break document structure.
- `internal/cli/record.go`: flags `--out` (default stdout) / `--force` (mirroring `init`'s overwrite refusal, exit 3) / `--shell` / `--snapshot` (requires `--out`; writes the normalized golden next to the spec); `recorded: exit N, X stdout line(s), Y file(s) created` summary on stderr; pty/HTTP recording named as non-goals in `--help`.
- CLI registration, top-level usage (also now mentions the `mock` init template), completion subcommand list + regenerated goldens.
- Docs: README Getting-started "record your first spec" subsection with a transcript, CHANGELOG entry. Drive-by: the reviewdog misspell nit from PR #55 (`cancelled`→`canceled` in a comment).
- Tests: generation goldens across observed shapes (empty output, non-zero exit, noisy stderr, shell mode, >10-file cap, hostile YAML-breaking strings — each also proving generate→load), snapshot-mode switch; self-hosted E2E `test/e2e/atago/record.atago.yaml` with the record→run round-trip as the core acceptance (using `${atago} version` as the recorded command so it runs on every OS — the spec joins BOTH Windows E2E allowlists), `--force` behavior, shell-mode created-file asserts, `--snapshot` golden round-trip, and the no-command usage error.

Closes #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `record` command to generate a starter test spec from an observed command run.
  * Updated command completion and help text to include the new command.
  * Expanded documentation and examples for recording runs, shell output, and snapshots.

* **Bug Fixes**
  * Improved Windows and cross-platform end-to-end coverage by including the new recording scenarios in scheduled regression checks.

* **Tests**
  * Added end-to-end coverage for recording, overwrite protection, shell mode, snapshot mode, and missing-command validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->