### PR TITLE
feat(assert): changes pins the exact workdir delta a step made (#70)

### DIFF
--- a/.github/workflows/e2e-cross.yml
+++ b/.github/workflows/e2e-cross.yml
@@ -65,7 +65,6 @@ jobs:
               ./test/e2e/atago/http.atago.yaml
               ./test/e2e/atago/mock_server.atago.yaml
               ./test/e2e/atago/dir_tree.atago.yaml
-
               ./test/e2e/atago/changes.atago.yaml
               ./test/e2e/atago/record.atago.yaml
               ./test/e2e/atago/duration.atago.yaml

--- a/.github/workflows/e2e-cross.yml
+++ b/.github/workflows/e2e-cross.yml
@@ -65,6 +65,8 @@ jobs:
               ./test/e2e/atago/http.atago.yaml
               ./test/e2e/atago/mock_server.atago.yaml
               ./test/e2e/atago/dir_tree.atago.yaml
+
+              ./test/e2e/atago/changes.atago.yaml
               ./test/e2e/atago/record.atago.yaml
               ./test/e2e/atago/duration.atago.yaml
               ./test/e2e/atago/sandbox_home.atago.yaml

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -120,7 +120,6 @@ jobs:
           ./test/e2e/atago/http.atago.yaml
           ./test/e2e/atago/mock_server.atago.yaml
           ./test/e2e/atago/dir_tree.atago.yaml
-
           ./test/e2e/atago/changes.atago.yaml
           ./test/e2e/atago/record.atago.yaml
           ./test/e2e/atago/duration.atago.yaml

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -120,6 +120,8 @@ jobs:
           ./test/e2e/atago/http.atago.yaml
           ./test/e2e/atago/mock_server.atago.yaml
           ./test/e2e/atago/dir_tree.atago.yaml
+
+          ./test/e2e/atago/changes.atago.yaml
           ./test/e2e/atago/record.atago.yaml
           ./test/e2e/atago/duration.atago.yaml
           ./test/e2e/atago/sandbox_home.atago.yaml

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Every feature has a commented, runnable spec under [examples/](examples/). The e
 | [snapshot](examples/snapshot.atago.yaml) | golden-file testing with normalized output |
 | [duration](examples/duration.atago.yaml) | bound a step's wall-clock time with `duration: {lt: 2s, gte: 100ms}` (use generous bounds — CI runners are slow) |
 | [dir_tree](examples/dir_tree.atago.yaml) | recursive dir assertions and directory-tree snapshots: pin a generator's whole output tree with one golden manifest |
+| [changes](examples/changes.atago.yaml) | `changes:` pins the exact workdir delta of a step — which files it created, modified, and deleted, and nothing else |
 | [services](examples/services.atago.yaml) | background servers: readiness probes, `ready.store`, teardown |
 | [signal](examples/signal.atago.yaml) | `signal:` steps deliver SIGTERM/SIGHUP/... to a managed service's process group for graceful-shutdown and reload testing (POSIX-only) |
 | [defaults](examples/defaults.atago.yaml) | sharing `shell`/`env`/`service` fragments across scenarios |

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-53 suites · 189 scenarios
+53 suites · 190 scenarios
 ## Contents
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 3 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
@@ -15,6 +15,10 @@
   - [manifest surfaces the browser-runner configuration](#scenario-manifest-surfaces-the-browser-runner-configuration)
   - [an upload action without a file fails validation (exit 2)](#scenario-an-upload-action-without-a-file-fails-validation-exit-2)
   - [a download action without a click selector fails validation (exit 2)](#scenario-a-download-action-without-a-click-selector-fails-validation-exit-2)
+- [atago self-hosting / changes (workdir delta assertions)](#atago-self-hosting--changes-workdir-delta-assertions) — 3 scenarios
+  - [a generator touches exactly the files it should (POSIX)](#scenario-a-generator-touches-exactly-the-files-it-should-posix)
+  - [an unexpected creation breaks the exact contract (POSIX)](#scenario-an-unexpected-creation-breaks-the-exact-contract-posix)
+  - [stdout_to counts as created, and modified nothing holds (portable)](#scenario-stdout_to-counts-as-created-and-modified-nothing-holds-portable)
 - [atago self-hosting / completion](#atago-self-hosting--completion) — 5 scenarios
   - [bash completion emits a recognizable script](#scenario-bash-completion-emits-a-recognizable-script)
   - [zsh completion emits a compdef script](#scenario-zsh-completion-emits-a-compdef-script)
@@ -177,9 +181,6 @@
   - [a failing assertion exits one and reports the failure](#scenario-a-failing-assertion-exits-one-and-reports-the-failure)
   - [a parse error exits with code two](#scenario-a-parse-error-exits-with-code-two)
   - [JSON report is valid JSON with a passed status](#scenario-json-report-is-valid-json-with-a-passed-status)
-- [atago self-hosting / sandbox_home (isolated per-OS home)](#atago-self-hosting--sandbox_home-isolated-per-os-home) — 2 scenarios
-  - [Unix XDG family — write config, read it back, inspect it under the workdir](#scenario-unix-xdg-family--write-config-read-it-back-inspect-it-under-the-workdir)
-  - [Windows APPDATA family — write config, read it back, inspect it under the workdir](#scenario-windows-appdata-family--write-config-read-it-back-inspect-it-under-the-workdir)
 - [atago self-hosting / security](#atago-self-hosting--security) — 3 scenarios
   - [declared secrets are masked in failure output](#scenario-declared-secrets-are-masked-in-failure-output)
   - [a file assertion path may not escape the scenario workdir](#scenario-a-file-assertion-path-may-not-escape-the-scenario-workdir)
@@ -498,6 +499,74 @@ ${atago} run baddownload.atago.yaml
 #### Then
 - exit code is `2`
 - stderr contains `download requires a click selector`
+## atago self-hosting / changes (workdir delta assertions)
+Source: `test/e2e/atago/changes.atago.yaml`
+### Scenario: a generator touches exactly the files it should (POSIX)
+_skipped on windows_
+#### Given
+- Fixture file `config.yaml` is created.
+- Fixture file `stale.html` is created.
+#### Inputs
+_Fixture `config.yaml`:_
+```text
+theme: light
+```
+_Fixture `stale.html`:_
+```text
+old
+```
+#### When
+```shell
+printf 'theme: dark\n' > config.yaml && rm stale.html && mkdir -p site/assets && printf '<html></html>' > site/index.html && printf 'body{}' > site/assets/app.css
+```
+#### Then
+- exit code is `0`
+- the step changed exactly created `site/index.html`, `site/assets/*.css`, modified `config.yaml`, deleted `stale.html`
+### Scenario: an unexpected creation breaks the exact contract (POSIX)
+_skipped on windows_
+#### Given
+- Fixture file `check.atago.yaml` is created.
+#### Inputs
+_Fixture `check.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: unexpected
+scenarios:
+  - name: extra file
+    steps:
+      - run:
+          shell: true
+          command: 'echo a > a.txt && echo b > b.txt'
+      - assert:
+          changes:
+            created:
+              - a.txt
+```
+#### When
+```shell
+${atago} run check.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `unexpected created file`
+### Scenario: stdout_to counts as created, and modified nothing holds (portable)
+#### Given
+- Fixture file `input.txt` is created.
+#### Inputs
+_Fixture `input.txt`:_
+```text
+seed
+```
+#### When
+```shell
+echo produced
+```
+#### Then
+- exit code is `0`
+- the step changed exactly created `result.txt`, modified nothing, deleted nothing
+#### Generated artifacts
+- `result.txt`
 ## atago self-hosting / completion
 Source: `test/e2e/atago/completion.atago.yaml`
 ### Scenario: bash completion emits a recognizable script
@@ -3196,42 +3265,6 @@ ${atago} run --report json ok.atago.yaml
 - stdout at `$.schema_version` equals `1`
 - stdout at `$.suites[0].status` equals `passed`
 - stdout at `$.suites[0].scenarios` has length 1
-## atago self-hosting / sandbox_home (isolated per-OS home)
-Source: `test/e2e/atago/sandbox_home.atago.yaml`
-### Scenario: Unix XDG family — write config, read it back, inspect it under the workdir
-_skipped on windows_
-#### Given
-- The command runs with an isolated home under `${workdir}/.atago-home` (HOME/XDG or APPDATA redirected).
-- The command runs with an isolated home under `${workdir}/.atago-home` (HOME/XDG or APPDATA redirected).
-#### When
-```shell
-mkdir -p "$XDG_CONFIG_HOME/mytool" && printf editor=vim > "$XDG_CONFIG_HOME/mytool/config"
-cat "$XDG_CONFIG_HOME/mytool/config"
-```
-#### Then
-- after `mkdir -p "$XDG_CONFIG_HOME/mytool" && printf editor=vim > "$XDG_CONFIG_HOME/mytool/config"`:
-  - exit code is `0`
-- after `cat "$XDG_CONFIG_HOME/mytool/config"`:
-  - exit code is `0`
-  - stdout equals an exact value
-  - file `.atago-home/.config/mytool/config` contains `editor=vim`
-### Scenario: Windows APPDATA family — write config, read it back, inspect it under the workdir
-_only on windows_
-#### Given
-- The command runs with an isolated home under `${workdir}/.atago-home` (HOME/XDG or APPDATA redirected).
-- The command runs with an isolated home under `${workdir}/.atago-home` (HOME/XDG or APPDATA redirected).
-#### When
-```shell
-mkdir "%APPDATA%\mytool" & echo editor=vim>"%APPDATA%\mytool\config.txt"
-type "%APPDATA%\mytool\config.txt"
-```
-#### Then
-- after `mkdir "%APPDATA%\mytool" & echo editor=vim>"%APPDATA%\mytool\config.txt"`:
-  - exit code is `0`
-- after `type "%APPDATA%\mytool\config.txt"`:
-  - exit code is `0`
-  - stdout contains `editor=vim`
-  - file `.atago-home/AppData/Roaming/mytool/config.txt` contains `editor=vim`
 ## atago self-hosting / security
 Source: `test/e2e/atago/security.atago.yaml`
 ### Scenario: declared secrets are masked in failure output

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-53 suites · 190 scenarios
+54 suites · 192 scenarios
 ## Contents
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 3 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
@@ -181,6 +181,9 @@
   - [a failing assertion exits one and reports the failure](#scenario-a-failing-assertion-exits-one-and-reports-the-failure)
   - [a parse error exits with code two](#scenario-a-parse-error-exits-with-code-two)
   - [JSON report is valid JSON with a passed status](#scenario-json-report-is-valid-json-with-a-passed-status)
+- [atago self-hosting / sandbox_home (isolated per-OS home)](#atago-self-hosting--sandbox_home-isolated-per-os-home) — 2 scenarios
+  - [Unix XDG family — write config, read it back, inspect it under the workdir](#scenario-unix-xdg-family--write-config-read-it-back-inspect-it-under-the-workdir)
+  - [Windows APPDATA family — write config, read it back, inspect it under the workdir](#scenario-windows-appdata-family--write-config-read-it-back-inspect-it-under-the-workdir)
 - [atago self-hosting / security](#atago-self-hosting--security) — 3 scenarios
   - [declared secrets are masked in failure output](#scenario-declared-secrets-are-masked-in-failure-output)
   - [a file assertion path may not escape the scenario workdir](#scenario-a-file-assertion-path-may-not-escape-the-scenario-workdir)
@@ -3265,6 +3268,42 @@ ${atago} run --report json ok.atago.yaml
 - stdout at `$.schema_version` equals `1`
 - stdout at `$.suites[0].status` equals `passed`
 - stdout at `$.suites[0].scenarios` has length 1
+## atago self-hosting / sandbox_home (isolated per-OS home)
+Source: `test/e2e/atago/sandbox_home.atago.yaml`
+### Scenario: Unix XDG family — write config, read it back, inspect it under the workdir
+_skipped on windows_
+#### Given
+- The command runs with an isolated home under `${workdir}/.atago-home` (HOME/XDG or APPDATA redirected).
+- The command runs with an isolated home under `${workdir}/.atago-home` (HOME/XDG or APPDATA redirected).
+#### When
+```shell
+mkdir -p "$XDG_CONFIG_HOME/mytool" && printf editor=vim > "$XDG_CONFIG_HOME/mytool/config"
+cat "$XDG_CONFIG_HOME/mytool/config"
+```
+#### Then
+- after `mkdir -p "$XDG_CONFIG_HOME/mytool" && printf editor=vim > "$XDG_CONFIG_HOME/mytool/config"`:
+  - exit code is `0`
+- after `cat "$XDG_CONFIG_HOME/mytool/config"`:
+  - exit code is `0`
+  - stdout equals an exact value
+  - file `.atago-home/.config/mytool/config` contains `editor=vim`
+### Scenario: Windows APPDATA family — write config, read it back, inspect it under the workdir
+_only on windows_
+#### Given
+- The command runs with an isolated home under `${workdir}/.atago-home` (HOME/XDG or APPDATA redirected).
+- The command runs with an isolated home under `${workdir}/.atago-home` (HOME/XDG or APPDATA redirected).
+#### When
+```shell
+mkdir "%APPDATA%\mytool" & echo editor=vim>"%APPDATA%\mytool\config.txt"
+type "%APPDATA%\mytool\config.txt"
+```
+#### Then
+- after `mkdir "%APPDATA%\mytool" & echo editor=vim>"%APPDATA%\mytool\config.txt"`:
+  - exit code is `0`
+- after `type "%APPDATA%\mytool\config.txt"`:
+  - exit code is `0`
+  - stdout contains `editor=vim`
+  - file `.atago-home/AppData/Roaming/mytool/config.txt` contains `editor=vim`
 ## atago self-hosting / security
 Source: `test/e2e/atago/security.atago.yaml`
 ### Scenario: declared secrets are masked in failure output

--- a/examples/changes.atago.yaml
+++ b/examples/changes.atago.yaml
@@ -1,0 +1,57 @@
+version: "1"
+
+# Workdir delta assertions (#70): `changes:` pins the EXACT set of files the
+# immediately preceding run/pty step created, modified, and deleted in the
+# scenario workdir. It states the contract a CLI product actually has —
+# "this command touches only these files" — which per-path `file:` asserts
+# cannot ("...and nothing else") and a `dir:` snapshot proves only by pinning a
+# whole tree.
+#
+# Each listed field is EXHAUSTIVE in both directions: every observed path must
+# match an entry (an exact workdir-relative path or a /-glob), and every entry
+# must match at least one observed path. So `modified: []` asserts "modified
+# nothing", and an omitted field is unconstrained. Fixture writes happen before
+# the step's pre-scan, so they are inputs, not changes.
+#
+# The multi-file setup uses a POSIX shell, so this scenario skips on Windows;
+# the delta computation itself is covered on every OS by unit tests.
+# Runs green as-is on Linux/macOS: atago run examples/changes.atago.yaml
+
+suite:
+  name: workdir delta assertions
+
+scenarios:
+  - name: a generator touches exactly the files it should
+    skip:
+      os: windows
+    steps:
+      # Seed inputs. These land before the measured step's pre-scan, so they are
+      # the baseline — not counted as "created".
+      - fixture:
+          file: config.yaml
+          content: "theme: light\n"
+      - fixture:
+          file: stale.html
+          content: "<!-- old -->\n"
+      # The generator rewrites config.yaml, deletes the stale page, and emits a
+      # fresh site/ tree.
+      - run:
+          shell: true
+          command: >-
+            printf 'theme: dark\n' > config.yaml &&
+            rm stale.html &&
+            mkdir -p site/assets &&
+            printf '<html></html>' > site/index.html &&
+            printf 'body{}' > site/assets/app.css
+      - assert:
+          exit_code: 0
+          # The exact delta: two files created (index.html plus any CSS under
+          # assets/), config.yaml modified, stale.html deleted — and nothing else.
+          changes:
+            created:
+              - site/index.html
+              - site/assets/*.css
+            modified:
+              - config.yaml
+            deleted:
+              - stale.html

--- a/examples_test.go
+++ b/examples_test.go
@@ -19,6 +19,7 @@ import (
 // implementation.
 var exampleSpecs = map[string]bool{ // path -> hermetic (run, not just validate)
 	"examples/browser.atago.yaml":             false,
+	"examples/changes.atago.yaml":             true,
 	"examples/db.atago.yaml":                  true,
 	"examples/defaults.atago.yaml":            true,
 	"examples/dir_tree.atago.yaml":            true,

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -175,6 +175,8 @@ func checkTarget(a *spec.Assert, target spec.AssertTarget, res *runner.Result, e
 		return checkScreen(a.Screen, res, env)
 	case spec.AssertDuration:
 		return checkDuration(a.Duration, res)
+	case spec.AssertChanges:
+		return checkChanges(a.Changes, res)
 	default:
 		return &CheckResult{Desc: string(target), Hint: "assertion target not supported yet"}
 	}

--- a/internal/assert/changes.go
+++ b/internal/assert/changes.go
@@ -1,0 +1,113 @@
+package assert
+
+import (
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/nao1215/atago/internal/fsdelta"
+	"github.com/nao1215/atago/internal/runner"
+	"github.com/nao1215/atago/internal/spec"
+)
+
+// checkChanges evaluates the workdir-delta assertion target (#70): the exact
+// set of files the immediately preceding run/pty step created, modified, and
+// deleted. Each set field is EXHAUSTIVE in both directions — every observed
+// path must be matched by an entry, and every entry must match at least one
+// observed path — so `modified: []` asserts "modified nothing". An omitted
+// (nil) field is unconstrained. Paths are compared with forward slashes, so the
+// same spec passes on Windows.
+func checkChanges(c *spec.ChangesAssert, res *runner.Result) *CheckResult {
+	desc := "assert changes"
+	if res == nil || res.Changes == nil {
+		return &CheckResult{
+			Desc: desc,
+			Hint: "no workdir delta was recorded; a changes assert must immediately follow a run/pty step",
+		}
+	}
+	d := res.Changes
+
+	var problems []string
+	checkCategory("created", c.Created, d.Created, &problems)
+	checkCategory("modified", c.Modified, d.Modified, &problems)
+	checkCategory("deleted", c.Deleted, d.Deleted, &problems)
+
+	if len(problems) == 0 {
+		return pass(desc)
+	}
+	sort.Strings(problems)
+	return &CheckResult{
+		Desc:     desc,
+		Expected: describeChangesExpected(c),
+		Actual:   describeChangesActual(d),
+		Hint:     strings.Join(problems, "; "),
+	}
+}
+
+// checkCategory enforces the exhaustive-set semantics for one category. A nil
+// entries pointer leaves the category unconstrained; a non-nil (possibly empty)
+// list requires an exact, bidirectional cover.
+func checkCategory(name string, entries *spec.StringList, observed []string, problems *[]string) {
+	if entries == nil {
+		return
+	}
+	pats := []string(*entries)
+	for _, obs := range observed {
+		if !matchesAny(pats, obs) {
+			*problems = append(*problems, fmt.Sprintf("unexpected %s file %q (no entry matches it)", name, obs))
+		}
+	}
+	for _, pat := range pats {
+		if !patternMatchesAny(pat, observed) {
+			*problems = append(*problems, fmt.Sprintf("%s entry %q matched no file the step %s", name, pat, name))
+		}
+	}
+}
+
+// matchesAny reports whether p matches at least one pattern (exact path or
+// path.Match glob, always /-separated).
+func matchesAny(pats []string, p string) bool {
+	for _, pat := range pats {
+		if ok, _ := path.Match(pat, p); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// patternMatchesAny reports whether pat matches at least one observed path.
+func patternMatchesAny(pat string, paths []string) bool {
+	for _, p := range paths {
+		if ok, _ := path.Match(pat, p); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// describeChangesExpected renders the asserted delta for the failure block.
+func describeChangesExpected(c *spec.ChangesAssert) string {
+	var parts []string
+	if c.Created != nil {
+		parts = append(parts, "created "+bracket(*c.Created))
+	}
+	if c.Modified != nil {
+		parts = append(parts, "modified "+bracket(*c.Modified))
+	}
+	if c.Deleted != nil {
+		parts = append(parts, "deleted "+bracket(*c.Deleted))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// describeChangesActual renders the observed delta for the failure block.
+func describeChangesActual(d *fsdelta.Delta) string {
+	return fmt.Sprintf("created %s, modified %s, deleted %s",
+		bracket(d.Created), bracket(d.Modified), bracket(d.Deleted))
+}
+
+// bracket renders a path list as "[a, b]" (or "[]" when empty).
+func bracket(items []string) string {
+	return "[" + strings.Join(items, ", ") + "]"
+}

--- a/internal/assert/changes_test.go
+++ b/internal/assert/changes_test.go
@@ -1,0 +1,105 @@
+package assert
+
+import (
+	"testing"
+
+	"github.com/nao1215/atago/internal/fsdelta"
+	"github.com/nao1215/atago/internal/runner"
+	"github.com/nao1215/atago/internal/spec"
+)
+
+func list(items ...string) *spec.StringList {
+	l := spec.StringList(items)
+	return &l
+}
+
+func changesResult(d fsdelta.Delta) *runner.Result {
+	return &runner.Result{Changes: &d}
+}
+
+func TestCheckChanges(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		assert *spec.ChangesAssert
+		delta  fsdelta.Delta
+		wantOK bool
+	}{
+		{
+			name:   "exact created match passes",
+			assert: &spec.ChangesAssert{Created: list("site/index.html")},
+			delta:  fsdelta.Delta{Created: []string{"site/index.html"}},
+			wantOK: true,
+		},
+		{
+			name:   "glob covers created files",
+			assert: &spec.ChangesAssert{Created: list("site/index.html", "site/assets/*.css")},
+			delta:  fsdelta.Delta{Created: []string{"site/index.html", "site/assets/app.css"}},
+			wantOK: true,
+		},
+		{
+			name:   "glob does not cross a slash boundary",
+			assert: &spec.ChangesAssert{Created: list("site/*.css")},
+			delta:  fsdelta.Delta{Created: []string{"site/assets/app.css"}},
+			wantOK: false, // * must not match "assets/app"
+		},
+		{
+			name:   "unexpected created file fails",
+			assert: &spec.ChangesAssert{Created: list("site/index.html")},
+			delta:  fsdelta.Delta{Created: []string{"site/index.html", "site/extra.html"}},
+			wantOK: false,
+		},
+		{
+			name:   "entry matching nothing fails",
+			assert: &spec.ChangesAssert{Created: list("site/index.html", "site/missing.html")},
+			delta:  fsdelta.Delta{Created: []string{"site/index.html"}},
+			wantOK: false,
+		},
+		{
+			name:   "empty modified asserts modified nothing (passes)",
+			assert: &spec.ChangesAssert{Created: list("out.txt"), Modified: list(), Deleted: list()},
+			delta:  fsdelta.Delta{Created: []string{"out.txt"}},
+			wantOK: true,
+		},
+		{
+			name:   "empty modified fails when something was modified",
+			assert: &spec.ChangesAssert{Modified: list()},
+			delta:  fsdelta.Delta{Modified: []string{"config.txt"}},
+			wantOK: false,
+		},
+		{
+			name:   "omitted field is unconstrained",
+			assert: &spec.ChangesAssert{Created: list("out.txt")},
+			delta:  fsdelta.Delta{Created: []string{"out.txt"}, Modified: []string{"other.txt"}, Deleted: []string{"gone.txt"}},
+			wantOK: true, // modified/deleted omitted → unconstrained
+		},
+		{
+			name:   "deleted category matched exhaustively",
+			assert: &spec.ChangesAssert{Deleted: list("tmp/*")},
+			delta:  fsdelta.Delta{Deleted: []string{"tmp/a", "tmp/b"}},
+			wantOK: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := checkChanges(tt.assert, changesResult(tt.delta))
+			if got.OK != tt.wantOK {
+				t.Errorf("checkChanges OK = %v, want %v (hint: %s)", got.OK, tt.wantOK, got.Hint)
+			}
+		})
+	}
+}
+
+// TestCheckChanges_NoDelta proves a missing delta (no preceding run/pty step)
+// is reported rather than silently passing.
+func TestCheckChanges_NoDelta(t *testing.T) {
+	t.Parallel()
+	got := checkChanges(&spec.ChangesAssert{Created: list("x")}, &runner.Result{})
+	if got.OK {
+		t.Error("checkChanges with nil delta should not pass")
+	}
+	if got = checkChanges(&spec.ChangesAssert{Created: list("x")}, nil); got.OK {
+		t.Error("checkChanges with nil result should not pass")
+	}
+}

--- a/internal/docgen/describe.go
+++ b/internal/docgen/describe.go
@@ -70,6 +70,8 @@ func describeTarget(a *spec.Assert, target spec.AssertTarget) string {
 		return "rendered screen " + describeStream(a.Screen)
 	case spec.AssertDuration:
 		return "completes " + a.Duration.DescribeDuration()
+	case spec.AssertChanges:
+		return "the step changed exactly " + describeChanges(a.Changes)
 	case spec.AssertStdout:
 		return "stdout " + describeStream(a.Stdout)
 	case spec.AssertStderr:
@@ -108,6 +110,33 @@ func describeTarget(a *spec.Assert, target spec.AssertTarget) string {
 	default:
 		return string(target)
 	}
+}
+
+// describeChanges renders a workdir-delta assertion (#70) as a compact phrase
+// listing each set category. `modified: []` renders as "modified nothing".
+func describeChanges(c *spec.ChangesAssert) string {
+	var parts []string
+	for _, cat := range []struct {
+		name    string
+		entries *spec.StringList
+	}{
+		{"created", c.Created},
+		{"modified", c.Modified},
+		{"deleted", c.Deleted},
+	} {
+		if cat.entries == nil {
+			continue
+		}
+		if len(*cat.entries) == 0 {
+			parts = append(parts, cat.name+" nothing")
+			continue
+		}
+		parts = append(parts, cat.name+" "+codeList(*cat.entries))
+	}
+	if len(parts) == 0 {
+		return "nothing"
+	}
+	return strings.Join(parts, ", ")
 }
 
 func describeHeader(h *spec.HeaderMatch) string {

--- a/internal/engine/changes_test.go
+++ b/internal/engine/changes_test.go
@@ -1,0 +1,143 @@
+package engine
+
+import (
+	"runtime"
+	"testing"
+)
+
+// TestEngine_Changes_CreatedModifiedDeleted proves the delta assertion pins
+// exactly what a run step created, modified, and deleted in the workdir (#70).
+func TestEngine_Changes_CreatedModifiedDeleted(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX shell for the multi-file setup")
+	}
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: changes
+scenarios:
+  - name: a generator touches only its files
+    steps:
+      # Seed inputs as fixtures — these are inputs, not changes, because they
+      # land before the measured step's pre-scan.
+      - fixture:
+          file: keep.txt
+          content: same
+      - fixture:
+          file: change.txt
+          content: before
+      - fixture:
+          file: gone.txt
+          content: bye
+      - run:
+          shell: true
+          command: 'echo after > change.txt && rm gone.txt && mkdir -p out && echo hi > out/new.txt'
+      - assert:
+          exit_code: 0
+          changes:
+            created:
+              - out/new.txt
+            modified:
+              - change.txt
+            deleted:
+              - gone.txt
+`)
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed: %+v", res.Status, res.Scenarios[0].Steps)
+	}
+}
+
+// TestEngine_Changes_FixtureWritesAreInputs proves a fixture written before the
+// measured step is NOT counted as a change (its content is part of the
+// baseline), while stdout_to created by the step IS counted as created (#70).
+func TestEngine_Changes_FixtureWritesAreInputs(t *testing.T) {
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: changes
+scenarios:
+  - name: only the step's own output counts
+    steps:
+      - fixture:
+          file: input.txt
+          content: seed
+      - run:
+          shell: true
+          command: echo produced
+          stdout_to: result.txt
+      - assert:
+          exit_code: 0
+          changes:
+            created:
+              - result.txt
+            modified: []
+            deleted: []
+`)
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed: %+v", res.Status, res.Scenarios[0].Steps)
+	}
+}
+
+// TestEngine_Changes_NoScanWithoutAssert proves the pre-scan is skipped when no
+// changes assert follows: a run step with no following changes assert leaves
+// current.Changes nil, so a later (validly preceded) changes assert that DOES
+// follow its own step still works — i.e. the scan is scoped per step. Here the
+// first run has no changes assert; the assertion after the SECOND run must see
+// only the second step's delta.
+func TestEngine_Changes_NoScanWithoutAssert(t *testing.T) {
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: changes
+scenarios:
+  - name: delta is scoped to the immediately preceding step
+    steps:
+      - run:
+          shell: true
+          command: echo one
+          stdout_to: first.txt
+      - run:
+          shell: true
+          command: echo two
+          stdout_to: second.txt
+      - assert:
+          changes:
+            created:
+              - second.txt
+            modified: []
+            deleted: []
+`)
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed: %+v", res.Status, res.Scenarios[0].Steps)
+	}
+}
+
+// TestEngine_Changes_UnexpectedFileFails proves an unexpected created file
+// fails the assertion (the exhaustive contract) (#70).
+func TestEngine_Changes_UnexpectedFileFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX shell")
+	}
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: changes
+scenarios:
+  - name: an extra file breaks the exact contract
+    steps:
+      - run:
+          shell: true
+          command: 'echo a > a.txt && echo b > b.txt'
+      - assert:
+          changes:
+            created:
+              - a.txt
+`)
+	if res.Status != StatusFailed {
+		t.Fatalf("status = %s, want failed (b.txt is an unexpected creation): %+v", res.Status, res.Scenarios[0].Steps)
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nao1215/atago/internal/artifact"
 	"github.com/nao1215/atago/internal/assert"
 	"github.com/nao1215/atago/internal/fixture"
+	"github.com/nao1215/atago/internal/fsdelta"
 	"github.com/nao1215/atago/internal/platform"
 	"github.com/nao1215/atago/internal/runner"
 	browserrunner "github.com/nao1215/atago/internal/runner/browser"
@@ -670,7 +671,24 @@ func (e *Engine) runScenario(ctx context.Context, scenarioIdx int, sc *spec.Scen
 			break
 		}
 
+		// The `changes:` assert (#70) pins the workdir delta of the immediately
+		// preceding run/pty step. Scan the workdir just before that step runs —
+		// and only then, so scenarios that never use it pay nothing — capturing a
+		// baseline in which prior fixture writes already exist (they are inputs,
+		// not changes). Fixtures written by THIS run/pty step's redirects
+		// (stdout_to/stderr_to) land after the baseline and count as created.
+		var preScan fsdelta.Snapshot
+		scanChanges := measurableForChanges(step.Kind()) && changesFollows(sc.Steps, i)
+		if scanChanges {
+			preScan, _ = fsdelta.Scan(workdir)
+		}
+
 		sr, status, secViolation := execStep(ctx, i, step)
+		if scanChanges && current != nil {
+			post, _ := fsdelta.Scan(workdir)
+			delta := fsdelta.Diff(preScan, post)
+			current.Changes = &delta
+		}
 		if secViolation {
 			out.SecurityViolation = true
 		}
@@ -847,6 +865,23 @@ func (e *Engine) runStep(ctx context.Context, run *spec.Run, st *store.Store, wo
 		}
 	}
 	return last, checks, nil
+}
+
+// measurableForChanges reports whether a step kind produces a workdir delta a
+// following `changes:` assert can pin (#70): only run and pty steps touch the
+// scenario workdir as their observable effect.
+func measurableForChanges(k spec.StepKind) bool {
+	return k == spec.StepRun || k == spec.StepPTY
+}
+
+// changesFollows reports whether the step at index i+1 is an assert carrying a
+// `changes:` target — the trigger for scanning the workdir around step i (#70).
+func changesFollows(steps []spec.Step, i int) bool {
+	if i+1 >= len(steps) {
+		return false
+	}
+	a := steps[i+1].Assert
+	return a != nil && a.Changes != nil
 }
 
 // worseStatus returns the more severe of two statuses (error > failed > passed,

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -306,6 +306,33 @@ func describeSignal(sg *spec.Signal) string {
 	return desc
 }
 
+// describeChangesExplain renders a workdir-delta assertion (#70) as a compact
+// phrase for `atago explain`. `modified: []` renders as "modified nothing".
+func describeChangesExplain(c *spec.ChangesAssert) string {
+	var parts []string
+	for _, cat := range []struct {
+		name    string
+		entries *spec.StringList
+	}{
+		{"created", c.Created},
+		{"modified", c.Modified},
+		{"deleted", c.Deleted},
+	} {
+		if cat.entries == nil {
+			continue
+		}
+		if len(*cat.entries) == 0 {
+			parts = append(parts, cat.name+" nothing")
+			continue
+		}
+		parts = append(parts, cat.name+" "+strings.Join([]string(*cat.entries), ", "))
+	}
+	if len(parts) == 0 {
+		return "nothing"
+	}
+	return strings.Join(parts, "; ")
+}
+
 // describeMockAssert renders a one-line summary of a mock assertion (#24).
 func describeMockAssert(m *spec.MockAssert) string {
 	desc := "mock " + m.Name
@@ -395,6 +422,8 @@ func describeTarget(a *spec.Assert, target spec.AssertTarget) string {
 		return "screen " + describeStream(a.Screen)
 	case spec.AssertDuration:
 		return "completes " + a.Duration.DescribeDuration()
+	case spec.AssertChanges:
+		return "changed exactly " + describeChangesExplain(a.Changes)
 	case spec.AssertStdout:
 		return "stdout " + describeStream(a.Stdout)
 	case spec.AssertStderr:

--- a/internal/fsdelta/fsdelta.go
+++ b/internal/fsdelta/fsdelta.go
@@ -1,0 +1,103 @@
+// Package fsdelta computes the content-based difference of a directory tree
+// between two points in time: which regular files were created, modified, or
+// deleted. It backs the `changes:` assertion target (#70), which pins exactly
+// what a run/pty step touched in the scenario workdir.
+package fsdelta
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// Snapshot maps a regular file's forward-slash path (relative to the scanned
+// root) to a hex-encoded SHA-256 of its content. Directories and symlinks are
+// not tracked: a rename is delete+create in v1, and an empty directory is not a
+// "file" the assertion reasons about.
+type Snapshot map[string]string
+
+// Scan walks root and hashes every regular file, keyed by its forward-slash
+// path relative to root. It is best-effort about individual files: one that
+// cannot be opened or read is skipped rather than failing the whole scan, so a
+// transient permission quirk never turns a delta assertion into an engine
+// error. A nil root scan (root missing) returns an empty snapshot.
+func Scan(root string) (Snapshot, error) {
+	snap := Snapshot{}
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			// A directory we cannot descend is skipped, not fatal: the scan
+			// still reports every file it could reach. Returning nil here is
+			// deliberate — a per-entry error must not abort the whole scan.
+			if d != nil && d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() || !d.Type().IsRegular() {
+			return nil
+		}
+		rel, rerr := filepath.Rel(root, path)
+		if rerr != nil {
+			return nil //nolint:nilerr // an un-relativizable path is skipped, not fatal
+		}
+		sum, herr := hashFile(path)
+		if herr != nil {
+			return nil //nolint:nilerr // skip an unreadable file rather than aborting
+		}
+		snap[filepath.ToSlash(rel)] = sum
+		return nil
+	})
+	if err != nil && !os.IsNotExist(err) {
+		return snap, err
+	}
+	return snap, nil
+}
+
+// hashFile returns the hex SHA-256 of a file's content.
+func hashFile(path string) (string, error) {
+	f, err := os.Open(path) //nolint:gosec // scanning the scenario workdir is the purpose
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// Delta is the content-based difference between a pre and post Snapshot. Each
+// list is sorted for deterministic reporting.
+type Delta struct {
+	Created  []string
+	Modified []string
+	Deleted  []string
+}
+
+// Diff compares pre against post: a path in post but not pre is Created, a path
+// in both whose hash changed is Modified, and a path in pre but not post is
+// Deleted. Paths whose hash is unchanged are untouched and reported nowhere.
+func Diff(pre, post Snapshot) Delta {
+	var d Delta
+	for p, postHash := range post {
+		if preHash, ok := pre[p]; !ok {
+			d.Created = append(d.Created, p)
+		} else if preHash != postHash {
+			d.Modified = append(d.Modified, p)
+		}
+	}
+	for p := range pre {
+		if _, ok := post[p]; !ok {
+			d.Deleted = append(d.Deleted, p)
+		}
+	}
+	sort.Strings(d.Created)
+	sort.Strings(d.Modified)
+	sort.Strings(d.Deleted)
+	return d
+}

--- a/internal/fsdelta/fsdelta_test.go
+++ b/internal/fsdelta/fsdelta_test.go
@@ -1,0 +1,101 @@
+package fsdelta
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func write(t *testing.T, root, rel, content string) {
+	t.Helper()
+	p := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestDiff_CreatedModifiedDeletedUntouched exercises every category plus nested
+// directories, and proves an untouched file appears in none of them (#70).
+func TestDiff_CreatedModifiedDeletedUntouched(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	write(t, root, "keep.txt", "same")
+	write(t, root, "change.txt", "before")
+	write(t, root, "gone.txt", "bye")
+	write(t, root, "nested/old.txt", "old")
+
+	pre, err := Scan(root)
+	if err != nil {
+		t.Fatalf("pre scan: %v", err)
+	}
+
+	// keep.txt untouched; change.txt modified; gone.txt & nested/old.txt deleted;
+	// nested/new.css created.
+	write(t, root, "change.txt", "after")
+	if err := os.Remove(filepath.Join(root, "gone.txt")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(root, "nested", "old.txt")); err != nil {
+		t.Fatal(err)
+	}
+	write(t, root, "nested/new.css", "body{}")
+
+	post, err := Scan(root)
+	if err != nil {
+		t.Fatalf("post scan: %v", err)
+	}
+
+	got := Diff(pre, post)
+	want := Delta{
+		Created:  []string{"nested/new.css"},
+		Modified: []string{"change.txt"},
+		Deleted:  []string{"gone.txt", "nested/old.txt"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Diff() = %+v, want %+v", got, want)
+	}
+}
+
+// TestScan_ForwardSlashKeys proves nested paths are keyed with forward slashes
+// on every OS, so a spec's globs compare in one space (#70).
+func TestScan_ForwardSlashKeys(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	write(t, root, "a/b/c.txt", "x")
+	snap, err := Scan(root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if _, ok := snap["a/b/c.txt"]; !ok {
+		t.Errorf("key = %v, want a/b/c.txt (forward slashes)", keys(snap))
+	}
+}
+
+// TestScan_SkipsDirectoriesOnly proves directories are not tracked as files: an
+// empty directory produces no snapshot entry (a rename is delete+create) (#70).
+func TestScan_SkipsDirectoriesOnly(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "emptydir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	snap, err := Scan(root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(snap) != 0 {
+		t.Errorf("snapshot = %v, want empty (directories are not files)", keys(snap))
+	}
+}
+
+func keys(m Snapshot) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -140,6 +140,82 @@ scenarios:
 	}
 }
 
+// TestLoadBytes_Changes covers the load-time validation of the changes: assert
+// target (#70): it must follow a run/pty step, entries must be workdir-relative
+// and confined, and a valid placement loads.
+func TestLoadBytes_Changes(t *testing.T) {
+	t.Parallel()
+	valid := `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: ok
+    steps:
+      - run:
+          command: echo hi
+      - assert:
+          changes:
+            created:
+              - out.txt
+              - "site/*.html"
+            modified: []
+            deleted: []
+`
+	s, err := LoadBytes("sample.atago.yaml", []byte(valid))
+	if err != nil {
+		t.Fatalf("valid changes spec should load: %v", err)
+	}
+	ch := s.Scenarios[0].Steps[1].Assert.Changes
+	if ch == nil || ch.Created == nil || len(*ch.Created) != 2 {
+		t.Fatalf("changes.created not decoded: %+v", ch)
+	}
+	if ch.Modified == nil || len(*ch.Modified) != 0 {
+		t.Errorf("modified: [] should decode to a non-nil empty list (assert nothing), got %+v", ch.Modified)
+	}
+
+	bad := []struct {
+		name    string
+		src     string
+		wantMsg string
+	}{
+		{
+			name:    "not preceded by run/pty",
+			src:     "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps:\n      - assert:\n          changes:\n            created: [out.txt]",
+			wantMsg: "requires an immediately preceding run/pty step",
+		},
+		{
+			name:    "preceded by http, not run/pty",
+			src:     "version: \"1\"\nsuite:\n  name: x\nrunners:\n  api:\n    type: http\n    base_url: http://127.0.0.1:1\nscenarios:\n  - name: a\n    steps:\n      - http: {runner: api, method: GET, path: /}\n      - assert:\n          changes:\n            created: [out.txt]",
+			wantMsg: "requires an immediately preceding run/pty step",
+		},
+		{
+			name:    "absolute entry",
+			src:     "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps:\n      - run: {command: echo}\n      - assert:\n          changes:\n            created: [/etc/passwd]",
+			wantMsg: "must be workdir-relative",
+		},
+		{
+			name:    "escaping entry",
+			src:     "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps:\n      - run: {command: echo}\n      - assert:\n          changes:\n            created: [\"../escape.txt\"]",
+			wantMsg: "escapes the scenario workdir",
+		},
+		{
+			name:    "empty changes block",
+			src:     "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps:\n      - run: {command: echo}\n      - assert:\n          changes: {}",
+			wantMsg: "set at least one of created/modified/deleted",
+		},
+	}
+	for _, tt := range bad {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := LoadBytes("sample.atago.yaml", []byte(tt.src))
+			if err == nil || !strings.Contains(err.Error(), tt.wantMsg) {
+				t.Errorf("error = %v, want containing %q", err, tt.wantMsg)
+			}
+		})
+	}
+}
+
 func TestLoadBytes_Errors(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/loader/validate.go
+++ b/internal/loader/validate.go
@@ -86,6 +86,7 @@ func validate(s *spec.Spec) []string {
 		// reject placements no step could feed.
 		ptySeen := false
 		prevMeasurable := false
+		prevRunOrPTY := false
 		for j := range sc.Steps {
 			sw := fmt.Sprintf("%s.steps[%d]", where, j)
 			st := &sc.Steps[j]
@@ -98,14 +99,25 @@ func validate(s *spec.Spec) []string {
 			if st.Assert != nil && st.Assert.Duration != nil && !prevMeasurable {
 				add("%s.assert.duration requires an immediately preceding run/http/query/grpc/pty step (the step whose wall-clock time it bounds)", sw)
 			}
+			// changes bounds the workdir delta of the immediately preceding
+			// run/pty step (#70): reject a placement no such step feeds.
+			if st.Assert != nil && st.Assert.Changes != nil && !prevRunOrPTY {
+				add("%s.assert.changes requires an immediately preceding run/pty step (the step whose workdir delta it pins)", sw)
+			}
 			validateStep(add, sw, st, s.Runners, serviceNames, mockNames)
 			prevMeasurable = measurableStep(st.Kind())
+			prevRunOrPTY = st.Kind() == spec.StepRun || st.Kind() == spec.StepPTY
 		}
 		for j := range sc.Teardown {
 			tw := fmt.Sprintf("%s.teardown[%d]", where, j)
 			st := &sc.Teardown[j]
 			if st.Assert != nil && st.Assert.Screen != nil && !ptySeen {
 				add("%s.assert.screen requires a pty step in the scenario", tw)
+			}
+			// The workdir delta is only tracked around Steps, so a changes assert
+			// in teardown could never be fed (#70).
+			if st.Assert != nil && st.Assert.Changes != nil {
+				add("%s.assert.changes is not supported in teardown (the workdir delta is tracked only around the scenario's steps)", tw)
 			}
 			validateStep(add, tw, st, s.Runners, serviceNames, mockNames)
 		}
@@ -899,6 +911,8 @@ func validateAssertTarget(add func(string, ...any), where string, a *spec.Assert
 		validateStream(add, where+".assert.screen", a.Screen)
 	case spec.AssertDuration:
 		validateDuration(add, where+".assert.duration", a.Duration)
+	case spec.AssertChanges:
+		validateChanges(add, where+".assert.changes", a.Changes)
 	case spec.AssertPDF:
 		validatePDF(add, where+".assert.pdf", a.PDF)
 	case spec.AssertGRPCStatus:
@@ -968,6 +982,54 @@ func validateDuration(add func(string, ...any), where string, d *spec.DurationAs
 			add("%s: the bounds form an empty interval (lower %s exceeds upper %s)", where, lower, upper)
 		}
 	}
+}
+
+// validateChanges checks a workdir-delta assertion (#70): at least one of
+// created/modified/deleted set, and every entry a workdir-relative, confined
+// path or a valid /-glob. Entries are compared with forward slashes at check
+// time, so confinement is validated in the same /-separated space.
+func validateChanges(add func(string, ...any), where string, c *spec.ChangesAssert) {
+	if c.Created == nil && c.Modified == nil && c.Deleted == nil {
+		add("%s: set at least one of created/modified/deleted (use [] to assert a category changed nothing)", where)
+		return
+	}
+	for _, cat := range []struct {
+		name    string
+		entries *spec.StringList
+	}{
+		{"created", c.Created},
+		{"modified", c.Modified},
+		{"deleted", c.Deleted},
+	} {
+		if cat.entries == nil {
+			continue
+		}
+		for _, entry := range []string(*cat.entries) {
+			field := fmt.Sprintf("%s.%s %q", where, cat.name, entry)
+			switch {
+			case entry == "":
+				add("%s must be a non-empty workdir-relative path or glob", field)
+			case strings.HasPrefix(entry, "/"):
+				add("%s must be workdir-relative, not absolute", field)
+			case pathEscapesWorkdir(entry):
+				add("%s escapes the scenario workdir (no ../ traversal)", field)
+			default:
+				// The entry doubles as a path.Match glob at check time; reject a
+				// malformed pattern here rather than silently matching nothing.
+				if _, err := path.Match(entry, "probe"); err != nil {
+					add("%s is not a valid glob: %v", field, err)
+				}
+			}
+		}
+	}
+}
+
+// pathEscapesWorkdir reports whether a /-separated relative entry would escape
+// the workdir root via ../ traversal, using the same containment rule as
+// security.ResolveWorkdirPath but in the loader's forward-slash space (#70).
+func pathEscapesWorkdir(entry string) bool {
+	cleaned := path.Clean(entry)
+	return cleaned == ".." || strings.HasPrefix(cleaned, "../")
 }
 
 // validatePDF checks a PDF assertion (#73): a path plus at least one constraint,

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/nao1215/atago/internal/fsdelta"
 	"github.com/nao1215/atago/internal/spec"
 )
 
@@ -64,6 +65,12 @@ type Result struct {
 	// eval capture is JSON.
 	IsCDP    bool
 	CDPValue []byte
+
+	// Changes is the workdir delta observed around a run/pty step (#70), set by
+	// the engine only when a `changes:` assert immediately follows the step. Nil
+	// means no delta was recorded (the assertion then reports that), so scenarios
+	// that never use `changes:` pay for no workdir scan.
+	Changes *fsdelta.Delta
 }
 
 // Runner executes a run step within a scenario workdir and returns the observed

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -863,6 +863,23 @@ type Assert struct {
 	// measurable step (run/http/query/grpc/pty): it bounds how long that step
 	// took with lt/lte/gt/gte Go-duration bounds.
 	Duration *DurationAssert `yaml:"duration,omitempty"`
+
+	// Changes is the workdir-delta assertion target (#70), valid after an
+	// immediately preceding run/pty step: it pins exactly which files that step
+	// created, modified, and deleted in the scenario workdir.
+	Changes *ChangesAssert `yaml:"changes,omitempty"`
+}
+
+// ChangesAssert pins the exact delta the immediately preceding run/pty step
+// made to the scenario workdir (#70). The delta is content-based (hash, not
+// mtime). Each set field is EXHAUSTIVE in both directions: every observed path
+// must be matched by an entry (an exact workdir-relative path or a /-glob) and
+// every entry must match at least one observed path — so `modified: []` asserts
+// "modified nothing". An omitted (nil) field is unconstrained.
+type ChangesAssert struct {
+	Created  *StringList `yaml:"created,omitempty"`
+	Modified *StringList `yaml:"modified,omitempty"`
+	Deleted  *StringList `yaml:"deleted,omitempty"`
 }
 
 // DurationAssert bounds a step's measured wall-clock time (#31). At least one

--- a/internal/spec/step.go
+++ b/internal/spec/step.go
@@ -93,6 +93,7 @@ const (
 	AssertMock       AssertTarget = "mock"
 	AssertScreen     AssertTarget = "screen"
 	AssertDuration   AssertTarget = "duration"
+	AssertChanges    AssertTarget = "changes"
 )
 
 // SetTargets returns the assertion target families present. A valid assert has
@@ -149,6 +150,9 @@ func (a *Assert) SetTargets() []AssertTarget {
 	}
 	if a.Duration != nil {
 		t = append(t, AssertDuration)
+	}
+	if a.Changes != nil {
+		t = append(t, AssertChanges)
 	}
 	return t
 }

--- a/schema/atago.schema.json
+++ b/schema/atago.schema.json
@@ -653,7 +653,8 @@
         { "required": ["pdf"] },
         { "required": ["mock"] },
         { "required": ["screen"] },
-        { "required": ["duration"] }
+        { "required": ["duration"] },
+        { "required": ["changes"] }
       ],
       "properties": {
         "exit_code": { "$ref": "#/$defs/exitCode" },
@@ -675,8 +676,27 @@
           "$ref": "#/$defs/stream",
           "description": "The rendered terminal screen of the preceding pty step (#27): the transcript replayed through a vt10x emulator, asserted as plain text (line.n = screen row)."
         },
-        "duration": { "$ref": "#/$defs/durationAssert" }
+        "duration": { "$ref": "#/$defs/durationAssert" },
+        "changes": { "$ref": "#/$defs/changesAssert" }
       }
+    },
+    "changesAssert": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Pins the exact workdir delta of the immediately preceding run/pty step (#70): which files it created, modified, and deleted. Each set field is EXHAUSTIVE in both directions (every observed path must match an entry, every entry must match a path), so `modified: []` asserts \"modified nothing\". An omitted field is unconstrained. Entries are workdir-relative paths or /-globs.",
+      "minProperties": 1,
+      "properties": {
+        "created": { "$ref": "#/$defs/changesEntries" },
+        "modified": { "$ref": "#/$defs/changesEntries" },
+        "deleted": { "$ref": "#/$defs/changesEntries" }
+      }
+    },
+    "changesEntries": {
+      "description": "A single workdir-relative path/glob, or a list of them (the empty list [] asserts the category changed nothing).",
+      "oneOf": [
+        { "type": "string" },
+        { "type": "array", "items": { "type": "string" } }
+      ]
     },
     "durationAssert": {
       "type": "object",

--- a/test/e2e/atago/changes.atago.yaml
+++ b/test/e2e/atago/changes.atago.yaml
@@ -1,0 +1,90 @@
+version: "1"
+
+suite:
+  name: atago self-hosting / changes (workdir delta assertions)
+
+# Exercises #70: the `changes:` assert pins the EXACT set of files the
+# immediately preceding run/pty step created, modified, and deleted in the
+# scenario workdir — the "this command touches only these files" contract that
+# per-path file: asserts cannot state. Each set field is exhaustive in both
+# directions, so `modified: []` asserts "modified nothing" and an omitted field
+# is unconstrained. Fixture writes are inputs (they land before the pre-scan),
+# not changes.
+#
+# The multi-file setup uses a POSIX shell, so the first scenario skips on
+# Windows; a portable stdout_to-only scenario runs everywhere to prove the
+# created-counting rule on Windows too.
+scenarios:
+  - name: a generator touches exactly the files it should (POSIX)
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: config.yaml
+          content: "theme: light\n"
+      - fixture:
+          file: stale.html
+          content: "old\n"
+      - run:
+          shell: true
+          command: >-
+            printf 'theme: dark\n' > config.yaml &&
+            rm stale.html &&
+            mkdir -p site/assets &&
+            printf '<html></html>' > site/index.html &&
+            printf 'body{}' > site/assets/app.css
+      - assert:
+          exit_code: 0
+          changes:
+            created:
+              - site/index.html
+              - site/assets/*.css
+            modified:
+              - config.yaml
+            deleted:
+              - stale.html
+
+  - name: an unexpected creation breaks the exact contract (POSIX)
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: check.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: unexpected
+            scenarios:
+              - name: extra file
+                steps:
+                  - run:
+                      shell: true
+                      command: 'echo a > a.txt && echo b > b.txt'
+                  - assert:
+                      changes:
+                        created:
+                          - a.txt
+      - run:
+          command: ${atago} run check.atago.yaml
+      # b.txt is an unexpected creation, so the inner run fails (exit 1).
+      - assert:
+          exit_code: 1
+          stdout:
+            contains: "unexpected created file"
+
+  - name: stdout_to counts as created, and modified nothing holds (portable)
+    steps:
+      - fixture:
+          file: input.txt
+          content: seed
+      - run:
+          shell: true
+          command: echo produced
+          stdout_to: result.txt
+      - assert:
+          exit_code: 0
+          changes:
+            created:
+              - result.txt
+            modified: []
+            deleted: []


### PR DESCRIPTION
Closes #70.

## Summary
Adds a `changes:` assertion target that compares the scenario workdir before and after the immediately preceding run/pty step and asserts the exact delta — which files the step created, modified, and deleted. It states the contract CLI products actually have: "this command touches only these files".

```yaml
- run:
    command: mytool generate --out site
- assert:
    exit_code: 0
    changes:
      created: [site/index.html, "site/assets/*.css"]
      modified: []
      deleted: []
```

- Content-based (SHA-256), not mtime. The pre-scan runs **only** when a `changes:` assert follows the step, so scenarios that never use it pay nothing.
- Honest accounting: `fixture:` writes land before the pre-scan (inputs, not changes); `stdout_to`/`stderr_to` targets count as created.
- Each set field is **exhaustive both ways** — every observed path must match an entry, every entry must match a path — so `modified: []` asserts "modified nothing"; an omitted field is unconstrained. Entries are workdir-relative paths or `/`-globs, compared with forward slashes (Windows-safe).
- Load-time validation: `changes` must directly follow a run/pty step (rejected in teardown); entries must be relative and workdir-confined.

## Tests
- New `internal/fsdelta` (Scan/Diff): created/modified/deleted/untouched, nested dirs, forward-slash keys, directories-not-files.
- Assert checker: exact/glob matching, glob not crossing `/`, unexpected path, entry-matches-nothing, `[]` semantics, omitted-is-unconstrained.
- Loader: placement (must follow run/pty, rejected after http), absolute/escaping entries, empty block.
- Engine: fixture writes excluded, `stdout_to` counted, per-step scoping, unexpected-file failure.
- Runnable `examples/changes.atago.yaml` (registered) + self-hosted E2E `test/e2e/atago/changes.atago.yaml` (wired into both Windows allowlists).
- JSON schema, docgen/explain (Then bullet), `doc/e2e/atago.md` regenerated.

`go test ./...`, `go vet ./...`, `golangci-lint run ./internal/...` all green; full self-hosted E2E dir passes (190 scenarios).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `changes` assertions to verify exact file system changes made by a step.
  * New examples and end-to-end coverage show how to check created, modified, and deleted files.
  * Documentation and schema updates now describe the new assertion format and behavior.

* **Bug Fixes**
  * Improved validation and error messages for invalid file paths, missing change data, and unexpected file changes.
  * Better handling of file change tracking across supported runs, including output files written to disk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->