### PR TITLE
docs: remove dangling ADR-NNNN references from comments

### DIFF
--- a/docs_test.go
+++ b/docs_test.go
@@ -25,7 +25,7 @@ func readDoc(t *testing.T, path string) string {
 }
 
 // TestDocs_NoStaleLintReferences is the regression from #55: user-facing docs and
-// demo assets must not invoke the removed `atago lint` command (ADR-0035).
+// demo assets must not invoke the removed `atago lint` command.
 func TestDocs_NoStaleLintReferences(t *testing.T) {
 	for _, path := range []string{"README.md", "doc/vhs/review.tape"} {
 		if strings.Contains(readDoc(t, path), "atago lint") {

--- a/internal/assert/http.go
+++ b/internal/assert/http.go
@@ -120,7 +120,7 @@ func cdpValue(res *runner.Result) []byte {
 }
 
 // checkGRPCStatus evaluates a `grpc_status` assertion against the numeric status
-// code captured by the grpc runner (ADR-0028).
+// code captured by the grpc runner.
 func checkGRPCStatus(want *int, res *runner.Result) *CheckResult {
 	if res == nil || !res.IsGRPC {
 		return &CheckResult{Desc: "assert grpc_status", Hint: "no gRPC call has run in this scenario yet"}

--- a/internal/assert/image.go
+++ b/internal/assert/image.go
@@ -25,7 +25,7 @@ import (
 	"github.com/nao1215/atago/internal/spec"
 )
 
-// checkImage evaluates an image assertion (ADR-0030). Every constraint set on
+// checkImage evaluates an image assertion. Every constraint set on
 // the assertion must hold. Relative paths resolve against the scenario workdir;
 // a relative similar_to baseline resolves against the spec file's directory.
 func checkImage(im *spec.ImageAssert, env Env) *CheckResult {

--- a/internal/docgen/docgen.go
+++ b/internal/docgen/docgen.go
@@ -192,7 +192,7 @@ func scenarioMeta(sc *spec.Scenario) string {
 func givenBullets(sc *spec.Scenario, expand func(string) string) []string {
 	var out []string
 	// Background services are part of the given world: they are started before
-	// the scenario's steps run (ADR-0031), so document them up front (#41).
+	// the scenario's steps run, so document them up front (#41).
 	for i := range sc.Services {
 		svc := &sc.Services[i]
 		out = append(out, fmt.Sprintf("Background service `%s` is started: `%s`.", svc.Name, expand(svc.Command)))

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -459,7 +459,7 @@ func (e *Engine) runScenario(ctx context.Context, scenarioIdx int, sc *spec.Scen
 		leadingFixtures++
 	}
 
-	// Background services (ADR-0031) start after the store is seeded — so their
+	// Background services start after the store is seeded — so their
 	// commands can reference ${workdir} and matrix vars — and after the leading
 	// fixtures, but before any other step runs. They are stopped in LIFO order
 	// when the scenario ends, however it ends.
@@ -725,7 +725,7 @@ func (e *Engine) runScenario(ctx context.Context, scenarioIdx int, sc *spec.Scen
 
 // skipReason reports whether a scenario should be skipped given its skip/only
 // conditions: the host OS, an environment variable's presence, and — last,
-// because it spawns a process — a probe command's exit status (ADR-0021). The cheap, side-effect-free checks run first so a probe only runs
+// because it spawns a process — a probe command's exit status. The cheap, side-effect-free checks run first so a probe only runs
 // when nothing else already decided the outcome.
 func (e *Engine) skipReason(ctx context.Context, sc *spec.Scenario) (string, bool) {
 	if sc.Only != nil && sc.Only.OS != "" && !platform.Matches(sc.Only.OS) {
@@ -770,9 +770,9 @@ func (e *Engine) probeSucceeds(ctx context.Context, command string) bool {
 // returns the final observed result, the until CheckResult (nil when no retry is
 // configured), and an execution error. With retry, the command is re-run until
 // until passes or the attempt budget is spent; the last attempt's result is what
-// later steps observe (ADR-0022).
+// later steps observe.
 func (e *Engine) runStep(ctx context.Context, run *spec.Run, st *store.Store, workdir, specDir string, rc runConfig, sshConns map[string]*sshrunner.Runner) (*runner.Result, []*assert.CheckResult, error) {
-	// A run step naming an ssh runner executes remotely (ADR-0027); otherwise it
+	// A run step naming an ssh runner executes remotely; otherwise it
 	// runs locally via the cmd runner. The runner is resolved once (not per
 	// retry attempt) so the timeout precedence below sees the pristine authored
 	// step value.

--- a/internal/engine/expand.go
+++ b/internal/engine/expand.go
@@ -44,7 +44,7 @@ func mergeScenarioEnv(scenarioEnv map[string]string, r *spec.Run, st *store.Stor
 
 // expandService applies ${name} substitution to a background service's command,
 // cwd, env, and readiness file/port so a service can reference ${workdir} and
-// matrix-bound variables (ADR-0031). Scenario env is layered under the service's
+// matrix-bound variables. Scenario env is layered under the service's
 // own env, mirroring run steps.
 func expandService(st *store.Store, scenarioEnv map[string]string, svc *spec.Service) *spec.Service {
 	c := *svc
@@ -119,7 +119,7 @@ func expandHTTP(st *store.Store, h *spec.HTTP) *spec.HTTP {
 }
 
 // expandHTTP's gRPC counterpart: expand ${name} in the method, header values,
-// and JSON request body so a grpc call can reference stored values (ADR-0028).
+// and JSON request body so a grpc call can reference stored values.
 func expandGRPC(st *store.Store, g *spec.GRPC) *spec.GRPC {
 	c := *g
 	c.Method = st.Expand(g.Method)
@@ -129,7 +129,7 @@ func expandGRPC(st *store.Store, g *spec.GRPC) *spec.GRPC {
 }
 
 // expandCDP applies ${name} substitution to a cdp step's action arguments so a
-// browser flow can reference stored values (ADR-0029).
+// browser flow can reference stored values.
 func expandCDP(st *store.Store, c *spec.CDP) *spec.CDP {
 	out := *c
 	out.Actions = make([]spec.CDPAction, len(c.Actions))

--- a/internal/engine/expand_test.go
+++ b/internal/engine/expand_test.go
@@ -12,7 +12,7 @@ import (
 
 func ptr(s string) *string { return &s }
 
-// TestExpandAssert_StreamAndFileMatchers covers ADR-0019: ${name}/${workdir}
+// TestExpandAssert_StreamAndFileMatchers covers that ${name}/${workdir}
 // substitution reaches stream and file matcher values, not just file.path.
 func TestExpandAssert_StreamAndFileMatchers(t *testing.T) {
 	t.Parallel()

--- a/internal/engine/feature_test.go
+++ b/internal/engine/feature_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 // TestEngine_MatrixRunsEachRow checks that a matrix scenario expands and each
-// instance resolves its own bound variables (ADR-0020).
+// instance resolves its own bound variables.
 func TestEngine_MatrixRunsEachRow(t *testing.T) {
 	t.Parallel()
 	res := runSpec(t, `
@@ -137,7 +137,7 @@ scenarios:
 	}
 }
 
-// TestEngine_SkipByCommand exercises the probe-command skip predicate (ADR-0021).
+// TestEngine_SkipByCommand exercises the probe-command skip predicate.
 func TestEngine_SkipByCommand(t *testing.T) {
 	t.Parallel()
 	res := runSpec(t, `

--- a/internal/engine/http.go
+++ b/internal/engine/http.go
@@ -15,7 +15,7 @@ import (
 )
 
 // runHTTPStep executes an http step, applying retry/until polling when
-// requested — the http counterpart of runStep (ADR-0022). The
+// requested — the http counterpart of runStep. The
 // request is re-issued until until passes or the attempt budget is spent; the
 // last response is what later steps observe. It returns the final response, the
 // until CheckResult (nil when no retry is configured), whether a failure was a

--- a/internal/engine/service_test.go
+++ b/internal/engine/service_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 )
 
-// TestEngine_ServiceReadyFileCapturedAndUsed covers ADR-0031 end to end through
-// the engine: a background service publishes a value to a ready file, the engine
+// TestEngine_ServiceReadyFileCapturedAndUsed covers the services feature end to
+// end through the engine: a background service publishes a value to a ready file, the engine
 // captures it into ${addr}, and a later step reads the value back.
 func TestEngine_ServiceReadyFileCapturedAndUsed(t *testing.T) {
 	t.Parallel()

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -245,7 +245,7 @@ func explainScenario(b *strings.Builder, sc *spec.Scenario) {
 }
 
 // describeService renders a one-line summary of a background service and how its
-// readiness is decided (ADR-0031).
+// readiness is decided.
 func describeService(svc *spec.Service) string {
 	desc := svc.Name + ": " + svc.Command
 	if svc.ClearEnvEnabled() {
@@ -274,7 +274,7 @@ func describeService(svc *spec.Service) string {
 	return desc
 }
 
-// describeCDP renders a one-line summary of a cdp step's action list (ADR-0029),
+// describeCDP renders a one-line summary of a cdp step's action list,
 // reusing the shared per-action labels so explain stays aligned with doc and
 // manifest (#50).
 func describeCDP(c *spec.CDP) string {

--- a/internal/loader/defaults.go
+++ b/internal/loader/defaults.go
@@ -7,7 +7,7 @@ import (
 )
 
 // applyDefaults expands the top-level `defaults:` block into the concrete
-// scenario model (ADR-0039). It runs after matrix expansion and before
+// scenario model. It runs after matrix expansion and before
 // validation, so the merged result is validated and the engine only ever sees
 // fully-resolved scenarios — `defaults` is pure authoring sugar with no runtime
 // model of its own.

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -69,7 +69,7 @@ func LoadBytes(path string, data []byte) (*spec.Spec, error) {
 	}
 	expandMatrix(&s)
 	// Expand the top-level defaults into the concrete scenario/step/service model
-	// so validation and the engine only ever see fully-resolved scenarios (ADR-0039).
+	// so validation and the engine only ever see fully-resolved scenarios.
 	applyDefaults(&s)
 	if errs := validate(&s); len(errs) > 0 {
 		return nil, &Error{Path: path, Kind: KindValidation, Msg: joinErrors(errs)}

--- a/internal/loader/matrix.go
+++ b/internal/loader/matrix.go
@@ -37,7 +37,7 @@ func validateMatrix(s *spec.Spec) []string {
 }
 
 // expandMatrix replaces every matrix scenario with one concrete scenario per row,
-// in definition order (ADR-0020). Each instance carries its row as
+// in definition order. Each instance carries its row as
 // Vars (seeded into the store before steps run) and a templated, unique Name.
 // Scenarios without a matrix are left untouched.
 func expandMatrix(s *spec.Spec) {

--- a/internal/loader/validate.go
+++ b/internal/loader/validate.go
@@ -171,7 +171,7 @@ func validateMockRoutes(add func(string, ...any), where string, routes []spec.Mo
 	}
 }
 
-// validateDefaults checks the top-level `defaults:` block (ADR-0039). The merge only
+// validateDefaults checks the top-level `defaults:` block. The merge only
 // covers non-identity, non-per-step fields, so a value the loader would silently
 // ignore is reported here instead. Fields the loader does merge are validated on
 // the concrete elements after applyDefaults (and, for a shared readiness probe,

--- a/internal/report/tap.go
+++ b/internal/report/tap.go
@@ -9,7 +9,7 @@ import (
 )
 
 // writeTAP emits a Test Anything Protocol (TAP version 13) stream, the format
-// several CI ecosystems and TAP consumers expect (ADR-0024). One
+// several CI ecosystems and TAP consumers expect. One
 // `ok`/`not ok` line per scenario across every suite, numbered from 1; failures
 // and errors carry a YAML diagnostic block, and skips use the `# SKIP` directive.
 // Rendered by Render (FormatTAP).

--- a/internal/runner/browser/browser.go
+++ b/internal/runner/browser/browser.go
@@ -1,6 +1,6 @@
 // Package browser implements the browser (CDP) runner: a `cdp` step drives a
 // headless Chrome via the Chrome DevTools Protocol and captures a value from the
-// page as a runner.Result (ADR-0029). It is the atago counterpart
+// page as a runner.Result. It is the atago counterpart
 // to runn's CDP runner and builds on github.com/chromedp/chromedp — the same
 // library runn uses. One browser session is shared across the cdp steps of a
 // scenario, so navigation state persists between them.

--- a/internal/runner/cmd/cmd_test.go
+++ b/internal/runner/cmd/cmd_test.go
@@ -457,7 +457,7 @@ func TestRun_CommandNotFound(t *testing.T) {
 }
 
 // TestRun_ShellNotShadowedByPath verifies that a `sh` placed first on PATH does
-// not hijack the harness shell (ADR-0018). A sabotaged `sh` that always prints
+// not hijack the harness shell. A sabotaged `sh` that always prints
 // HIJACKED and exits 0 sits in the workdir; with PATH pointing only at it, a
 // PATH-resolved shell would run it, but the absolute /bin/sh must be used.
 func TestRun_ShellNotShadowedByPath(t *testing.T) {

--- a/internal/runner/db/db.go
+++ b/internal/runner/db/db.go
@@ -1,7 +1,7 @@
 // Package db implements the database runner: it runs a SQL statement from a
 // `query:` step through a named db runner and captures the result — rows (for a
 // SELECT) as a JSON array, or the affected-row count (for INSERT/UPDATE/DDL) —
-// as a runner.Result (ADR-0026). It is the atago counterpart to
+// as a runner.Result. It is the atago counterpart to
 // runn's DB runner. Only pure-Go drivers are linked in (no cgo): SQLite via
 // modernc.org/sqlite, PostgreSQL via lib/pq, MySQL via go-sql-driver/mysql.
 package db

--- a/internal/runner/grpc/grpc.go
+++ b/internal/runner/grpc/grpc.go
@@ -1,6 +1,6 @@
 // Package grpc implements the gRPC runner: a `grpc` step calls a unary method on
 // a target server and captures the response message (as JSON) and status code as
-// a runner.Result (ADR-0028). It is the atago counterpart to runn's
+// a runner.Result. It is the atago counterpart to runn's
 // gRPC runner and resolves the service schema dynamically via server reflection
 // (jhump/protoreflect/v2 + google.golang.org/grpc) — no compiled stubs, keeping
 // specs declarative.

--- a/internal/runner/service/service.go
+++ b/internal/runner/service/service.go
@@ -1,5 +1,5 @@
 // Package service runs the background processes a scenario declares under
-// `services` (ADR-0031): a long-lived peer (a TCP server, an API stub) started
+// `services`: a long-lived peer (a TCP server, an API stub) started
 // before the scenario's steps and torn down — with its whole process group —
 // when the scenario ends. It reuses the command runner's tokenization and
 // environment handling so a service spawns identically to a run step.

--- a/internal/runner/ssh/ssh.go
+++ b/internal/runner/ssh/ssh.go
@@ -1,6 +1,6 @@
 // Package ssh implements the SSH runner: a `run` step naming an ssh runner
 // executes its command on a remote host over SSH, capturing stdout, stderr, and
-// the exit code as a runner.Result (ADR-0027). It is the atago
+// the exit code as a runner.Result. It is the atago
 // counterpart to runn's SSH runner and builds on golang.org/x/crypto/ssh — the
 // same transport runn uses — driven entirely by the runner's declared
 // connection fields (no ~/.ssh/config dependency, so runs stay reproducible).

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -22,14 +22,14 @@ type Spec struct {
 	Permissions *Permissions      `yaml:"permissions,omitempty"`
 	Secrets     []string          `yaml:"secrets,omitempty"`
 	// Defaults declares spec-wide default fragments merged into every matching
-	// element at load time (ADR-0039). It is authoring sugar only: the loader
+	// element at load time. It is authoring sugar only: the loader
 	// expands it into the concrete scenario/step/service model before validation,
 	// so nothing downstream (engine, manifest, explain) ever observes `defaults`.
 	Defaults  *Defaults  `yaml:"defaults,omitempty"`
 	Scenarios []Scenario `yaml:"scenarios"`
 }
 
-// Defaults holds the top-level `defaults:` block (ADR-0039). Each fragment is
+// Defaults holds the top-level `defaults:` block. Each fragment is
 // merged into the concrete model at load time to cut repetition without adding a
 // runtime model: `run` layers under every `run` step, `scenario.env` under every
 // scenario env, and `service` under every service.
@@ -90,13 +90,13 @@ type Runner struct {
 	BaseURL string `yaml:"base_url,omitempty"`
 	// DSN is the data source for a db runner, e.g. "sqlite:./app.db",
 	// "postgres://user:pass@host/db", or "mysql://user:pass@host:3306/db". The
-	// driver is inferred from the scheme unless Driver is set (ADR-0026).
+	// driver is inferred from the scheme unless Driver is set.
 	DSN string `yaml:"dsn,omitempty"`
 	// Driver, when set, names the database/sql driver explicitly (sqlite,
 	// postgres, or mysql), overriding scheme inference.
 	Driver string `yaml:"driver,omitempty"`
 
-	// SSH runner fields (ADR-0027). A `run` step naming an ssh runner executes its
+	// SSH runner fields. A `run` step naming an ssh runner executes its
 	// command on the remote host, capturing stdout/stderr/exit like a local run.
 	Host       string `yaml:"host,omitempty"`        // host or host:port (default port 22)
 	User       string `yaml:"user,omitempty"`        // login user
@@ -108,12 +108,12 @@ type Runner struct {
 	// configuration error rather than a silent MITM-able default (issue #17).
 	InsecureHostKey bool `yaml:"insecure_host_key,omitempty"`
 
-	// gRPC runner fields (ADR-0028). A `grpc` step calls a unary method on the
+	// gRPC runner fields. A `grpc` step calls a unary method on the
 	// target, resolving the schema via server reflection (no compiled stubs).
 	Target string `yaml:"target,omitempty"` // host:port of the gRPC server
 	TLS    bool   `yaml:"tls,omitempty"`    // use TLS (default plaintext)
 
-	// Browser runner fields (ADR-0038). A minimal, black-box configuration surface
+	// Browser runner fields. A minimal, black-box configuration surface
 	// for the CDP runner; all are optional and preserve the zero-config headless
 	// default when omitted.
 	//
@@ -147,7 +147,7 @@ type Scenario struct {
 	Only *Condition        `yaml:"only,omitempty"`
 	Env  map[string]string `yaml:"env,omitempty"`
 	// Matrix, when set, makes this scenario a template: the loader expands it into
-	// one concrete scenario per row before validation (ADR-0020).
+	// one concrete scenario per row before validation.
 	// Each row's key/value pairs are seeded as ${name} variables for that instance.
 	Matrix []map[string]string `yaml:"matrix,omitempty"`
 	// Vars holds the bound matrix row for an expanded scenario instance. It is
@@ -160,7 +160,7 @@ type Scenario struct {
 	// index — and therefore its source location (#80). Never decoded from YAML.
 	SourceIndex int `yaml:"-"`
 	// Services are background processes started before the scenario's steps run
-	// and terminated when the scenario ends (ADR-0031). They let a spec exercise a
+	// and terminated when the scenario ends. They let a spec exercise a
 	// CLI that talks to a peer (a TCP client, an API consumer) by standing up that
 	// peer for the duration of the scenario.
 	Services []Service `yaml:"services,omitempty"`
@@ -183,7 +183,7 @@ type Scenario struct {
 }
 
 // Service is a background process started before a scenario's steps run and
-// terminated (with its whole process group) when the scenario ends (ADR-0031).
+// terminated (with its whole process group) when the scenario ends.
 // It runs in the scenario workdir and gets the same ${name} expansion and
 // scenario-env layering as a run step.
 type Service struct {
@@ -272,7 +272,7 @@ type MockAssert struct {
 	Body *StreamAssert `yaml:"body,omitempty"`
 }
 
-// Ready is a service readiness probe (ADR-0031). Exactly one of File/Port/Log/
+// Ready is a service readiness probe. Exactly one of File/Port/Log/
 // Delay decides when the service is considered up; Timeout bounds the wait.
 type Ready struct {
 	// File waits until this workdir-relative file exists and is non-empty — the
@@ -299,7 +299,7 @@ type Ready struct {
 // `skip: { env: X }` skips when X is set; `only: { env: X }` runs only when X is
 // set. For Command, the condition is true when the probe command succeeds (exits
 // 0): `skip: { command: X }` skips when X succeeds; `only: { command: X }` runs
-// only when X succeeds (ADR-0021). The probe runs through the shell.
+// only when X succeeds. The probe runs through the shell.
 type Condition struct {
 	OS      string `yaml:"os,omitempty"`
 	Env     string `yaml:"env,omitempty"`
@@ -377,7 +377,7 @@ func NormalizeSignalName(name string) string {
 // ValidSignalName reports whether the (normalized) signal name is accepted.
 func ValidSignalName(name string) bool { return validSignalNames[NormalizeSignalName(name)] }
 
-// Query runs a SQL statement through a named db runner (ADR-0026). The result
+// Query runs a SQL statement through a named db runner. The result
 // rows (for a SELECT) are captured as JSON for the `rows` assertion target and
 // `store from.rows`; a non-row statement records its affected-row count.
 type Query struct {
@@ -385,7 +385,7 @@ type Query struct {
 	SQL    string `yaml:"sql"`
 }
 
-// GRPC calls a unary gRPC method through a named grpc runner (ADR-0028). The
+// GRPC calls a unary gRPC method through a named grpc runner. The
 // response message is captured as JSON for the `message` assertion target and
 // `store from.message`; the status code feeds the `grpc_status` target.
 type GRPC struct {
@@ -395,7 +395,7 @@ type GRPC struct {
 	JSON   any               `yaml:"json,omitempty"` // request message
 }
 
-// CDP drives a headless browser through a named browser runner (ADR-0029). The
+// CDP drives a headless browser through a named browser runner. The
 // action list runs in order against one browser session; the value captured by
 // the last `text`/`eval` action feeds the `value` assertion target and
 // `store from.value`.
@@ -537,7 +537,7 @@ type Run struct {
 	StdoutTo string `yaml:"stdout_to,omitempty"`
 	StderrTo string `yaml:"stderr_to,omitempty"`
 	// Retry, when set, re-runs the command until the Until assertion passes,
-	// polling declaratively for async behavior (ADR-0022).
+	// polling declaratively for async behavior.
 	Retry *Retry `yaml:"retry,omitempty"`
 }
 
@@ -775,7 +775,7 @@ type HTTP struct {
 	// Retry, when set, re-issues the request until the Until assertion passes,
 	// polling declaratively for eventually-consistent endpoints (a metric that
 	// appears after a scrape, an async job flipping to done) exactly like a run
-	// step's retry (ADR-0022).
+	// step's retry.
 	Retry *Retry `yaml:"retry,omitempty"`
 }
 
@@ -803,19 +803,19 @@ type Assert struct {
 	Body   *StreamAssert `yaml:"body,omitempty"`
 
 	// Rows is the db assertion target: the query result rows as a JSON array,
-	// matched with the stream matchers (json path/length, contains, …) (ADR-0026).
+	// matched with the stream matchers (json path/length, contains, …).
 	Rows *StreamAssert `yaml:"rows,omitempty"`
 
-	// gRPC assertion targets (ADR-0028): GRPCStatus checks the numeric status
+	// gRPC assertion targets: GRPCStatus checks the numeric status
 	// code; Message matches the response message (as JSON) with the stream matchers.
 	GRPCStatus *int          `yaml:"grpc_status,omitempty"`
 	Message    *StreamAssert `yaml:"message,omitempty"`
 
-	// Value is the browser assertion target (ADR-0029): the value captured by the
+	// Value is the browser assertion target: the value captured by the
 	// last text/eval action, matched with the stream matchers.
 	Value *StreamAssert `yaml:"value,omitempty"`
 
-	// Image is the image assertion target (ADR-0030): it inspects a generated
+	// Image is the image assertion target: it inspects a generated
 	// image file's decoded properties (format, dimensions, alpha) and can compare
 	// its pixels against a baseline image.
 	Image *ImageAssert `yaml:"image,omitempty"`
@@ -945,7 +945,7 @@ type DirAssert struct {
 	Ignore []string `yaml:"ignore,omitempty"`
 }
 
-// ImageAssert checks a generated image file (ADR-0030). Unlike the one-of
+// ImageAssert checks a generated image file. Unlike the one-of
 // stream/file targets, every field that is set is a separate constraint and all
 // of them must hold, because an image has several independent observable
 // attributes. At least one constraint must be set.

--- a/test/e2e/atago/assert_expand.atago.yaml
+++ b/test/e2e/atago/assert_expand.atago.yaml
@@ -6,7 +6,7 @@ suite:
 # Regression for the mimixbox migration: ShellSpec specs embed paths in expected
 # output, e.g. `The output should equal "${MIMIXBOX_IT_ROOT}/cat.txt"`. atago
 # now expands ${name}/${workdir} in stream and file matcher values too
-# (ADR-0019), not just in commands and file.path.
+#, not just in commands and file.path.
 scenarios:
   - name: stdout.equals expands ${workdir}
     steps:

--- a/test/e2e/atago/cdp.atago.yaml
+++ b/test/e2e/atago/cdp.atago.yaml
@@ -4,7 +4,7 @@ suite:
   name: atago self-hosting / browser (cdp) runner
 
 # Exercises the browser/CDP runner's wiring through the real atago binary
-# (ADR-0029). Live browser automation needs a headless Chrome and is covered
+#. Live browser automation needs a headless Chrome and is covered
 # hermetically by a Go test that launches one and serves test HTML
 # (internal/engine/browser_test.go, skipped when Chrome is unavailable); these
 # scenarios pin the binary's config validation and dispatch errors, which need

--- a/test/e2e/atago/db.atago.yaml
+++ b/test/e2e/atago/db.atago.yaml
@@ -3,7 +3,7 @@ version: "1"
 suite:
   name: atago self-hosting / db runner
 
-# Exercises the DB runner end-to-end through the real atago binary (ADR-0026),
+# Exercises the DB runner end-to-end through the real atago binary,
 # using an in-memory SQLite database (pure-Go modernc driver, no cgo, no external
 # server). Live multi-driver behavior is covered by Go tests
 # (internal/runner/db, internal/engine/db_test.go).

--- a/test/e2e/atago/defaults.atago.yaml
+++ b/test/e2e/atago/defaults.atago.yaml
@@ -3,7 +3,7 @@ version: "1"
 suite:
   name: atago self-hosting / top-level defaults
 
-# Exercises the top-level `defaults:` block (ADR-0039): shared authoring sugar
+# Exercises the top-level `defaults:` block: shared authoring sugar
 # merged into the concrete scenario/step/service model at load time. These specs
 # run the built ${atago} against inner specs and assert the merged behavior, so
 # the feature is verified end-to-end (not just in loader unit tests). The scope

--- a/test/e2e/atago/grpc.atago.yaml
+++ b/test/e2e/atago/grpc.atago.yaml
@@ -3,7 +3,7 @@ version: "1"
 suite:
   name: atago self-hosting / grpc runner
 
-# Exercises the gRPC runner's wiring through the real atago binary (ADR-0028).
+# Exercises the gRPC runner's wiring through the real atago binary.
 # Live unary calls (reflection-resolved, status/message asserts, value binding)
 # are covered hermetically by a Go test with an in-process grpcstub server
 # (internal/engine/grpc_test.go); these scenarios pin the binary's config

--- a/test/e2e/atago/http.atago.yaml
+++ b/test/e2e/atago/http.atago.yaml
@@ -3,7 +3,7 @@ version: "1"
 suite:
   name: atago self-hosting / http runner
 
-# Exercises the HTTP runner end-to-end through the real atago binary (ADR-0025).
+# Exercises the HTTP runner end-to-end through the real atago binary.
 # Live request/response behavior is covered by Go httptest integration tests
 # (internal/runner/http, internal/engine/http_test.go); these self-host scenarios
 # pin the binary's wiring and exit codes for the paths that need no live server:

--- a/test/e2e/atago/image.atago.yaml
+++ b/test/e2e/atago/image.atago.yaml
@@ -3,7 +3,7 @@ version: "1"
 suite:
   name: atago self-hosting / image
 
-# Exercises the `image` assertion target (ADR-0030) end-to-end through the real
+# Exercises the `image` assertion target end-to-end through the real
 # binary: a generated image's format/dimensions/alpha are checked, and a pixel
 # comparison against a baseline image passes or fails as expected. Images are
 # materialized from base64 fixtures so the spec stays hermetic (no image tool on

--- a/test/e2e/atago/json_compare.atago.yaml
+++ b/test/e2e/atago/json_compare.atago.yaml
@@ -3,7 +3,7 @@ version: "1"
 suite:
   name: atago self-hosting / json numeric comparators
 
-# Exercises the numeric bound matchers gt/gte/lt/lte on a json target (ADR-0034).
+# Exercises the numeric bound matchers gt/gte/lt/lte on a json target.
 # They let a spec pin a non-deterministic-but-bounded metric — a processed-record
 # count, a coverage figure, a rate — where an exact `equals` is impossible but
 # "at least N" / "below N" is exactly the contract worth asserting. Surfaced

--- a/test/e2e/atago/matrix.atago.yaml
+++ b/test/e2e/atago/matrix.atago.yaml
@@ -3,7 +3,7 @@ version: "1"
 suite:
   name: atago self-hosting / matrix scenarios
 
-# Exercises declarative parameterized scenarios via `matrix:` (ADR-0020): one
+# Exercises declarative parameterized scenarios via `matrix:`: one
 # template scenario expands into a concrete scenario per row, with each row's
 # variables seeded for ${name} substitution. This is atago's answer to
 # ShellSpec `Parameters`, staying declarative with no expression language.

--- a/test/e2e/atago/not_equals.atago.yaml
+++ b/test/e2e/atago/not_equals.atago.yaml
@@ -3,7 +3,7 @@ version: "1"
 suite:
   name: atago self-hosting / not_equals matcher
 
-# Exercises the negative exact-text matcher `not_equals` (ADR-0023), the
+# Exercises the negative exact-text matcher `not_equals`, the
 # symmetric counterpart of `equals`. Modeled on ShellSpec's `should not equal`,
 # which procps/util-linux ports had to work around with contains/matches.
 scenarios:

--- a/test/e2e/atago/retry.atago.yaml
+++ b/test/e2e/atago/retry.atago.yaml
@@ -3,7 +3,7 @@ version: "1"
 suite:
   name: atago self-hosting / retry until
 
-# Exercises declarative retry/until polling on a run step (ADR-0022): the command
+# Exercises declarative retry/until polling on a run step: the command
 # is re-run until the `until` assertion passes or the attempt budget is spent.
 # This is atago's answer to runn's retry for async behavior, with no hand-rolled
 # shell `timeout` loops.

--- a/test/e2e/atago/services.atago.yaml
+++ b/test/e2e/atago/services.atago.yaml
@@ -3,7 +3,7 @@ version: "1"
 suite:
   name: atago self-hosting / background services
 
-# Exercises scenario-level `services` (ADR-0031) through the real atago binary:
+# Exercises scenario-level `services` through the real atago binary:
 # a background process is started before the steps, its readiness is awaited via
 # file/log/delay probes, a dynamic value is captured from its ready file into a
 # ${var}, and the process group is torn down when the scenario ends. These

--- a/test/e2e/atago/shell_path.atago.yaml
+++ b/test/e2e/atago/shell_path.atago.yaml
@@ -7,7 +7,7 @@ suite:
 # under test*, and a CLI may legitimately ship its own `sh` (e.g. mimixbox's sh
 # applet). If `shell: true` resolved its shell through that PATH, the program
 # under test would hijack atago's shell and change pipe/redirect/exit
-# semantics. The runner therefore invokes an absolute shell (ADR-0018), so a
+# semantics. The runner therefore invokes an absolute shell, so a
 # PATH-resident `sh` cannot take over.
 scenarios:
   - name: a PATH-resident fake sh does not hijack shell:true

--- a/test/e2e/atago/skip_command.atago.yaml
+++ b/test/e2e/atago/skip_command.atago.yaml
@@ -3,7 +3,7 @@ version: "1"
 suite:
   name: atago self-hosting / skip-only command predicate
 
-# Exercises the runtime probe-command skip/only predicate (ADR-0021): a scenario
+# Exercises the runtime probe-command skip/only predicate: a scenario
 # is gated by whether a probe command succeeds (exits 0). This is atago's
 # declarative answer to ShellSpec's `Skip if <shell test>`.
 scenarios:

--- a/test/e2e/atago/ssh.atago.yaml
+++ b/test/e2e/atago/ssh.atago.yaml
@@ -3,7 +3,7 @@ version: "1"
 suite:
   name: atago self-hosting / ssh runner
 
-# Exercises the SSH runner's wiring through the real atago binary (ADR-0027).
+# Exercises the SSH runner's wiring through the real atago binary.
 # Live remote execution is covered hermetically by a Go test with an in-process
 # SSH server (internal/engine/ssh_test.go); these scenarios pin the binary's
 # config validation and dispatch errors, which need no server.

--- a/test/e2e/tools/iso8583tool/ergonomics.atago.yaml
+++ b/test/e2e/tools/iso8583tool/ergonomics.atago.yaml
@@ -12,7 +12,7 @@ suite:
 
 # Every command here needs the shell (env vars like $ISO_EXAMPLES, pipes into
 # `cat -v`, redirects), so default shell:true once instead of on every run step
-# (ADR-0039). A step can still add its own runner/cwd/timeout/env/stdin.
+#. A step can still add its own runner/cwd/timeout/env/stdin.
 defaults:
   run:
     shell: true

--- a/test/e2e/tools/iso8583tool/send.atago.yaml
+++ b/test/e2e/tools/iso8583tool/send.atago.yaml
@@ -2,7 +2,7 @@
 # send: drive the TCP client against a local, in-repo mock server. The mock
 # (spec/mock, built as `iso-mock` by run.sh) listens on 127.0.0.1 with an
 # ephemeral port, reads one framed request, and replies with a fixed 0810
-# response framed the same way. atago's `services` (ADR-0031) replace the
+# response framed the same way. atago's `services` replace the
 # ShellSpec build_mock/start_mock/stop_mock helpers: each scenario starts its
 # own single-shot mock, waits for it to publish its address into ready.txt, and
 # captures that address into ${addr}. No external network; deterministic reply.

--- a/test/e2e/tools/sqly/output_format.atago.yaml
+++ b/test/e2e/tools/sqly/output_format.atago.yaml
@@ -6,7 +6,7 @@
 # The fixture inlines a trimmed copy of sqly's testdata/user.csv (only the two
 # columns these queries touch) so the suite stays hermetic.
 #
-# This is the spec family the `line:` selector (ADR-0012) was added to migrate:
+# This is the spec family the `line:` selector was added to migrate:
 # ShellSpec's `The line N should equal '...'` becomes `line: N` + `equals:`.
 version: "1"
 

--- a/test/e2e/tools/truss/convert.atago.yaml
+++ b/test/e2e/tools/truss/convert.atago.yaml
@@ -1,4 +1,4 @@
-# Dogfood spec: exercises atago's `image` assertion (ADR-0030) against the real
+# Dogfood spec: exercises atago's `image` assertion against the real
 # `truss` image-transform CLI (github.com/nao1215/truss). Requires `truss` on
 # PATH; run with: make dogfood. Each scenario is gated on truss being present so
 # the suite skips cleanly where it is not installed.


### PR DESCRIPTION
## Summary

Code and E2E-spec comments cited ADR numbers (`ADR-0018` … `ADR-0039`) for decisions that were never committed as files under `doc/adr/`, so each reference was a dead end for a contributor trying to follow it (#39).

Rather than backfill ADR documents and a guard test, this drops the citations. Each reference was a parenthetical tag appended to a comment that already states the rationale inline (e.g. `// gRPC runner fields (ADR-0028).` → `// gRPC runner fields.`), so the bare number carried no information a reader could act on. Keeping decision rationale in the code comments themselves — not in separate numbered documents or issue threads — is the convention going forward.

## Changes

- Removed every `ADR-NNNN` reference from Go comments (23 files) and `*.atago.yaml` spec comments (leading comment blocks).
- No ADR files or guard test added.

## Verification

`git diff` is comment-only (verified: no non-comment line changed). `go build`, `go vet`, `go test ./...`, `golangci-lint` (0 issues), `make docs` (no drift — spec comments don't feed generated docs), and `GOOS=windows go build` all green.

Closes #39