### PR TITLE
fix: reject unsatisfiable spec shapes, early record --pty --out check, and an E2E bug-hunt expansion

### DIFF
--- a/doc/e2e/age.md
+++ b/doc/e2e/age.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-1 suite · 5 scenarios
+2 suites · 6 scenarios
 ## Contents
 - [age (modern file encryption)](#age-modern-file-encryption) — 5 scenarios
   - [keygen writes a key and reports the public half](#scenario-keygen-writes-a-key-and-reports-the-public-half)
@@ -8,6 +8,8 @@
   - [armored output is PEM-wrapped](#scenario-armored-output-is-pem-wrapped)
   - [decrypting with the wrong identity fails](#scenario-decrypting-with-the-wrong-identity-fails)
   - [passphrase mode encrypts and decrypts interactively](#scenario-passphrase-mode-encrypts-and-decrypts-interactively)
+- [age + changes (single-artifact generator)](#age--changes-single-artifact-generator) — 1 scenario
+  - [age-keygen writes exactly the key file (HOME untouched)](#scenario-age-keygen-writes-exactly-the-key-file-home-untouched)
 ## age (modern file encryption)
 Source: `test/e2e/thirdparty/age/age.atago.yaml`
 ### Scenario: keygen writes a key and reports the public half
@@ -114,3 +116,14 @@ passphrase protected
 - file `out.txt` contains `passphrase protected`
 #### Generated artifacts
 - `secret.age`
+## age + changes (single-artifact generator)
+Source: `test/e2e/thirdparty/age/changes.atago.yaml`
+### Scenario: age-keygen writes exactly the key file (HOME untouched)
+#### When
+```shell
+age-keygen -o key.txt
+```
+#### Then
+- exit code is `0`
+- the step changed exactly created `key.txt`, modified nothing, deleted nothing
+- file `key.txt` contains `AGE-SECRET-KEY-1`

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,11 +1,14 @@
 # atago Behavior Specs
 ## Summary
-54 suites · 204 scenarios
+54 suites · 208 scenarios
 ## Contents
-- [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 3 scenarios
+- [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 6 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
   - [stdout.contains and not_contains expand a stored variable](#scenario-stdoutcontains-and-not_contains-expand-a-stored-variable)
   - [file.contains expands ${workdir}](#scenario-filecontains-expands-workdir)
+  - [dir.path expands a stored variable](#scenario-dirpath-expands-a-stored-variable)
+  - [changes entries expand a stored variable](#scenario-changes-entries-expand-a-stored-variable)
+  - [screen matcher expands a stored variable](#scenario-screen-matcher-expands-a-stored-variable)
 - [atago self-hosting / browser (cdp) runner](#atago-self-hosting--browser-cdp-runner) — 8 scenarios
   - [a cdp step with no actions fails validation (exit 2)](#scenario-a-cdp-step-with-no-actions-fails-validation-exit-2)
   - [a cdp step naming an undeclared runner fails validation (exit 2)](#scenario-a-cdp-step-naming-an-undeclared-runner-fails-validation-exit-2)
@@ -161,7 +164,7 @@
   - [screen asserts see the final frame where the transcript sees history](#scenario-screen-asserts-see-the-final-frame-where-the-transcript-sees-history)
   - [a screen snapshot round-trips through update and compare](#scenario-a-screen-snapshot-round-trips-through-update-and-compare)
   - [a screen assert without a pty step is a load-time error](#scenario-a-screen-assert-without-a-pty-step-is-a-load-time-error)
-- [atago self-hosting / record (spec skeleton from an observed run)](#atago-self-hosting--record-spec-skeleton-from-an-observed-run) — 11 scenarios
+- [atago self-hosting / record (spec skeleton from an observed run)](#atago-self-hosting--record-spec-skeleton-from-an-observed-run) — 12 scenarios
   - [record then run round-trips green](#scenario-record-then-run-round-trips-green)
   - [refusing to overwrite without --force](#scenario-refusing-to-overwrite-without---force)
   - [record --pty refuses an existing --out before driving the session](#scenario-record---pty-refuses-an-existing---out-before-driving-the-session)
@@ -173,6 +176,7 @@
   - [record --pty records a live session and the generated spec replays green](#scenario-record---pty-records-a-live-session-and-the-generated-spec-replays-green)
   - [record --pty of a no-input command yields a session-less spec that replays green](#scenario-record---pty-of-a-no-input-command-yields-a-session-less-spec-that-replays-green)
   - [a prompt with regex metacharacters is escaped in the generated expect](#scenario-a-prompt-with-regex-metacharacters-is-escaped-in-the-generated-expect)
+  - [recorded text containing dollar-brace round-trips as literal text](#scenario-recorded-text-containing-dollar-brace-round-trips-as-literal-text)
 - [atago self-hosting / reports](#atago-self-hosting--reports) — 5 scenarios
   - [JUnit report is XML with a testsuite and testcase](#scenario-junit-report-is-xml-with-a-testsuite-and-testcase)
   - [GitHub Actions annotations are emitted on failure](#scenario-github-actions-annotations-are-emitted-on-failure)
@@ -287,6 +291,34 @@ printf "%s\n" "${workdir}/marker" > note.txt
 ```
 #### Then
 - file `note.txt` contains `${workdir}/marker`
+### Scenario: dir.path expands a stored variable
+#### When
+```shell
+mkdir -p site && touch site/a.html && echo site
+# capture ${outdir} from stdout
+```
+#### Then
+- dir `${outdir}` contains `a.html`
+### Scenario: changes entries expand a stored variable
+#### When
+```shell
+echo out
+# capture ${base} from stdout
+echo w > ${base}2.txt
+```
+#### Then
+- after `echo w > ${base}2.txt`:
+  - the step changed exactly created `${base}2.txt`, modified nothing, deleted nothing
+### Scenario: screen matcher expands a stored variable
+_skipped on windows_
+#### When
+```shell
+echo needle
+# capture ${pat} from stdout
+# interactive (pty): echo needle
+```
+#### Then
+- rendered screen contains `${pat}`
 ## atago self-hosting / browser (cdp) runner
 Source: `test/e2e/atago/cdp.atago.yaml`
 ### Scenario: a cdp step with no actions fails validation (exit 2)
@@ -3018,6 +3050,20 @@ ${atago} run meta.atago.yaml
 - file `meta.atago.yaml` contains `expect: "Continue\\? \\(y/n\\):"`, `- send:`
 - exit code is `0`
 - stdout contains `1 passed`
+### Scenario: recorded text containing dollar-brace round-trips as literal text
+_skipped on windows_
+#### When
+```shell
+${atago} record --out dollar.atago.yaml -- printf %s 'literal $${HOME} here'
+${atago} run dollar.atago.yaml
+```
+#### Then
+- after `${atago} record --out dollar.atago.yaml -- printf %s 'literal $${HOME} here'`:
+  - exit code is `0`
+  - file `dollar.atago.yaml` contains `$$${HOME}`
+- after `${atago} run dollar.atago.yaml`:
+  - exit code is `0`
+  - stdout contains `1 passed`
 ## atago self-hosting / reports
 Source: `test/e2e/atago/reports.atago.yaml`
 ### Scenario: JUnit report is XML with a testsuite and testcase

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-54 suites · 193 scenarios
+54 suites · 204 scenarios
 ## Contents
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 3 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
@@ -15,10 +15,15 @@
   - [manifest surfaces the browser-runner configuration](#scenario-manifest-surfaces-the-browser-runner-configuration)
   - [an upload action without a file fails validation (exit 2)](#scenario-an-upload-action-without-a-file-fails-validation-exit-2)
   - [a download action without a click selector fails validation (exit 2)](#scenario-a-download-action-without-a-click-selector-fails-validation-exit-2)
-- [atago self-hosting / changes (workdir delta assertions)](#atago-self-hosting--changes-workdir-delta-assertions) — 3 scenarios
+- [atago self-hosting / changes (workdir delta assertions)](#atago-self-hosting--changes-workdir-delta-assertions) — 8 scenarios
   - [a generator touches exactly the files it should (POSIX)](#scenario-a-generator-touches-exactly-the-files-it-should-posix)
   - [an unexpected creation breaks the exact contract (POSIX)](#scenario-an-unexpected-creation-breaks-the-exact-contract-posix)
   - [stdout_to counts as created, and modified nothing holds (portable)](#scenario-stdout_to-counts-as-created-and-modified-nothing-holds-portable)
+  - [the delta over a retried step is cumulative across all attempts (POSIX)](#scenario-the-delta-over-a-retried-step-is-cumulative-across-all-attempts-posix)
+  - [deleting and recreating a byte-identical file appears in no list (POSIX)](#scenario-deleting-and-recreating-a-byte-identical-file-appears-in-no-list-posix)
+  - [deleting and recreating with different content is modified only (POSIX)](#scenario-deleting-and-recreating-with-different-content-is-modified-only-posix)
+  - [stdout_to overwrites a fixture (modified) while stderr_to creates an empty file (POSIX)](#scenario-stdout_to-overwrites-a-fixture-modified-while-stderr_to-creates-an-empty-file-posix)
+  - [a pty step feeds the delta scan just like a run step (POSIX)](#scenario-a-pty-step-feeds-the-delta-scan-just-like-a-run-step-posix)
 - [atago self-hosting / completion](#atago-self-hosting--completion) — 5 scenarios
   - [bash completion emits a recognizable script](#scenario-bash-completion-emits-a-recognizable-script)
   - [zsh completion emits a compdef script](#scenario-zsh-completion-emits-a-compdef-script)
@@ -156,15 +161,18 @@
   - [screen asserts see the final frame where the transcript sees history](#scenario-screen-asserts-see-the-final-frame-where-the-transcript-sees-history)
   - [a screen snapshot round-trips through update and compare](#scenario-a-screen-snapshot-round-trips-through-update-and-compare)
   - [a screen assert without a pty step is a load-time error](#scenario-a-screen-assert-without-a-pty-step-is-a-load-time-error)
-- [atago self-hosting / record (spec skeleton from an observed run)](#atago-self-hosting--record-spec-skeleton-from-an-observed-run) — 8 scenarios
+- [atago self-hosting / record (spec skeleton from an observed run)](#atago-self-hosting--record-spec-skeleton-from-an-observed-run) — 11 scenarios
   - [record then run round-trips green](#scenario-record-then-run-round-trips-green)
   - [refusing to overwrite without --force](#scenario-refusing-to-overwrite-without---force)
+  - [record --pty refuses an existing --out before driving the session](#scenario-record---pty-refuses-an-existing---out-before-driving-the-session)
   - [created files become exists asserts (shell mode)](#scenario-created-files-become-exists-asserts-shell-mode)
   - [snapshot mode writes a golden the run then matches](#scenario-snapshot-mode-writes-a-golden-the-run-then-matches)
   - [no command is a usage error](#scenario-no-command-is-a-usage-error)
   - [argv boundaries survive spaced arguments](#scenario-argv-boundaries-survive-spaced-arguments)
   - [a shell metacharacter argument stays one token](#scenario-a-shell-metacharacter-argument-stays-one-token)
   - [record --pty records a live session and the generated spec replays green](#scenario-record---pty-records-a-live-session-and-the-generated-spec-replays-green)
+  - [record --pty of a no-input command yields a session-less spec that replays green](#scenario-record---pty-of-a-no-input-command-yields-a-session-less-spec-that-replays-green)
+  - [a prompt with regex metacharacters is escaped in the generated expect](#scenario-a-prompt-with-regex-metacharacters-is-escaped-in-the-generated-expect)
 - [atago self-hosting / reports](#atago-self-hosting--reports) — 5 scenarios
   - [JUnit report is XML with a testsuite and testcase](#scenario-junit-report-is-xml-with-a-testsuite-and-testcase)
   - [GitHub Actions annotations are emitted on failure](#scenario-github-actions-annotations-are-emitted-on-failure)
@@ -174,17 +182,19 @@
 - [atago self-hosting / rerun-failed](#atago-self-hosting--rerun-failed) — 2 scenarios
   - [a failing run is recorded and rerun-failed selects only it](#scenario-a-failing-run-is-recorded-and-rerun-failed-selects-only-it)
   - [rerun-failed with nothing recorded is a no-op success](#scenario-rerun-failed-with-nothing-recorded-is-a-no-op-success)
-- [atago self-hosting / retry until](#atago-self-hosting--retry-until) — 2 scenarios
+- [atago self-hosting / retry until](#atago-self-hosting--retry-until) — 3 scenarios
   - [retry polls until the condition becomes true](#scenario-retry-polls-until-the-condition-becomes-true)
   - [retry fails the inner spec when until never holds](#scenario-retry-fails-the-inner-spec-when-until-never-holds)
+  - [until with a changes target is a load-time error](#scenario-until-with-a-changes-target-is-a-load-time-error)
 - [atago self-hosting / run](#atago-self-hosting--run) — 4 scenarios
   - [a passing spec exits zero and reports PASS](#scenario-a-passing-spec-exits-zero-and-reports-pass)
   - [a failing assertion exits one and reports the failure](#scenario-a-failing-assertion-exits-one-and-reports-the-failure)
   - [a parse error exits with code two](#scenario-a-parse-error-exits-with-code-two)
   - [JSON report is valid JSON with a passed status](#scenario-json-report-is-valid-json-with-a-passed-status)
-- [atago self-hosting / sandbox_home (isolated per-OS home)](#atago-self-hosting--sandbox_home-isolated-per-os-home) — 2 scenarios
+- [atago self-hosting / sandbox_home (isolated per-OS home)](#atago-self-hosting--sandbox_home-isolated-per-os-home) — 3 scenarios
   - [Unix XDG family — write config, read it back, inspect it under the workdir](#scenario-unix-xdg-family--write-config-read-it-back-inspect-it-under-the-workdir)
   - [Windows APPDATA family — write config, read it back, inspect it under the workdir](#scenario-windows-appdata-family--write-config-read-it-back-inspect-it-under-the-workdir)
+  - [cwd anchors the run, but sandbox_home stays at the workdir ROOT (Unix)](#scenario-cwd-anchors-the-run-but-sandbox_home-stays-at-the-workdir-root-unix)
 - [atago self-hosting / security](#atago-self-hosting--security) — 3 scenarios
   - [declared secrets are masked in failure output](#scenario-declared-secrets-are-masked-in-failure-output)
   - [a file assertion path may not escape the scenario workdir](#scenario-a-file-assertion-path-may-not-escape-the-scenario-workdir)
@@ -216,9 +226,10 @@
   - [a snapshot assertion passes against a committed snapshot](#scenario-a-snapshot-assertion-passes-against-a-committed-snapshot)
   - [snapshot update creates the snapshot file](#scenario-snapshot-update-creates-the-snapshot-file)
   - [a snapshot mismatch writes the normalized actual as an artifact](#scenario-a-snapshot-mismatch-writes-the-normalized-actual-as-an-artifact)
-- [atago self-hosting / ssh runner](#atago-self-hosting--ssh-runner) — 2 scenarios
+- [atago self-hosting / ssh runner](#atago-self-hosting--ssh-runner) — 3 scenarios
   - [an ssh runner without host/user fails validation (exit 2)](#scenario-an-ssh-runner-without-hostuser-fails-validation-exit-2)
   - [a run step naming an undeclared runner fails validation (exit 2)](#scenario-a-run-step-naming-an-undeclared-runner-fails-validation-exit-2)
+  - [a local-only run field on an ssh runner fails validation (exit 2)](#scenario-a-local-only-run-field-on-an-ssh-runner-fails-validation-exit-2)
 - [atago self-hosting / stdin sources (file + base64)](#atago-self-hosting--stdin-sources-file--base64) — 5 scenarios
   - [base64 stdin delivers the exact byte count](#scenario-base64-stdin-delivers-the-exact-byte-count)
   - [stdin file is expanded and read from the workdir](#scenario-stdin-file-is-expanded-and-read-from-the-workdir)
@@ -571,6 +582,74 @@ echo produced
 - the step changed exactly created `result.txt`, modified nothing, deleted nothing
 #### Generated artifacts
 - `result.txt`
+### Scenario: the delta over a retried step is cumulative across all attempts (POSIX)
+_skipped on windows_
+#### When
+```shell
+touch a; [ -f b ] && touch c; touch b; [ -f c ]
+```
+#### Then
+- exit code is `0`
+- the step changed exactly created `a`, `b`, `c`, modified nothing, deleted nothing
+### Scenario: deleting and recreating a byte-identical file appears in no list (POSIX)
+_skipped on windows_
+#### Given
+- Fixture file `f.txt` is created.
+#### Inputs
+_Fixture `f.txt`:_
+```text
+hello
+```
+#### When
+```shell
+rm f.txt && printf hello > f.txt
+```
+#### Then
+- exit code is `0`
+- the step changed exactly created nothing, modified nothing, deleted nothing
+### Scenario: deleting and recreating with different content is modified only (POSIX)
+_skipped on windows_
+#### Given
+- Fixture file `f.txt` is created.
+#### Inputs
+_Fixture `f.txt`:_
+```text
+hello
+```
+#### When
+```shell
+rm f.txt && printf world > f.txt
+```
+#### Then
+- exit code is `0`
+- the step changed exactly created nothing, modified `f.txt`, deleted nothing
+### Scenario: stdout_to overwrites a fixture (modified) while stderr_to creates an empty file (POSIX)
+_skipped on windows_
+#### Given
+- Fixture file `existing.txt` is created.
+#### Inputs
+_Fixture `existing.txt`:_
+```text
+old
+```
+#### When
+```shell
+printf newcontent
+```
+#### Then
+- exit code is `0`
+- the step changed exactly created `err.txt`, modified `existing.txt`, deleted nothing
+#### Generated artifacts
+- `existing.txt`
+- `err.txt`
+### Scenario: a pty step feeds the delta scan just like a run step (POSIX)
+_skipped on windows_
+#### When
+```shell
+# interactive (pty): sh -c "touch from-pty; echo done"
+```
+#### Then
+- the step changed exactly created `from-pty`
 ## atago self-hosting / completion
 Source: `test/e2e/atago/completion.atago.yaml`
 ### Scenario: bash completion emits a recognizable script
@@ -2821,6 +2900,22 @@ ${atago} record --force --out existing.atago.yaml -- ${atago} version
 - after `${atago} record --force --out existing.atago.yaml -- ${atago} version`:
   - exit code is `0`
   - file `existing.atago.yaml` contains `exit_code: 0`
+### Scenario: record --pty refuses an existing --out before driving the session
+#### Given
+- Fixture file `taken.atago.yaml` is created.
+#### Inputs
+_Fixture `taken.atago.yaml`:_
+```text
+precious
+```
+#### When
+```shell
+${atago} record --pty --out taken.atago.yaml -- echo hi
+```
+#### Then
+- exit code is `3`
+- stderr contains `use --force to overwrite`
+- file `taken.atago.yaml` contains `precious`
 ### Scenario: created files become exists asserts (shell mode)
 _skipped on windows_
 #### When
@@ -2896,6 +2991,31 @@ ${atago} run generated.atago.yaml
 #### Then
 - exit code is `0`
 - file `generated.atago.yaml` contains `- pty:`, `- send:`
+- exit code is `0`
+- stdout contains `1 passed`
+### Scenario: record --pty of a no-input command yields a session-less spec that replays green
+_skipped on windows_
+#### When
+```shell
+# interactive (pty): ${atago} record --pty --out echo.atago.yaml -- echo done
+${atago} run echo.atago.yaml
+```
+#### Then
+- exit code is `0`
+- file `echo.atago.yaml` contains `- pty:`, `command: echo done`
+- file `echo.atago.yaml` is checked
+- exit code is `0`
+- stdout contains `1 passed`
+### Scenario: a prompt with regex metacharacters is escaped in the generated expect
+_skipped on windows_
+#### When
+```shell
+# interactive (pty): ${atago} record --pty --out meta.atago.yaml -- sh -c 'printf "Continue? (y/n): "; read a; echo got-$a'
+${atago} run meta.atago.yaml
+```
+#### Then
+- exit code is `0`
+- file `meta.atago.yaml` contains `expect: "Continue\\? \\(y/n\\):"`, `- send:`
 - exit code is `0`
 - stdout contains `1 passed`
 ## atago self-hosting / reports
@@ -3182,6 +3302,33 @@ ${atago} run never.atago.yaml
 ```
 #### Then
 - exit code is `1`
+### Scenario: until with a changes target is a load-time error
+#### Given
+- Fixture file `badchanges.atago.yaml` is created.
+#### Inputs
+_Fixture `badchanges.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: bad
+scenarios:
+  - name: unsatisfiable until
+    steps:
+      - run:
+          command: echo hi
+          retry:
+            times: 3
+            until:
+              changes:
+                created: [out.txt]
+```
+#### When
+```shell
+${atago} run badchanges.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `retry.until.changes cannot be satisfied`, `steps[0].run`
 ## atago self-hosting / run
 Source: `test/e2e/atago/run.atago.yaml`
 ### Scenario: a passing spec exits zero and reports PASS
@@ -3317,6 +3464,20 @@ type "%APPDATA%\mytool\config.txt"
   - exit code is `0`
   - stdout contains `editor=vim`
   - file `.atago-home/AppData/Roaming/mytool/config.txt` contains `editor=vim`
+### Scenario: cwd anchors the run, but sandbox_home stays at the workdir ROOT (Unix)
+_skipped on windows_
+#### Given
+- The command runs with an isolated home under `${workdir}/.atago-home` (HOME/XDG or APPDATA redirected).
+#### When
+```shell
+mkdir -p sub
+mkdir -p "$XDG_CONFIG_HOME/mytool" && printf editor=vim > "$XDG_CONFIG_HOME/mytool/config"
+```
+#### Then
+- after `mkdir -p "$XDG_CONFIG_HOME/mytool" && printf editor=vim > "$XDG_CONFIG_HOME/mytool/config"`:
+  - exit code is `0`
+  - file `.atago-home/.config/mytool/config` contains `editor=vim`
+  - file `sub/.atago-home/.config/mytool/config` does not exist
 ## atago self-hosting / security
 Source: `test/e2e/atago/security.atago.yaml`
 ### Scenario: declared secrets are masked in failure output
@@ -3931,6 +4092,35 @@ ${atago} run norunner.atago.yaml
 #### Then
 - exit code is `2`
 - stderr contains `is not declared`
+### Scenario: a local-only run field on an ssh runner fails validation (exit 2)
+#### Given
+- Fixture file `sshfield.atago.yaml` is created.
+#### Inputs
+_Fixture `sshfield.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: ssh
+runners:
+  box:
+    type: ssh
+    host: deploy.example.com
+    user: deploy
+scenarios:
+  - name: remote run
+    steps:
+      - run:
+          runner: box
+          command: uptime
+          cwd: /var/tmp
+```
+#### When
+```shell
+${atago} run sshfield.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `run.cwd has no effect on an ssh runner`, `steps[0].run`
 ## atago self-hosting / stdin sources (file + base64)
 Source: `test/e2e/atago/stdin_sources.atago.yaml`
 ### Scenario: base64 stdin delivers the exact byte count

--- a/doc/e2e/ffmpeg.md
+++ b/doc/e2e/ffmpeg.md
@@ -1,7 +1,9 @@
 # atago Behavior Specs
 ## Summary
-1 suite · 6 scenarios
+2 suites · 7 scenarios
 ## Contents
+- [ffmpeg + changes (single-artifact encode)](#ffmpeg--changes-single-artifact-encode) — 1 scenario
+  - [lavfi source encodes exactly one output file](#scenario-lavfi-source-encodes-exactly-one-output-file)
 - [ffmpeg / ffprobe (media pipeline)](#ffmpeg--ffprobe-media-pipeline) — 6 scenarios
   - [lavfi synthesizes a video file](#scenario-lavfi-synthesizes-a-video-file)
   - [ffprobe exposes the stream JSON contract](#scenario-ffprobe-exposes-the-stream-json-contract)
@@ -9,6 +11,16 @@
   - [transcode to webm and re-probe the codec](#scenario-transcode-to-webm-and-re-probe-the-codec)
   - [a missing input file fails with a not-found error](#scenario-a-missing-input-file-fails-with-a-not-found-error)
   - [ffprobe on non-media data reports invalid input](#scenario-ffprobe-on-non-media-data-reports-invalid-input)
+## ffmpeg + changes (single-artifact encode)
+Source: `test/e2e/thirdparty/ffmpeg/changes.atago.yaml`
+### Scenario: lavfi source encodes exactly one output file
+#### When
+```shell
+ffmpeg -v error -f lavfi -i testsrc=duration=0.1:size=64x64 -y out.mp4
+```
+#### Then
+- exit code is `0`
+- the step changed exactly created `out.mp4`, modified nothing, deleted nothing
 ## ffmpeg / ffprobe (media pipeline)
 Source: `test/e2e/thirdparty/ffmpeg/ffmpeg.atago.yaml`
 ### Scenario: lavfi synthesizes a video file

--- a/doc/e2e/git.md
+++ b/doc/e2e/git.md
@@ -1,13 +1,39 @@
 # atago Behavior Specs
 ## Summary
-1 suite · 5 scenarios
+3 suites · 7 scenarios
 ## Contents
+- [git + changes (a staged blob touches exactly index + one object)](#git--changes-a-staged-blob-touches-exactly-index--one-object) — 1 scenario
+  - [staging one file creates the index and a single loose object (POSIX)](#scenario-staging-one-file-creates-the-index-and-a-single-loose-object-posix)
 - [git (third-party CLI, no build required)](#git-third-party-cli-no-build-required) — 5 scenarios
   - [init creates an empty repository](#scenario-init-creates-an-empty-repository)
   - [add and commit make the working tree clean](#scenario-add-and-commit-make-the-working-tree-clean)
   - [a captured commit hash flows into a later command](#scenario-a-captured-commit-hash-flows-into-a-later-command)
   - [checking out a missing ref fails with an explanation (no-such-branch)](#scenario-checking-out-a-missing-ref-fails-with-an-explanation-no-such-branch)
   - [checking out a missing ref fails with an explanation (v9.9.9)](#scenario-checking-out-a-missing-ref-fails-with-an-explanation-v999)
+- [git + sandbox_home (global config in an isolated HOME)](#git--sandbox_home-global-config-in-an-isolated-home) — 1 scenario
+  - [global user.name is written under the sandbox home and read back (POSIX)](#scenario-global-username-is-written-under-the-sandbox-home-and-read-back-posix)
+## git + changes (a staged blob touches exactly index + one object)
+Source: `test/e2e/thirdparty/git/changes.atago.yaml`
+### Scenario: staging one file creates the index and a single loose object (POSIX)
+_skipped on windows_
+#### Given
+- Fixture file `repo/f.txt` is created.
+#### Inputs
+_Fixture `repo/f.txt`:_
+```text
+hello from atago
+```
+#### When
+```shell
+git init -q repo
+git -C repo add f.txt
+```
+#### Then
+- after `git init -q repo`:
+  - exit code is `0`
+- after `git -C repo add f.txt`:
+  - exit code is `0`
+  - the step changed exactly created `repo/.git/index`, `repo/.git/objects/*/*`, modified nothing, deleted nothing
 ## git (third-party CLI, no build required)
 Source: `test/e2e/thirdparty/git/git.atago.yaml`
 ### Scenario: init creates an empty repository
@@ -87,3 +113,22 @@ git -C repo checkout v9.9.9
 - after `git -C repo checkout v9.9.9`:
   - exit code is not `0`
   - stderr contains `v9.9.9`
+## git + sandbox_home (global config in an isolated HOME)
+Source: `test/e2e/thirdparty/git/sandbox_home.atago.yaml`
+### Scenario: global user.name is written under the sandbox home and read back (POSIX)
+_skipped on windows_
+#### Given
+- The command runs with an isolated home under `${workdir}/.atago-home` (HOME/XDG or APPDATA redirected).
+- The command runs with an isolated home under `${workdir}/.atago-home` (HOME/XDG or APPDATA redirected).
+#### When
+```shell
+git config --global user.name atago-sandbox-user
+git config --global user.name
+```
+#### Then
+- after `git config --global user.name atago-sandbox-user`:
+  - exit code is `0`
+  - file `.atago-home/.gitconfig` contains `atago-sandbox-user`
+- after `git config --global user.name`:
+  - exit code is `0`
+  - stdout equals an exact value

--- a/doc/e2e/gup.md
+++ b/doc/e2e/gup.md
@@ -1,10 +1,13 @@
 # atago Behavior Specs
 ## Summary
-2 suites · 4 scenarios
+3 suites · 6 scenarios
 ## Contents
 - [gup list (isolated empty environment)](#gup-list-isolated-empty-environment) — 2 scenarios
   - [reports a friendly note on an empty environment (#350)](#scenario-reports-a-friendly-note-on-an-empty-environment-350)
   - [emits a valid empty JSON array on an empty environment with --json](#scenario-emits-a-valid-empty-json-array-on-an-empty-environment-with---json)
+- [gup read-only subcommands (no HOME writes)](#gup-read-only-subcommands-no-home-writes) — 2 scenarios
+  - [gup version writes nothing to the workdir or its sandbox home](#scenario-gup-version-writes-nothing-to-the-workdir-or-its-sandbox-home)
+  - [gup list is a pure read of GOBIN and writes nothing](#scenario-gup-list-is-a-pure-read-of-gobin-and-writes-nothing)
 - [gup](#gup) — 2 scenarios
   - [version reports a semver string](#scenario-version-reports-a-semver-string)
   - [help describes the tool and exits zero](#scenario-help-describes-the-tool-and-exits-zero)
@@ -33,6 +36,31 @@ gup list --json
 - exit code is `0`
 - stdout equals an exact value
 - stdout at `$` has length 0
+## gup read-only subcommands (no HOME writes)
+Source: `test/e2e/tools/gup/sandbox_home.atago.yaml`
+### Scenario: gup version writes nothing to the workdir or its sandbox home
+_skipped on windows_
+#### Given
+- The command runs with an isolated home under `${workdir}/.atago-home` (HOME/XDG or APPDATA redirected).
+#### When
+```shell
+gup version
+```
+#### Then
+- exit code is `0`
+- stdout contains `gup version`
+- the step changed exactly created nothing, modified nothing, deleted nothing
+### Scenario: gup list is a pure read of GOBIN and writes nothing
+_skipped on windows_
+#### Given
+- The command runs with an isolated home under `${workdir}/.atago-home` (HOME/XDG or APPDATA redirected).
+#### When
+```shell
+gup list
+```
+#### Then
+- exit code is `0`
+- the step changed exactly created nothing, modified nothing, deleted nothing
 ## gup
 Source: `test/e2e/tools/gup/smoke.atago.yaml`
 ### Scenario: version reports a semver string

--- a/doc/e2e/jq.md
+++ b/doc/e2e/jq.md
@@ -1,7 +1,10 @@
 # atago Behavior Specs
 ## Summary
-1 suite · 9 scenarios
+2 suites · 11 scenarios
 ## Contents
+- [jq (uncovered contracts — unicode passthrough + empty validation)](#jq-uncovered-contracts--unicode-passthrough--empty-validation) — 2 scenarios
+  - [multibyte unicode passes through unchanged](#scenario-multibyte-unicode-passes-through-unchanged)
+  - [jq empty validates JSON — silent success, loud failure](#scenario-jq-empty-validates-json--silent-success-loud-failure)
 - [jq (third-party CLI, no build required)](#jq-third-party-cli-no-build-required) — 9 scenarios
   - [identity filter echoes the document from stdin](#scenario-identity-filter-echoes-the-document-from-stdin)
   - [sort-keys output is deterministic and exact](#scenario-sort-keys-output-is-deterministic-and-exact)
@@ -12,6 +15,45 @@
   - [a program that does not compile exits 3 with a diagnostic on stderr](#scenario-a-program-that-does-not-compile-exits-3-with-a-diagnostic-on-stderr)
   - [invalid JSON input fails loudly and keeps stdout clean](#scenario-invalid-json-input-fails-loudly-and-keeps-stdout-clean)
   - [streaming several documents produces one result per document](#scenario-streaming-several-documents-produces-one-result-per-document)
+## jq (uncovered contracts — unicode passthrough + empty validation)
+Source: `test/e2e/thirdparty/jq/extra.atago.yaml`
+### Scenario: multibyte unicode passes through unchanged
+#### Inputs
+_stdin for `jq`:_
+```text
+{"s":"café 😀 日本語"}
+```
+#### When
+```shell
+jq -c .
+```
+#### Then
+- exit code is `0`
+- stdout equals an exact value
+### Scenario: jq empty validates JSON — silent success, loud failure
+#### Inputs
+_stdin for `jq`:_
+```text
+{"a":1,"b":[2,3]}
+```
+_stdin for `jq`:_
+```text
+not json
+```
+#### When
+```shell
+jq empty
+jq empty
+```
+#### Then
+- after `jq empty`:
+  - exit code is `0`
+  - stdout is empty
+  - stderr is empty
+- after `jq empty`:
+  - exit code is `5`
+  - stdout is empty
+  - stderr contains `parse error`
 ## jq (third-party CLI, no build required)
 Source: `test/e2e/thirdparty/jq/jq.atago.yaml`
 ### Scenario: identity filter echoes the document from stdin

--- a/doc/e2e/openssl.md
+++ b/doc/e2e/openssl.md
@@ -1,7 +1,10 @@
 # atago Behavior Specs
 ## Summary
-1 suite · 7 scenarios
+2 suites · 9 scenarios
 ## Contents
+- [openssl + changes (key and cert generation footprints)](#openssl--changes-key-and-cert-generation-footprints) — 2 scenarios
+  - [genrsa writes exactly the key file](#scenario-genrsa-writes-exactly-the-key-file)
+  - [a self-signed cert is the only new file the req step creates](#scenario-a-self-signed-cert-is-the-only-new-file-the-req-step-creates)
 - [openssl (third-party CLI, no build required)](#openssl-third-party-cli-no-build-required) — 7 scenarios
   - [sha256 digest of a fixed input is exact and stable](#scenario-sha256-digest-of-a-fixed-input-is-exact-and-stable)
   - [base64 encode and decode round-trip via stdin](#scenario-base64-encode-and-decode-round-trip-via-stdin)
@@ -10,6 +13,29 @@
   - [symmetric encryption round-trips and a wrong password fails loudly](#scenario-symmetric-encryption-round-trips-and-a-wrong-password-fails-loudly)
   - [a self-signed certificate carries the requested subject](#scenario-a-self-signed-certificate-carries-the-requested-subject)
   - [signing with the private key verifies with the public key](#scenario-signing-with-the-private-key-verifies-with-the-public-key)
+## openssl + changes (key and cert generation footprints)
+Source: `test/e2e/thirdparty/openssl/changes.atago.yaml`
+### Scenario: genrsa writes exactly the key file
+#### When
+```shell
+openssl genrsa -out key.pem 2048
+```
+#### Then
+- exit code is `0`
+- the step changed exactly created `key.pem`, modified nothing, deleted nothing
+### Scenario: a self-signed cert is the only new file the req step creates
+#### When
+```shell
+openssl genrsa -out key.pem 2048
+openssl req -new -x509 -key key.pem -out cert.pem -subj /CN=atago-test -days 1
+```
+#### Then
+- after `openssl genrsa -out key.pem 2048`:
+  - exit code is `0`
+- after `openssl req -new -x509 -key key.pem -out cert.pem -subj /CN=atago-test -days 1`:
+  - exit code is `0`
+  - the step changed exactly created `cert.pem`, modified nothing, deleted nothing
+  - file `cert.pem` contains `BEGIN CERTIFICATE`
 ## openssl (third-party CLI, no build required)
 Source: `test/e2e/thirdparty/openssl/openssl.atago.yaml`
 ### Scenario: sha256 digest of a fixed input is exact and stable

--- a/doc/e2e/pandoc.md
+++ b/doc/e2e/pandoc.md
@@ -1,13 +1,35 @@
 # atago Behavior Specs
 ## Summary
-1 suite · 5 scenarios
+2 suites · 6 scenarios
 ## Contents
+- [pandoc + changes (a conversion writes exactly its output)](#pandoc--changes-a-conversion-writes-exactly-its-output) — 1 scenario
+  - [markdown-to-html creates exactly the output file](#scenario-markdown-to-html-creates-exactly-the-output-file)
 - [pandoc (document conversion filter)](#pandoc-document-conversion-filter) — 5 scenarios
   - [markdown converts to HTML and a binary docx](#scenario-markdown-converts-to-html-and-a-binary-docx)
   - [pandoc is a stdin-to-stdout filter](#scenario-pandoc-is-a-stdin-to-stdout-filter)
   - [the JSON AST is a queryable contract](#scenario-the-json-ast-is-a-queryable-contract)
   - [standalone HTML carries the metadata title](#scenario-standalone-html-carries-the-metadata-title)
   - [an unknown output format is rejected](#scenario-an-unknown-output-format-is-rejected)
+## pandoc + changes (a conversion writes exactly its output)
+Source: `test/e2e/thirdparty/pandoc/changes.atago.yaml`
+### Scenario: markdown-to-html creates exactly the output file
+#### Given
+- Fixture file `in.md` is created.
+#### Inputs
+_Fixture `in.md`:_
+```text
+# Title
+
+Some text with *emphasis*.
+```
+#### When
+```shell
+pandoc in.md -o out.html
+```
+#### Then
+- exit code is `0`
+- the step changed exactly created `out.html`, modified nothing, deleted nothing
+- file `out.html` contains `<em>emphasis</em>`
 ## pandoc (document conversion filter)
 Source: `test/e2e/thirdparty/pandoc/pandoc.atago.yaml`
 ### Scenario: markdown converts to HTML and a binary docx

--- a/doc/e2e/python.md
+++ b/doc/e2e/python.md
@@ -1,7 +1,10 @@
 # atago Behavior Specs
 ## Summary
-1 suite · 6 scenarios
+2 suites · 8 scenarios
 ## Contents
+- [python3 + changes (bytecode cache footprint)](#python3--changes-bytecode-cache-footprint) — 2 scenarios
+  - [importing a local module writes exactly one .pyc](#scenario-importing-a-local-module-writes-exactly-one-pyc)
+  - [PYTHONDONTWRITEBYTECODE suppresses the cache entirely](#scenario-pythondontwritebytecode-suppresses-the-cache-entirely)
 - [python3 REPL (interactive pty testbed)](#python3-repl-interactive-pty-testbed) — 6 scenarios
   - [version and -c contracts (non-interactive)](#scenario-version-and--c-contracts-non-interactive)
   - [a missing script exits 2 with a can't-open-file error](#scenario-a-missing-script-exits-2-with-a-cant-open-file-error)
@@ -9,6 +12,55 @@
   - [an interactive session drives the REPL across exchanges](#scenario-an-interactive-session-drives-the-repl-across-exchanges)
   - [EOF (ctrl-d) ends the session cleanly](#scenario-eof-ctrl-d-ends-the-session-cleanly)
   - [a traceback is reported and the REPL recovers](#scenario-a-traceback-is-reported-and-the-repl-recovers)
+## python3 + changes (bytecode cache footprint)
+Source: `test/e2e/thirdparty/python/changes.atago.yaml`
+### Scenario: importing a local module writes exactly one .pyc
+#### Given
+- Fixture file `mymod.py` is created.
+- Fixture file `main.py` is created.
+#### Inputs
+_Fixture `mymod.py`:_
+```text
+def val():
+    return 42
+```
+_Fixture `main.py`:_
+```text
+import mymod
+print(mymod.val())
+```
+#### When
+```shell
+python3 main.py
+```
+#### Then
+- exit code is `0`
+- stdout equals an exact value
+- the step changed exactly created `__pycache__/*.pyc`, modified nothing, deleted nothing
+### Scenario: PYTHONDONTWRITEBYTECODE suppresses the cache entirely
+#### Given
+- Fixture file `mymod.py` is created.
+- Fixture file `main.py` is created.
+- Environment variables are set: PYTHONDONTWRITEBYTECODE.
+#### Inputs
+_Fixture `mymod.py`:_
+```text
+def val():
+    return 42
+```
+_Fixture `main.py`:_
+```text
+import mymod
+print(mymod.val())
+```
+#### When
+```shell
+python3 main.py
+```
+#### Then
+- exit code is `0`
+- stdout equals an exact value
+- the step changed exactly created nothing, modified nothing, deleted nothing
 ## python3 REPL (interactive pty testbed)
 Source: `test/e2e/thirdparty/python/python.atago.yaml`
 ### Scenario: version and -c contracts (non-interactive)

--- a/doc/e2e/sqlite3.md
+++ b/doc/e2e/sqlite3.md
@@ -1,7 +1,10 @@
 # atago Behavior Specs
 ## Summary
-1 suite · 8 scenarios
+2 suites · 10 scenarios
 ## Contents
+- [sqlite3 + changes (workdir-delta of a database write)](#sqlite3--changes-workdir-delta-of-a-database-write) — 2 scenarios
+  - [default rollback-journal mode creates exactly the db file](#scenario-default-rollback-journal-mode-creates-exactly-the-db-file)
+  - [WAL mode leaves no -wal/-shm behind after a clean close](#scenario-wal-mode-leaves-no--wal-shm-behind-after-a-clean-close)
 - [sqlite3 (third-party CLI, no build required)](#sqlite3-third-party-cli-no-build-required) — 8 scenarios
   - [one-shot SQL creates, inserts, and counts in a single invocation](#scenario-one-shot-sql-creates-inserts-and-counts-in-a-single-invocation)
   - [the database file is durable across invocations](#scenario-the-database-file-is-durable-across-invocations)
@@ -11,6 +14,24 @@
   - [.import loads a CSV fixture into a table](#scenario-import-loads-a-csv-fixture-into-a-table)
   - [bad SQL exits 1 with the error position on stderr](#scenario-bad-sql-exits-1-with-the-error-position-on-stderr)
   - [querying a missing table names it in the diagnostics](#scenario-querying-a-missing-table-names-it-in-the-diagnostics)
+## sqlite3 + changes (workdir-delta of a database write)
+Source: `test/e2e/thirdparty/sqlite3/changes.atago.yaml`
+### Scenario: default rollback-journal mode creates exactly the db file
+#### When
+```shell
+sqlite3 t.db "create table x(a); insert into x values(1)"
+```
+#### Then
+- exit code is `0`
+- the step changed exactly created `t.db`, modified nothing, deleted nothing
+### Scenario: WAL mode leaves no -wal/-shm behind after a clean close
+#### When
+```shell
+sqlite3 t.db "PRAGMA journal_mode=WAL; create table x(a); insert into x values(1)"
+```
+#### Then
+- exit code is `0`
+- the step changed exactly created `t.db`, modified nothing, deleted nothing
 ## sqlite3 (third-party CLI, no build required)
 Source: `test/e2e/thirdparty/sqlite3/sqlite3.atago.yaml`
 ### Scenario: one-shot SQL creates, inserts, and counts in a single invocation

--- a/doc/e2e/sqly.md
+++ b/doc/e2e/sqly.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-44 suites · 389 scenarios
+46 suites · 393 scenarios
 ## Contents
 - [sqly ACH/Fedwire native write-back](#sqly-achfedwire-native-write-back) — 4 scenarios
   - [round-trips an ACH file through --save --force after an UPDATE](#scenario-round-trips-an-ach-file-through---save---force-after-an-update)
@@ -38,6 +38,9 @@
   - [reuses the cache that lives inside the imported directory and ignores its manifest](#scenario-reuses-the-cache-that-lives-inside-the-imported-directory-and-ignores-its-manifest)
   - [keeps the cache warm when only an unsupported sibling file changes](#scenario-keeps-the-cache-warm-when-only-an-unsupported-sibling-file-changes)
   - [still invalidates the cache when the supported file changes](#scenario-still-invalidates-the-cache-when-the-supported-file-changes)
+- [sqly changes delta cross-checks (exhaustive-set semantics)](#sqly-changes-delta-cross-checks-exhaustive-set-semantics) — 2 scenarios
+  - [omitting sqly's history DB from an exhaustive list is rejected](#scenario-omitting-sqlys-history-db-from-an-exhaustive-list-is-rejected)
+  - [the exhaustive list including the history DB passes](#scenario-the-exhaustive-list-including-the-history-db-passes)
 - [sqly CLI surface](#sqly-cli-surface) — 10 scenarios
   - [prints the version](#scenario-prints-the-version)
   - [prints usage with --help](#scenario-prints-usage-with---help)
@@ -223,6 +226,9 @@
   - [loads ACH records into multiple tables](#scenario-loads-ach-records-into-multiple-tables)
   - [queries the ACH entries table](#scenario-queries-the-ach-entries-table)
   - [loads a Fedwire file into a single message table](#scenario-loads-a-fedwire-file-into-a-single-message-table)
+- [sqly sandbox_home + changes (history DB isolation)](#sqly-sandbox_home--changes-history-db-isolation) — 2 scenarios
+  - [sqly --sql writes exactly its history DB, only inside the sandbox home](#scenario-sqly---sql-writes-exactly-its-history-db-only-inside-the-sandbox-home)
+  - [a second sqly batch run leaves its sandbox home byte-identical](#scenario-a-second-sqly-batch-run-leaves-its-sandbox-home-byte-identical)
 - [sqly write-back](#sqly-write-back) — 8 scenarios
   - [writes to --save-dir without modifying the source](#scenario-writes-to---save-dir-without-modifying-the-source)
   - [refuses --save without --force](#scenario-refuses---save-without---force)
@@ -1168,6 +1174,59 @@ sqly --cache snap.cache --sql "SELECT COUNT(*) AS n FROM data" indir
   - exit code is `0`
   - stdout contains `2`
   - stderr does not contain `cache: reused`
+## sqly changes delta cross-checks (exhaustive-set semantics)
+Source: `test/e2e/tools/sqly/changes_crosscheck.atago.yaml`
+### Scenario: omitting sqly's history DB from an exhaustive list is rejected
+_skipped on windows_
+#### Given
+- Fixture file `inner.atago.yaml` is created.
+#### Inputs
+_Fixture `inner.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: inner
+scenarios:
+  - name: under-specified created list
+    steps:
+      - fixture:
+          file: user.csv
+          content: |
+            n,v
+            a,1
+      - run:
+          sandbox_home: true
+          command: sqly --sql "SELECT 1" user.csv
+      - assert:
+          changes:
+            created: []
+```
+#### When
+```shell
+${atago} run inner.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `unexpected created file`
+- stdout contains `.atago-home/.config/sqly/history.db`
+### Scenario: the exhaustive list including the history DB passes
+_skipped on windows_
+#### Given
+- Fixture file `user.csv` is created.
+- The command runs with an isolated home under `${workdir}/.atago-home` (HOME/XDG or APPDATA redirected).
+#### Inputs
+_Fixture `user.csv`:_
+```text
+n,v
+a,1
+```
+#### When
+```shell
+sqly --sql "SELECT 1" user.csv
+```
+#### Then
+- exit code is `0`
+- the step changed exactly created `.atago-home/.config/sqly/history.db`, modified nothing, deleted nothing
 ## sqly CLI surface
 Source: `test/e2e/tools/sqly/cli.atago.yaml`
 ### Scenario: prints the version
@@ -4186,6 +4245,53 @@ sqly customer-transfer.fed
 #### Then
 - exit code is `0`
 - stdout contains `customer_transfer_message`
+## sqly sandbox_home + changes (history DB isolation)
+Source: `test/e2e/tools/sqly/sandbox_home.atago.yaml`
+### Scenario: sqly --sql writes exactly its history DB, only inside the sandbox home
+_skipped on windows_
+#### Given
+- Fixture file `user.csv` is created.
+- The command runs with an isolated home under `${workdir}/.atago-home` (HOME/XDG or APPDATA redirected).
+#### Inputs
+_Fixture `user.csv`:_
+```text
+user_name,identifier
+booker12,1
+```
+#### When
+```shell
+sqly --sql "SELECT identifier FROM user WHERE user_name = 'booker12'" user.csv
+```
+#### Then
+- exit code is `0`
+- stdout contains `1`
+- the step changed exactly created `.atago-home/.config/sqly/history.db`, modified nothing, deleted nothing
+- file `.atago-home/.config/sqly/history.db` exists
+#### Generated artifacts
+- `.atago-home/.config/sqly/history.db`
+### Scenario: a second sqly batch run leaves its sandbox home byte-identical
+_skipped on windows_
+#### Given
+- Fixture file `user.csv` is created.
+- The command runs with an isolated home under `${workdir}/.atago-home` (HOME/XDG or APPDATA redirected).
+- The command runs with an isolated home under `${workdir}/.atago-home` (HOME/XDG or APPDATA redirected).
+#### Inputs
+_Fixture `user.csv`:_
+```text
+user_name,identifier
+booker12,1
+```
+#### When
+```shell
+sqly --sql "SELECT 1" user.csv
+sqly --sql "SELECT 2" user.csv
+```
+#### Then
+- after `sqly --sql "SELECT 1" user.csv`:
+  - exit code is `0`
+- after `sqly --sql "SELECT 2" user.csv`:
+  - exit code is `0`
+  - the step changed exactly created nothing, modified nothing, deleted nothing
 ## sqly write-back
 Source: `test/e2e/tools/sqly/save.atago.yaml`
 ### Scenario: writes to --save-dir without modifying the source

--- a/doc/e2e/truss.md
+++ b/doc/e2e/truss.md
@@ -1,7 +1,10 @@
 # atago Behavior Specs
 ## Summary
-1 suite · 7 scenarios
+2 suites · 9 scenarios
 ## Contents
+- [truss convert (filesystem footprint)](#truss-convert-filesystem-footprint) — 2 scenarios
+  - [convert PNG->JPEG creates only the output file](#scenario-convert-png-jpeg-creates-only-the-output-file)
+  - [convert to a glob-matched output honors path.Match](#scenario-convert-to-a-glob-matched-output-honors-pathmatch)
 - [truss image conversion](#truss-image-conversion) — 7 scenarios
   - [inspect reports PNG format and dimensions as JSON](#scenario-inspect-reports-png-format-and-dimensions-as-json)
   - [convert PNG to JPEG yields a same-size opaque JPEG](#scenario-convert-png-to-jpeg-yields-a-same-size-opaque-jpeg)
@@ -10,6 +13,33 @@
   - [a high-quality JPEG stays visually close to the source](#scenario-a-high-quality-jpeg-stays-visually-close-to-the-source)
   - [a lossless PNG re-encode is pixel-identical to the source](#scenario-a-lossless-png-re-encode-is-pixel-identical-to-the-source)
   - [a missing input file exits with the I/O error code](#scenario-a-missing-input-file-exits-with-the-io-error-code)
+## truss convert (filesystem footprint)
+Source: `test/e2e/tools/truss/changes.atago.yaml`
+### Scenario: convert PNG->JPEG creates only the output file
+_skipped on windows_
+#### Given
+- Fixture file `in.png` is created.
+#### When
+```shell
+truss convert in.png -o out.jpg
+```
+#### Then
+- exit code is `0`
+- the step changed exactly created `out.jpg`, modified nothing, deleted nothing
+- image `out.jpg` is `jpeg`, width 2, height 2
+#### Generated artifacts
+- `out.jpg`
+### Scenario: convert to a glob-matched output honors path.Match
+_skipped on windows_
+#### Given
+- Fixture file `in.png` is created.
+#### When
+```shell
+truss convert in.png -o thumb.webp --format webp
+```
+#### Then
+- exit code is `0`
+- the step changed exactly created `*.webp`, modified nothing, deleted nothing
 ## truss image conversion
 Source: `test/e2e/tools/truss/convert.atago.yaml`
 ### Scenario: inspect reports PNG format and dimensions as JSON

--- a/internal/cli/record.go
+++ b/internal/cli/record.go
@@ -159,6 +159,14 @@ recording is a non-goal for now — write those steps by hand.
 // interactive session by hand, and generate a spec whose pty: step replays it
 // as expect/send pairs. POSIX-only; Windows returns a clear error.
 func recordPTY(cmdArgs []string, shell bool, out string, force bool, stdout, stderr io.Writer) int {
+	// Refuse an existing --out up front, before driving the session: otherwise
+	// a user hand-drives the whole interactive session only to be told the file
+	// already exists once it is too late to save the transcript.
+	if _, err := os.Stat(out); err == nil && !force {
+		fmt.Fprintf(stderr, "atago record: %q already exists (use --force to overwrite)\n", out)
+		return ExitConfig
+	}
+
 	command := shellJoin(cmdArgs)
 	if shell {
 		command = strings.Join(cmdArgs, " ")
@@ -189,10 +197,6 @@ func recordPTY(cmdArgs []string, shell bool, out string, force bool, stdout, std
 	if out == "" {
 		fmt.Fprint(stdout, string(generated))
 		return ExitOK
-	}
-	if _, err := os.Stat(out); err == nil && !force {
-		fmt.Fprintf(stderr, "atago record: %q already exists (use --force to overwrite)\n", out)
-		return ExitConfig
 	}
 	if dir := filepath.Dir(out); dir != "." {
 		if err := os.MkdirAll(dir, 0o750); err != nil {

--- a/internal/cli/record_test.go
+++ b/internal/cli/record_test.go
@@ -1,7 +1,11 @@
 package cli
 
 import (
+	"bytes"
+	"os"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	shellwords "github.com/mattn/go-shellwords"
@@ -35,6 +39,30 @@ func TestPOSIXJoin_RoundTrip(t *testing.T) {
 		if !reflect.DeepEqual(got, argv) {
 			t.Errorf("round-trip changed argv: %v -> %q -> %v", argv, joined, got)
 		}
+	}
+}
+
+// TestRecordPTY_ExistingOutExitsEarly proves `record --pty --out FILE` refuses
+// an existing --out BEFORE driving any session (#69 follow-up): the check now
+// fires first, so it returns ExitConfig without opening a pty (which would hang
+// waiting on stdin here) and leaves the existing file untouched.
+func TestRecordPTY_ExistingOutExitsEarly(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	out := filepath.Join(dir, "generated.atago.yaml")
+	if err := os.WriteFile(out, []byte("precious"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := recordCmd([]string{"--pty", "--out", out, "--", "echo", "hi"}, &stdout, &stderr)
+	if code != ExitConfig {
+		t.Fatalf("exit = %d, want %d", code, ExitConfig)
+	}
+	if !strings.Contains(stderr.String(), "use --force") {
+		t.Errorf("stderr = %q, want mention of --force", stderr.String())
+	}
+	if b, _ := os.ReadFile(out); string(b) != "precious" {
+		t.Errorf("existing file was modified: %q", b)
 	}
 }
 

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -216,6 +216,61 @@ scenarios:
 	}
 }
 
+// TestLoadBytes_SSHRunFields covers the rejection of run-step fields that only
+// shape local execution when the step names an ssh runner: the command runs
+// remotely, so env/clear_env/pass_env/sandbox_home/stdin/stdout_to/stderr_to/cwd
+// are silently dropped and must fail at load time. The same fields load fine on
+// a cmd runner, and an ssh step limited to command/runner/timeout/retry loads.
+func TestLoadBytes_SSHRunFields(t *testing.T) {
+	t.Parallel()
+	// sshSpec wraps a run: mapping naming ssh runner "box" (host+user set).
+	sshSpec := func(run string) string {
+		return "version: \"1\"\nsuite:\n  name: x\nrunners:\n  box: {type: ssh, host: h, user: u}\nscenarios:\n  - name: a\n    steps:\n      - run: {runner: box, " + run + "}"
+	}
+	cmdSpec := func(run string) string {
+		return "version: \"1\"\nsuite:\n  name: x\nrunners:\n  local: {type: cmd}\nscenarios:\n  - name: a\n    steps:\n      - run: {runner: local, " + run + "}"
+	}
+
+	rejected := []struct {
+		name  string
+		run   string
+		field string
+	}{
+		{"sandbox_home", "command: uptime, sandbox_home: true", "sandbox_home"},
+		{"clear_env", "command: uptime, clear_env: true", "clear_env"},
+		{"pass_env", "command: uptime, clear_env: true, pass_env: [PATH]", "pass_env"},
+		{"env", "command: uptime, env: {A: b}", "env"},
+		{"stdin", "command: cat, stdin: hello", "stdin"},
+		{"stdout_to", "command: uptime, stdout_to: out.txt", "stdout_to"},
+		{"stderr_to", "command: uptime, stderr_to: err.txt", "stderr_to"},
+		{"cwd", "command: uptime, cwd: sub", "cwd"},
+	}
+	for _, tt := range rejected {
+		t.Run("ssh rejects "+tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := LoadBytes("t.atago.yaml", []byte(sshSpec(tt.run)))
+			want := "run." + tt.field + " has no effect on an ssh runner"
+			if err == nil || !strings.Contains(err.Error(), want) {
+				t.Errorf("error = %v, want substring %q", err, want)
+			}
+		})
+		t.Run("cmd accepts "+tt.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := LoadBytes("t.atago.yaml", []byte(cmdSpec(tt.run))); err != nil {
+				t.Errorf("cmd runner should load %s: %v", tt.name, err)
+			}
+		})
+	}
+
+	t.Run("ssh with only command/runner/timeout/retry loads", func(t *testing.T) {
+		t.Parallel()
+		src := sshSpec("command: uptime, timeout: 30s, retry: {times: 3, until: {exit_code: 0}}")
+		if _, err := LoadBytes("t.atago.yaml", []byte(src)); err != nil {
+			t.Errorf("minimal ssh run step should load: %v", err)
+		}
+	})
+}
+
 func TestLoadBytes_Errors(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -269,6 +269,27 @@ func TestLoadBytes_SSHRunFields(t *testing.T) {
 			t.Errorf("minimal ssh run step should load: %v", err)
 		}
 	})
+
+	// shell is rejected with its own message: the remote login shell always
+	// interprets the command, so the knob has nothing to switch.
+	t.Run("ssh rejects shell", func(t *testing.T) {
+		t.Parallel()
+		_, err := LoadBytes("t.atago.yaml", []byte(sshSpec("command: uptime, shell: true")))
+		want := "run.shell has no effect on an ssh runner (the remote login shell always interprets the command)"
+		if err == nil || !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %v, want substring %q", err, want)
+		}
+	})
+
+	// A remote pipeline needs no shell: opt-in — the metacharacter hint (which
+	// would suggest the now-rejected shell: true) must not fire for ssh steps.
+	t.Run("ssh command with metacharacters loads without the shell hint", func(t *testing.T) {
+		t.Parallel()
+		src := sshSpec("command: \"ps aux | grep sshd > /tmp/out\"")
+		if _, err := LoadBytes("t.atago.yaml", []byte(src)); err != nil {
+			t.Errorf("ssh command with metacharacters should load (the remote shell interprets them): %v", err)
+		}
+	})
 }
 
 func TestLoadBytes_Errors(t *testing.T) {

--- a/internal/loader/matrix_test.go
+++ b/internal/loader/matrix_test.go
@@ -130,6 +130,26 @@ func TestLoadBytes_RetryValidation(t *testing.T) {
 			wantMsg: "",
 		},
 		{
+			name:    "until changes cannot be satisfied",
+			src:     "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps:\n      - run:\n          command: echo\n          retry:\n            times: 3\n            until: {changes: {created: [out.txt]}}",
+			wantMsg: "retry.until.changes cannot be satisfied",
+		},
+		{
+			name:    "until screen cannot be satisfied",
+			src:     "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps:\n      - run:\n          command: echo\n          retry:\n            times: 3\n            until: {screen: {contains: hi}}",
+			wantMsg: "retry.until.screen cannot be satisfied",
+		},
+		{
+			name:    "until duration is accepted",
+			src:     "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps:\n      - run:\n          command: echo\n          retry:\n            times: 3\n            until: {duration: {lt: 2s}}",
+			wantMsg: "",
+		},
+		{
+			name:    "until exit_code is accepted",
+			src:     "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps:\n      - run:\n          command: echo\n          retry:\n            times: 3\n            until: {exit_code: 0}",
+			wantMsg: "",
+		},
+		{
 			name:    "http retry times below 1",
 			src:     "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps:\n      - http:\n          method: GET\n          path: /job\n          retry:\n            times: 0\n            until: {status: 200}",
 			wantMsg: "http.retry.times must be >= 1",

--- a/internal/loader/validate.go
+++ b/internal/loader/validate.go
@@ -102,7 +102,7 @@ func validate(s *spec.Spec) []string {
 			// changes bounds the workdir delta of the immediately preceding
 			// run/pty step (#70): reject a placement no such step feeds.
 			if st.Assert != nil && st.Assert.Changes != nil && !prevRunOrPTY {
-				add("%s.assert.changes requires an immediately preceding run/pty step (the step whose workdir delta it pins)", sw)
+				add("%s.assert.changes requires an immediately preceding run/pty step (the step whose workdir delta it pins); combine it with the assert block directly after the step (one assert may set exit_code, stdout, and changes together)", sw)
 			}
 			validateStep(add, sw, st, s.Runners, serviceNames, mockNames)
 			prevMeasurable = measurableStep(st.Kind())
@@ -601,6 +601,7 @@ func validateStep(add func(string, ...any), where string, st *spec.Step, runners
 		validateHermeticEnv(add, where+".run", st.Run.ClearEnv, st.Run.PassEnv)
 		validateStdin(add, where+".run", st.Run.Stdin)
 		validateRetry(add, where+".run", st.Run.Retry)
+		validateSSHRunFields(add, where, st.Run, runners)
 	case spec.StepAssert:
 		validateAssert(add, where, st.Assert, mockNames)
 	case spec.StepHTTP:
@@ -651,6 +652,40 @@ func validateStep(add func(string, ...any), where string, st *spec.Step, runners
 		validatePTY(add, where, st.PTY)
 	case spec.StepSignal:
 		validateSignal(add, where, st.Signal, serviceNames)
+	}
+}
+
+// validateSSHRunFields rejects run-step fields that only shape LOCAL execution
+// when the step names an ssh runner: the command runs on the remote host, so
+// env/clear_env/pass_env/sandbox_home/stdin/stdout_to/stderr_to/cwd are silently
+// dropped by the engine's remote path (it forwards only the command). Rejecting
+// them at load time turns a silent no-op into a clear error. timeout and retry
+// are honored remotely and are intentionally absent here.
+func validateSSHRunFields(add func(string, ...any), where string, r *spec.Run, runners map[string]spec.Runner) {
+	if r.Runner == "" {
+		return
+	}
+	rdef, ok := runners[r.Runner]
+	if !ok || rdef.Type != "ssh" {
+		return
+	}
+	fields := []struct {
+		set   bool
+		field string
+	}{
+		{r.SandboxHome != nil, "sandbox_home"},
+		{r.ClearEnv != nil, "clear_env"},
+		{len(r.PassEnv) > 0, "pass_env"},
+		{len(r.Env) > 0, "env"},
+		{!r.Stdin.IsZero(), "stdin"},
+		{r.StdoutTo != "", "stdout_to"},
+		{r.StderrTo != "", "stderr_to"},
+		{r.Cwd != "", "cwd"},
+	}
+	for _, f := range fields {
+		if f.set {
+			add("%s.run.%s has no effect on an ssh runner (the command runs remotely; only command/runner/timeout apply)", where, f.field)
+		}
 	}
 }
 
@@ -1422,6 +1457,17 @@ func validateRetry(add func(string, ...any), where string, r *spec.Retry) {
 		return
 	}
 	validateAssert(add, where+".retry.until", r.Until, nil)
+	// A retry's until is evaluated against the raw exec result of each attempt.
+	// changes (the workdir delta) is computed only for a top-level assert
+	// directly after the step, and screen renders a pty step's terminal — a
+	// run/http result is never a pty. Neither can ever hold here, so the step
+	// would only ever exhaust its budget: reject them at load time instead.
+	if r.Until.Changes != nil {
+		add("%s.retry.until.changes cannot be satisfied in a retry condition (the workdir delta is computed only for a top-level assert directly after the step, never for the exec result a retry polls); move it to an assert after the step", where)
+	}
+	if r.Until.Screen != nil {
+		add("%s.retry.until.screen cannot be satisfied in a retry condition (screen renders a pty step's terminal, and a run/http result is never a pty); move it to an assert after a pty step", where)
+	}
 }
 
 func validateJSON(add func(string, ...any), where string, j *spec.JSONAssert) {

--- a/internal/loader/validate.go
+++ b/internal/loader/validate.go
@@ -587,11 +587,13 @@ func validateStep(add func(string, ...any), where string, st *spec.Step, runners
 		}
 		if st.Run.Command == "" {
 			add("%s.run.command is required", where)
-		} else if !st.Run.ShellEnabled() {
+		} else if !st.Run.ShellEnabled() && !runnerIsSSH(st.Run.Runner, runners) {
 			// Without shell, the command is tokenized into argv, so shell operators
 			// (redirects, pipes, sequencing, substitution) are not honored. Rather
 			// than silently pass them as literal argv, flag them with a fix-forward
-			// hint (#: shell authoring UX).
+			// hint (#: shell authoring UX). An ssh command is exempt: it travels
+			// as one string and the REMOTE login shell always interprets it, so
+			// metacharacters are honored there without any shell: opt-in.
 			if tok := shellMetachar(st.Run.Command); tok != "" {
 				add("%s.run.command contains the shell metacharacter %q but shell is not enabled; "+
 					"set `shell: true` to run it through a shell, split it into multiple `run` steps, "+
@@ -661,13 +663,24 @@ func validateStep(add func(string, ...any), where string, st *spec.Step, runners
 // dropped by the engine's remote path (it forwards only the command). Rejecting
 // them at load time turns a silent no-op into a clear error. timeout and retry
 // are honored remotely and are intentionally absent here.
+// runnerIsSSH reports whether name references a declared ssh-type runner.
+func runnerIsSSH(name string, runners map[string]spec.Runner) bool {
+	if name == "" {
+		return false
+	}
+	rdef, ok := runners[name]
+	return ok && rdef.Type == "ssh"
+}
+
 func validateSSHRunFields(add func(string, ...any), where string, r *spec.Run, runners map[string]spec.Runner) {
-	if r.Runner == "" {
+	if !runnerIsSSH(r.Runner, runners) {
 		return
 	}
-	rdef, ok := runners[r.Runner]
-	if !ok || rdef.Type != "ssh" {
-		return
+	// shell gets its own message: it is not merely ignored — the remote login
+	// shell ALWAYS interprets the command string, so the knob has nothing to
+	// switch and an authored value only misleads.
+	if r.Shell != nil {
+		add("%s.run.shell has no effect on an ssh runner (the remote login shell always interprets the command)", where)
 	}
 	fields := []struct {
 		set   bool

--- a/internal/record/pty.go
+++ b/internal/record/pty.go
@@ -74,7 +74,7 @@ func GeneratePTY(rec PTYRecording, opts Options) ([]byte, error) {
 	if rec.Shell {
 		b.WriteString("          shell: true\n")
 	}
-	fmt.Fprintf(&b, "          command: %s\n", yamlScalar(rec.Command))
+	fmt.Fprintf(&b, "          command: %s\n", yamlScalar(escapeVarRefs(rec.Command)))
 	if rec.Rows > 0 {
 		fmt.Fprintf(&b, "          rows: %d\n", rec.Rows)
 	}
@@ -95,7 +95,7 @@ func GeneratePTY(rec PTYRecording, opts Options) ([]byte, error) {
 	if anchor := stableLine(lastOutput); anchor != "" {
 		b.WriteString("      - assert:\n")
 		b.WriteString("          stdout:\n")
-		fmt.Fprintf(&b, "            contains: %s # last stable line of the transcript\n", yamlScalar(anchor))
+		fmt.Fprintf(&b, "            contains: %s # last stable line of the transcript\n", yamlScalar(escapeVarRefs(anchor)))
 	}
 
 	out := []byte(b.String())
@@ -146,7 +146,10 @@ func renderSend(seg PTYSegment, secretN *int) []string {
 	if key, ok := spec.PTYKeyForSequence(string(seg.Input)); ok {
 		return []string{fmt.Sprintf("            - send: {key: %s}\n", key)}
 	}
-	return []string{fmt.Sprintf("            - send: %s\n", yamlDoubleQuoted(literalSend(seg.Input)))}
+	// Typed text is raw: escape ${...} so the replay engine types the literal
+	// bytes the user typed instead of expanding them (the secret placeholder
+	// above is the one send that MUST stay a live reference).
+	return []string{fmt.Sprintf("            - send: %s\n", yamlDoubleQuoted(escapeVarRefs(literalSend(seg.Input))))}
 }
 
 // yamlDoubleQuoted renders s as a YAML double-quoted flow scalar, escaping

--- a/internal/record/pty_test.go
+++ b/internal/record/pty_test.go
@@ -110,6 +110,51 @@ func TestGeneratePTY(t *testing.T) {
 	}
 }
 
+// TestGeneratePTY_EscapesVariableReferences proves the pty round-trip law for
+// text containing ${...}: the engine expands ${name} in the pty command and in
+// literal send text at replay, so both must carry the $${...} literal escape.
+// Expect anchors must NOT be $$-escaped: regexp.QuoteMeta already renders the
+// reference as \$\{...\} which the expander ignores, and double-escaping would
+// make the compiled pattern miss the transcript.
+func TestGeneratePTY_EscapesVariableReferences(t *testing.T) {
+	t.Parallel()
+	rec := PTYRecording{
+		Command:  "sh -c 'read x; echo got'",
+		ExitCode: 0,
+		Segments: []PTYSegment{
+			outSeg("enter ${VAR} value: "),
+			inSeg("literal ${HOME}\r"),
+			outSeg("got\r\n"),
+		},
+	}
+	got, err := GeneratePTY(rec, Options{SuiteName: "esc"})
+	if err != nil {
+		t.Fatalf("GeneratePTY: %v", err)
+	}
+	// Assert on the DECODED session (yamlScalar doubles backslashes on the
+	// wire, so string-matching the file text would test the quoting, not the
+	// semantics).
+	pty := loadGenerated(t, got)
+	var expect, send string
+	for _, a := range pty.Session {
+		if a.Expect != "" {
+			expect = a.Expect
+		}
+		if a.Send != nil && a.Send.Text != nil {
+			send = *a.Send.Text
+		}
+	}
+	if send != "literal $${HOME}\n" {
+		t.Errorf("literal send = %q, want the $${...} escape carried through", send)
+	}
+	// The expect stays QuoteMeta-only: \$\{VAR\} matches the literal prompt
+	// and is already inert to the expander; $$-escaping it too would make the
+	// compiled pattern miss the transcript.
+	if expect != `enter \$\{VAR\} value:` {
+		t.Errorf("expect = %q, want QuoteMeta-escaped exactly once", expect)
+	}
+}
+
 // TestGeneratePTY_EchoOffNeverLeaksSecret proves an echo-off (password) input
 // burst produces an ${env:...} placeholder and that the literal secret never
 // reaches the generated YAML (#69).

--- a/internal/record/record.go
+++ b/internal/record/record.go
@@ -59,7 +59,7 @@ func Generate(obs Observation, opts Options) ([]byte, error) {
 	if obs.Shell {
 		b.WriteString("          shell: true\n")
 	}
-	fmt.Fprintf(&b, "          command: %s\n", yamlScalar(obs.Command))
+	fmt.Fprintf(&b, "          command: %s\n", yamlScalar(escapeVarRefs(obs.Command)))
 	b.WriteString("      - assert:\n")
 	fmt.Fprintf(&b, "          exit_code: %d\n", obs.ExitCode)
 
@@ -71,7 +71,7 @@ func Generate(obs Observation, opts Options) ([]byte, error) {
 	case firstLine(obs.Stdout) != "":
 		b.WriteString("      - assert:\n")
 		b.WriteString("          stdout:\n")
-		fmt.Fprintf(&b, "            contains: %s # first non-empty line, trimmed\n", yamlScalar(firstLine(obs.Stdout)))
+		fmt.Fprintf(&b, "            contains: %s # first non-empty line, trimmed\n", yamlScalar(escapeVarRefs(firstLine(obs.Stdout))))
 	}
 	if len(obs.Stderr) == 0 {
 		b.WriteString("      - assert:\n")
@@ -88,7 +88,7 @@ func Generate(obs Observation, opts Options) ([]byte, error) {
 	for _, f := range files {
 		b.WriteString("      - assert:\n")
 		b.WriteString("          file:\n")
-		fmt.Fprintf(&b, "            path: %s\n", yamlScalar(f))
+		fmt.Fprintf(&b, "            path: %s\n", yamlScalar(escapeVarRefs(f)))
 		b.WriteString("            exists: true\n")
 	}
 	if capped {
@@ -100,6 +100,18 @@ func Generate(obs Observation, opts Options) ([]byte, error) {
 		return nil, fmt.Errorf("generated spec does not validate (this is an atago bug, please report it): %w", err)
 	}
 	return out, nil
+}
+
+// escapeVarRefs rewrites every "${" in observed text as the documented "$${"
+// literal escape. Recorded commands, output anchors, file paths, and typed
+// pty input are RAW text — any ${...} in them is literal — but the engine
+// expands ${name} in run.command, assert values, and pty sends at replay (and
+// rejects an unresolved reference in a no-shell command), so an unescaped
+// reference would make the generated spec diverge from, or fail to replay,
+// the recorded run. The uniform rewrite round-trips: the expander turns
+// "$${" back into the literal "${" the tool actually saw.
+func escapeVarRefs(s string) string {
+	return strings.ReplaceAll(s, "${", "$${")
 }
 
 // firstLine returns the first non-empty line, trimmed.

--- a/internal/record/record_test.go
+++ b/internal/record/record_test.go
@@ -40,6 +40,45 @@ func TestGenerate_Skeleton(t *testing.T) {
 	}
 }
 
+// TestGenerate_EscapesVariableReferences proves the round-trip law for
+// observed text containing ${...}: the engine expands ${name} in run.command
+// and assert values at replay (and errors on an unresolved reference in a
+// no-shell command), so record must emit the documented $${...} literal escape
+// for the command, the stdout anchor, and created-file paths — otherwise the
+// generated spec diverges from (or outright fails to replay) the recorded run.
+func TestGenerate_EscapesVariableReferences(t *testing.T) {
+	t.Parallel()
+	out, err := Generate(Observation{
+		Command:      "printf %s 'literal ${HOME} here'",
+		ExitCode:     0,
+		Stdout:       []byte("saw ${workdir} in output\n"),
+		CreatedFiles: []string{"weird/${name}.txt"},
+	}, Options{SuiteName: "esc"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"command: printf %s 'literal $${HOME} here'",
+		"contains: saw $${workdir} in output",
+		"path: weird/$${name}.txt",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("generated spec missing escaped form %q:\n%s", want, got)
+		}
+	}
+	// The scenario name is a human label the engine never expands, so it may
+	// keep the raw text; the leak check applies to the expanded fields only.
+	for _, line := range strings.Split(got, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "command:") || strings.HasPrefix(trimmed, "contains:") || strings.HasPrefix(trimmed, "path:") {
+			if strings.Contains(strings.ReplaceAll(trimmed, "$${", ""), "${") {
+				t.Errorf("live ${...} reference leaked into an expanded field: %s", trimmed)
+			}
+		}
+	}
+}
+
 // TestGenerate_EdgeShapes proves generation stays valid across observed
 // shapes: empty output, non-zero exit, noisy stderr, shell mode, file cap,
 // and hostile strings that must not break YAML structure.

--- a/internal/spec/walk.go
+++ b/internal/spec/walk.go
@@ -54,18 +54,66 @@ func WalkAssertStrings(a *Assert, visit func(string) string) *Assert {
 		fc.JSON = walkJSONAssert(a.File.JSON, visit)
 		c.File = &fc
 	}
-	if a.Header != nil {
-		hc := *a.Header
-		hc.Contains = walkPtr(a.Header.Contains, visit)
-		hc.Equals = walkPtr(a.Header.Equals, visit)
-		c.Header = &hc
-	}
+	c.Header = walkHeaderMatch(a.Header, visit)
 	if a.Image != nil {
 		ic := *a.Image
 		ic.Path = visit(a.Image.Path)
 		ic.SimilarTo = visit(a.Image.SimilarTo)
 		c.Image = &ic
 	}
+	// The rendered-screen matcher is a stream matcher like stdout/stderr.
+	c.Screen = walkStream(a.Screen, visit)
+	if a.Dir != nil {
+		dc := *a.Dir
+		dc.Path = visit(a.Dir.Path)
+		dc.Contains = walkStrings(a.Dir.Contains, visit)
+		dc.NotContains = walkStrings(a.Dir.NotContains, visit)
+		dc.Glob = visit(a.Dir.Glob)
+		dc.Ignore = walkStrings(a.Dir.Ignore, visit)
+		c.Dir = &dc
+	}
+	if a.PDF != nil {
+		pc := *a.PDF
+		pc.Path = visit(a.PDF.Path)
+		if len(a.PDF.Metadata) > 0 {
+			m := make(map[string]string, len(a.PDF.Metadata))
+			for k, v := range a.PDF.Metadata {
+				m[k] = visit(v)
+			}
+			pc.Metadata = m
+		}
+		pc.Text = walkStream(a.PDF.Text, visit)
+		c.PDF = &pc
+	}
+	if a.Mock != nil {
+		mc := *a.Mock
+		// Name stays untouched: it references a mock server declared in the
+		// spec, checked against the declared set at load time.
+		mc.Path = visit(a.Mock.Path)
+		mc.Header = walkHeaderMatch(a.Mock.Header, visit)
+		mc.Body = walkStream(a.Mock.Body, visit)
+		c.Mock = &mc
+	}
+	if a.Changes != nil {
+		cc := *a.Changes
+		cc.Created = walkListPtr(a.Changes.Created, visit)
+		cc.Modified = walkListPtr(a.Changes.Modified, visit)
+		cc.Deleted = walkListPtr(a.Changes.Deleted, visit)
+		c.Changes = &cc
+	}
+	return &c
+}
+
+// walkHeaderMatch returns a copy of a header matcher with visit applied to its
+// matcher arguments (the header name is a protocol identifier, not user text).
+func walkHeaderMatch(h *HeaderMatch, visit func(string) string) *HeaderMatch {
+	if h == nil {
+		return nil
+	}
+	c := *h
+	c.Contains = walkPtr(h.Contains, visit)
+	c.Equals = walkPtr(h.Equals, visit)
+	c.Matches = walkPtr(h.Matches, visit)
 	return &c
 }
 
@@ -129,6 +177,34 @@ func WalkJSONValueStrings(v any, visit func(string) string) any {
 	default:
 		return v
 	}
+}
+
+// walkStrings applies visit to each element of a plain []string field (dir
+// contains/not_contains/ignore), returning a new slice, or nil for nil input.
+func walkStrings(l []string, visit func(string) string) []string {
+	if l == nil {
+		return nil
+	}
+	out := make([]string, len(l))
+	for i, v := range l {
+		out[i] = visit(v)
+	}
+	return out
+}
+
+// walkListPtr applies visit through a *StringList (the changes entry lists),
+// preserving the nil-vs-empty distinction the exhaustive-set semantics depend
+// on: nil stays nil (unconstrained) and an empty list stays empty (asserts the
+// category changed nothing).
+func walkListPtr(l *StringList, visit func(string) string) *StringList {
+	if l == nil {
+		return nil
+	}
+	out := walkList(*l, visit)
+	if out == nil {
+		out = StringList{}
+	}
+	return &out
 }
 
 // walkList applies visit to each element of a StringList, returning a new list,

--- a/internal/spec/walk_test.go
+++ b/internal/spec/walk_test.go
@@ -34,14 +34,20 @@ func sp(s string) *string { return &s }
 // interpolatable field, and that it returns a copy without mutating the input.
 func TestWalkAssertStrings_CollectAndExpand(t *testing.T) {
 	t.Parallel()
+	emptyList := StringList{}
 	a := &Assert{
 		Stdout:  &StreamAssert{Contains: StringList{"${a}"}},
 		Rows:    &StreamAssert{JSON: &JSONAssert{Path: "$.${b}", Equals: "${c}"}},
 		Message: &StreamAssert{Equals: sp("${d}")},
 		Value:   &StreamAssert{YAML: &JSONAssert{Path: "$.x", Matches: sp("${e}")}},
 		File:    &FileAssert{Path: "${f}", Contains: StringList{"${g}"}},
-		Header:  &HeaderMatch{Name: "X", Equals: sp("${h}")},
+		Header:  &HeaderMatch{Name: "X", Equals: sp("${h}"), Matches: sp("${r}")},
 		Image:   &ImageAssert{Path: "${i}", SimilarTo: "${j}"},
+		Screen:  &StreamAssert{Contains: StringList{"${k}"}},
+		Dir:     &DirAssert{Path: "${l}", Contains: []string{"${m}"}, NotContains: []string{"${n}"}, Glob: "${o}", Ignore: []string{"${p}"}},
+		PDF:     &PDFAssert{Path: "${q}", Metadata: map[string]string{"title": "${s}"}, Text: &StreamAssert{Contains: StringList{"${t}"}}},
+		Mock:    &MockAssert{Name: "api", Path: "${u}", Header: &HeaderMatch{Name: "Y", Contains: sp("${v}")}, Body: &StreamAssert{Contains: StringList{"${w}"}}},
+		Changes: &ChangesAssert{Created: &StringList{"${x}"}, Modified: &emptyList},
 	}
 
 	// Collect: identity visit records every reference.
@@ -52,7 +58,7 @@ func TestWalkAssertStrings_CollectAndExpand(t *testing.T) {
 		}
 		return s
 	})
-	for _, want := range []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"} {
+	for _, want := range []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x"} {
 		if !seen[want] {
 			t.Errorf("collect missed ${%s}; got %v", want, seen)
 		}
@@ -65,6 +71,16 @@ func TestWalkAssertStrings_CollectAndExpand(t *testing.T) {
 	}
 	if a.Stdout.Contains[0] != "${a}" {
 		t.Error("WalkAssertStrings mutated its input")
+	}
+
+	// The changes lists keep the nil-vs-empty distinction the exhaustive-set
+	// semantics depend on: a visited empty list stays non-nil-and-empty, and an
+	// omitted (nil) list stays nil.
+	if out.Changes.Modified == nil || len(*out.Changes.Modified) != 0 {
+		t.Errorf("changes.modified = %v, want a non-nil empty list", out.Changes.Modified)
+	}
+	if out.Changes.Deleted != nil {
+		t.Errorf("changes.deleted = %v, want nil (omitted stays unconstrained)", out.Changes.Deleted)
 	}
 }
 

--- a/test/e2e/atago/assert_expand.atago.yaml
+++ b/test/e2e/atago/assert_expand.atago.yaml
@@ -46,3 +46,59 @@ scenarios:
           file:
             path: note.txt
             contains: "${workdir}/marker"
+
+  # The newer target families must expand like the stream/file matchers above:
+  # dir.path, screen matchers, and changes entries all went through the same
+  # walker gap once, so each family gets its own regression pin.
+  - name: dir.path expands a stored variable
+    steps:
+      - run:
+          shell: true
+          command: 'mkdir -p site && touch site/a.html && echo site'
+      - store:
+          name: outdir
+          from:
+            stdout:
+              matches: "(site)"
+      - assert:
+          dir:
+            path: "${outdir}"
+            contains: [a.html]
+
+  - name: changes entries expand a stored variable
+    steps:
+      - run:
+          shell: true
+          command: 'echo out'
+      - store:
+          name: base
+          from:
+            stdout:
+              matches: "(out)"
+      - run:
+          shell: true
+          command: 'echo w > ${base}2.txt'
+      - assert:
+          changes:
+            created: ["${base}2.txt"]
+            modified: []
+            deleted: []
+
+  - name: screen matcher expands a stored variable
+    skip:
+      os: windows
+    steps:
+      - run:
+          shell: true
+          command: 'echo needle'
+      - store:
+          name: pat
+          from:
+            stdout:
+              matches: "(needle)"
+      - pty:
+          shell: true
+          command: 'echo needle'
+      - assert:
+          screen:
+            contains: ["${pat}"]

--- a/test/e2e/atago/changes.atago.yaml
+++ b/test/e2e/atago/changes.atago.yaml
@@ -88,3 +88,111 @@ scenarios:
               - result.txt
             modified: []
             deleted: []
+
+  - name: the delta over a retried step is cumulative across all attempts (POSIX)
+    skip:
+      os: windows
+    steps:
+      # Pinned semantic: with retry, atago pre-scans ONCE before attempt 1 and
+      # post-scans ONCE after the LAST attempt — so the changes delta is the
+      # cumulative footprint of every attempt, not just the winning one. This
+      # command fails on attempt 1 (c does not exist yet) and passes on attempt
+      # 2, and a, b, c are all created along the way.
+      - run:
+          shell: true
+          command: 'touch a; [ -f b ] && touch c; touch b; [ -f c ]'
+          retry:
+            times: 3
+            interval: 10ms
+            until:
+              exit_code: 0
+      - assert:
+          exit_code: 0
+          changes:
+            created:
+              - a
+              - b
+              - c
+            modified: []
+            deleted: []
+
+  - name: deleting and recreating a byte-identical file appears in no list (POSIX)
+    skip:
+      os: windows
+    steps:
+      # The delta is content-hash based, not event based: a file that is
+      # removed and rewritten with its ORIGINAL bytes is indistinguishable from
+      # untouched, so it appears in none of created/modified/deleted.
+      - fixture:
+          file: f.txt
+          content: "hello"
+      - run:
+          shell: true
+          command: 'rm f.txt && printf hello > f.txt'
+      - assert:
+          exit_code: 0
+          changes:
+            created: []
+            modified: []
+            deleted: []
+
+  - name: deleting and recreating with different content is modified only (POSIX)
+    skip:
+      os: windows
+    steps:
+      # Same delete+recreate, but the new bytes differ — so the content hash
+      # changes and the file reports as modified (not deleted+created).
+      - fixture:
+          file: f.txt
+          content: "hello"
+      - run:
+          shell: true
+          command: 'rm f.txt && printf world > f.txt'
+      - assert:
+          exit_code: 0
+          changes:
+            created: []
+            modified:
+              - f.txt
+            deleted: []
+
+  - name: stdout_to overwrites a fixture (modified) while stderr_to creates an empty file (POSIX)
+    skip:
+      os: windows
+    steps:
+      # stdout_to onto a pre-existing fixture rewrites it with new bytes, so it
+      # is modified; stderr_to captures an empty stderr, which still creates a
+      # brand-new 0-byte file that the delta counts as created.
+      - fixture:
+          file: existing.txt
+          content: "old"
+      - run:
+          shell: true
+          command: printf newcontent
+          stdout_to: existing.txt
+          stderr_to: err.txt
+      - assert:
+          exit_code: 0
+          changes:
+            created:
+              - err.txt
+            modified:
+              - existing.txt
+            deleted: []
+
+  - name: a pty step feeds the delta scan just like a run step (POSIX)
+    skip:
+      os: windows
+    steps:
+      # The pre/post workdir scan wraps a pty step too: the file the
+      # interactive command touched shows up in the very next changes assert.
+      - pty:
+          shell: true
+          command: 'sh -c "touch from-pty; echo done"'
+          timeout: 10s
+          session:
+            - expect: done
+      - assert:
+          changes:
+            created:
+              - from-pty

--- a/test/e2e/atago/record.atago.yaml
+++ b/test/e2e/atago/record.atago.yaml
@@ -269,3 +269,28 @@ scenarios:
           exit_code: 0
           stdout:
             contains: "1 passed"
+
+  - name: recorded text containing dollar-brace round-trips as literal text
+    skip:
+      os: windows
+    steps:
+      # The tool's argv and output contain a literal ${HOME}. The engine
+      # expands ${name} in command/assert values at replay, so record emits
+      # the $${...} escape — without it the generated no-shell command would
+      # error on the unresolved reference instead of replaying. This outer
+      # spec needs the same discipline: $${HOME} below reaches the recorder as
+      # the literal ${HOME}, and the contains value is $$$-escaped so it still
+      # reads $${HOME} after its own expansion.
+      - run:
+          command: ${atago} record --out dollar.atago.yaml -- printf %s 'literal $${HOME} here'
+      - assert:
+          exit_code: 0
+          file:
+            path: dollar.atago.yaml
+            contains: "$$${HOME}"
+      - run:
+          command: ${atago} run dollar.atago.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "1 passed"

--- a/test/e2e/atago/record.atago.yaml
+++ b/test/e2e/atago/record.atago.yaml
@@ -51,6 +51,26 @@ scenarios:
             path: existing.atago.yaml
             contains: "exit_code: 0"
 
+  - name: record --pty refuses an existing --out before driving the session
+    steps:
+      # The --out existence check fires BEFORE any pty work, so this exits
+      # immediately with exit 3 — no interactive session is driven (and no tty
+      # is needed), proving a user is never made to hand-drive a whole session
+      # only to be told the file already exists afterwards.
+      - fixture:
+          file: taken.atago.yaml
+          content: "precious"
+      - run:
+          command: ${atago} record --pty --out taken.atago.yaml -- echo hi
+      - assert:
+          exit_code: 3
+          stderr:
+            contains: "use --force to overwrite"
+      - assert:
+          file:
+            path: taken.atago.yaml
+            contains: precious
+
   - name: created files become exists asserts (shell mode)
     skip:
       os: windows
@@ -174,6 +194,77 @@ scenarios:
       # The round-trip: replaying the generated spec passes.
       - run:
           command: ${atago} run generated.atago.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "1 passed"
+
+  - name: record --pty of a no-input command yields a session-less spec that replays green
+    skip:
+      os: windows
+    steps:
+      # `echo` reads nothing, so the recorder captures output only and the
+      # generated spec's pty step has NO interactive session (no expect/send).
+      # An OUTER pty step still hand-drives the recorder because record --pty
+      # needs a real tty.
+      - pty:
+          command: '${atago} record --pty --out echo.atago.yaml -- echo done'
+          timeout: 20s
+          session:
+            # The recorder's closing summary reports the send count; anchoring
+            # on it proves the session ended with zero sends.
+            - expect: "0 send"
+      - assert:
+          exit_code: 0
+      - assert:
+          file:
+            path: echo.atago.yaml
+            contains:
+              - "- pty:"
+              - "command: echo done"
+      # No session was recorded — the pty step carries no send/session key.
+      - assert:
+          file:
+            path: echo.atago.yaml
+            not_contains:
+              - "- send:"
+              - "session:"
+      # The round-trip: replaying the generated spec passes.
+      - run:
+          command: ${atago} run echo.atago.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "1 passed"
+
+  - name: a prompt with regex metacharacters is escaped in the generated expect
+    skip:
+      os: windows
+    steps:
+      # The prompt "Continue? (y/n): " contains regex metacharacters (? and
+      # parens). The recorder must emit a LITERAL matcher, so the generated
+      # expect escapes them (\? \( \)); an unescaped expect would treat them as
+      # regex operators and could match the wrong output.
+      - pty:
+          command: '${atago} record --pty --out meta.atago.yaml -- sh -c ''printf "Continue? (y/n): "; read a; echo got-$a'''
+          timeout: 20s
+          session:
+            - expect: "Continue\\? \\(y/n\\):"
+            - send: "y\n"
+            - expect: "got-y"
+      - assert:
+          exit_code: 0
+      # The generated expect is regex-escaped (single-quoted here so the
+      # backslashes are the literal bytes the recorder wrote).
+      - assert:
+          file:
+            path: meta.atago.yaml
+            contains:
+              - 'expect: "Continue\\? \\(y/n\\):"'
+              - "- send:"
+      # The round-trip: replaying the escaped matcher passes.
+      - run:
+          command: ${atago} run meta.atago.yaml
       - assert:
           exit_code: 0
           stdout:

--- a/test/e2e/atago/retry.atago.yaml
+++ b/test/e2e/atago/retry.atago.yaml
@@ -61,3 +61,33 @@ scenarios:
           command: ${atago} run never.atago.yaml
       - assert:
           exit_code: 1
+
+  - name: until with a changes target is a load-time error
+    steps:
+      # A retry polls the raw exec result of each attempt, where the workdir
+      # delta is never computed — so `until: {changes: ...}` could never pass.
+      # The loader rejects it up front (exit 2) instead of exhausting the budget.
+      - fixture:
+          file: badchanges.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: bad
+            scenarios:
+              - name: unsatisfiable until
+                steps:
+                  - run:
+                      command: echo hi
+                      retry:
+                        times: 3
+                        until:
+                          changes:
+                            created: [out.txt]
+      - run:
+          command: ${atago} run badchanges.atago.yaml
+      - assert:
+          exit_code: 2
+          stderr:
+            contains:
+              - "retry.until.changes cannot be satisfied"
+              - steps[0].run

--- a/test/e2e/atago/sandbox_home.atago.yaml
+++ b/test/e2e/atago/sandbox_home.atago.yaml
@@ -62,3 +62,32 @@ scenarios:
           file:
             path: .atago-home/AppData/Roaming/mytool/config.txt
             contains: editor=vim
+
+  - name: cwd anchors the run, but sandbox_home stays at the workdir ROOT (Unix)
+    skip:
+      os: windows
+    steps:
+      # A step can run in a sub-directory via cwd:, but sandbox_home is anchored
+      # to the workdir ROOT, not the step's cwd — so .atago-home is created at
+      # ${workdir}/.atago-home even when the command runs from sub/. This keeps
+      # the isolated home shared and its path deterministic regardless of cwd.
+      - run:
+          shell: true
+          command: mkdir -p sub
+      - run:
+          shell: true
+          cwd: sub
+          sandbox_home: true
+          command: 'mkdir -p "$XDG_CONFIG_HOME/mytool" && printf editor=vim > "$XDG_CONFIG_HOME/mytool/config"'
+      - assert:
+          exit_code: 0
+      # The config lands under the ROOT .atago-home...
+      - assert:
+          file:
+            path: .atago-home/.config/mytool/config
+            contains: editor=vim
+      # ...and NOT under a sub/.atago-home that the cwd might have suggested.
+      - assert:
+          file:
+            path: sub/.atago-home/.config/mytool/config
+            exists: false

--- a/test/e2e/atago/ssh.atago.yaml
+++ b/test/e2e/atago/ssh.atago.yaml
@@ -52,3 +52,35 @@ scenarios:
           exit_code: 2
           stderr:
             contains: is not declared
+
+  - name: a local-only run field on an ssh runner fails validation (exit 2)
+    steps:
+      # env/clear_env/pass_env/sandbox_home/stdin/stdout_to/stderr_to/cwd shape
+      # LOCAL execution only; the ssh runner forwards just the command, so the
+      # loader rejects them instead of silently dropping them.
+      - fixture:
+          file: sshfield.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: ssh
+            runners:
+              box:
+                type: ssh
+                host: deploy.example.com
+                user: deploy
+            scenarios:
+              - name: remote run
+                steps:
+                  - run:
+                      runner: box
+                      command: uptime
+                      cwd: /var/tmp
+      - run:
+          command: ${atago} run sshfield.atago.yaml
+      - assert:
+          exit_code: 2
+          stderr:
+            contains:
+              - "run.cwd has no effect on an ssh runner"
+              - steps[0].run

--- a/test/e2e/thirdparty/age/changes.atago.yaml
+++ b/test/e2e/thirdparty/age/changes.atago.yaml
@@ -4,17 +4,20 @@ suite:
   name: age + changes (single-artifact generator)
 
 # Companion to age.atago.yaml: age-keygen writes exactly one file and touches
-# nothing else — not even HOME (it self-contains its output). A minimal proof
-# that the delta engine reports a clean single creation. Gate: only where age
-# is installed.
+# nothing else — not even HOME. sandbox_home points HOME (and the per-OS
+# config/cache dirs) INSIDE the workdir, so a home write would surface in the
+# delta and break the exhaustive created list below — the "HOME untouched"
+# claim is enforced by the assert, not just stated in prose. Gate: only where
+# age is installed.
 scenarios:
   - name: age-keygen writes exactly the key file (HOME untouched)
     only:
       command: age --version
     steps:
-      # sandbox_home would create .atago-home; here we prove age-keygen touches
-      # nothing outside the named output, so no sandbox is needed.
+      # sandbox_home creates only directories under .atago-home (the delta
+      # tracks files), so a clean run still yields the single-file delta.
       - run:
+          sandbox_home: true
           command: age-keygen -o key.txt
       - assert:
           exit_code: 0

--- a/test/e2e/thirdparty/age/changes.atago.yaml
+++ b/test/e2e/thirdparty/age/changes.atago.yaml
@@ -1,0 +1,29 @@
+version: "1"
+
+suite:
+  name: age + changes (single-artifact generator)
+
+# Companion to age.atago.yaml: age-keygen writes exactly one file and touches
+# nothing else — not even HOME (it self-contains its output). A minimal proof
+# that the delta engine reports a clean single creation. Gate: only where age
+# is installed.
+scenarios:
+  - name: age-keygen writes exactly the key file (HOME untouched)
+    only:
+      command: age --version
+    steps:
+      # sandbox_home would create .atago-home; here we prove age-keygen touches
+      # nothing outside the named output, so no sandbox is needed.
+      - run:
+          command: age-keygen -o key.txt
+      - assert:
+          exit_code: 0
+          changes:
+            created:
+              - key.txt
+            modified: []
+            deleted: []
+      - assert:
+          file:
+            path: key.txt
+            contains: "AGE-SECRET-KEY-1"

--- a/test/e2e/thirdparty/ffmpeg/changes.atago.yaml
+++ b/test/e2e/thirdparty/ffmpeg/changes.atago.yaml
@@ -1,0 +1,23 @@
+version: "1"
+
+suite:
+  name: ffmpeg + changes (single-artifact encode)
+
+# Companion to ffmpeg.atago.yaml: a lavfi-sourced encode writes exactly one
+# output file and touches nothing else. A minimal proof that the delta engine
+# reports a clean single creation for a media tool. Encodes are kept tiny so
+# the job stays fast. Gate: only where ffmpeg is installed.
+scenarios:
+  - name: lavfi source encodes exactly one output file
+    only:
+      command: ffmpeg -version
+    steps:
+      - run:
+          command: ffmpeg -v error -f lavfi -i testsrc=duration=0.1:size=64x64 -y out.mp4
+      - assert:
+          exit_code: 0
+          changes:
+            created:
+              - out.mp4
+            modified: []
+            deleted: []

--- a/test/e2e/thirdparty/git/changes.atago.yaml
+++ b/test/e2e/thirdparty/git/changes.atago.yaml
@@ -1,0 +1,43 @@
+version: "1"
+
+suite:
+  name: git + changes (a staged blob touches exactly index + one object)
+
+# A practical workdir-delta over git internals, companion to git.atago.yaml.
+# `git init` (a prior step) lays down the whole .git tree as the delta
+# baseline; the immediately-following `git add` then touches exactly two new
+# files: the staging index and one loose object. Object files are hash-named at
+# EXACTLY two levels (objects/<2-hex>/<38-hex>), so the v1 glob
+# `repo/.git/objects/*/*` covers them precisely — path.Match '*' never crosses
+# '/', so it cannot match a deeper path by accident.
+#
+# Unlike the rest of the git suite (which runs unchanged on every OS), this
+# scenario is POSIX-only: git-for-windows applies core.autocrlf/filemode
+# defaults whose exact effect on the loose-object footprint could not be
+# verified here, so the delta contract is gated to platforms it was proven on.
+scenarios:
+  - name: staging one file creates the index and a single loose object (POSIX)
+    skip:
+      os: windows
+    steps:
+      # f.txt is a fixture, so it lands before the pre-scan (baseline), not in
+      # the delta.
+      - fixture:
+          file: repo/f.txt
+          content: "hello from atago\n"
+      # git init's own tree is created here; this step's delta is not asserted.
+      - run:
+          command: git init -q repo
+      - assert:
+          exit_code: 0
+      # The add is the step under test: index + exactly one loose object.
+      - run:
+          command: git -C repo add f.txt
+      - assert:
+          exit_code: 0
+          changes:
+            created:
+              - repo/.git/index
+              - repo/.git/objects/*/*
+            modified: []
+            deleted: []

--- a/test/e2e/thirdparty/git/sandbox_home.atago.yaml
+++ b/test/e2e/thirdparty/git/sandbox_home.atago.yaml
@@ -1,0 +1,37 @@
+version: "1"
+
+suite:
+  name: git + sandbox_home (global config in an isolated HOME)
+
+# git --global writes to $HOME/.gitconfig. With sandbox_home the child's HOME
+# is redirected to ${workdir}/.atago-home, so the write is hermetic and the
+# result is inspectable at a deterministic path. A second sandbox_home step
+# reads the same value back — the isolated home is reused across steps.
+#
+# POSIX-only: this pins the HOME-based path .atago-home/.gitconfig. On Windows
+# git resolves config through USERPROFILE (which sandbox_home also sets), but
+# the exact on-disk path was not verified here, so the scenario is gated.
+scenarios:
+  - name: global user.name is written under the sandbox home and read back (POSIX)
+    skip:
+      os: windows
+    steps:
+      - run:
+          command: git config --global user.name atago-sandbox-user
+          sandbox_home: true
+      - assert:
+          exit_code: 0
+      # git wrote to $HOME/.gitconfig, which sandbox_home pinned under the
+      # workdir — an ordinary file: assert can inspect it.
+      - assert:
+          file:
+            path: .atago-home/.gitconfig
+            contains: atago-sandbox-user
+      # A second sandbox_home step reads the same value: the home is reused.
+      - run:
+          command: git config --global user.name
+          sandbox_home: true
+      - assert:
+          exit_code: 0
+          stdout:
+            equals: atago-sandbox-user

--- a/test/e2e/thirdparty/jq/extra.atago.yaml
+++ b/test/e2e/thirdparty/jq/extra.atago.yaml
@@ -1,0 +1,41 @@
+version: "1"
+
+suite:
+  name: jq (uncovered contracts — unicode passthrough + empty validation)
+
+# Two contracts the main jq suite does not pin: multibyte unicode survives a
+# round-trip byte-exact, and `jq empty` is the canonical "validate only" idiom
+# — it consumes the document, prints nothing, and exits 0 on valid JSON but 5
+# on malformed input (the same not-JSON code the suite already relies on
+# elsewhere, here proven for the validation use-case with clean stdout).
+scenarios:
+  - name: multibyte unicode passes through unchanged
+    steps:
+      - run:
+          command: jq -c .
+          stdin: '{"s":"café 😀 日本語"}'
+      - assert:
+          exit_code: 0
+          stdout:
+            equals: '{"s":"café 😀 日本語"}'
+
+  - name: jq empty validates JSON — silent success, loud failure
+    steps:
+      - run:
+          command: jq empty
+          stdin: '{"a":1,"b":[2,3]}'
+      - assert:
+          exit_code: 0
+          stdout:
+            empty: true
+          stderr:
+            empty: true
+      - run:
+          command: jq empty
+          stdin: "not json"
+      - assert:
+          exit_code: 5
+          stdout:
+            empty: true
+          stderr:
+            contains: "parse error"

--- a/test/e2e/thirdparty/jq/extra.atago.yaml
+++ b/test/e2e/thirdparty/jq/extra.atago.yaml
@@ -33,8 +33,11 @@ scenarios:
       - run:
           command: jq empty
           stdin: "not json"
+      # The parse-failure exit code changed across jq releases (1.6 exits 4,
+      # 1.7 exits 5), so pin the documented set rather than one version.
       - assert:
-          exit_code: 5
+          exit_code:
+            in: [4, 5]
           stdout:
             empty: true
           stderr:

--- a/test/e2e/thirdparty/openssl/changes.atago.yaml
+++ b/test/e2e/thirdparty/openssl/changes.atago.yaml
@@ -1,0 +1,49 @@
+version: "1"
+
+suite:
+  name: openssl + changes (key and cert generation footprints)
+
+# Companion to openssl.atago.yaml: key/cert generation should write exactly the
+# file named by -out and nothing else. Each `changes:` assert pins one created
+# artifact; the second scenario's baseline includes key.pem (created by the
+# prior step, whose delta is not asserted there). Gate: only where openssl is
+# installed.
+scenarios:
+  - name: genrsa writes exactly the key file
+    only:
+      command: openssl version
+    steps:
+      - run:
+          command: openssl genrsa -out key.pem 2048
+      - assert:
+          exit_code: 0
+          changes:
+            created:
+              - key.pem
+            modified: []
+            deleted: []
+
+  - name: a self-signed cert is the only new file the req step creates
+    only:
+      command: openssl version
+    steps:
+      # key.pem is created by this step; its delta is not asserted.
+      - run:
+          command: openssl genrsa -out key.pem 2048
+      - assert:
+          exit_code: 0
+      # The req step's baseline already contains key.pem, so its only creation
+      # is cert.pem.
+      - run:
+          command: openssl req -new -x509 -key key.pem -out cert.pem -subj /CN=atago-test -days 1
+      - assert:
+          exit_code: 0
+          changes:
+            created:
+              - cert.pem
+            modified: []
+            deleted: []
+      - assert:
+          file:
+            path: cert.pem
+            contains: "BEGIN CERTIFICATE"

--- a/test/e2e/thirdparty/pandoc/changes.atago.yaml
+++ b/test/e2e/thirdparty/pandoc/changes.atago.yaml
@@ -1,0 +1,33 @@
+version: "1"
+
+suite:
+  name: pandoc + changes (a conversion writes exactly its output)
+
+# Companion to pandoc.atago.yaml: a file-to-file conversion should touch
+# nothing but its named output. The `changes:` assert states that as an exact
+# contract — the input is a fixture (baseline), and the single created file is
+# out.html. Gate: only where pandoc is installed.
+scenarios:
+  - name: markdown-to-html creates exactly the output file
+    only:
+      command: pandoc --version
+    steps:
+      - fixture:
+          file: in.md
+          content: |
+            # Title
+
+            Some text with *emphasis*.
+      - run:
+          command: pandoc in.md -o out.html
+      - assert:
+          exit_code: 0
+          changes:
+            created:
+              - out.html
+            modified: []
+            deleted: []
+      - assert:
+          file:
+            path: out.html
+            contains: "<em>emphasis</em>"

--- a/test/e2e/thirdparty/python/changes.atago.yaml
+++ b/test/e2e/thirdparty/python/changes.atago.yaml
@@ -1,0 +1,67 @@
+version: "1"
+
+suite:
+  name: python3 + changes (bytecode cache footprint)
+
+# Companion to python.atago.yaml, pinning the filesystem side effect of an
+# import with the `changes:` assert. Importing a local module writes a compiled
+# __pycache__/*.pyc; the entry script itself is never cached. A paired scenario
+# proves PYTHONDONTWRITEBYTECODE=1 suppresses the cache entirely (created: [] —
+# the run touches nothing). Gate: only where python3 is installed.
+scenarios:
+  - name: importing a local module writes exactly one .pyc
+    only:
+      command: python3 --version
+    steps:
+      - fixture:
+          file: mymod.py
+          content: |
+            def val():
+                return 42
+      - fixture:
+          file: main.py
+          content: |
+            import mymod
+            print(mymod.val())
+      - run:
+          command: python3 main.py
+      # main.py is the entry point (never cached); only the imported module
+      # produces a .pyc. The interpreter-tagged name (mymod.cpython-3XX.pyc) is
+      # covered by a single-level glob.
+      - assert:
+          exit_code: 0
+          stdout:
+            equals: "42"
+          changes:
+            created:
+              - __pycache__/*.pyc
+            modified: []
+            deleted: []
+
+  - name: PYTHONDONTWRITEBYTECODE suppresses the cache entirely
+    only:
+      command: python3 --version
+    steps:
+      - fixture:
+          file: mymod.py
+          content: |
+            def val():
+                return 42
+      - fixture:
+          file: main.py
+          content: |
+            import mymod
+            print(mymod.val())
+      - run:
+          command: python3 main.py
+          env:
+            PYTHONDONTWRITEBYTECODE: "1"
+      # No bytecode is written: the run creates nothing at all.
+      - assert:
+          exit_code: 0
+          stdout:
+            equals: "42"
+          changes:
+            created: []
+            modified: []
+            deleted: []

--- a/test/e2e/thirdparty/sqlite3/changes.atago.yaml
+++ b/test/e2e/thirdparty/sqlite3/changes.atago.yaml
@@ -1,0 +1,39 @@
+version: "1"
+
+suite:
+  name: sqlite3 + changes (workdir-delta of a database write)
+
+# The companion to sqlite3.atago.yaml, pinning the exact filesystem footprint
+# of a one-shot write with the `changes:` assert. Counterintuitively, the
+# rollback-journal (default) and WAL modes both create side files
+# (t.db-journal / t.db-wal / t.db-shm) DURING the invocation, but a clean
+# sqlite3 process close deletes or checkpoints them before it exits — so the
+# pre/post workdir delta ever only sees the database file itself.
+scenarios:
+  - name: default rollback-journal mode creates exactly the db file
+    steps:
+      - run:
+          shell: true
+          command: sqlite3 t.db "create table x(a); insert into x values(1)"
+      - assert:
+          exit_code: 0
+          changes:
+            created:
+              - t.db
+            modified: []
+            deleted: []
+
+  - name: WAL mode leaves no -wal/-shm behind after a clean close
+    steps:
+      - run:
+          shell: true
+          command: sqlite3 t.db "PRAGMA journal_mode=WAL; create table x(a); insert into x values(1)"
+      # Only t.db survives: the -wal and -shm files are created and removed
+      # within the single invocation, so the delta never sees them.
+      - assert:
+          exit_code: 0
+          changes:
+            created:
+              - t.db
+            modified: []
+            deleted: []

--- a/test/e2e/tools/gup/sandbox_home.atago.yaml
+++ b/test/e2e/tools/gup/sandbox_home.atago.yaml
@@ -32,7 +32,7 @@ scenarios:
 
   - name: gup list is a pure read of GOBIN and writes nothing
     only:
-      command: gup version
+      command: gup list
     skip:
       os: windows
     steps:

--- a/test/e2e/tools/gup/sandbox_home.atago.yaml
+++ b/test/e2e/tools/gup/sandbox_home.atago.yaml
@@ -1,0 +1,48 @@
+# Dogfood spec: exercises atago's sandbox_home + changes against the real `gup`
+# CLI (github.com/nao1215/gup). Requires `gup` on PATH. Run with: make dogfood
+#
+# gup's network-free subcommands (version/list) are pure reads — they write
+# NOTHING, not even to HOME. The changes assert with all three lists empty is
+# the strongest possible "touches nothing" statement, and sandbox_home
+# guarantees any stray dotfile write would land inside .atago-home where changes
+# would catch it.
+version: "1"
+
+suite:
+  name: gup read-only subcommands (no HOME writes)
+
+scenarios:
+  - name: gup version writes nothing to the workdir or its sandbox home
+    only:
+      command: gup version
+    skip:
+      os: windows
+    steps:
+      - run:
+          sandbox_home: true
+          command: gup version
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: gup version
+          changes:
+            created: []
+            modified: []
+            deleted: []
+
+  - name: gup list is a pure read of GOBIN and writes nothing
+    only:
+      command: gup version
+    skip:
+      os: windows
+    steps:
+      - run:
+          sandbox_home: true
+          command: gup list
+      # Even under an isolated home, list produces no side effects.
+      - assert:
+          exit_code: 0
+          changes:
+            created: []
+            modified: []
+            deleted: []

--- a/test/e2e/tools/sqly/changes_crosscheck.atago.yaml
+++ b/test/e2e/tools/sqly/changes_crosscheck.atago.yaml
@@ -1,0 +1,79 @@
+# Dogfood spec: cross-checks atago's `changes` delta against the real `sqly`
+# CLI (github.com/nao1215/sqly). Requires `sqly` on PATH. Run with: make dogfood
+#
+# Does atago's changes delta report nested sandbox-home paths with forward
+# slashes (Windows-portable) and account for EVERY file a real tool writes?
+# These scenarios deliberately over/under-specify to confirm the exhaustive-set
+# semantics fail loudly and correctly, using a nested ${atago} run to observe
+# the inner failure.
+version: "1"
+
+suite:
+  name: sqly changes delta cross-checks (exhaustive-set semantics)
+
+scenarios:
+  # NEGATIVE: an exhaustive created list that OMITS the sqly history DB must
+  # FAIL with "unexpected created file". We assert on the failing inner run via
+  # a nested atago invocation, so a PASS here means atago correctly rejected the
+  # incomplete list. This guards against a phantom/omission bug in the delta.
+  - name: omitting sqly's history DB from an exhaustive list is rejected
+    only:
+      command: sqly --version
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: inner.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: inner
+            scenarios:
+              - name: under-specified created list
+                steps:
+                  - fixture:
+                      file: user.csv
+                      content: |
+                        n,v
+                        a,1
+                  - run:
+                      sandbox_home: true
+                      command: sqly --sql "SELECT 1" user.csv
+                  - assert:
+                      changes:
+                        created: []
+      - run:
+          command: ${atago} run inner.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains: "unexpected created file"
+      # The reported phantom path must be forward-slashed and nested — the
+      # Windows-portability contract the changes assert promises.
+      - assert:
+          stdout:
+            contains: ".atago-home/.config/sqly/history.db"
+
+  # POSITIVE control: the same run WITH the history DB listed must PASS, proving
+  # the rejection above was about the omission, not a spurious engine error.
+  - name: the exhaustive list including the history DB passes
+    only:
+      command: sqly --version
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: user.csv
+          content: |
+            n,v
+            a,1
+      - run:
+          sandbox_home: true
+          command: sqly --sql "SELECT 1" user.csv
+      - assert:
+          exit_code: 0
+          changes:
+            created:
+              - .atago-home/.config/sqly/history.db
+            modified: []
+            deleted: []

--- a/test/e2e/tools/sqly/sandbox_home.atago.yaml
+++ b/test/e2e/tools/sqly/sandbox_home.atago.yaml
@@ -1,0 +1,78 @@
+# Dogfood spec: exercises atago's sandbox_home + changes against the real
+# `sqly` CLI (github.com/nao1215/sqly). Requires `sqly` on PATH. Run with:
+# make dogfood
+#
+# sqly writes a shell-history DB under $XDG_CONFIG_HOME even in non-interactive
+# --sql mode. sandbox_home redirects that under ${workdir}/.atago-home; the
+# changes assert then pins the EXACT set of files sqly touched — the "this
+# command writes only these files, and only to its sandbox home" contract.
+version: "1"
+
+suite:
+  name: sqly sandbox_home + changes (history DB isolation)
+
+scenarios:
+  - name: sqly --sql writes exactly its history DB, only inside the sandbox home
+    only:
+      command: sqly --version
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: user.csv
+          content: |
+            user_name,identifier
+            booker12,1
+      - run:
+          sandbox_home: true
+          command: sqly --sql "SELECT identifier FROM user WHERE user_name = 'booker12'" user.csv
+      # changes must live in the SAME assert block as its run (an intervening
+      # assert step severs the "immediately preceding run/pty" link the loader
+      # enforces), so exit_code + stdout + changes are pinned together here.
+      # The ONLY filesystem change is the history DB under the isolated home;
+      # user.csv is a baseline input (untouched); nothing else appears.
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "1"
+          changes:
+            created:
+              - .atago-home/.config/sqly/history.db
+            modified: []
+            deleted: []
+      # The DB really landed at the deterministic sandbox path (not real $HOME).
+      - assert:
+          file:
+            path: .atago-home/.config/sqly/history.db
+            exists: true
+
+  - name: a second sqly batch run leaves its sandbox home byte-identical
+    only:
+      command: sqly --version
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: user.csv
+          content: |
+            user_name,identifier
+            booker12,1
+      # Prime the sandbox home so history.db already exists as a baseline.
+      - run:
+          sandbox_home: true
+          command: sqly --sql "SELECT 1" user.csv
+      - assert:
+          exit_code: 0
+      # Second batch run: sqly's --sql mode creates history.db once and does NOT
+      # persist executed queries into it, so a different query leaves the DB
+      # byte-identical. The delta is therefore EMPTY in all three categories —
+      # the strongest "re-running touches nothing" contract.
+      - run:
+          sandbox_home: true
+          command: sqly --sql "SELECT 2" user.csv
+      - assert:
+          exit_code: 0
+          changes:
+            created: []
+            modified: []
+            deleted: []

--- a/test/e2e/tools/truss/changes.atago.yaml
+++ b/test/e2e/tools/truss/changes.atago.yaml
@@ -1,0 +1,59 @@
+# Dogfood spec: exercises atago's `changes` delta against the real `truss`
+# image-transform CLI (github.com/nao1215/truss). Requires `truss` on PATH; run
+# with: make dogfood. Complements the image:-assert coverage in convert.atago.yaml
+# with the filesystem-footprint angle: truss convert reads the input and writes
+# exactly one output — no temp/backup files, and nothing in HOME.
+#
+# The input PNG is generated deterministically in-workdir from base64 (a 2x2 red
+# PNG), so the spec is hermetic and needs no committed testdata.
+version: "1"
+
+suite:
+  name: truss convert (filesystem footprint)
+
+scenarios:
+  - name: convert PNG->JPEG creates only the output file
+    only:
+      command: truss --version
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: in.png
+          base64: iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAEElEQVR4nGP4z8AARAwQCgAf7gP9i18U1AAAAABJRU5ErkJggg==
+      - run:
+          command: truss convert in.png -o out.jpg
+      - assert:
+          exit_code: 0
+          changes:
+            created:
+              - out.jpg
+            modified: []
+            deleted: []
+      # And the created file really is a JPEG of the right size.
+      - assert:
+          image:
+            path: out.jpg
+            format: jpeg
+            width: 2
+            height: 2
+
+  - name: convert to a glob-matched output honors path.Match
+    only:
+      command: truss --version
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: in.png
+          base64: iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAEElEQVR4nGP4z8AARAwQCgAf7gP9i18U1AAAAABJRU5ErkJggg==
+      - run:
+          command: truss convert in.png -o thumb.webp --format webp
+      - assert:
+          exit_code: 0
+          # *.webp must match the single output; * does not cross '/'.
+          changes:
+            created:
+              - "*.webp"
+            modified: []
+            deleted: []


### PR DESCRIPTION
## Summary
An E2E bug-hunt sweep (atago self-hosted × third-party tools × dogfood CLIs) flushed out three defects in the features shipped this week; this PR fixes them and lands the sweep's scenarios as permanent E2E coverage.

### Fixes
1. **`retry.until` accepted unsatisfiable targets.** `until: {changes: ...}` / `until: {screen: ...}` loaded fine but could never pass — the until condition is evaluated against the raw exec result inside the retry loop, where the workdir delta is never computed and a run/http result is never a pty. Every attempt failed with a confusing "no workdir delta was recorded", exhausting the retry budget. The loader now rejects both with a message explaining why and where to put the assert instead. `duration`/`exit_code`/stream targets in `until` keep working (pinned by tests).
2. **ssh-runner run steps silently dropped local-only fields.** The remote path executes only the command string, so `sandbox_home`, `clear_env`, `pass_env`, `env`, `stdin`, `stdout_to`, `stderr_to`, and `cwd` were no-ops — exactly the silent divergence `clear_env` exists to kill. The loader now rejects them on ssh-runner steps ("only command/runner/timeout apply"); `timeout` and `retry` keep working.
3. **`record --pty` checked `--out` only after the session.** A user hand-drove the entire interactive session and was then told `already exists (use --force)`. The check now runs before the terminal is touched (also proves the no-tty early exit: a plain run step invoking it exits 3 instantly).
4. (message) The `changes`-placement error now suggests combining the target into the assert block directly after the step — the `run → assert{exit_code} → assert{changes}` split was a confusing trap.

### E2E expansion (all green locally; tools suites are daily/dogfood-gated as usual)
- **atago**: retry×changes cumulative-delta semantics, delete/recreate content-hash semantics, `stdout_to`-overwrite=modified / `stderr_to`-empty=created accounting, pty-fed deltas, sandbox_home×`cwd` anchoring, no-input & regex-metachar pty recordings, plus load-error contracts for the three fixes.
- **thirdparty**: sqlite3 (journal/WAL side files invisible to a clean invocation's delta — counterintuitive, now documented), git (`add` = index + `objects/*/*` 2-level glob; `--global` config isolated by sandbox_home), python (`__pycache__` footprint pair with `PYTHONDONTWRITEBYTECODE`), pandoc/openssl/age/ffmpeg exact single-artifact deltas, jq unicode passthrough + `jq empty` exit contract.
- **tools**: sqly history DB isolated under `.atago-home` (+ exhaustive-delta crosscheck), truss "touches only its declared output", gup version/list write nothing.

`doc/e2e/*.md` regenerated for every touched suite; site in sync.

## Verification
`go test ./...`, `go vet`, `golangci-lint run` all green. Consolidated E2E: **676 scenarios, 0 failed** (atago 204 + thirdparty 64 + tools 408). PR-CI-visible suites (atago + git) re-verified: 211 scenarios green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded end-to-end coverage for file-change tracking across more tools and workflows (including new “changes” suites and additional scenario cases for common third-party commands).
  * Improved sandboxed home behavior coverage, plus read-only command checks.
* **Bug Fixes**
  * Recorded specs now preserve literal `${...}` text correctly during replay.
  * `record --pty` now exits early when `--out` already exists (without `--force`).
  * Added stricter authoring-time validation for SSH runs and retry `until` conditions, with clearer errors.
* **Documentation / Tests**
  * Updated end-to-end documentation and added new scenarios for multiple tool integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->