### PR TITLE
fix(record): quote POSIX metacharacters so recorded argv round-trips

### DIFF
--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-51 suites · 182 scenarios
+51 suites · 183 scenarios
 ## Contents
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 3 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
@@ -147,13 +147,14 @@
   - [screen asserts see the final frame where the transcript sees history](#scenario-screen-asserts-see-the-final-frame-where-the-transcript-sees-history)
   - [a screen snapshot round-trips through update and compare](#scenario-a-screen-snapshot-round-trips-through-update-and-compare)
   - [a screen assert without a pty step is a load-time error](#scenario-a-screen-assert-without-a-pty-step-is-a-load-time-error)
-- [atago self-hosting / record (spec skeleton from an observed run)](#atago-self-hosting--record-spec-skeleton-from-an-observed-run) — 6 scenarios
+- [atago self-hosting / record (spec skeleton from an observed run)](#atago-self-hosting--record-spec-skeleton-from-an-observed-run) — 7 scenarios
   - [record then run round-trips green](#scenario-record-then-run-round-trips-green)
   - [refusing to overwrite without --force](#scenario-refusing-to-overwrite-without---force)
   - [created files become exists asserts (shell mode)](#scenario-created-files-become-exists-asserts-shell-mode)
   - [snapshot mode writes a golden the run then matches](#scenario-snapshot-mode-writes-a-golden-the-run-then-matches)
   - [no command is a usage error](#scenario-no-command-is-a-usage-error)
   - [argv boundaries survive spaced arguments](#scenario-argv-boundaries-survive-spaced-arguments)
+  - [a shell metacharacter argument stays one token](#scenario-a-shell-metacharacter-argument-stays-one-token)
 - [atago self-hosting / reports](#atago-self-hosting--reports) — 5 scenarios
   - [JUnit report is XML with a testsuite and testcase](#scenario-junit-report-is-xml-with-a-testsuite-and-testcase)
   - [GitHub Actions annotations are emitted on failure](#scenario-github-actions-annotations-are-emitted-on-failure)
@@ -2722,6 +2723,20 @@ ${atago} run spaced.atago.yaml
   - exit code is `0`
   - file `spaced.atago.yaml` contains `contains: hello world`
 - after `${atago} run spaced.atago.yaml`:
+  - exit code is `0`
+  - stdout contains `1 passed`
+### Scenario: a shell metacharacter argument stays one token
+_skipped on windows_
+#### When
+```shell
+${atago} record --out meta.atago.yaml -- printf %s "foo|bar"
+${atago} run meta.atago.yaml
+```
+#### Then
+- after `${atago} record --out meta.atago.yaml -- printf %s "foo|bar"`:
+  - exit code is `0`
+  - file `meta.atago.yaml` contains `contains: foo|bar`
+- after `${atago} run meta.atago.yaml`:
   - exit code is `0`
   - stdout contains `1 passed`
 ## atago self-hosting / reports

--- a/internal/cli/record.go
+++ b/internal/cli/record.go
@@ -9,6 +9,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -165,38 +166,67 @@ func listFiles(root string) ([]string, error) {
 }
 
 // shellJoin renders argv as one command string that re-tokenizes to the same
-// argv through the cmd runner (go-shellwords on POSIX, native argv splitting
-// on Windows). Only whitespace splits a token, so a token is left verbatim
-// unless it carries whitespace, a quote, or is empty; those are wrapped in
-// DOUBLE quotes — the one quoting both tokenizers accept — with embedded
-// backslashes and double-quotes escaped. A Windows path like C:\tool.exe has
-// no whitespace, so it passes through unquoted (single-quoting it would leave
-// Windows treating the quotes as part of the filename).
+// argv through the cmd runner, which uses go-shellwords on POSIX and native
+// argv splitting on Windows. The two tokenizers reinterpret different
+// characters, so quoting is platform-specific: it runs on the machine that
+// records, which is the machine that replays.
 func shellJoin(args []string) string {
-	quoted := make([]string, len(args))
-	for i, a := range args {
-		if !needsQuoting(a) {
-			quoted[i] = a
-			continue
-		}
-		// Escape only embedded double-quotes: a backslash inside double
-		// quotes is a POSIX escape but a literal on Windows, so escaping it
-		// would round-trip on one platform and double up on the other.
-		// Leaving it literal keeps a spaced Windows path (C:\Program
-		// Files\tool.exe) intact on both.
-		quoted[i] = `"` + strings.ReplaceAll(a, `"`, `\"`) + `"`
+	if runtime.GOOS == "windows" {
+		return windowsJoin(args)
 	}
-	return strings.Join(quoted, " ")
+	return posixJoin(args)
 }
 
-// needsQuoting reports whether a token would lose its argv boundary when
-// re-tokenized unquoted: the empty string (would vanish) or anything with
-// whitespace or a quote character.
-func needsQuoting(s string) bool {
-	if s == "" {
-		return true
+// posixJoin single-quotes every token that is not a plain word. Single quotes
+// disable ALL go-shellwords interpretation — whitespace, the metacharacters
+// it treats as boundaries (; & | < > ( )), globs, $-expansion, and
+// backslashes — so `foo|bar`, `a>b`, and `C:\tmp\file` all round-trip. An
+// embedded single quote is closed, escaped, and reopened ('\”).
+func posixJoin(args []string) string {
+	out := make([]string, len(args))
+	for i, a := range args {
+		if plainPOSIXWord(a) {
+			out[i] = a
+			continue
+		}
+		out[i] = "'" + strings.ReplaceAll(a, "'", `'\''`) + "'"
 	}
-	return strings.ContainsAny(s, " \t\n'\"")
+	return strings.Join(out, " ")
+}
+
+// windowsJoin double-quotes tokens the native tokenizer would split or
+// mis-read. Windows argv splitting breaks only on whitespace (the shell
+// metacharacters go-shellwords honors are not argv boundaries there), and
+// backslashes are literal, so a path like C:\tool.exe passes through and only
+// whitespace/quote-bearing tokens need wrapping.
+func windowsJoin(args []string) string {
+	out := make([]string, len(args))
+	for i, a := range args {
+		if a != "" && !strings.ContainsAny(a, " \t\n\"") {
+			out[i] = a
+			continue
+		}
+		out[i] = `"` + strings.ReplaceAll(a, `"`, `\"`) + `"`
+	}
+	return strings.Join(out, " ")
+}
+
+// plainPOSIXWord reports whether a token survives go-shellwords tokenization
+// unquoted: only alphanumerics and a small set of punctuation that carries no
+// shell meaning.
+func plainPOSIXWord(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case strings.ContainsRune("_@%+=:,./-", r):
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // suiteNameFor derives a suite name from the command's base name.

--- a/internal/cli/record_test.go
+++ b/internal/cli/record_test.go
@@ -7,11 +7,11 @@ import (
 	shellwords "github.com/mattn/go-shellwords"
 )
 
-// TestShellJoin_RoundTrip proves shellJoin's output re-tokenizes to the same
-// argv through the POSIX tokenizer the cmd runner uses (#30 follow-up): argv
-// boundaries must survive spaces and quotes. A no-whitespace token — Windows
-// paths included — passes through verbatim (asserted separately).
-func TestShellJoin_RoundTrip(t *testing.T) {
+// TestPOSIXJoin_RoundTrip proves posixJoin's output re-tokenizes to the same
+// argv through go-shellwords — the tokenizer the cmd runner uses on POSIX
+// (#30 follow-up). Boundaries must survive spaces, quotes, the metacharacters
+// go-shellwords treats as separators, and backslashes.
+func TestPOSIXJoin_RoundTrip(t *testing.T) {
 	t.Parallel()
 	cases := [][]string{
 		{"mytool", "convert", "input.txt"},
@@ -19,10 +19,14 @@ func TestShellJoin_RoundTrip(t *testing.T) {
 		{"tool", "it's"},
 		{"tool", `she said "hi"`},
 		{"tool", "spaced arg", "--flag=with space"},
+		{"grep", "foo|bar"},
+		{"tool", "a>b", "c<d", "e;f", "g&h"},
+		{"tool", `C:\tmp\file`},
+		{"tool", "$HOME", "*.go"},
 		{"tool", ""}, // an empty argument must survive as a distinct entry
 	}
 	for _, argv := range cases {
-		joined := shellJoin(argv)
+		joined := posixJoin(argv)
 		got, err := shellwords.Parse(joined)
 		if err != nil {
 			t.Errorf("%v -> %q does not tokenize: %v", argv, joined, err)
@@ -34,14 +38,15 @@ func TestShellJoin_RoundTrip(t *testing.T) {
 	}
 }
 
-// TestShellJoin_PassesThroughPlainTokens proves whitespace-free tokens are
-// left verbatim so a Windows path never gets quotes the native tokenizer
-// would treat as part of the filename (the e2e-windows regression this fixes).
-func TestShellJoin_PassesThroughPlainTokens(t *testing.T) {
+// TestWindowsJoin_Boundaries proves windowsJoin leaves a whitespace-free path
+// verbatim (the e2e-windows regression this fixes: single quotes had been
+// treated as part of the filename) while quoting whitespace-bearing tokens.
+func TestWindowsJoin_Boundaries(t *testing.T) {
 	t.Parallel()
-	got := shellJoin([]string{`C:\Users\runner\atago.exe`, "version"})
-	want := `C:\Users\runner\atago.exe version`
-	if got != want {
-		t.Errorf("shellJoin = %q, want %q (plain tokens must not be quoted)", got, want)
+	if got := windowsJoin([]string{`C:\Users\runner\atago.exe`, "version"}); got != `C:\Users\runner\atago.exe version` {
+		t.Errorf("plain Windows path must pass through: %q", got)
+	}
+	if got := windowsJoin([]string{`C:\Program Files\tool.exe`, "run"}); got != `"C:\Program Files\tool.exe" run` {
+		t.Errorf("spaced path must be double-quoted verbatim (backslashes literal): %q", got)
 	}
 }

--- a/test/e2e/atago/record.atago.yaml
+++ b/test/e2e/atago/record.atago.yaml
@@ -125,3 +125,24 @@ scenarios:
           exit_code: 0
           stdout:
             contains: "1 passed"
+
+  - name: a shell metacharacter argument stays one token
+    skip:
+      os: windows
+    steps:
+      # `foo|bar` is one argv element to the tool, but go-shellwords would
+      # split it on the pipe if it were re-emitted unquoted — record must
+      # quote it so the round-trip run reproduces the same single argument.
+      - run:
+          command: ${atago} record --out meta.atago.yaml -- printf %s "foo|bar"
+      - assert:
+          exit_code: 0
+          file:
+            path: meta.atago.yaml
+            contains: "contains: foo|bar"
+      - run:
+          command: ${atago} run meta.atago.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "1 passed"


### PR DESCRIPTION
## Summary

Follow-up to #30 (PR #57 review, Major finding): `shellJoin` only quoted whitespace and quote characters, but go-shellwords — the tokenizer the cmd runner uses on POSIX — also treats `;`, `&`, `|`, `<`, `>`, `(`, `)`, globs, `$`, and backslashes as significant, so an argument like `foo|bar` or `a>b` split into multiple tokens when the generated spec re-ran.

## Changes

- Quoting is now platform-specific (it runs on the machine that records, which is the machine that replays):
  - **POSIX** (`posixJoin`): single-quote any non-plain-word token. Single quotes disable ALL go-shellwords interpretation — whitespace, boundary metacharacters, globs, `$`-expansion, backslashes — so `foo|bar`, `a>b`, `C:\tmp\file`, `$HOME`, `*.go` all round-trip; embedded single quotes use the `'\''` idiom.
  - **Windows** (`windowsJoin`): the native argv tokenizer splits only on whitespace and keeps backslashes literal, so a path like `C:\tool.exe` passes through verbatim (the e2e-windows regression from PR #57) and only whitespace/quote-bearing tokens get double-quoted. `--shell` still joins verbatim.
- Tests target the platform functions directly (so they validate regardless of the host OS): `TestPOSIXJoin_RoundTrip` runs its output back through go-shellwords across spaces, quotes, metacharacters, backslashes, glob/$, and the empty string; `TestWindowsJoin_Boundaries` proves a plain path stays verbatim and a spaced path is double-quoted with literal backslashes. New self-hosted E2E scenario records `printf %s "foo|bar"` and re-runs it green.

Verified: full `make e2e` (188 scenarios) + `go test ./...` + lint clean.