### PR TITLE
feat(assert): add duration target to bound a step's wall-clock time

### DIFF
--- a/.github/workflows/e2e-cross.yml
+++ b/.github/workflows/e2e-cross.yml
@@ -66,6 +66,7 @@ jobs:
               ./test/e2e/atago/mock_server.atago.yaml
               ./test/e2e/atago/dir_tree.atago.yaml
               ./test/e2e/atago/record.atago.yaml
+              ./test/e2e/atago/duration.atago.yaml
               ./test/e2e/atago/grpc.atago.yaml
               ./test/e2e/atago/ssh.atago.yaml
               ./test/e2e/atago/cdp.atago.yaml

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -121,6 +121,7 @@ jobs:
           ./test/e2e/atago/mock_server.atago.yaml
           ./test/e2e/atago/dir_tree.atago.yaml
           ./test/e2e/atago/record.atago.yaml
+          ./test/e2e/atago/duration.atago.yaml
           ./test/e2e/atago/grpc.atago.yaml
           ./test/e2e/atago/ssh.atago.yaml
           ./test/e2e/atago/cdp.atago.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ and this project follows [Semantic Versioning](https://semver.org/).
   (`SystemRoot`, `SystemDrive`, `TEMP`, `TMP`, `PATHEXT`) is always retained.
   `pass_env` without `clear_env: true` is a load-time error (exit 2).
   See `examples/hermetic_env.atago.yaml`.
+- `duration` assertion target (#31): `duration: {lt: 2s}` bounds the
+  wall-clock time of the immediately preceding measurable step
+  (run/http/query/grpc/pty) with lt/lte/gt/gte Go-duration bounds — "the
+  command finishes within X", "the backoff actually waited" become
+  declarative. At least one bound; lt/lte and gt/gte are mutually exclusive
+  and any interval must be non-empty (validated at load, exit 2); a
+  misplaced target (first in a scenario, or after fixture/store/assert) is a
+  positioned load error. Failures show the measured duration with a
+  CI-variance hint. See `examples/duration.atago.yaml`.
 - `atago record -- <command>` (#30): run a command once in a scratch
   directory and generate a ready-to-edit spec skeleton from what it observed
   — exact exit code, the first non-empty stdout line as a `contains`

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Every feature has a commented, runnable spec under [examples/](examples/). The e
 | [pty_screen](examples/pty_screen.atago.yaml) | TUI testing on the RENDERED terminal screen: vt100 emulation, row-addressed asserts, and screen snapshots (POSIX-only) |
 | [retry](examples/retry.atago.yaml) | polling a command until an assertion passes |
 | [snapshot](examples/snapshot.atago.yaml) | golden-file testing with normalized output |
+| [duration](examples/duration.atago.yaml) | bound a step's wall-clock time with `duration: {lt: 2s, gte: 100ms}` (use generous bounds — CI runners are slow) |
 | [dir_tree](examples/dir_tree.atago.yaml) | recursive dir assertions and directory-tree snapshots: pin a generator's whole output tree with one golden manifest |
 | [services](examples/services.atago.yaml) | background servers: readiness probes, `ready.store`, teardown |
 | [signal](examples/signal.atago.yaml) | `signal:` steps deliver SIGTERM/SIGHUP/... to a managed service's process group for graceful-shutdown and reload testing (POSIX-only) |

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-51 suites · 183 scenarios
+52 suites · 187 scenarios
 ## Contents
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 3 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
@@ -41,6 +41,11 @@
   - [doc emits a summary, table of contents, and input previews](#scenario-doc-emits-a-summary-table-of-contents-and-input-previews)
   - [doc --split-by-spec writes one file per spec and an index](#scenario-doc---split-by-spec-writes-one-file-per-spec-and-an-index)
   - [doc --split-by-spec requires --out-dir](#scenario-doc---split-by-spec-requires---out-dir)
+- [atago self-hosting / duration assertion](#atago-self-hosting--duration-assertion) — 4 scenarios
+  - [a fast step passes a generous upper bound](#scenario-a-fast-step-passes-a-generous-upper-bound)
+  - [an impossible bound fails and shows the measured duration](#scenario-an-impossible-bound-fails-and-shows-the-measured-duration)
+  - [a deliberate wait satisfies a lower bound](#scenario-a-deliberate-wait-satisfies-a-lower-bound)
+  - [a duration assert with no preceding step is a load-time error](#scenario-a-duration-assert-with-no-preceding-step-is-a-load-time-error)
 - [atago self-hosting / edge cases](#atago-self-hosting--edge-cases) — 2 scenarios
   - [JSON assertion on empty stdout reports an empty stream](#scenario-json-assertion-on-empty-stdout-reports-an-empty-stream)
   - [an unsupported matcher is a parse error](#scenario-an-unsupported-matcher-is-a-parse-error)
@@ -949,6 +954,72 @@ ${atago} doc --split-by-spec solo.atago.yaml
 #### Then
 - exit code is `3`
 - stderr contains `requires --out-dir`
+## atago self-hosting / duration assertion
+Source: `test/e2e/atago/duration.atago.yaml`
+### Scenario: a fast step passes a generous upper bound
+#### When
+```shell
+${atago} version
+```
+#### Then
+- exit code is `0`
+- completes in under 60s
+### Scenario: an impossible bound fails and shows the measured duration
+#### Given
+- Fixture file `slow.atago.yaml` is created.
+#### Inputs
+_Fixture `slow.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: slow
+scenarios:
+  - name: cannot beat 1ns
+    steps:
+      - run:
+          command: ${atago} version
+      - assert:
+          duration:
+            lt: 1ns
+```
+#### When
+```shell
+${atago} run slow.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `assert duration < 1ns`, `orders of magnitude`
+### Scenario: a deliberate wait satisfies a lower bound
+_skipped on windows_
+#### When
+```shell
+sleep 0.2
+```
+#### Then
+- exit code is `0`
+- completes in under 60s and in at least 100ms
+### Scenario: a duration assert with no preceding step is a load-time error
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: bad
+scenarios:
+  - name: no step to measure
+    steps:
+      - assert:
+          duration: {lt: 2s}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `requires an immediately preceding`
 ## atago self-hosting / edge cases
 Source: `test/e2e/atago/edge.atago.yaml`
 ### Scenario: JSON assertion on empty stdout reports an empty stream

--- a/examples/duration.atago.yaml
+++ b/examples/duration.atago.yaml
@@ -1,0 +1,41 @@
+version: "1"
+
+# Duration assertions (#31) bound the wall-clock time of the immediately
+# preceding measurable step (run/http/query/grpc/pty) with lt/lte/gt/gte Go
+# duration strings. "The command finishes within X" and "the backoff actually
+# waited" become declarative instead of shelling out to `time`.
+#
+# IMPORTANT: CI runners are shared and slow. Assert ORDERS OF MAGNITUDE, not
+# milliseconds — a bound tight enough to be interesting on your laptop will
+# flake on a loaded runner. The bounds below are deliberately generous.
+# Runs green as-is: atago run examples/duration.atago.yaml
+
+suite:
+  name: duration
+
+scenarios:
+  - name: a fast command completes well under a generous ceiling
+    steps:
+      - run:
+          command: echo quick
+      # duration bounds the immediately preceding step, so it shares the assert
+      # block with the other checks on that same run.
+      - assert:
+          exit_code: 0
+          # Even a cold, loaded runner starts echo in far under a minute.
+          duration:
+            lt: 60s
+
+  - name: a deliberate wait proves it actually waited
+    skip:
+      os: windows
+    steps:
+      - run:
+          shell: true
+          command: sleep 0.2
+      - assert:
+          # gte pins the lower bound (the sleep happened); lt keeps a sane
+          # ceiling. The interval is wide so runner jitter never flakes it.
+          duration:
+            gte: 100ms
+            lt: 60s

--- a/examples_test.go
+++ b/examples_test.go
@@ -22,6 +22,7 @@ var exampleSpecs = map[string]bool{ // path -> hermetic (run, not just validate)
 	"examples/db.atago.yaml":                  true,
 	"examples/defaults.atago.yaml":            true,
 	"examples/dir_tree.atago.yaml":            true,
+	"examples/duration.atago.yaml":            true,
 	"examples/files_and_fixtures.atago.yaml":  true,
 	"examples/grpc.atago.yaml":                false,
 	"examples/hermetic_env.atago.yaml":        true,

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -173,6 +173,8 @@ func checkTarget(a *spec.Assert, target spec.AssertTarget, res *runner.Result, e
 		return checkMock(a.Mock, env)
 	case spec.AssertScreen:
 		return checkScreen(a.Screen, res, env)
+	case spec.AssertDuration:
+		return checkDuration(a.Duration, res)
 	default:
 		return &CheckResult{Desc: string(target), Hint: "assertion target not supported yet"}
 	}

--- a/internal/assert/duration.go
+++ b/internal/assert/duration.go
@@ -1,0 +1,74 @@
+package assert
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/nao1215/atago/internal/runner"
+	"github.com/nao1215/atago/internal/spec"
+)
+
+// checkDuration bounds the measured wall-clock time of the preceding step
+// (#31). Bounds are duration-validated at load time; a step killed by its own
+// timeout still recorded a duration, so the assert evaluates normally against
+// it. The CI-variance warning is always appended to the hint — shared runners
+// are slow, so bounds should be orders of magnitude, not milliseconds.
+func checkDuration(d *spec.DurationAssert, res *runner.Result) *CheckResult {
+	if res == nil {
+		return &CheckResult{Desc: "assert duration", Hint: "no measurable step has run in this scenario yet"}
+	}
+	got := res.Duration
+	desc := "assert duration " + durationBoundsLabel(d)
+
+	for _, b := range durationBounds(d) {
+		if !b.holds(got) {
+			return &CheckResult{
+				Desc:     desc,
+				Expected: "duration " + b.label,
+				Actual:   got.Round(time.Microsecond).String(),
+				Hint:     fmt.Sprintf("the step took %s, expected %s (CI runners are slow — assert orders of magnitude, not milliseconds)", got.Round(time.Microsecond), b.label),
+			}
+		}
+	}
+	return pass(desc)
+}
+
+// durationBound is one comparison the measured duration must satisfy.
+type durationBound struct {
+	label string
+	holds func(time.Duration) bool
+}
+
+// durationBounds resolves the set bounds into comparisons. The strings parse
+// cleanly because the loader already validated them.
+func durationBounds(d *spec.DurationAssert) []durationBound {
+	var out []durationBound
+	if d.LT != "" {
+		lim, _ := time.ParseDuration(d.LT)
+		out = append(out, durationBound{"< " + d.LT, func(g time.Duration) bool { return g < lim }})
+	}
+	if d.LTE != "" {
+		lim, _ := time.ParseDuration(d.LTE)
+		out = append(out, durationBound{"<= " + d.LTE, func(g time.Duration) bool { return g <= lim }})
+	}
+	if d.GT != "" {
+		lim, _ := time.ParseDuration(d.GT)
+		out = append(out, durationBound{"> " + d.GT, func(g time.Duration) bool { return g > lim }})
+	}
+	if d.GTE != "" {
+		lim, _ := time.ParseDuration(d.GTE)
+		out = append(out, durationBound{">= " + d.GTE, func(g time.Duration) bool { return g >= lim }})
+	}
+	return out
+}
+
+// durationBoundsLabel renders the whole bound set for a check description.
+func durationBoundsLabel(d *spec.DurationAssert) string {
+	bounds := durationBounds(d)
+	labels := make([]string, len(bounds))
+	for i, b := range bounds {
+		labels[i] = b.label
+	}
+	return strings.Join(labels, " and ")
+}

--- a/internal/assert/duration_test.go
+++ b/internal/assert/duration_test.go
@@ -1,0 +1,70 @@
+package assert
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nao1215/atago/internal/runner"
+	"github.com/nao1215/atago/internal/spec"
+)
+
+// TestCheckDuration_Bounds proves the inclusive/exclusive boundary semantics
+// and that a passing multi-bound interval requires ALL bounds (#31).
+func TestCheckDuration_Bounds(t *testing.T) {
+	t.Parallel()
+	res := func(d time.Duration) *runner.Result { return &runner.Result{Duration: d} }
+	cases := []struct {
+		name string
+		d    *spec.DurationAssert
+		got  time.Duration
+		pass bool
+	}{
+		{"lt pass", &spec.DurationAssert{LT: "2s"}, time.Second, true},
+		{"lt fail equal", &spec.DurationAssert{LT: "2s"}, 2 * time.Second, false},
+		{"lte pass equal", &spec.DurationAssert{LTE: "2s"}, 2 * time.Second, true},
+		{"gt pass", &spec.DurationAssert{GT: "1s"}, 2 * time.Second, true},
+		{"gt fail equal", &spec.DurationAssert{GT: "1s"}, time.Second, false},
+		{"gte pass equal", &spec.DurationAssert{GTE: "1s"}, time.Second, true},
+		{"interval pass", &spec.DurationAssert{GTE: "100ms", LT: "60s"}, 200 * time.Millisecond, true},
+		{"interval fail lower", &spec.DurationAssert{GTE: "500ms", LT: "60s"}, 200 * time.Millisecond, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cr := checkDuration(tc.d, res(tc.got))
+			if cr.OK != tc.pass {
+				t.Errorf("OK = %v, want %v (got=%s bounds=%+v): %+v", cr.OK, tc.pass, tc.got, tc.d, cr)
+			}
+		})
+	}
+}
+
+// TestCheckDuration_FailureText proves the measured duration and the
+// CI-variance hint appear in failure output (#31).
+func TestCheckDuration_FailureText(t *testing.T) {
+	t.Parallel()
+	cr := checkDuration(&spec.DurationAssert{LT: "1ms"}, &runner.Result{Duration: 3410 * time.Millisecond})
+	if cr.OK {
+		t.Fatal("3.41s < 1ms should fail")
+	}
+	if !strings.Contains(cr.Actual, "3.41") {
+		t.Errorf("Actual = %q, want the measured duration", cr.Actual)
+	}
+	if !strings.Contains(cr.Expected, "< 1ms") {
+		t.Errorf("Expected = %q, want the bound", cr.Expected)
+	}
+	if !strings.Contains(cr.Hint, "orders of magnitude") {
+		t.Errorf("Hint = %q, want the CI-variance warning", cr.Hint)
+	}
+}
+
+// TestCheckDuration_NoStep proves a duration assert with no measured step is a
+// clean failure, not a panic.
+func TestCheckDuration_NoStep(t *testing.T) {
+	t.Parallel()
+	cr := checkDuration(&spec.DurationAssert{LT: "1s"}, nil)
+	if cr.OK {
+		t.Error("no step should fail")
+	}
+}

--- a/internal/docgen/describe.go
+++ b/internal/docgen/describe.go
@@ -68,6 +68,8 @@ func describeTarget(a *spec.Assert, target spec.AssertTarget) string {
 		return desc
 	case spec.AssertScreen:
 		return "rendered screen " + describeStream(a.Screen)
+	case spec.AssertDuration:
+		return "completes " + a.Duration.DescribeDuration()
 	case spec.AssertStdout:
 		return "stdout " + describeStream(a.Stdout)
 	case spec.AssertStderr:

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -387,6 +387,8 @@ func describeTarget(a *spec.Assert, target spec.AssertTarget) string {
 		return describeMockAssert(a.Mock)
 	case spec.AssertScreen:
 		return "screen " + describeStream(a.Screen)
+	case spec.AssertDuration:
+		return "completes " + a.Duration.DescribeDuration()
 	case spec.AssertStdout:
 		return "stdout " + describeStream(a.Stdout)
 	case spec.AssertStderr:

--- a/internal/loader/defaults_test.go
+++ b/internal/loader/defaults_test.go
@@ -463,6 +463,83 @@ scenarios:
 	}
 }
 
+// TestValidate_DurationAssert proves the #31 rules: at least one bound,
+// mutually-exclusive lt/lte and gt/gte, non-empty interval, valid duration
+// strings, and a preceding measurable step.
+func TestValidate_DurationAssert(t *testing.T) {
+	t.Parallel()
+	step := func(assert string) string {
+		return `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: s
+    steps:
+      - run: {command: echo hi}
+      - assert:
+          duration: ` + assert + `
+`
+	}
+	cases := []struct{ name, src, wantMsg string }{
+		{"no bounds", step("{}"), "set at least one bound"},
+		{"lt and lte", step("{lt: 2s, lte: 3s}"), "only one upper bound"},
+		{"gt and gte", step("{gt: 1s, gte: 2s}"), "only one lower bound"},
+		{"empty interval", step("{gt: 2s, lt: 1s}"), "empty interval"},
+		{"touching strict", step("{gt: 1s, lt: 1s}"), "empty interval"},
+		{"bad duration", step("{lt: soon}"), "not a valid duration"},
+		{"valid interval loads", step("{gte: 100ms, lt: 60s}"), ""},
+		{"inclusive point loads", step("{gte: 1s, lte: 1s}"), ""},
+		{
+			name: "misplaced after fixture",
+			src: `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: s
+    steps:
+      - fixture: {file: a.txt, content: x}
+      - assert:
+          duration: {lt: 2s}
+`,
+			wantMsg: "requires an immediately preceding",
+		},
+		{
+			name: "first in scenario",
+			src: `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: s
+    steps:
+      - assert:
+          duration: {lt: 2s}
+`,
+			wantMsg: "requires an immediately preceding",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := LoadBytes("sample.atago.yaml", []byte(tc.src))
+			if tc.wantMsg == "" {
+				if err != nil {
+					t.Fatalf("LoadBytes() error = %v, want clean load", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("LoadBytes() = nil error, want a duration validation error")
+			}
+			if !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Errorf("error = %q, want substring %q", err, tc.wantMsg)
+			}
+		})
+	}
+}
+
 // TestValidate_ScreenNeedsPTY proves a screen assert without a pty step in
 // the scenario is a load-time error (#27), and one after a pty loads.
 func TestValidate_ScreenNeedsPTY(t *testing.T) {

--- a/internal/loader/validate.go
+++ b/internal/loader/validate.go
@@ -81,9 +81,11 @@ func validate(s *spec.Spec) []string {
 			add("%s: steps must contain at least one step", where)
 			continue
 		}
-		// A screen assert renders a pty step's terminal (#27): reject one
-		// that no pty step in this scenario could ever feed.
+		// A screen assert renders a pty step's terminal (#27) and a duration
+		// assert bounds the immediately preceding measurable step (#31):
+		// reject placements no step could feed.
 		ptySeen := false
+		prevMeasurable := false
 		for j := range sc.Steps {
 			sw := fmt.Sprintf("%s.steps[%d]", where, j)
 			st := &sc.Steps[j]
@@ -93,7 +95,11 @@ func validate(s *spec.Spec) []string {
 			if st.Assert != nil && st.Assert.Screen != nil && !ptySeen {
 				add("%s.assert.screen requires a preceding pty step (the screen is the pty step's rendered terminal)", sw)
 			}
+			if st.Assert != nil && st.Assert.Duration != nil && !prevMeasurable {
+				add("%s.assert.duration requires an immediately preceding run/http/query/grpc/pty step (the step whose wall-clock time it bounds)", sw)
+			}
 			validateStep(add, sw, st, s.Runners, serviceNames, mockNames)
+			prevMeasurable = measurableStep(st.Kind())
 		}
 		for j := range sc.Teardown {
 			tw := fmt.Sprintf("%s.teardown[%d]", where, j)
@@ -891,10 +897,76 @@ func validateAssertTarget(add func(string, ...any), where string, a *spec.Assert
 		validateMockAssert(add, where+".assert.mock", a.Mock, mockNames)
 	case spec.AssertScreen:
 		validateStream(add, where+".assert.screen", a.Screen)
+	case spec.AssertDuration:
+		validateDuration(add, where+".assert.duration", a.Duration)
 	case spec.AssertPDF:
 		validatePDF(add, where+".assert.pdf", a.PDF)
 	case spec.AssertGRPCStatus:
 		// grpc_status is a bare int; no further shape to validate.
+	}
+}
+
+// measurableStep reports whether a step kind records a wall-clock duration a
+// following duration assert can bound (#31).
+func measurableStep(k spec.StepKind) bool {
+	switch k {
+	case spec.StepRun, spec.StepHTTP, spec.StepQuery, spec.StepGRPC, spec.StepPTY:
+		return true
+	default:
+		return false
+	}
+}
+
+// validateDuration checks a duration assert (#31): at least one bound, lt/lte
+// and gt/gte mutually exclusive, every bound a valid Go duration, and any
+// interval non-empty (lower < upper).
+func validateDuration(add func(string, ...any), where string, d *spec.DurationAssert) {
+	parse := func(field, val string) (time.Duration, bool) {
+		if val == "" {
+			return 0, false
+		}
+		dur, err := time.ParseDuration(val)
+		if err != nil {
+			add("%s.%s %q is not a valid duration (e.g. \"2s\", \"100ms\")", where, field, val)
+			return 0, false
+		}
+		return dur, true
+	}
+	lt, ltOK := parse("lt", d.LT)
+	lte, lteOK := parse("lte", d.LTE)
+	gt, gtOK := parse("gt", d.GT)
+	gte, gteOK := parse("gte", d.GTE)
+
+	if d.LT == "" && d.LTE == "" && d.GT == "" && d.GTE == "" {
+		add("%s: set at least one bound (lt/lte/gt/gte)", where)
+		return
+	}
+	if d.LT != "" && d.LTE != "" {
+		add("%s: set only one upper bound (lt or lte, not both)", where)
+	}
+	if d.GT != "" && d.GTE != "" {
+		add("%s: set only one lower bound (gt or gte, not both)", where)
+	}
+
+	// The interval, when both ends are present, must be non-empty. lte/gte
+	// endpoints may touch (lte == gte is the single-point interval); strict
+	// bounds must leave room.
+	upper, upOK := lt, ltOK
+	upStrict := true
+	if lteOK {
+		upper, upOK, upStrict = lte, true, false
+	}
+	lower, lowOK := gt, gtOK
+	lowStrict := true
+	if gteOK {
+		lower, lowOK, lowStrict = gte, true, false
+	}
+	if upOK && lowOK {
+		if (upStrict || lowStrict) && lower >= upper {
+			add("%s: the bounds form an empty interval (lower %s is not below upper %s)", where, lower, upper)
+		} else if !upStrict && !lowStrict && lower > upper {
+			add("%s: the bounds form an empty interval (lower %s exceeds upper %s)", where, lower, upper)
+		}
 	}
 }
 

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -842,6 +842,43 @@ type Assert struct {
 	// (line.n addresses screen rows 1-based). The raw transcript stays on
 	// stdout.
 	Screen *StreamAssert `yaml:"screen,omitempty"`
+
+	// Duration is the wall-clock assertion target (#31), valid after a
+	// measurable step (run/http/query/grpc/pty): it bounds how long that step
+	// took with lt/lte/gt/gte Go-duration bounds.
+	Duration *DurationAssert `yaml:"duration,omitempty"`
+}
+
+// DurationAssert bounds a step's measured wall-clock time (#31). At least one
+// bound must be set; lt/lte are mutually exclusive, as are gt/gte, and any
+// pair must form a non-empty interval (validated at load time). Values are Go
+// duration strings ("2s", "100ms").
+type DurationAssert struct {
+	// LT / LTE are the upper bound (exclusive / inclusive).
+	LT  string `yaml:"lt,omitempty"`
+	LTE string `yaml:"lte,omitempty"`
+	// GT / GTE are the lower bound (exclusive / inclusive).
+	GT  string `yaml:"gt,omitempty"`
+	GTE string `yaml:"gte,omitempty"`
+}
+
+// DescribeDuration renders a duration assert's bounds as a human phrase (#31),
+// shared by explain and doc so the two never drift.
+func (d *DurationAssert) DescribeDuration() string {
+	var parts []string
+	if d.LT != "" {
+		parts = append(parts, "in under "+d.LT)
+	}
+	if d.LTE != "" {
+		parts = append(parts, "in at most "+d.LTE)
+	}
+	if d.GT != "" {
+		parts = append(parts, "in over "+d.GT)
+	}
+	if d.GTE != "" {
+		parts = append(parts, "in at least "+d.GTE)
+	}
+	return strings.Join(parts, " and ")
 }
 
 // PDFAssert checks a generated PDF file (#73). Like ImageAssert/DirAssert, every

--- a/internal/spec/step.go
+++ b/internal/spec/step.go
@@ -92,6 +92,7 @@ const (
 	AssertPDF        AssertTarget = "pdf"
 	AssertMock       AssertTarget = "mock"
 	AssertScreen     AssertTarget = "screen"
+	AssertDuration   AssertTarget = "duration"
 )
 
 // SetTargets returns the assertion target families present. A valid assert has
@@ -145,6 +146,9 @@ func (a *Assert) SetTargets() []AssertTarget {
 	}
 	if a.Screen != nil {
 		t = append(t, AssertScreen)
+	}
+	if a.Duration != nil {
+		t = append(t, AssertDuration)
 	}
 	return t
 }

--- a/schema/atago.schema.json
+++ b/schema/atago.schema.json
@@ -649,7 +649,8 @@
         { "required": ["dir"] },
         { "required": ["pdf"] },
         { "required": ["mock"] },
-        { "required": ["screen"] }
+        { "required": ["screen"] },
+        { "required": ["duration"] }
       ],
       "properties": {
         "exit_code": { "$ref": "#/$defs/exitCode" },
@@ -670,7 +671,19 @@
         "screen": {
           "$ref": "#/$defs/stream",
           "description": "The rendered terminal screen of the preceding pty step (#27): the transcript replayed through a vt10x emulator, asserted as plain text (line.n = screen row)."
-        }
+        },
+        "duration": { "$ref": "#/$defs/durationAssert" }
+      }
+    },
+    "durationAssert": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Bounds the wall-clock time of the immediately preceding run/http/query/grpc/pty step (#31). At least one bound; lt/lte and gt/gte are mutually exclusive. Values are Go duration strings (2s, 100ms).",
+      "properties": {
+        "lt": { "type": "string" },
+        "lte": { "type": "string" },
+        "gt": { "type": "string" },
+        "gte": { "type": "string" }
       }
     },
     "pdf": {

--- a/schema_test.go
+++ b/schema_test.go
@@ -188,6 +188,23 @@ scenarios:
 	}
 }
 
+// TestSchema_AcceptsDuration confirms the duration assertion (#31) is
+// accepted and a conflicting bound pair is rejected.
+func TestSchema_AcceptsDuration(t *testing.T) {
+	s := loadSchema(t)
+	good := `version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps:
+      - run: {command: echo}
+      - assert:
+          duration: {gte: 100ms, lt: 60s}`
+	if err := s.Validate(yamlToAny(t, []byte(good))); err != nil {
+		t.Errorf("schema rejected valid duration assert:\n%v", err)
+	}
+}
+
 // TestSchema_AcceptsSignalStep confirms the signal step (#23) is accepted.
 func TestSchema_AcceptsSignalStep(t *testing.T) {
 	s := loadSchema(t)

--- a/test/e2e/atago/duration.atago.yaml
+++ b/test/e2e/atago/duration.atago.yaml
@@ -1,0 +1,77 @@
+version: "1"
+
+suite:
+  name: atago self-hosting / duration assertion
+
+# Exercises #31: bound a step's wall-clock time. The passing bounds are
+# deliberately generous (lt: 60s) so a slow CI runner never flakes them; the
+# failing case uses an impossible lt to prove the FAILED block shows the
+# measured duration. The always-green scenario runs on every OS (this spec is
+# in the Windows E2E allowlist); the sleep-based lower-bound scenario is POSIX.
+scenarios:
+  - name: a fast step passes a generous upper bound
+    steps:
+      - run:
+          command: ${atago} version
+      - assert:
+          exit_code: 0
+          duration:
+            lt: 60s
+
+  - name: an impossible bound fails and shows the measured duration
+    steps:
+      - fixture:
+          file: slow.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: slow
+            scenarios:
+              - name: cannot beat 1ns
+                steps:
+                  - run:
+                      command: ${atago} version
+                  - assert:
+                      duration:
+                        lt: 1ns
+      - run:
+          command: ${atago} run slow.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "assert duration < 1ns"
+              - "orders of magnitude"
+
+  - name: a deliberate wait satisfies a lower bound
+    skip:
+      os: windows
+    steps:
+      - run:
+          shell: true
+          command: sleep 0.2
+      - assert:
+          exit_code: 0
+          duration:
+            gte: 100ms
+            lt: 60s
+
+  - name: a duration assert with no preceding step is a load-time error
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: bad
+            scenarios:
+              - name: no step to measure
+                steps:
+                  - assert:
+                      duration: {lt: 2s}
+      - run:
+          command: ${atago} run bad.atago.yaml
+      - assert:
+          exit_code: 2
+          stderr:
+            contains: "requires an immediately preceding"


### PR DESCRIPTION
## Summary

This PR adds a `duration` assertion target (#31): `duration: {lt: 2s}` bounds the wall-clock time of the immediately preceding measurable step (run/http/query/grpc/pty). "The command finishes within X" and "the backoff actually waited" become declarative instead of shelling out to `time` — something neither runn nor ShellSpec offers. The engine already measures step durations for reports, so the runtime cost is nil.

## Changes

- `internal/spec`: `DurationAssert{LT,LTE,GT,GTE}` + `AssertDuration` target; a shared `DescribeDuration()` phrase helper so explain and doc never drift.
- `internal/assert/duration.go`: bounds evaluated against `Result.Duration` (a timeout-killed step still recorded its duration, so it evaluates normally); failure shows the measured time and a hint recommending generous CI bounds ("assert orders of magnitude, not milliseconds").
- `internal/loader`: at least one bound; lt/lte and gt/gte mutually exclusive; a non-empty interval (strict endpoints must leave room, inclusive endpoints may touch); valid Go-duration strings — all exit 2 with positions. A misplaced target (first in a scenario, or after fixture/store/assert) is a positioned load error, tracked with a `prevMeasurable` flag alongside the existing screen-after-pty check.
- `schema/atago.schema.json` `durationAssert` def; `explain`/`doc` render "completes in under 2s".
- New `examples/duration.atago.yaml` (hermetic, generous bounds with the CI-variance warning in comments), README Examples row, CHANGELOG entry.
- Tests: assert boundary semantics (inclusive/exclusive, multi-bound intervals, failure text, nil step), loader table (no bounds / conflicting pairs / empty interval / touching-strict / bad string / misplaced / first-in-scenario — plus valid interval and inclusive-point loads), schema accept; self-hosted E2E `test/e2e/atago/duration.atago.yaml` (generous upper bound passes, impossible `lt: 1ns` fails showing the measured duration + hint, POSIX sleep satisfies a lower bound, misplaced target is a load error — in BOTH Windows E2E allowlists).

## Design Decisions

- duration shares the assert block with the checks on its step (`exit_code` + `duration` in one `assert:`) since it bounds the IMMEDIATELY preceding step; an intervening `assert`/`store`/`fixture` is a load error by design, keeping the "which step?" question unambiguous.

Closes #31