### PR TITLE
feat(record): record an interactive pty session as an expect/send spec (#69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ $ atago run mytool.atago.yaml
 PASSED  1 scenario: 1 passed, 0 failed, 0 errored, 0 skipped (12ms)
 ```
 
+Interactive tools record too: `atago record --pty -- <command>` runs it in a real terminal, lets you drive one session by hand, and writes a `pty:` step that replays your keystrokes as expect/send pairs (POSIX-only; password prompts become `${env:...}` placeholders, never literals):
+
+```shell
+$ atago record --pty --out wizard.atago.yaml -- mytool init
+```
+
 Prefer a blank template? `atago init` scaffolds one. Either way, the shape is always the same: declare a command, run it, assert on what it produced.
 
 ### 1. Check exit code, stdout, and stderr

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-54 suites · 192 scenarios
+54 suites · 193 scenarios
 ## Contents
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 3 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
@@ -156,7 +156,7 @@
   - [screen asserts see the final frame where the transcript sees history](#scenario-screen-asserts-see-the-final-frame-where-the-transcript-sees-history)
   - [a screen snapshot round-trips through update and compare](#scenario-a-screen-snapshot-round-trips-through-update-and-compare)
   - [a screen assert without a pty step is a load-time error](#scenario-a-screen-assert-without-a-pty-step-is-a-load-time-error)
-- [atago self-hosting / record (spec skeleton from an observed run)](#atago-self-hosting--record-spec-skeleton-from-an-observed-run) — 7 scenarios
+- [atago self-hosting / record (spec skeleton from an observed run)](#atago-self-hosting--record-spec-skeleton-from-an-observed-run) — 8 scenarios
   - [record then run round-trips green](#scenario-record-then-run-round-trips-green)
   - [refusing to overwrite without --force](#scenario-refusing-to-overwrite-without---force)
   - [created files become exists asserts (shell mode)](#scenario-created-files-become-exists-asserts-shell-mode)
@@ -164,6 +164,7 @@
   - [no command is a usage error](#scenario-no-command-is-a-usage-error)
   - [argv boundaries survive spaced arguments](#scenario-argv-boundaries-survive-spaced-arguments)
   - [a shell metacharacter argument stays one token](#scenario-a-shell-metacharacter-argument-stays-one-token)
+  - [record --pty records a live session and the generated spec replays green](#scenario-record---pty-records-a-live-session-and-the-generated-spec-replays-green)
 - [atago self-hosting / reports](#atago-self-hosting--reports) — 5 scenarios
   - [JUnit report is XML with a testsuite and testcase](#scenario-junit-report-is-xml-with-a-testsuite-and-testcase)
   - [GitHub Actions annotations are emitted on failure](#scenario-github-actions-annotations-are-emitted-on-failure)
@@ -2885,6 +2886,18 @@ ${atago} run meta.atago.yaml
 - after `${atago} run meta.atago.yaml`:
   - exit code is `0`
   - stdout contains `1 passed`
+### Scenario: record --pty records a live session and the generated spec replays green
+_skipped on windows_
+#### When
+```shell
+# interactive (pty): ${atago} record --pty --out generated.atago.yaml -- sh -c 'printf PROMPT; read n; echo hi-$n'
+${atago} run generated.atago.yaml
+```
+#### Then
+- exit code is `0`
+- file `generated.atago.yaml` contains `- pty:`, `- send:`
+- exit code is `0`
+- stdout contains `1 passed`
 ## atago self-hosting / reports
 Source: `test/e2e/atago/reports.atago.yaml`
 ### Scenario: JUnit report is XML with a testsuite and testcase

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,8 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	golang.org/x/crypto v0.53.0
 	golang.org/x/image v0.43.0
+	golang.org/x/sys v0.46.0
+	golang.org/x/term v0.44.0
 	google.golang.org/grpc v1.82.0
 	google.golang.org/protobuf v1.36.11
 	modernc.org/sqlite v1.53.0
@@ -56,7 +58,6 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
-	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/internal/cli/record.go
+++ b/internal/cli/record.go
@@ -30,13 +30,19 @@ func recordCmd(args []string, stdout, stderr io.Writer) int {
 	force := fs.Bool("force", false, "overwrite --out if it already exists")
 	shell := fs.Bool("shell", false, "record the command line verbatim with shell: true")
 	snap := fs.Bool("snapshot", false, "assert stdout against a snapshot golden (requires --out; the golden is written next to it)")
+	ptyMode := fs.Bool("pty", false, "record an interactive pty session and generate an expect/send spec (POSIX-only)")
 	fs.Usage = func() {
 		fmt.Fprint(stderr, `Usage: atago record [--out FILE] [--force] [--shell] [--snapshot] -- <command> [args...]
+       atago record --pty [--out FILE] [--force] [--shell] -- <command> [args...]
 
 Runs the command once in a scratch directory and prints a spec skeleton
 derived from what it observed: exit code, first stdout line, empty stderr,
-and created files. Interactive (pty) and HTTP recording are non-goals for
-now — write those steps by hand.
+and created files.
+
+With --pty, runs the command in a real pseudo-terminal wired to your
+terminal, lets you drive one interactive session by hand, and generates a
+spec whose pty: step replays it as expect/send pairs (POSIX-only). HTTP
+recording is a non-goal for now — write those steps by hand.
 `)
 		fs.PrintDefaults()
 	}
@@ -54,6 +60,14 @@ now — write those steps by hand.
 	if *snap && *out == "" {
 		fmt.Fprintln(stderr, "atago record: --snapshot needs --out (the golden is written next to the spec)")
 		return ExitConfig
+	}
+	if *ptyMode && *snap {
+		// A hand-driven screen golden is too brittle to auto-record in v1.
+		fmt.Fprintln(stderr, "atago record: --snapshot cannot be combined with --pty")
+		return ExitConfig
+	}
+	if *ptyMode {
+		return recordPTY(cmdArgs, *shell, *out, *force, stdout, stderr)
 	}
 
 	// Preserve argv boundaries: the runner (and later the generated spec)
@@ -137,6 +151,60 @@ now — write those steps by hand.
 		return ExitExec
 	}
 	fmt.Fprintf(stderr, "wrote %s\n", *out)
+	return ExitOK
+}
+
+// recordPTY implements `atago record --pty` (#69): run the command in a real
+// pseudo-terminal wired to the developer's own terminal, let them drive one
+// interactive session by hand, and generate a spec whose pty: step replays it
+// as expect/send pairs. POSIX-only; Windows returns a clear error.
+func recordPTY(cmdArgs []string, shell bool, out string, force bool, stdout, stderr io.Writer) int {
+	command := shellJoin(cmdArgs)
+	if shell {
+		command = strings.Join(cmdArgs, " ")
+	}
+
+	fmt.Fprintln(stderr, "recording pty session — drive it by hand; it ends when the program exits")
+	rec, err := record.CapturePTY(command, shell, os.Stdin, os.Stdout)
+	if err != nil {
+		fmt.Fprintf(stderr, "atago record: %v\n", err)
+		return ExitExec
+	}
+
+	opts := record.Options{SuiteName: suiteNameFor(cmdArgs[0])}
+	generated, err := record.GeneratePTY(rec, opts)
+	if err != nil {
+		fmt.Fprintf(stderr, "atago record: %v\n", err)
+		return ExitInternal
+	}
+
+	sends := 0
+	for _, seg := range rec.Segments {
+		if seg.Input != nil {
+			sends++
+		}
+	}
+	fmt.Fprintf(stderr, "recorded: pty session, exit %d, %d send(s)\n", rec.ExitCode, sends)
+
+	if out == "" {
+		fmt.Fprint(stdout, string(generated))
+		return ExitOK
+	}
+	if _, err := os.Stat(out); err == nil && !force {
+		fmt.Fprintf(stderr, "atago record: %q already exists (use --force to overwrite)\n", out)
+		return ExitConfig
+	}
+	if dir := filepath.Dir(out); dir != "." {
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			fmt.Fprintf(stderr, "atago record: %v\n", err)
+			return ExitExec
+		}
+	}
+	if err := os.WriteFile(out, generated, 0o644); err != nil { //nolint:gosec // a spec file the user asked for
+		fmt.Fprintf(stderr, "atago record: %v\n", err)
+		return ExitExec
+	}
+	fmt.Fprintf(stderr, "wrote %s\n", out)
 	return ExitOK
 }
 

--- a/internal/record/capture_termios_linux.go
+++ b/internal/record/capture_termios_linux.go
@@ -1,0 +1,9 @@
+//go:build linux
+
+package record
+
+import "golang.org/x/sys/unix"
+
+// ioctlGetTermios is the request that reads a terminal's attributes on Linux,
+// used to check the pty's ECHO flag while recording (#69).
+const ioctlGetTermios = unix.TCGETS

--- a/internal/record/capture_termios_other.go
+++ b/internal/record/capture_termios_other.go
@@ -1,0 +1,9 @@
+//go:build !windows && !linux
+
+package record
+
+import "golang.org/x/sys/unix"
+
+// ioctlGetTermios is the request that reads a terminal's attributes on Darwin
+// and the BSDs, used to check the pty's ECHO flag while recording (#69).
+const ioctlGetTermios = unix.TIOCGETA

--- a/internal/record/capture_unix.go
+++ b/internal/record/capture_unix.go
@@ -1,0 +1,155 @@
+//go:build !windows
+
+// Interactive pty recording (#69): run a command in a real pseudo-terminal
+// wired to the developer's own terminal, forward keystrokes and output
+// unchanged, and record the session so it can be reconstructed as an
+// expect/send spec. This is the POSIX capture half; the pure transcript→session
+// generation lives in pty.go.
+package record
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/creack/pty"
+	"golang.org/x/sys/unix"
+	"golang.org/x/term"
+
+	runnercmd "github.com/nao1215/atago/internal/runner/cmd"
+)
+
+// captureDrainGrace bounds how long capture waits for the pty's final output to
+// drain after the child exits before closing the master.
+const captureDrainGrace = 500 * time.Millisecond
+
+// CapturePTY runs command inside a pseudo-terminal wired to in/out (the
+// developer's terminal), puts in into raw mode, forwards keystrokes and output
+// until the program exits, and returns the recorded session (#69). It is
+// POSIX-only; the Windows build returns a clear error.
+func CapturePTY(command string, shell bool, in, out *os.File) (PTYRecording, error) {
+	name, args, err := runnercmd.CommandLine(command, shell)
+	if err != nil {
+		return PTYRecording{}, err
+	}
+
+	// The session runs until the child exits under the developer's own hand, so
+	// there is no timeout to bound — Background gives the interactive session no
+	// deadline while still satisfying the context-aware exec contract.
+	cmd := exec.CommandContext(context.Background(), name, args...) //nolint:gosec // recording the user's declared command is the purpose
+	cmd.Env = os.Environ()
+	// A fresh session so the child owns the pty and a stray descendant does not
+	// keep it open past the child's exit.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+
+	rows, cols := terminalSize(out)
+	master, err := pty.StartWithSize(cmd, &pty.Winsize{Rows: uint16(rows), Cols: uint16(cols)}) //nolint:gosec // geometry is bounded by terminalSize
+	if err != nil {
+		return PTYRecording{}, fmt.Errorf("record --pty: start %q: %w", command, err)
+	}
+	defer func() { _ = master.Close() }()
+
+	rec := PTYRecording{Command: command, Shell: shell, Rows: rows, Cols: cols}
+	var mu sync.Mutex
+
+	// Raw mode on the invoking terminal so keystrokes (including control keys and
+	// arrows) reach the child unbuffered and unechoed by the outer terminal —
+	// the inner pty does its own echo. Restored before we return.
+	if oldState, rerr := term.MakeRaw(int(in.Fd())); rerr == nil {
+		defer func() { _ = term.Restore(int(in.Fd()), oldState) }()
+	}
+
+	// Input: developer keystrokes → child. Each Read is one burst; the pty's
+	// current ECHO state tags it as a secret (echo off) or not. This goroutine
+	// blocks on in.Read and is abandoned when the one-shot process exits — the
+	// child's exit is what ends the recording, not end-of-input.
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			n, rerr := in.Read(buf)
+			if n > 0 {
+				echoOff := echoDisabled(master)
+				mu.Lock()
+				rec.AppendInput(buf[:n], echoOff)
+				mu.Unlock()
+				if _, werr := master.Write(buf[:n]); werr != nil {
+					return
+				}
+			}
+			if rerr != nil {
+				return
+			}
+		}
+	}()
+
+	// Output: child → developer's screen, recorded verbatim (ANSI intact).
+	outDone := make(chan struct{})
+	go func() {
+		defer close(outDone)
+		buf := make([]byte, 4096)
+		for {
+			n, rerr := master.Read(buf)
+			if n > 0 {
+				mu.Lock()
+				rec.AppendOutput(buf[:n])
+				mu.Unlock()
+				_, _ = out.Write(buf[:n])
+			}
+			if rerr != nil {
+				return
+			}
+		}
+	}()
+
+	waitErr := cmd.Wait()
+	// Drain the pty's final bytes before closing the master, then stop the
+	// output reader. A bounded grace keeps a lingering descendant from hanging us.
+	select {
+	case <-outDone:
+	case <-time.After(captureDrainGrace):
+	}
+	_ = master.Close()
+	<-outDone
+
+	mu.Lock()
+	rec.ExitCode = exitCode(waitErr)
+	mu.Unlock()
+	return rec, nil
+}
+
+// terminalSize returns the invoking terminal's rows/cols, or the pty default
+// (24x80) when out is not a terminal.
+func terminalSize(out *os.File) (rows, cols int) {
+	if r, c, err := pty.Getsize(out); err == nil && r > 0 && c > 0 {
+		return r, c
+	}
+	return 24, 80
+}
+
+// echoDisabled reports whether the pty's terminal echo is currently off — the
+// signal of a password prompt, whose typed bytes must not be recorded (#69).
+func echoDisabled(master *os.File) bool {
+	t, err := unix.IoctlGetTermios(int(master.Fd()), ioctlGetTermios)
+	if err != nil {
+		return false
+	}
+	return t.Lflag&unix.ECHO == 0
+}
+
+// exitCode extracts a process exit code from cmd.Wait's error (0 on success,
+// the signal-derived code otherwise, -1 when it cannot be determined).
+func exitCode(waitErr error) int {
+	if waitErr == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if errors.As(waitErr, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return -1
+}

--- a/internal/record/capture_windows.go
+++ b/internal/record/capture_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package record
+
+import (
+	"errors"
+	"os"
+)
+
+// CapturePTY reports that interactive pty recording is POSIX-only, mirroring the
+// pty runner's Windows behavior (#69). ConPTY support can lift this later.
+func CapturePTY(_ string, _ bool, _, _ *os.File) (PTYRecording, error) {
+	return PTYRecording{}, errors.New("record --pty is not supported on Windows yet (POSIX-only; the generated pty steps are POSIX-only too)")
+}

--- a/internal/record/capture_windows_test.go
+++ b/internal/record/capture_windows_test.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package record
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestCapturePTY_WindowsUnsupported proves interactive pty recording reports a
+// clear POSIX-only error on Windows rather than failing obscurely (#69).
+func TestCapturePTY_WindowsUnsupported(t *testing.T) {
+	_, err := CapturePTY("echo hi", false, os.Stdin, os.Stdout)
+	if err == nil {
+		t.Fatal("CapturePTY on Windows should return an error")
+	}
+	if !strings.Contains(err.Error(), "not supported on Windows") {
+		t.Errorf("error = %v, want a Windows-unsupported message", err)
+	}
+}

--- a/internal/record/pty.go
+++ b/internal/record/pty.go
@@ -1,0 +1,211 @@
+package record
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/nao1215/atago/internal/loader"
+	"github.com/nao1215/atago/internal/spec"
+)
+
+// PTYSegment is one chronological chunk of a recorded interactive session:
+// either program output (program → terminal) or a burst of user input
+// (keystrokes → program). Exactly one of Output/Input is set (#69).
+type PTYSegment struct {
+	// Output is a run of bytes the program wrote to the terminal.
+	Output []byte
+	// Input is one burst of bytes the user typed (nil for an output segment).
+	Input []byte
+	// EchoOff marks an input burst typed while terminal echo was disabled — a
+	// password prompt. Its literal bytes must never reach the generated spec.
+	EchoOff bool
+}
+
+// PTYRecording is a captured interactive `atago record --pty` session: the
+// command that ran, the recording terminal's geometry, the observed exit code,
+// and the ordered output/input segments the session generator turns into a
+// declarative pty step (#69).
+type PTYRecording struct {
+	Command  string
+	Shell    bool
+	Rows     int
+	Cols     int
+	ExitCode int
+	Segments []PTYSegment
+}
+
+// AppendOutput records a run of program output, coalescing it with a trailing
+// output segment so consecutive writes form one chunk.
+func (r *PTYRecording) AppendOutput(b []byte) {
+	if n := len(r.Segments); n > 0 && r.Segments[n-1].Input == nil {
+		r.Segments[n-1].Output = append(r.Segments[n-1].Output, b...)
+		return
+	}
+	r.Segments = append(r.Segments, PTYSegment{Output: append([]byte(nil), b...)})
+}
+
+// AppendInput records one burst of user input, tagged with whether terminal
+// echo was off (a secret prompt) at the time it was typed.
+func (r *PTYRecording) AppendInput(b []byte, echoOff bool) {
+	r.Segments = append(r.Segments, PTYSegment{Input: append([]byte(nil), b...), EchoOff: echoOff})
+}
+
+// ansiPattern matches the terminal control sequences that carry no visible
+// text: CSI (ESC [ ... final), OSC (ESC ] ... BEL/ST), and two-byte ESC forms.
+// Stripping them yields the plain prompt text an expect should anchor on.
+var ansiPattern = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)|\x1b[@-Z\\-_]`)
+
+// GeneratePTY renders a spec skeleton whose single pty: step replays the
+// recorded session as expect/send pairs, and proves it loads cleanly before
+// returning it (the same round-trip guarantee plain record gives) (#69).
+func GeneratePTY(rec PTYRecording, opts Options) ([]byte, error) {
+	var b strings.Builder
+	b.WriteString("version: \"1\"\n\n")
+	b.WriteString("# Recorded by `atago record --pty` — a starting point, not a verdict:\n")
+	b.WriteString("# each send replays a burst you typed, and each expect anchors on the\n")
+	b.WriteString("# prompt that preceded it. Tighten the matchers to pin what you care about.\n")
+	fmt.Fprintf(&b, "suite:\n  name: %s\n\n", yamlScalar(opts.SuiteName))
+	b.WriteString("scenarios:\n")
+	fmt.Fprintf(&b, "  - name: %s # TODO: describe the behavior\n", yamlScalar(rec.Command))
+	b.WriteString("    skip:\n      os: windows # pty steps are POSIX-only\n")
+	b.WriteString("    steps:\n")
+	b.WriteString("      - pty:\n")
+	if rec.Shell {
+		b.WriteString("          shell: true\n")
+	}
+	fmt.Fprintf(&b, "          command: %s\n", yamlScalar(rec.Command))
+	if rec.Rows > 0 {
+		fmt.Fprintf(&b, "          rows: %d\n", rec.Rows)
+	}
+	if rec.Cols > 0 {
+		fmt.Fprintf(&b, "          cols: %d\n", rec.Cols)
+	}
+
+	session, lastOutput := renderSession(&rec)
+	if len(session) > 0 {
+		b.WriteString("          session:\n")
+		for _, line := range session {
+			b.WriteString(line)
+		}
+	}
+
+	b.WriteString("      - assert:\n")
+	fmt.Fprintf(&b, "          exit_code: %d\n", rec.ExitCode)
+	if anchor := stableLine(lastOutput); anchor != "" {
+		b.WriteString("      - assert:\n")
+		b.WriteString("          stdout:\n")
+		fmt.Fprintf(&b, "            contains: %s # last stable line of the transcript\n", yamlScalar(anchor))
+	}
+
+	out := []byte(b.String())
+	if _, err := loader.LoadBytes("recorded.atago.yaml", out); err != nil {
+		return nil, fmt.Errorf("generated spec does not validate (this is an atago bug, please report it): %w", err)
+	}
+	return out, nil
+}
+
+// renderSession walks the recorded segments and emits the YAML session lines:
+// each input burst becomes a send, preceded by an expect derived from the last
+// stable line of the output before it. It returns the session lines and the
+// trailing output (after the final input) for the closing assertion (#69).
+func renderSession(rec *PTYRecording) (lines []string, trailingOutput []byte) {
+	var pending []byte
+	secretN := 0
+	for _, seg := range rec.Segments {
+		if seg.Input == nil {
+			pending = append(pending, seg.Output...)
+			continue
+		}
+		if anchor := stableLine(pending); anchor != "" {
+			lines = append(lines, fmt.Sprintf("            - expect: %s\n", yamlScalar(regexp.QuoteMeta(anchor))))
+		}
+		lines = append(lines, renderSend(seg, &secretN)...)
+		pending = nil
+	}
+	return lines, pending
+}
+
+// renderSend renders one input burst as a send entry: an ${env:...} placeholder
+// for echo-off (secret) input, a named key for a lone control key, or literal
+// text otherwise. The literal secret is never emitted (#69).
+func renderSend(seg PTYSegment, secretN *int) []string {
+	if seg.EchoOff {
+		*secretN++
+		name := fmt.Sprintf("ATAGO_SECRET_%d", *secretN)
+		suffix := ""
+		if endsWithNewline(seg.Input) {
+			suffix = "\n"
+		}
+		return []string{
+			"            # secret input (terminal echo was off): the literal value is NOT recorded.\n",
+			fmt.Sprintf("            # set %s in the environment and add its value to `secrets:` to mask it.\n", name),
+			fmt.Sprintf("            - send: %s\n", yamlDoubleQuoted("${env:"+name+"}"+suffix)),
+		}
+	}
+	if key, ok := spec.PTYKeyForSequence(string(seg.Input)); ok {
+		return []string{fmt.Sprintf("            - send: {key: %s}\n", key)}
+	}
+	return []string{fmt.Sprintf("            - send: %s\n", yamlDoubleQuoted(literalSend(seg.Input)))}
+}
+
+// yamlDoubleQuoted renders s as a YAML double-quoted flow scalar, escaping
+// control characters (notably \n and \r) so a multi-line send stays on one line
+// instead of becoming a block scalar that would break the session list (#69).
+func yamlDoubleQuoted(s string) string {
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '\\':
+			b.WriteString(`\\`)
+		case '"':
+			b.WriteString(`\"`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		default:
+			if r < 0x20 {
+				fmt.Fprintf(&b, `\x%02x`, r)
+			} else {
+				b.WriteRune(r)
+			}
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
+// literalSend renders a printable input burst for a send scalar: carriage
+// returns become "\n" (the readable Enter the pty examples use) and other
+// control bytes are left for yamlScalar to escape.
+func literalSend(b []byte) string {
+	s := string(b)
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\r", "\n")
+	return s
+}
+
+// endsWithNewline reports whether an input burst ended with Enter (CR or LF),
+// so a secret placeholder can reproduce the line submission without the value.
+func endsWithNewline(b []byte) bool {
+	return len(b) > 0 && (b[len(b)-1] == '\r' || b[len(b)-1] == '\n')
+}
+
+// stableLine returns the last non-empty visible line of output with ANSI
+// control sequences stripped and surrounding whitespace trimmed — the
+// conservative literal an expect/contains anchors on (#69).
+func stableLine(output []byte) string {
+	clean := ansiPattern.ReplaceAllString(string(output), "")
+	clean = strings.ReplaceAll(clean, "\r", "\n")
+	best := ""
+	for _, line := range strings.Split(clean, "\n") {
+		if t := strings.TrimSpace(line); t != "" {
+			best = t
+		}
+	}
+	return best
+}

--- a/internal/record/pty_test.go
+++ b/internal/record/pty_test.go
@@ -1,0 +1,169 @@
+package record
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nao1215/atago/internal/loader"
+	"github.com/nao1215/atago/internal/spec"
+)
+
+func outSeg(s string) PTYSegment { return PTYSegment{Output: []byte(s)} }
+func inSeg(s string) PTYSegment  { return PTYSegment{Input: []byte(s)} }
+
+// loadGenerated asserts the generated spec both validates (GeneratePTY does this
+// internally) and re-loads to a single pty step, returning that step.
+func loadGenerated(t *testing.T, data []byte) *spec.PTY {
+	t.Helper()
+	s, err := loader.LoadBytes("gen.atago.yaml", data)
+	if err != nil {
+		t.Fatalf("generated spec does not load: %v\n%s", err, data)
+	}
+	if len(s.Scenarios) != 1 || len(s.Scenarios[0].Steps) == 0 || s.Scenarios[0].Steps[0].PTY == nil {
+		t.Fatalf("generated spec has no leading pty step:\n%s", data)
+	}
+	return s.Scenarios[0].Steps[0].PTY
+}
+
+func TestGeneratePTY(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		rec         PTYRecording
+		wantContain []string
+		wantAbsent  []string
+	}{
+		{
+			name: "prompt at line end becomes expect, input becomes literal send",
+			rec: PTYRecording{
+				Command:  "sh -c 'printf name:; read n; echo hi $n'",
+				ExitCode: 0,
+				Segments: []PTYSegment{
+					outSeg("name: "),
+					inSeg("world\r"),
+					outSeg("world\r\nhi world\r\n"),
+				},
+			},
+			wantContain: []string{"- expect:", "name:", "- send:", "world", "exit_code: 0", "hi world"},
+		},
+		{
+			name: "a lone control key maps to a named key",
+			rec: PTYRecording{
+				Command:  "cat",
+				ExitCode: 0,
+				Segments: []PTYSegment{
+					outSeg("> "),
+					inSeg("\r"),
+					outSeg("\r\n"),
+				},
+			},
+			wantContain: []string{"send: {key: enter}"},
+		},
+		{
+			name: "ctrl-c maps to its named key",
+			rec: PTYRecording{
+				Command:  "top",
+				ExitCode: 130,
+				Segments: []PTYSegment{
+					outSeg("load: 0.1\n"),
+					inSeg("\x03"),
+				},
+			},
+			wantContain: []string{"send: {key: ctrl-c}", "exit_code: 130"},
+		},
+		{
+			name: "multi-line output between inputs anchors on the last stable line",
+			rec: PTYRecording{
+				Command:  "wizard",
+				ExitCode: 0,
+				Segments: []PTYSegment{
+					outSeg("Welcome\nStep 1 of 2\nProject name: "),
+					inSeg("demo\r"),
+					outSeg("created demo/\n"),
+				},
+			},
+			// The expect anchors on "Project name:", not the earlier lines.
+			wantContain: []string{"Project name", "created demo"},
+			wantAbsent:  []string{"expect: \"Welcome"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := GeneratePTY(tt.rec, Options{SuiteName: "gen"})
+			if err != nil {
+				t.Fatalf("GeneratePTY: %v", err)
+			}
+			s := string(got)
+			for _, want := range tt.wantContain {
+				if !strings.Contains(s, want) {
+					t.Errorf("generated spec missing %q:\n%s", want, s)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(s, absent) {
+					t.Errorf("generated spec unexpectedly contains %q:\n%s", absent, s)
+				}
+			}
+			loadGenerated(t, got) // proves the round-trip guarantee
+		})
+	}
+}
+
+// TestGeneratePTY_EchoOffNeverLeaksSecret proves an echo-off (password) input
+// burst produces an ${env:...} placeholder and that the literal secret never
+// reaches the generated YAML (#69).
+func TestGeneratePTY_EchoOffNeverLeaksSecret(t *testing.T) {
+	t.Parallel()
+	const secret = "hunter2SuperSecret"
+	rec := PTYRecording{
+		Command:  "login",
+		ExitCode: 0,
+		Segments: []PTYSegment{
+			outSeg("Username: "),
+			inSeg("alice\r"),
+			outSeg("alice\r\nPassword: "),
+			{Input: []byte(secret + "\r"), EchoOff: true},
+			outSeg("\r\nwelcome alice\r\n"),
+		},
+	}
+	got, err := GeneratePTY(rec, Options{SuiteName: "login"})
+	if err != nil {
+		t.Fatalf("GeneratePTY: %v", err)
+	}
+	s := string(got)
+	if strings.Contains(s, secret) {
+		t.Fatalf("SECRET LEAKED into generated spec:\n%s", s)
+	}
+	if !strings.Contains(s, "${env:ATAGO_SECRET_1}") {
+		t.Errorf("expected an ${env:...} placeholder for the secret input:\n%s", s)
+	}
+	if !strings.Contains(s, "echo was off") {
+		t.Errorf("expected a comment explaining the redacted secret:\n%s", s)
+	}
+	// The non-secret username still round-trips as a normal send.
+	if !strings.Contains(s, "alice") {
+		t.Errorf("non-secret input should still be recorded:\n%s", s)
+	}
+	loadGenerated(t, got)
+}
+
+// TestStableLine strips ANSI control sequences and returns the last visible line.
+func TestStableLine(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"name: ", "name:"},
+		{"\x1b[2J\x1b[H> ", ">"},
+		{"line one\r\nline two\r\n", "line two"},
+		{"\x1b[32mgreen prompt\x1b[0m ", "green prompt"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := stableLine([]byte(tt.in)); got != tt.want {
+			t.Errorf("stableLine(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -721,6 +721,35 @@ func ValidPTYKey(name string) bool {
 	return ok
 }
 
+// ptyKeyBySequence reverse-maps an xterm byte sequence to its friendly key name
+// (#69), preferring the readable name over a ctrl-* alias when a byte is shared
+// (e.g. \r is both enter and ctrl-m — enter wins). Built once at init: the
+// ctrl-* aliases go in first, then the friendly names overwrite any collision.
+var ptyKeyBySequence = func() map[string]string {
+	m := make(map[string]string, len(ptyKeySequences))
+	for c := byte('a'); c <= 'z'; c++ {
+		m[string([]byte{c - 'a' + 1})] = "ctrl-" + string(c)
+	}
+	for _, name := range []string{
+		"enter", "tab", "esc", "space", "backspace", "delete",
+		"up", "down", "right", "left", "home", "end",
+		"pageup", "pagedown",
+		"f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10", "f11", "f12",
+	} {
+		m[ptyKeySequences[name]] = name
+	}
+	return m
+}()
+
+// PTYKeyForSequence returns the friendly named key whose xterm sequence exactly
+// equals seq (#69), so `atago record --pty` can render a lone control key as
+// {key: <name>} instead of an opaque escape. It reports false when no named key
+// matches the bytes exactly.
+func PTYKeyForSequence(seq string) (string, bool) {
+	name, ok := ptyKeyBySequence[seq]
+	return name, ok
+}
+
 // PTYKeyNames lists the vocabulary for error messages, compactly.
 func PTYKeyNames() string {
 	return "enter, tab, esc, space, backspace, delete, up, down, left, right, home, end, pageup, pagedown, f1-f12, ctrl-a..ctrl-z"

--- a/test/e2e/atago/record.atago.yaml
+++ b/test/e2e/atago/record.atago.yaml
@@ -146,3 +146,35 @@ scenarios:
           exit_code: 0
           stdout:
             contains: "1 passed"
+
+  - name: record --pty records a live session and the generated spec replays green
+    skip:
+      os: windows
+    steps:
+      # The recorder recorded by atago (#69): an OUTER pty step drives
+      # `atago record --pty` by hand — typing "world" at the prompt — and the
+      # inner recorder reconstructs an expect/send spec from the transcript.
+      - pty:
+          shell: true
+          command: '${atago} record --pty --out generated.atago.yaml -- sh -c ''printf PROMPT; read n; echo hi-$n'''
+          timeout: 20s
+          session:
+            - expect: "PROMPT"
+            - send: "world\n"
+            - expect: "hi-world"
+      - assert:
+          exit_code: 0
+      # The generated spec exists and captured the session as a pty step.
+      - assert:
+          file:
+            path: generated.atago.yaml
+            contains:
+              - "- pty:"
+              - "- send:"
+      # The round-trip: replaying the generated spec passes.
+      - run:
+          command: ${atago} run generated.atago.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "1 passed"


### PR DESCRIPTION
Closes #69.

## Summary
Adds `--pty` to `atago record`: run the command in a real pseudo-terminal wired to the developer's own terminal, drive one interactive session by hand, and generate a spec whose `pty:` step replays it as `expect`/`send` pairs — autoexpect, but emitting declarative atago YAML.

```shell
atago record --pty --out wizard.atago.yaml -- mytool init
```

- Runs in a pty sized from the invoking terminal; keystrokes/output pass through in raw mode until the program exits.
- Each input burst becomes a `send` (a lone control key → `{key: enter/ctrl-c/...}`, else literal text with `\n`); each is preceded by an `expect` derived from the last stable, ANSI-stripped output line. Closing assertion mirrors plain record: `exit_code` + at most one stable `contains`.
- **Secrets**: input typed while terminal echo is OFF (password prompts) is never written — the send becomes an `${env:...}` placeholder with a wiring comment. The literal never touches disk.
- POSIX-only (so are the generated pty steps); `--pty` + `--snapshot` rejected; the generated spec is validated before writing.

## Tests
- `internal/record/pty.go` pure generation: table tests (prompt-at-line-end, named-key mapping, multi-line output, ctrl-c), a test proving the echo-off secret never reaches the YAML, and `stableLine` ANSI stripping. Every generated spec is re-loaded to prove the round-trip.
- `capture_unix.go` raw-terminal pty capture (`x/term` + termios ECHO probe); Windows stub with its documented-error test.
- Self-hosted E2E (`test/e2e/atago/record.atago.yaml`): an outer `pty:` step drives `atago record --pty`, then `atago run` replays the generated spec green — the recorder recorded by atago.
- README "Start from a real run" gains the `--pty` variant (only that subsection); record usage/help updated; `doc/e2e/atago.md` regenerated.

`go test ./...`, `go vet ./...`, `golangci-lint run ./...` all green; full self-hosted E2E dir passes.