### PR TITLE
feat(run): sandbox_home isolates HOME and per-OS config/cache dirs (#71)

### DIFF
--- a/.github/workflows/e2e-cross.yml
+++ b/.github/workflows/e2e-cross.yml
@@ -67,6 +67,7 @@ jobs:
               ./test/e2e/atago/dir_tree.atago.yaml
               ./test/e2e/atago/record.atago.yaml
               ./test/e2e/atago/duration.atago.yaml
+              ./test/e2e/atago/sandbox_home.atago.yaml
               ./test/e2e/atago/grpc.atago.yaml
               ./test/e2e/atago/ssh.atago.yaml
               ./test/e2e/atago/cdp.atago.yaml

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -122,6 +122,7 @@ jobs:
           ./test/e2e/atago/dir_tree.atago.yaml
           ./test/e2e/atago/record.atago.yaml
           ./test/e2e/atago/duration.atago.yaml
+          ./test/e2e/atago/sandbox_home.atago.yaml
           ./test/e2e/atago/grpc.atago.yaml
           ./test/e2e/atago/ssh.atago.yaml
           ./test/e2e/atago/cdp.atago.yaml

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Every feature has a commented, runnable spec under [examples/](examples/). The e
 | [files_and_fixtures](examples/files_and_fixtures.atago.yaml) | input fixtures (text and base64), `file` and `dir` assertions |
 | [store_and_variables](examples/store_and_variables.atago.yaml) | capturing values into `${name}`, `${workdir}`, `${env:NAME}` host-environment reads, the `$${...}` literal escape |
 | [teardown](examples/teardown.atago.yaml) | cleanup steps that always run — pass or fail — sharing the scenario's variables |
-| [hermetic_env](examples/hermetic_env.atago.yaml) | `clear_env: true` starts commands from an empty environment, `pass_env` re-admits an allowlist of host variables |
+| [hermetic_env](examples/hermetic_env.atago.yaml) | `clear_env: true` starts commands from an empty environment, `pass_env` re-admits an allowlist of host variables, `sandbox_home: true` isolates HOME and per-OS config/cache dirs |
 | [timeouts](examples/timeouts.atago.yaml) | the built-in 60s default step timeout, `suite.timeout`, per-step overrides, and the `timeout: "0"` escape hatch |
 | [stdin](examples/stdin.atago.yaml) | stdin sources: inline text, `stdin: {file: ...}` from a workdir file, and binary input via `stdin: {base64: ...}` |
 | [matrix](examples/matrix.atago.yaml) | one template scenario expanded per parameter row |

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-52 suites · 187 scenarios
+53 suites · 189 scenarios
 ## Contents
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 3 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
@@ -177,6 +177,9 @@
   - [a failing assertion exits one and reports the failure](#scenario-a-failing-assertion-exits-one-and-reports-the-failure)
   - [a parse error exits with code two](#scenario-a-parse-error-exits-with-code-two)
   - [JSON report is valid JSON with a passed status](#scenario-json-report-is-valid-json-with-a-passed-status)
+- [atago self-hosting / sandbox_home (isolated per-OS home)](#atago-self-hosting--sandbox_home-isolated-per-os-home) — 2 scenarios
+  - [Unix XDG family — write config, read it back, inspect it under the workdir](#scenario-unix-xdg-family--write-config-read-it-back-inspect-it-under-the-workdir)
+  - [Windows APPDATA family — write config, read it back, inspect it under the workdir](#scenario-windows-appdata-family--write-config-read-it-back-inspect-it-under-the-workdir)
 - [atago self-hosting / security](#atago-self-hosting--security) — 3 scenarios
   - [declared secrets are masked in failure output](#scenario-declared-secrets-are-masked-in-failure-output)
   - [a file assertion path may not escape the scenario workdir](#scenario-a-file-assertion-path-may-not-escape-the-scenario-workdir)
@@ -3193,6 +3196,42 @@ ${atago} run --report json ok.atago.yaml
 - stdout at `$.schema_version` equals `1`
 - stdout at `$.suites[0].status` equals `passed`
 - stdout at `$.suites[0].scenarios` has length 1
+## atago self-hosting / sandbox_home (isolated per-OS home)
+Source: `test/e2e/atago/sandbox_home.atago.yaml`
+### Scenario: Unix XDG family — write config, read it back, inspect it under the workdir
+_skipped on windows_
+#### Given
+- The command runs with an isolated home under `${workdir}/.atago-home` (HOME/XDG or APPDATA redirected).
+- The command runs with an isolated home under `${workdir}/.atago-home` (HOME/XDG or APPDATA redirected).
+#### When
+```shell
+mkdir -p "$XDG_CONFIG_HOME/mytool" && printf editor=vim > "$XDG_CONFIG_HOME/mytool/config"
+cat "$XDG_CONFIG_HOME/mytool/config"
+```
+#### Then
+- after `mkdir -p "$XDG_CONFIG_HOME/mytool" && printf editor=vim > "$XDG_CONFIG_HOME/mytool/config"`:
+  - exit code is `0`
+- after `cat "$XDG_CONFIG_HOME/mytool/config"`:
+  - exit code is `0`
+  - stdout equals an exact value
+  - file `.atago-home/.config/mytool/config` contains `editor=vim`
+### Scenario: Windows APPDATA family — write config, read it back, inspect it under the workdir
+_only on windows_
+#### Given
+- The command runs with an isolated home under `${workdir}/.atago-home` (HOME/XDG or APPDATA redirected).
+- The command runs with an isolated home under `${workdir}/.atago-home` (HOME/XDG or APPDATA redirected).
+#### When
+```shell
+mkdir "%APPDATA%\mytool" & echo editor=vim>"%APPDATA%\mytool\config.txt"
+type "%APPDATA%\mytool\config.txt"
+```
+#### Then
+- after `mkdir "%APPDATA%\mytool" & echo editor=vim>"%APPDATA%\mytool\config.txt"`:
+  - exit code is `0`
+- after `type "%APPDATA%\mytool\config.txt"`:
+  - exit code is `0`
+  - stdout contains `editor=vim`
+  - file `.atago-home/AppData/Roaming/mytool/config.txt` contains `editor=vim`
 ## atago self-hosting / security
 Source: `test/e2e/atago/security.atago.yaml`
 ### Scenario: declared secrets are masked in failure output

--- a/examples/hermetic_env.atago.yaml
+++ b/examples/hermetic_env.atago.yaml
@@ -73,3 +73,33 @@ scenarios:
           exit_code: 0
           stdout:
             equals: /hermetic/home
+
+  # sandbox_home (#71) does the OS-specific work clear_env leaves to you: it
+  # points HOME and the XDG config/cache/data/state dirs (USERPROFILE/APPDATA on
+  # Windows) at a fresh ${workdir}/.atago-home, so a CLI that reads or writes
+  # ~/.config runs hermetically with one key. The path is deterministic, so an
+  # ordinary file: assert can inspect what the CLI wrote there.
+  - name: sandbox_home isolates the home directory
+    skip:
+      os: windows
+    steps:
+      # Write a config file under the sandboxed home, then read it back in a
+      # second step — the isolated home is created once and reused.
+      - run:
+          shell: true
+          sandbox_home: true
+          command: 'mkdir -p "$XDG_CONFIG_HOME/mytool" && echo dark > "$XDG_CONFIG_HOME/mytool/theme"'
+      - run:
+          shell: true
+          sandbox_home: true
+          command: 'cat "$XDG_CONFIG_HOME/mytool/theme"'
+      - assert:
+          exit_code: 0
+          stdout:
+            equals: "dark\n"
+      # The file lives at the deterministic path under ${workdir}, so no new
+      # builtin variable is needed to inspect it.
+      - assert:
+          file:
+            path: .atago-home/.config/mytool/theme
+            contains: dark

--- a/internal/docgen/docgen.go
+++ b/internal/docgen/docgen.go
@@ -213,14 +213,24 @@ func givenBullets(sc *spec.Scenario, expand func(string) string) []string {
 			if step.Run.ClearEnvEnabled() {
 				out = append(out, clearedEnvBullet(step.Run.PassEnv))
 			}
+			if step.Run.SandboxHomeEnabled() {
+				out = append(out, sandboxHomeBullet)
+			}
 		case spec.StepPTY:
 			if step.PTY.ClearEnvEnabled() {
 				out = append(out, clearedEnvBullet(step.PTY.PassEnv))
+			}
+			if step.PTY.SandboxHomeEnabled() {
+				out = append(out, sandboxHomeBullet)
 			}
 		}
 	}
 	return out
 }
+
+// sandboxHomeBullet is the Given bullet for a step that runs with an isolated
+// home (sandbox_home, #71).
+const sandboxHomeBullet = "The command runs with an isolated home under `${workdir}/.atago-home` (HOME/XDG or APPDATA redirected)."
 
 // clearedEnvBullet renders the hermetic-environment Given bullet shared by run
 // and pty steps (#16).

--- a/internal/engine/pty.go
+++ b/internal/engine/pty.go
@@ -44,7 +44,16 @@ func (e *Engine) runPTY(ctx context.Context, p *spec.PTY, st *store.Store, scena
 			c.Session[i] = na
 		}
 	}
-	return ptyrun.Run(ctx, &c, workdir, runnercmd.BuildEnv(c.Env, c.ClearEnvEnabled(), c.PassEnv))
+	// sandbox_home (#71) redirects the pty child's home under ${workdir}/.atago-home.
+	var sandbox map[string]string
+	if c.SandboxHomeEnabled() {
+		s, err := runnercmd.EnsureSandboxHome(workdir)
+		if err != nil {
+			return nil, nil, err
+		}
+		sandbox = s
+	}
+	return ptyrun.Run(ctx, &c, workdir, runnercmd.BuildEnv(c.Env, c.ClearEnvEnabled(), c.PassEnv, sandbox))
 }
 
 // ptyExpectCheck converts a never-matched session expect into the structured

--- a/internal/engine/sandbox_home_test.go
+++ b/internal/engine/sandbox_home_test.go
@@ -1,0 +1,114 @@
+package engine
+
+import (
+	"runtime"
+	"testing"
+)
+
+// TestEngine_SandboxHome_ReuseAcrossSteps proves the isolated home is created
+// once and reused: a CLI writes config under the sandboxed home in step 1 and
+// reads it back in step 2, and the file is visible under ${workdir}/.atago-home
+// to an ordinary file: assert (#71).
+func TestEngine_SandboxHome_ReuseAcrossSteps(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("XDG variable family is POSIX-only")
+	}
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: sandbox
+scenarios:
+  - name: writes then reads its config
+    steps:
+      - run:
+          shell: true
+          sandbox_home: true
+          command: 'mkdir -p "$XDG_CONFIG_HOME/app" && echo vim > "$XDG_CONFIG_HOME/app/editor"'
+      - run:
+          shell: true
+          sandbox_home: true
+          command: 'cat "$XDG_CONFIG_HOME/app/editor"'
+      - assert:
+          stdout:
+            equals: "vim\n"
+      - assert:
+          file:
+            path: .atago-home/.config/app/editor
+            contains: vim
+`)
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed: %+v", res.Status, res.Scenarios[0].Steps)
+	}
+}
+
+// TestEngine_SandboxHome_ClearEnvComposition proves that with clear_env +
+// sandbox_home the child sees the sandbox HOME rather than the host's, and that
+// pass_env: [HOME] cannot leak the host home past the sandbox (#71).
+func TestEngine_SandboxHome_ClearEnvComposition(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("HOME/XDG family is POSIX-only")
+	}
+	t.Setenv("HOME", "/definitely/not/the/sandbox")
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: sandbox
+scenarios:
+  - name: sandbox home wins over pass_env
+    steps:
+      - run:
+          shell: true
+          clear_env: true
+          pass_env: [HOME]
+          sandbox_home: true
+          command: 'printf "%s" "$HOME"'
+      - assert:
+          stdout:
+            matches: '/\.atago-home$'
+      - assert:
+          stdout:
+            not_contains: /definitely/not/the/sandbox
+`)
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed: %+v", res.Status, res.Scenarios[0].Steps)
+	}
+}
+
+// TestEngine_SandboxHome_IsolatedBetweenScenarios proves each scenario gets its
+// own workdir and therefore its own isolated home: a file written in one
+// scenario is not visible in the next (#71).
+func TestEngine_SandboxHome_IsolatedBetweenScenarios(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("XDG variable family is POSIX-only")
+	}
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: sandbox
+scenarios:
+  - name: first writes a marker
+    steps:
+      - run:
+          shell: true
+          sandbox_home: true
+          command: 'echo one > "$XDG_DATA_HOME/marker"'
+      - assert:
+          file:
+            path: .atago-home/.local/share/marker
+            exists: true
+  - name: second starts clean
+    steps:
+      - run:
+          shell: true
+          sandbox_home: true
+          command: 'test ! -e "$XDG_DATA_HOME/marker"; echo $?'
+      - assert:
+          stdout:
+            equals: "0\n"
+`)
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed: %+v", res.Status, res.Scenarios)
+	}
+}

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -144,6 +144,9 @@ func explainScenario(b *strings.Builder, sc *spec.Scenario) {
 					}
 					desc += note + ")"
 				}
+				if step.PTY.SandboxHomeEnabled() {
+					desc += "  (isolated home)"
+				}
 				commands = append(commands, desc)
 				collectVars(vars, step.PTY.Command, step.PTY.Cwd)
 				for _, v := range step.PTY.Env {
@@ -339,6 +342,9 @@ func describeRun(r *spec.Run) string {
 			note += " (passes: " + strings.Join(r.PassEnv, ", ") + ")"
 		}
 		notes = append(notes, note)
+	}
+	if r.SandboxHomeEnabled() {
+		notes = append(notes, "isolated home")
 	}
 	switch {
 	case r.Stdin.File != "":

--- a/internal/loader/defaults.go
+++ b/internal/loader/defaults.go
@@ -86,6 +86,9 @@ func mergeRunDefaults(def, r *spec.Run) {
 	if r.ClearEnv == nil {
 		r.ClearEnv = def.ClearEnv
 	}
+	if r.SandboxHome == nil {
+		r.SandboxHome = def.SandboxHome
+	}
 	// pass_env is meaningless without clear_env, so a step that authored
 	// `clear_env: false` does not inherit the default allowlist (#16).
 	if r.PassEnv == nil && r.ClearEnvEnabled() {

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -88,6 +88,58 @@ scenarios:
 	}
 }
 
+// TestLoadBytes_SandboxHome proves sandbox_home is accepted on run, pty, and
+// defaults.run, decodes to the pointer, and is strict-rejected on a service (#71).
+func TestLoadBytes_SandboxHome(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: sample
+defaults:
+  run:
+    sandbox_home: true
+scenarios:
+  - name: ok
+    steps:
+      - run:
+          command: echo hi
+      - pty:
+          command: echo hi
+          sandbox_home: true
+`
+	s, err := LoadBytes("sample.atago.yaml", []byte(src))
+	if err != nil {
+		t.Fatalf("LoadBytes() error = %v", err)
+	}
+	run := s.Scenarios[0].Steps[0].Run
+	if !run.SandboxHomeEnabled() {
+		t.Errorf("defaults.run.sandbox_home did not layer onto the run step: %+v", run.SandboxHome)
+	}
+	pty := s.Scenarios[0].Steps[1].PTY
+	if !pty.SandboxHomeEnabled() {
+		t.Errorf("pty.sandbox_home not decoded: %+v", pty.SandboxHome)
+	}
+
+	// A service has no sandbox_home key: strict decode must reject it.
+	bad := `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: ok
+    services:
+      - name: peer
+        command: sleep 1
+        sandbox_home: true
+    steps:
+      - run: {command: echo hi}
+`
+	if _, err := LoadBytes("sample.atago.yaml", []byte(bad)); err == nil {
+		t.Error("sandbox_home on a service should be strict-rejected, got nil error")
+	}
+}
+
 func TestLoadBytes_Errors(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/runner/cmd/cmd.go
+++ b/internal/runner/cmd/cmd.go
@@ -54,7 +54,17 @@ func (r *Runner) Run(ctx context.Context, run *spec.Run, workdir string) (*runne
 		ConfigureShell(cmd, run.Command)
 	}
 	cmd.Dir = resolveDir(workdir, run.Cwd)
-	cmd.Env = buildEnv(run.Env, run.ClearEnvEnabled(), run.PassEnv)
+	// sandbox_home (#71) redirects the child's home and per-OS config/cache dirs
+	// at ${workdir}/.atago-home. The overlay sits between pass_env and the step's
+	// own env in precedence and composes with clear_env.
+	var sandbox map[string]string
+	if run.SandboxHomeEnabled() {
+		sandbox, err = EnsureSandboxHome(workdir)
+		if err != nil {
+			return nil, err
+		}
+	}
+	cmd.Env = buildEnv(run.Env, run.ClearEnvEnabled(), run.PassEnv, sandbox)
 	// On cancellation (Ctrl-C / suite cancel / step timeout), kill the whole
 	// process group, not just the shell we spawned: `sh -c "sleep 30"` orphans its
 	// child, and that orphan keeps the stdout/stderr pipe open, so cmd.Wait would
@@ -294,9 +304,11 @@ func ResolveDir(workdir, cwd string) string { return resolveDir(workdir, cwd) }
 // BuildEnv composes a child process environment: it inherits the parent
 // environment (or starts empty when clearEnv is set, re-admitting only the
 // passEnv allowlist) and applies per-command overrides on top (shared with the
-// service and pty runners) (#16).
-func BuildEnv(overrides map[string]string, clearEnv bool, passEnv []string) []string {
-	return buildEnv(overrides, clearEnv, passEnv)
+// service and pty runners) (#16). sandbox is the optional sandbox_home overlay
+// (#71), layered above pass_env/host but below the step's own overrides; pass
+// nil when no isolated home is requested.
+func BuildEnv(overrides map[string]string, clearEnv bool, passEnv []string, sandbox map[string]string) []string {
+	return buildEnv(overrides, clearEnv, passEnv, sandbox)
 }
 
 // resolveDir returns the working directory for the command. cwd is interpreted
@@ -316,23 +328,27 @@ func resolveDir(workdir, cwd string) string {
 var windowsCriticalEnv = []string{"SystemRoot", "SystemDrive", "TEMP", "TMP", "PATHEXT"}
 
 // buildEnv composes the child environment. Without clearEnv it inherits the
-// parent environment and appends per-step overrides (a nil return means
-// "inherit os.Environ()", exec's default). With clearEnv it starts empty:
-// only the passEnv allowlist (plus the Windows system-critical set) is copied
-// from the host, and overrides are layered on top so the existing
-// suite → scenario → step precedence is preserved (#16).
-func buildEnv(overrides map[string]string, clearEnv bool, passEnv []string) []string {
+// parent environment and appends the sandbox_home overlay and per-step
+// overrides (a nil return means "inherit os.Environ()", exec's default). With
+// clearEnv it starts empty: only the passEnv allowlist (plus the Windows
+// system-critical set) is copied from the host, then the sandbox overlay, then
+// overrides — so the precedence step env > sandbox > pass_env > host holds
+// (os/exec keeps the last value for a duplicated key) (#16, #71).
+func buildEnv(overrides map[string]string, clearEnv bool, passEnv []string, sandbox map[string]string) []string {
 	if !clearEnv {
-		if len(overrides) == 0 {
+		if len(overrides) == 0 && len(sandbox) == 0 {
 			return nil // nil → inherit os.Environ() (exec default)
 		}
 		env := os.Environ()
+		for k, v := range sandbox {
+			env = append(env, k+"="+v)
+		}
 		for k, v := range overrides {
 			env = append(env, k+"="+v)
 		}
 		return env
 	}
-	env := make([]string, 0, len(passEnv)+len(overrides)+len(windowsCriticalEnv))
+	env := make([]string, 0, len(passEnv)+len(sandbox)+len(overrides)+len(windowsCriticalEnv))
 	if runtime.GOOS == "windows" {
 		for _, name := range windowsCriticalEnv {
 			if v, ok := lookupHostEnv(name); ok {
@@ -344,6 +360,12 @@ func buildEnv(overrides map[string]string, clearEnv bool, passEnv []string) []st
 		if v, ok := lookupHostEnv(name); ok {
 			env = append(env, name+"="+v)
 		}
+	}
+	// The sandbox overlay is injected after the environment is cleared and after
+	// pass_env, so `pass_env: [HOME]` cannot leak the host home past an enabled
+	// sandbox (#71).
+	for k, v := range sandbox {
+		env = append(env, k+"="+v)
 	}
 	for k, v := range overrides {
 		env = append(env, k+"="+v)

--- a/internal/runner/cmd/cmd_test.go
+++ b/internal/runner/cmd/cmd_test.go
@@ -143,7 +143,7 @@ func envMap(env []string) map[string]string {
 // empty environment: a canary host var must not reach the child (#16).
 func TestBuildEnv_ClearEnvDropsHostEnv(t *testing.T) {
 	t.Setenv("ATAGO_TEST_CANARY", "leaked")
-	env := BuildEnv(nil, true, nil)
+	env := BuildEnv(nil, true, nil, nil)
 	if env == nil {
 		t.Fatal("BuildEnv(clear) = nil, want a non-nil slice (nil inherits os.Environ)")
 	}
@@ -157,7 +157,7 @@ func TestBuildEnv_ClearEnvDropsHostEnv(t *testing.T) {
 func TestBuildEnv_PassEnvCopiesListedVars(t *testing.T) {
 	t.Setenv("ATAGO_TEST_KEEP", "kept")
 	t.Setenv("ATAGO_TEST_DROP", "dropped")
-	env := envMap(BuildEnv(nil, true, []string{"ATAGO_TEST_KEEP", "ATAGO_TEST_UNSET"}))
+	env := envMap(BuildEnv(nil, true, []string{"ATAGO_TEST_KEEP", "ATAGO_TEST_UNSET"}, nil))
 	if got := env["ATAGO_TEST_KEEP"]; got != "kept" {
 		t.Errorf("passed var = %q, want kept", got)
 	}
@@ -173,7 +173,7 @@ func TestBuildEnv_PassEnvCopiesListedVars(t *testing.T) {
 // passed-through host vars, preserving the existing layering order (#16).
 func TestBuildEnv_OverridesLayerOnTop(t *testing.T) {
 	t.Setenv("ATAGO_TEST_LAYER", "host")
-	env := envMap(BuildEnv(map[string]string{"ATAGO_TEST_LAYER": "step"}, true, []string{"ATAGO_TEST_LAYER"}))
+	env := envMap(BuildEnv(map[string]string{"ATAGO_TEST_LAYER": "step"}, true, []string{"ATAGO_TEST_LAYER"}, nil))
 	if got := env["ATAGO_TEST_LAYER"]; got != "step" {
 		t.Errorf("override = %q, want step (explicit env wins over pass_env)", got)
 	}
@@ -182,11 +182,11 @@ func TestBuildEnv_OverridesLayerOnTop(t *testing.T) {
 // TestBuildEnv_NoClearKeepsInheritance proves the pre-#16 behavior is
 // untouched when clear_env is off.
 func TestBuildEnv_NoClearKeepsInheritance(t *testing.T) {
-	if env := BuildEnv(nil, false, nil); env != nil {
+	if env := BuildEnv(nil, false, nil, nil); env != nil {
 		t.Errorf("BuildEnv(no overrides) = %v, want nil (inherit os.Environ)", env)
 	}
 	t.Setenv("ATAGO_TEST_INHERIT", "here")
-	env := envMap(BuildEnv(map[string]string{"EXTRA": "1"}, false, nil))
+	env := envMap(BuildEnv(map[string]string{"EXTRA": "1"}, false, nil, nil))
 	if got := env["ATAGO_TEST_INHERIT"]; got != "here" {
 		t.Errorf("inherited var = %q, want here", got)
 	}
@@ -201,7 +201,7 @@ func TestBuildEnv_WindowsKeepsSystemCriticalVars(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("windows-only behavior")
 	}
-	env := envMap(BuildEnv(nil, true, nil))
+	env := envMap(BuildEnv(nil, true, nil, nil))
 	for _, name := range []string{"SystemRoot", "SystemDrive", "PATHEXT"} {
 		if _, ok := env[name]; !ok {
 			t.Errorf("system-critical var %s missing from cleared env", name)

--- a/internal/runner/cmd/sandbox.go
+++ b/internal/runner/cmd/sandbox.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// SandboxHomeDirName is the fixed directory created inside the scenario workdir
+// to hold the isolated home (#71). Its path is deterministic
+// (`${workdir}/.atago-home`), so a spec can inspect files the CLI wrote there
+// with ordinary file: asserts — no new builtin variable is needed.
+const SandboxHomeDirName = ".atago-home"
+
+// SandboxHomeVars returns the environment variables that redirect a child
+// process's home and per-OS config/cache/data/state directories at home, plus
+// the concrete directories that must exist under it (#71). goos selects the
+// variable family so the mapping is unit-testable off-platform; separators are
+// chosen from goos too, which is correct on the host because goos == GOOS in
+// real use.
+func SandboxHomeVars(goos, home string) (vars map[string]string, dirs []string) {
+	sep := "/"
+	if goos == "windows" {
+		sep = `\`
+	}
+	join := func(parts ...string) string { return strings.Join(parts, sep) }
+
+	if goos == "windows" {
+		appdata := join(home, "AppData", "Roaming")
+		local := join(home, "AppData", "Local")
+		vars = map[string]string{
+			"USERPROFILE":  home,
+			"APPDATA":      appdata,
+			"LOCALAPPDATA": local,
+		}
+		// HOMEDRIVE/HOMEPATH split the home path the way cmd.exe expects. Derive
+		// the drive from the path itself (not filepath.VolumeName, which is a
+		// no-op off Windows) so the mapping is deterministic in tests.
+		if len(home) >= 2 && home[1] == ':' {
+			vars["HOMEDRIVE"] = home[:2]
+			vars["HOMEPATH"] = home[2:]
+		}
+		return vars, []string{home, appdata, local}
+	}
+
+	// Unix and macOS: HOME plus the XDG base-directory family. macOS derives its
+	// ~/Library paths from HOME, so setting HOME plus the XDG vars covers both.
+	config := join(home, ".config")
+	cache := join(home, ".cache")
+	data := join(home, ".local", "share")
+	state := join(home, ".local", "state")
+	vars = map[string]string{
+		"HOME":            home,
+		"XDG_CONFIG_HOME": config,
+		"XDG_CACHE_HOME":  cache,
+		"XDG_DATA_HOME":   data,
+		"XDG_STATE_HOME":  state,
+	}
+	return vars, []string{home, config, cache, data, state}
+}
+
+// EnsureSandboxHome creates `${workdir}/.atago-home` and its per-OS subdirectories
+// and returns the environment overlay redirecting the child's home there (#71).
+// The directory path is deterministic and reused across steps within a scenario:
+// MkdirAll is idempotent, so a CLI can write config in one step and read it back
+// in the next.
+func EnsureSandboxHome(workdir string) (map[string]string, error) {
+	home := filepath.Join(workdir, SandboxHomeDirName)
+	vars, dirs := SandboxHomeVars(runtime.GOOS, home)
+	for _, d := range dirs {
+		if err := os.MkdirAll(d, 0o755); err != nil { //nolint:gosec // the sandbox home lives inside the scenario workdir
+			return nil, fmt.Errorf("sandbox_home: %w", err)
+		}
+	}
+	return vars, nil
+}

--- a/internal/runner/cmd/sandbox_test.go
+++ b/internal/runner/cmd/sandbox_test.go
@@ -1,0 +1,151 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestSandboxHomeVars_PerOS pins the environment family each OS gets and proves
+// every path lands under the isolated home (#71).
+func TestSandboxHomeVars_PerOS(t *testing.T) {
+	tests := []struct {
+		name     string
+		goos     string
+		home     string
+		want     map[string]string
+		wantDirs []string
+	}{
+		{
+			name: "unix",
+			goos: "linux",
+			home: "/work/.atago-home",
+			want: map[string]string{
+				"HOME":            "/work/.atago-home",
+				"XDG_CONFIG_HOME": "/work/.atago-home/.config",
+				"XDG_CACHE_HOME":  "/work/.atago-home/.cache",
+				"XDG_DATA_HOME":   "/work/.atago-home/.local/share",
+				"XDG_STATE_HOME":  "/work/.atago-home/.local/state",
+			},
+			wantDirs: []string{
+				"/work/.atago-home",
+				"/work/.atago-home/.config",
+				"/work/.atago-home/.cache",
+				"/work/.atago-home/.local/share",
+				"/work/.atago-home/.local/state",
+			},
+		},
+		{
+			name: "darwin",
+			goos: "darwin",
+			home: "/work/.atago-home",
+			want: map[string]string{
+				"HOME":            "/work/.atago-home",
+				"XDG_CONFIG_HOME": "/work/.atago-home/.config",
+				"XDG_CACHE_HOME":  "/work/.atago-home/.cache",
+				"XDG_DATA_HOME":   "/work/.atago-home/.local/share",
+				"XDG_STATE_HOME":  "/work/.atago-home/.local/state",
+			},
+			wantDirs: []string{
+				"/work/.atago-home",
+				"/work/.atago-home/.config",
+				"/work/.atago-home/.cache",
+				"/work/.atago-home/.local/share",
+				"/work/.atago-home/.local/state",
+			},
+		},
+		{
+			name: "windows",
+			goos: "windows",
+			home: `C:\work\.atago-home`,
+			want: map[string]string{
+				"USERPROFILE":  `C:\work\.atago-home`,
+				"APPDATA":      `C:\work\.atago-home\AppData\Roaming`,
+				"LOCALAPPDATA": `C:\work\.atago-home\AppData\Local`,
+				"HOMEDRIVE":    "C:",
+				"HOMEPATH":     `\work\.atago-home`,
+			},
+			wantDirs: []string{
+				`C:\work\.atago-home`,
+				`C:\work\.atago-home\AppData\Roaming`,
+				`C:\work\.atago-home\AppData\Local`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vars, dirs := SandboxHomeVars(tt.goos, tt.home)
+			if len(vars) != len(tt.want) {
+				t.Fatalf("vars = %v, want %v", vars, tt.want)
+			}
+			for k, want := range tt.want {
+				if got := vars[k]; got != want {
+					t.Errorf("vars[%q] = %q, want %q", k, got, want)
+				}
+			}
+			if len(dirs) != len(tt.wantDirs) {
+				t.Fatalf("dirs = %v, want %v", dirs, tt.wantDirs)
+			}
+			for i, want := range tt.wantDirs {
+				if dirs[i] != want {
+					t.Errorf("dirs[%d] = %q, want %q", i, dirs[i], want)
+				}
+			}
+		})
+	}
+}
+
+// TestEnsureSandboxHome_CreatesDirs proves the isolated home tree is created
+// under the workdir and that a second call is idempotent (reuse across steps).
+func TestEnsureSandboxHome_CreatesDirs(t *testing.T) {
+	workdir := t.TempDir()
+	vars, err := EnsureSandboxHome(workdir)
+	if err != nil {
+		t.Fatalf("EnsureSandboxHome: %v", err)
+	}
+	home := filepath.Join(workdir, SandboxHomeDirName)
+	if runtime.GOOS == "windows" {
+		if vars["USERPROFILE"] != home {
+			t.Errorf("USERPROFILE = %q, want %q", vars["USERPROFILE"], home)
+		}
+	} else if vars["HOME"] != home {
+		t.Errorf("HOME = %q, want %q", vars["HOME"], home)
+	}
+	if fi, err := os.Stat(home); err != nil || !fi.IsDir() {
+		t.Fatalf("home dir not created: %v", err)
+	}
+	// Idempotent: a second call must not error even though the dirs exist.
+	if _, err := EnsureSandboxHome(workdir); err != nil {
+		t.Fatalf("second EnsureSandboxHome: %v", err)
+	}
+}
+
+// TestBuildEnv_SandboxPrecedence proves the precedence chain
+// step env > sandbox > pass_env > host holds under clear_env (#71): pass_env
+// cannot leak the host home past the sandbox, but an explicit env wins.
+func TestBuildEnv_SandboxPrecedence(t *testing.T) {
+	t.Setenv("HOME", "/host/home")
+	sandbox := map[string]string{"HOME": "/sandbox/home", "XDG_CONFIG_HOME": "/sandbox/home/.config"}
+
+	// clear_env + pass_env [HOME] + sandbox: the sandbox wins over pass_env.
+	env := envMap(BuildEnv(nil, true, []string{"HOME"}, sandbox))
+	if got := env["HOME"]; got != "/sandbox/home" {
+		t.Errorf("HOME = %q, want /sandbox/home (sandbox beats pass_env)", got)
+	}
+	if got := env["XDG_CONFIG_HOME"]; got != "/sandbox/home/.config" {
+		t.Errorf("XDG_CONFIG_HOME = %q, want /sandbox/home/.config", got)
+	}
+
+	// An explicit step env still wins over the sandbox.
+	env = envMap(BuildEnv(map[string]string{"HOME": "/explicit"}, true, []string{"HOME"}, sandbox))
+	if got := env["HOME"]; got != "/explicit" {
+		t.Errorf("HOME = %q, want /explicit (step env beats sandbox)", got)
+	}
+
+	// Without clear_env the sandbox still overrides the inherited host HOME.
+	env = envMap(BuildEnv(nil, false, nil, sandbox))
+	if got := env["HOME"]; got != "/sandbox/home" {
+		t.Errorf("HOME = %q, want /sandbox/home (sandbox overrides inherited host)", got)
+	}
+}

--- a/internal/runner/service/service.go
+++ b/internal/runner/service/service.go
@@ -61,7 +61,7 @@ func Start(ctx context.Context, svc *spec.Service, workdir string) (*Proc, strin
 		cmd.ConfigureShell(pc.cmd, svc.Command)
 	}
 	pc.cmd.Dir = cmd.ResolveDir(workdir, svc.Cwd)
-	pc.cmd.Env = cmd.BuildEnv(svc.Env, svc.ClearEnvEnabled(), svc.PassEnv)
+	pc.cmd.Env = cmd.BuildEnv(svc.Env, svc.ClearEnvEnabled(), svc.PassEnv, nil)
 	pc.cmd.Stdout = out
 	pc.cmd.Stderr = out
 

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -525,6 +525,13 @@ type Run struct {
 	// (#16). Only meaningful with ClearEnv (the loader rejects it otherwise);
 	// unset host variables are skipped, not an error.
 	PassEnv []string `yaml:"pass_env,omitempty"`
+	// SandboxHome points the child's home directory and per-OS config/cache/
+	// data/state locations at a fresh `${workdir}/.atago-home` so a CLI that
+	// reads or writes ~/.config, ~/.cache, or %APPDATA% runs hermetically. The
+	// sandbox variables sit between pass_env and the step's own env in
+	// precedence, and compose with clear_env (injected after the clear). A
+	// pointer so an authored `sandbox_home: false` beats a defaulted true.
+	SandboxHome *bool `yaml:"sandbox_home,omitempty"`
 	// Stdin feeds the command's standard input: a scalar string (inline
 	// text), {file: path} (workdir-relative, expanded and confined), or
 	// {base64: data} for binary bytes (#18).
@@ -559,6 +566,12 @@ func (s *Service) ClearEnvEnabled() bool { return s.ClearEnv != nil && *s.ClearE
 
 // ClearEnvEnabled reports whether the pty step opts into a cleared environment (#16).
 func (p *PTY) ClearEnvEnabled() bool { return p.ClearEnv != nil && *p.ClearEnv }
+
+// SandboxHomeEnabled reports whether the run step opts into an isolated home (#71).
+func (r *Run) SandboxHomeEnabled() bool { return r.SandboxHome != nil && *r.SandboxHome }
+
+// SandboxHomeEnabled reports whether the pty step opts into an isolated home (#71).
+func (p *PTY) SandboxHomeEnabled() bool { return p.SandboxHome != nil && *p.SandboxHome }
 
 // Retry re-runs a command until Until passes or the attempt budget is exhausted.
 // The last attempt's result is what subsequent steps observe.
@@ -596,6 +609,9 @@ type PTY struct {
 	// PassEnv copies the listed host variables into the cleared environment
 	// (#16). Only meaningful with ClearEnv; unset host variables are skipped.
 	PassEnv []string `yaml:"pass_env,omitempty"`
+	// SandboxHome isolates the pty child's home and per-OS config/cache/data/
+	// state directories under `${workdir}/.atago-home`, mirroring run.sandbox_home.
+	SandboxHome *bool `yaml:"sandbox_home,omitempty"`
 	// Session is the ordered expect/send script. Each entry sets exactly one
 	// of Expect (wait until the accumulated transcript matches the regexp) or
 	// Send (write the string to the terminal; an empty send transmits EOF,

--- a/schema/atago.schema.json
+++ b/schema/atago.schema.json
@@ -89,7 +89,8 @@
             "timeout": { "type": "string" },
             "env": { "type": "object", "additionalProperties": { "type": "string" } },
             "clear_env": { "type": "boolean", "description": "Start the child from an empty environment instead of inheriting the host environment (#16). On Windows a small system-critical set (SystemRoot, SystemDrive, TEMP, TMP, PATHEXT) is always retained." },
-            "pass_env": { "type": "array", "items": { "type": "string", "minLength": 1 }, "description": "Host variables copied into the cleared environment (#16). Requires clear_env: true; unset host variables are skipped." }
+            "pass_env": { "type": "array", "items": { "type": "string", "minLength": 1 }, "description": "Host variables copied into the cleared environment (#16). Requires clear_env: true; unset host variables are skipped." },
+            "sandbox_home": { "type": "boolean", "description": "Point the child's home and per-OS config/cache/data/state dirs at ${workdir}/.atago-home so a CLI touching ~/.config, ~/.cache, or %APPDATA% runs hermetically (#71). Precedence: step env > sandbox > pass_env > host; composes with clear_env." }
           }
         },
         "scenario": {
@@ -449,6 +450,7 @@
         "env": { "type": "object", "additionalProperties": { "type": "string" } },
         "clear_env": { "type": "boolean", "description": "Start the child from an empty environment instead of inheriting the host environment (#16). On Windows a small system-critical set (SystemRoot, SystemDrive, TEMP, TMP, PATHEXT) is always retained." },
         "pass_env": { "type": "array", "items": { "type": "string", "minLength": 1 }, "description": "Host variables copied into the cleared environment (#16). Requires clear_env: true; unset host variables are skipped." },
+        "sandbox_home": { "type": "boolean", "description": "Point the child's home and per-OS config/cache/data/state dirs at ${workdir}/.atago-home so a CLI touching ~/.config, ~/.cache, or %APPDATA% runs hermetically (#71). Precedence: step env > sandbox > pass_env > host; composes with clear_env." },
         "stdin": {
           "description": "Standard input for the command (#18): a plain string (inline text), {file: path} (workdir-relative, path-confined), or {base64: data} for binary bytes.",
           "oneOf": [
@@ -497,6 +499,7 @@
         "env": { "type": "object", "additionalProperties": { "type": "string" } },
         "clear_env": { "type": "boolean", "description": "Start the child from an empty environment instead of inheriting the host environment (#16). On Windows a small system-critical set (SystemRoot, SystemDrive, TEMP, TMP, PATHEXT) is always retained." },
         "pass_env": { "type": "array", "items": { "type": "string", "minLength": 1 }, "description": "Host variables copied into the cleared environment (#16). Requires clear_env: true; unset host variables are skipped." },
+        "sandbox_home": { "type": "boolean", "description": "Point the pty child's home and per-OS config/cache/data/state dirs at ${workdir}/.atago-home so a CLI touching ~/.config, ~/.cache, or %APPDATA% runs hermetically (#71)." },
         "session": {
           "type": "array",
           "minItems": 1,

--- a/test/e2e/atago/sandbox_home.atago.yaml
+++ b/test/e2e/atago/sandbox_home.atago.yaml
@@ -1,0 +1,64 @@
+version: "1"
+
+suite:
+  name: atago self-hosting / sandbox_home (isolated per-OS home)
+
+# Exercises #71: `sandbox_home: true` points the child's home and per-OS
+# config/cache/data/state locations at a fresh ${workdir}/.atago-home, so a CLI
+# that reads or writes ~/.config (or %APPDATA% on Windows) runs hermetically
+# with one key. The isolated home is created once and reused across steps, and
+# its path is deterministic — so an ordinary file: assert can inspect what the
+# CLI wrote there without any new builtin variable.
+#
+# The variable families differ per OS, so the write/read commands are OS-gated:
+# the Unix scenario drives $XDG_CONFIG_HOME, the Windows scenario drives
+# %APPDATA%. Both prove the same contract.
+scenarios:
+  - name: Unix XDG family — write config, read it back, inspect it under the workdir
+    skip:
+      os: windows
+    steps:
+      # Step 1 writes a config file under the sandboxed XDG config home.
+      - run:
+          shell: true
+          sandbox_home: true
+          command: 'mkdir -p "$XDG_CONFIG_HOME/mytool" && printf editor=vim > "$XDG_CONFIG_HOME/mytool/config"'
+      - assert:
+          exit_code: 0
+      # Step 2 reads it back — the isolated home is reused across steps.
+      - run:
+          shell: true
+          sandbox_home: true
+          command: 'cat "$XDG_CONFIG_HOME/mytool/config"'
+      - assert:
+          exit_code: 0
+          stdout:
+            equals: editor=vim
+      # The file lives at the deterministic path under ${workdir}.
+      - assert:
+          file:
+            path: .atago-home/.config/mytool/config
+            contains: editor=vim
+
+  - name: Windows APPDATA family — write config, read it back, inspect it under the workdir
+    only:
+      os: windows
+    steps:
+      - run:
+          shell: true
+          sandbox_home: true
+          command: 'mkdir "%APPDATA%\mytool" & echo editor=vim>"%APPDATA%\mytool\config.txt"'
+      - assert:
+          exit_code: 0
+      - run:
+          shell: true
+          sandbox_home: true
+          command: 'type "%APPDATA%\mytool\config.txt"'
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: editor=vim
+      - assert:
+          file:
+            path: .atago-home/AppData/Roaming/mytool/config.txt
+            contains: editor=vim


### PR DESCRIPTION
Closes #71.

## Summary
Adds `sandbox_home: true` on run/pty steps (and `defaults.run`). It points the child process's home and per-OS config/cache/data/state locations at a fresh `${workdir}/.atago-home`, so a CLI touching `~/.config`, `~/.cache`, or `%APPDATA%` runs hermetically with one key.

- **Unix/macOS**: `HOME` + `XDG_CONFIG_HOME`/`XDG_CACHE_HOME`/`XDG_DATA_HOME`/`XDG_STATE_HOME`.
- **Windows**: `USERPROFILE`/`APPDATA`/`LOCALAPPDATA` + `HOMEDRIVE`/`HOMEPATH`.
- **Precedence**: step `env` > sandbox > `pass_env` > host; injected after `clear_env`, so `pass_env: [HOME]` cannot leak the host home past the sandbox, but an explicit `env: {HOME: ...}` still wins.
- The isolated home is created once per scenario and reused across steps at a deterministic path — specs inspect it with ordinary `file:` asserts, no new builtin variable.

## Tests
- Unit: per-OS env construction (table tests), the full precedence chain, directory reuse/idempotence.
- Engine: `clear_env` composition, reuse across steps, isolation between scenarios.
- Loader: accepted on run/pty/defaults, strict-rejected on a service.
- Extends `examples/hermetic_env.atago.yaml`; adds portable self-hosted E2E `test/e2e/atago/sandbox_home.atago.yaml` (Unix + Windows OS-gated), wired into both e2e Windows allowlists.
- JSON schema, docgen/explain (Given/isolated-home bullet), `doc/e2e/atago.md` regenerated.

`go test ./...`, `go vet ./...`, `golangci-lint run` all green; full self-hosted E2E dir passes (189 scenarios).