### PR TITLE
feat(assert): recursive `**` globs and documented metacharacter escaping for changes entries

### DIFF
--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-54 suites · 208 scenarios
+54 suites · 210 scenarios
 ## Contents
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 6 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
@@ -18,7 +18,7 @@
   - [manifest surfaces the browser-runner configuration](#scenario-manifest-surfaces-the-browser-runner-configuration)
   - [an upload action without a file fails validation (exit 2)](#scenario-an-upload-action-without-a-file-fails-validation-exit-2)
   - [a download action without a click selector fails validation (exit 2)](#scenario-a-download-action-without-a-click-selector-fails-validation-exit-2)
-- [atago self-hosting / changes (workdir delta assertions)](#atago-self-hosting--changes-workdir-delta-assertions) — 8 scenarios
+- [atago self-hosting / changes (workdir delta assertions)](#atago-self-hosting--changes-workdir-delta-assertions) — 10 scenarios
   - [a generator touches exactly the files it should (POSIX)](#scenario-a-generator-touches-exactly-the-files-it-should-posix)
   - [an unexpected creation breaks the exact contract (POSIX)](#scenario-an-unexpected-creation-breaks-the-exact-contract-posix)
   - [stdout_to counts as created, and modified nothing holds (portable)](#scenario-stdout_to-counts-as-created-and-modified-nothing-holds-portable)
@@ -27,6 +27,8 @@
   - [deleting and recreating with different content is modified only (POSIX)](#scenario-deleting-and-recreating-with-different-content-is-modified-only-posix)
   - [stdout_to overwrites a fixture (modified) while stderr_to creates an empty file (POSIX)](#scenario-stdout_to-overwrites-a-fixture-modified-while-stderr_to-creates-an-empty-file-posix)
   - [a pty step feeds the delta scan just like a run step (POSIX)](#scenario-a-pty-step-feeds-the-delta-scan-just-like-a-run-step-posix)
+  - [a doublestar glob pins an arbitrary-depth generated tree exactly (POSIX)](#scenario-a-doublestar-glob-pins-an-arbitrary-depth-generated-tree-exactly-posix)
+  - [a stray file outside the doublestar prefix breaks the exact contract (POSIX)](#scenario-a-stray-file-outside-the-doublestar-prefix-breaks-the-exact-contract-posix)
 - [atago self-hosting / completion](#atago-self-hosting--completion) — 5 scenarios
   - [bash completion emits a recognizable script](#scenario-bash-completion-emits-a-recognizable-script)
   - [zsh completion emits a compdef script](#scenario-zsh-completion-emits-a-compdef-script)
@@ -682,6 +684,43 @@ _skipped on windows_
 ```
 #### Then
 - the step changed exactly created `from-pty`
+### Scenario: a doublestar glob pins an arbitrary-depth generated tree exactly (POSIX)
+_skipped on windows_
+#### When
+```shell
+mkdir -p out/a/b && printf '1' > out/top.txt && printf '2' > out/a/mid.txt && printf '3' > out/a/b/leaf.txt
+```
+#### Then
+- exit code is `0`
+- the step changed exactly created `out/**`, modified nothing, deleted nothing
+### Scenario: a stray file outside the doublestar prefix breaks the exact contract (POSIX)
+_skipped on windows_
+#### Given
+- Fixture file `check.atago.yaml` is created.
+#### Inputs
+_Fixture `check.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: stray-outside-doublestar
+scenarios:
+  - name: extra file beside the tree
+    steps:
+      - run:
+          shell: true
+          command: 'mkdir -p out/a && printf x > out/a/leaf.txt && printf y > stray.txt'
+      - assert:
+          changes:
+            created:
+              - "out/**"
+```
+#### When
+```shell
+${atago} run check.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `unexpected created file`
 ## atago self-hosting / completion
 Source: `test/e2e/atago/completion.atago.yaml`
 ### Scenario: bash completion emits a recognizable script

--- a/doc/e2e/git.md
+++ b/doc/e2e/git.md
@@ -1,9 +1,10 @@
 # atago Behavior Specs
 ## Summary
-3 suites · 7 scenarios
+3 suites · 8 scenarios
 ## Contents
-- [git + changes (a staged blob touches exactly index + one object)](#git--changes-a-staged-blob-touches-exactly-index--one-object) — 1 scenario
+- [git + changes (a staged blob touches exactly index + one object)](#git--changes-a-staged-blob-touches-exactly-index--one-object) — 2 scenarios
   - [staging one file creates the index and a single loose object (POSIX)](#scenario-staging-one-file-creates-the-index-and-a-single-loose-object-posix)
+  - [git init's whole .git tree is pinned by one recursive glob (POSIX)](#scenario-git-inits-whole-git-tree-is-pinned-by-one-recursive-glob-posix)
 - [git (third-party CLI, no build required)](#git-third-party-cli-no-build-required) — 5 scenarios
   - [init creates an empty repository](#scenario-init-creates-an-empty-repository)
   - [add and commit make the working tree clean](#scenario-add-and-commit-make-the-working-tree-clean)
@@ -34,6 +35,15 @@ git -C repo add f.txt
 - after `git -C repo add f.txt`:
   - exit code is `0`
   - the step changed exactly created `repo/.git/index`, `repo/.git/objects/*/*`, modified nothing, deleted nothing
+### Scenario: git init's whole .git tree is pinned by one recursive glob (POSIX)
+_skipped on windows_
+#### When
+```shell
+git init -q repo
+```
+#### Then
+- exit code is `0`
+- the step changed exactly created `repo/.git/**`, modified nothing, deleted nothing
 ## git (third-party CLI, no build required)
 Source: `test/e2e/thirdparty/git/git.atago.yaml`
 ### Scenario: init creates an empty repository

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/nao1215/atago
 go 1.26
 
 require (
+	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/chromedp/cdproto v0.0.0-20260321001828-e3e3800016bc
 	github.com/chromedp/chromedp v0.15.1
 	github.com/creack/pty v1.1.24
@@ -30,7 +31,6 @@ require (
 	filippo.io/edwards25519 v1.2.0 // indirect
 	github.com/IGLOU-EU/go-wildcard/v2 v2.1.0 // indirect
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
-	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect
 	github.com/bufbuild/protocompile v0.14.1 // indirect
 	github.com/chromedp/sysutil v1.1.0 // indirect
 	github.com/clipperhouse/displaywidth v0.6.2 // indirect

--- a/internal/assert/changes.go
+++ b/internal/assert/changes.go
@@ -2,10 +2,10 @@ package assert
 
 import (
 	"fmt"
-	"path"
 	"sort"
 	"strings"
 
+	"github.com/bmatcuk/doublestar/v4"
 	"github.com/nao1215/atago/internal/fsdelta"
 	"github.com/nao1215/atago/internal/runner"
 	"github.com/nao1215/atago/internal/spec"
@@ -65,11 +65,12 @@ func checkCategory(name string, entries *spec.StringList, observed []string, pro
 	}
 }
 
-// matchesAny reports whether p matches at least one pattern (exact path or
-// path.Match glob, always /-separated).
+// matchesAny reports whether p matches at least one pattern (exact path, a
+// single-level `*` glob, or a `**` doublestar that crosses `/`), always
+// /-separated. A backslash escapes a literal metacharacter (`\[`, `\?`, `\*`).
 func matchesAny(pats []string, p string) bool {
 	for _, pat := range pats {
-		if ok, _ := path.Match(pat, p); ok {
+		if ok, _ := doublestar.Match(pat, p); ok {
 			return true
 		}
 	}
@@ -79,7 +80,7 @@ func matchesAny(pats []string, p string) bool {
 // patternMatchesAny reports whether pat matches at least one observed path.
 func patternMatchesAny(pat string, paths []string) bool {
 	for _, p := range paths {
-		if ok, _ := path.Match(pat, p); ok {
+		if ok, _ := doublestar.Match(pat, p); ok {
 			return true
 		}
 	}

--- a/internal/assert/changes_test.go
+++ b/internal/assert/changes_test.go
@@ -79,6 +79,58 @@ func TestCheckChanges(t *testing.T) {
 			delta:  fsdelta.Delta{Deleted: []string{"tmp/a", "tmp/b"}},
 			wantOK: true,
 		},
+		{
+			name:   "doublestar matches at any depth",
+			assert: &spec.ChangesAssert{Created: list("site/**")},
+			delta:  fsdelta.Delta{Created: []string{"site/index.html", "site/a/b/c.txt"}},
+			wantOK: true,
+		},
+		{
+			name:   "doublestar matches at depth 1",
+			assert: &spec.ChangesAssert{Created: list("site/**")},
+			delta:  fsdelta.Delta{Created: []string{"site/index.html"}},
+			wantOK: true,
+		},
+		{
+			name:   "doublestar composes with a suffix pattern",
+			assert: &spec.ChangesAssert{Created: list("dist/**/*.css")},
+			delta:  fsdelta.Delta{Created: []string{"dist/app.css", "dist/a/b/theme.css"}},
+			wantOK: true,
+		},
+		{
+			name:   "doublestar composition rejects the wrong suffix",
+			assert: &spec.ChangesAssert{Created: list("dist/**/*.css")},
+			delta:  fsdelta.Delta{Created: []string{"dist/app.js"}},
+			wantOK: false, // .js is not covered, and the entry itself matches nothing
+		},
+		{
+			name:   "doublestar does not spill onto a sibling prefix",
+			assert: &spec.ChangesAssert{Created: list("site/**")},
+			delta:  fsdelta.Delta{Created: []string{"sitex/y.txt"}},
+			wantOK: false, // site/** must not match sitex/...
+		},
+		{
+			// Pinned semantics: `site/**` matches the bare `site` path itself
+			// (doublestar's native behavior), not only paths strictly under it.
+			name:   "doublestar matches the bare prefix path itself",
+			assert: &spec.ChangesAssert{Created: list("site/**")},
+			delta:  fsdelta.Delta{Created: []string{"site"}},
+			wantOK: true,
+		},
+		{
+			name:   "backslash escapes a literal metacharacter",
+			assert: &spec.ChangesAssert{Created: list(`a\[1\].txt`)},
+			delta:  fsdelta.Delta{Created: []string{"a[1].txt"}},
+			wantOK: true,
+		},
+		{
+			// Documented: an UNescaped `[` is still a character class, so
+			// `a[1].txt` matches `a1.txt` (and not the literal `a[1].txt`).
+			name:   "unescaped bracket stays a character class",
+			assert: &spec.ChangesAssert{Created: list("a[1].txt")},
+			delta:  fsdelta.Delta{Created: []string{"a1.txt"}},
+			wantOK: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -159,6 +159,8 @@ scenarios:
             created:
               - out.txt
               - "site/*.html"
+              - "dist/**"
+              - "assets/**/*.css"
             modified: []
             deleted: []
 `
@@ -167,7 +169,7 @@ scenarios:
 		t.Fatalf("valid changes spec should load: %v", err)
 	}
 	ch := s.Scenarios[0].Steps[1].Assert.Changes
-	if ch == nil || ch.Created == nil || len(*ch.Created) != 2 {
+	if ch == nil || ch.Created == nil || len(*ch.Created) != 4 {
 		t.Fatalf("changes.created not decoded: %+v", ch)
 	}
 	if ch.Modified == nil || len(*ch.Modified) != 0 {
@@ -203,6 +205,11 @@ scenarios:
 			name:    "empty changes block",
 			src:     "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps:\n      - run: {command: echo}\n      - assert:\n          changes: {}",
 			wantMsg: "set at least one of created/modified/deleted",
+		},
+		{
+			name:    "malformed glob entry",
+			src:     "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps:\n      - run: {command: echo}\n      - assert:\n          changes:\n            created: [\"site/[unclosed\"]",
+			wantMsg: "is not a valid glob",
 		},
 	}
 	for _, tt := range bad {

--- a/internal/loader/validate.go
+++ b/internal/loader/validate.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bmatcuk/doublestar/v4"
 	"github.com/nao1215/atago/internal/runner/db"
 	"github.com/nao1215/atago/internal/spec"
 )
@@ -1062,10 +1063,11 @@ func validateChanges(add func(string, ...any), where string, c *spec.ChangesAsse
 			case pathEscapesWorkdir(entry):
 				add("%s escapes the scenario workdir (no ../ traversal)", field)
 			default:
-				// The entry doubles as a path.Match glob at check time; reject a
-				// malformed pattern here rather than silently matching nothing.
-				if _, err := path.Match(entry, "probe"); err != nil {
-					add("%s is not a valid glob: %v", field, err)
+				// The entry doubles as a doublestar glob at check time (single
+				// `*` stays single-level; `**` crosses `/`); reject a malformed
+				// pattern here rather than silently matching nothing.
+				if !doublestar.ValidatePattern(entry) {
+					add("%s is not a valid glob: bad pattern syntax", field)
 				}
 			}
 		}

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -905,6 +905,13 @@ type Assert struct {
 // must be matched by an entry (an exact workdir-relative path or a /-glob) and
 // every entry must match at least one observed path — so `modified: []` asserts
 // "modified nothing". An omitted (nil) field is unconstrained.
+//
+// Entries are doublestar globs, always /-separated (#76): a single `*` matches
+// within one path segment, while `**` matches across `/` at any depth
+// (`site/**` covers the whole tree under site/, `dist/**/*.css` composes with a
+// suffix). A backslash escapes a literal metacharacter — `a\[1\].txt` matches
+// the file `a[1].txt`; because entries are always /-separated the escape is
+// portable across operating systems.
 type ChangesAssert struct {
 	Created  *StringList `yaml:"created,omitempty"`
 	Modified *StringList `yaml:"modified,omitempty"`

--- a/schema/atago.schema.json
+++ b/schema/atago.schema.json
@@ -683,7 +683,7 @@
     "changesAssert": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Pins the exact workdir delta of the immediately preceding run/pty step (#70): which files it created, modified, and deleted. Each set field is EXHAUSTIVE in both directions (every observed path must match an entry, every entry must match a path), so `modified: []` asserts \"modified nothing\". An omitted field is unconstrained. Entries are workdir-relative paths or /-globs.",
+      "description": "Pins the exact workdir delta of the immediately preceding run/pty step (#70): which files it created, modified, and deleted. Each set field is EXHAUSTIVE in both directions (every observed path must match an entry, every entry must match a path), so `modified: []` asserts \"modified nothing\". An omitted field is unconstrained. Entries are workdir-relative doublestar globs, always /-separated: a single `*` stays within one path segment while `**` crosses `/` at any depth (`site/**` covers the whole tree, `dist/**/*.css` composes with a suffix). A backslash escapes a literal metacharacter (`\\[`, `\\?`, `\\*`) — `a\\[1\\].txt` matches the file `a[1].txt`; the escape is portable because entries are always /-separated.",
       "minProperties": 1,
       "properties": {
         "created": { "$ref": "#/$defs/changesEntries" },
@@ -692,7 +692,7 @@
       }
     },
     "changesEntries": {
-      "description": "A single workdir-relative path/glob, or a list of them (the empty list [] asserts the category changed nothing).",
+      "description": "A single workdir-relative path/glob, or a list of them (the empty list [] asserts the category changed nothing). Globs are doublestar and /-separated: `*` within a segment, `**` across `/`; a backslash escapes a literal metacharacter.",
       "oneOf": [
         { "type": "string" },
         { "type": "array", "items": { "type": "string" } }

--- a/test/e2e/atago/changes.atago.yaml
+++ b/test/e2e/atago/changes.atago.yaml
@@ -196,3 +196,55 @@ scenarios:
           changes:
             created:
               - from-pty
+
+  - name: a doublestar glob pins an arbitrary-depth generated tree exactly (POSIX)
+    skip:
+      os: windows
+    steps:
+      # A generator that writes a 3-level tree of unknown depth: a single
+      # `out/**` entry (#76) pins the whole subtree at once — impossible with
+      # single-level `*`, which never crosses `/` — while modified/deleted stay
+      # empty to keep the exhaustive-both-ways contract intact.
+      - run:
+          shell: true
+          command: >-
+            mkdir -p out/a/b &&
+            printf '1' > out/top.txt &&
+            printf '2' > out/a/mid.txt &&
+            printf '3' > out/a/b/leaf.txt
+      - assert:
+          exit_code: 0
+          changes:
+            created:
+              - "out/**"
+            modified: []
+            deleted: []
+
+  - name: a stray file outside the doublestar prefix breaks the exact contract (POSIX)
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: check.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: stray-outside-doublestar
+            scenarios:
+              - name: extra file beside the tree
+                steps:
+                  - run:
+                      shell: true
+                      command: 'mkdir -p out/a && printf x > out/a/leaf.txt && printf y > stray.txt'
+                  - assert:
+                      changes:
+                        created:
+                          - "out/**"
+      - run:
+          command: ${atago} run check.atago.yaml
+      # stray.txt is created outside out/, so `out/**` cannot cover it and the
+      # exhaustive contract fails (exit 1).
+      - assert:
+          exit_code: 1
+          stdout:
+            contains: "unexpected created file"

--- a/test/e2e/thirdparty/git/changes.atago.yaml
+++ b/test/e2e/thirdparty/git/changes.atago.yaml
@@ -41,3 +41,24 @@ scenarios:
               - repo/.git/objects/*/*
             modified: []
             deleted: []
+
+  - name: git init's whole .git tree is pinned by one recursive glob (POSIX)
+    skip:
+      os: windows
+    steps:
+      # The real-world case that motivated #76: `git init` lays down a .git tree
+      # of arbitrary, git-version-dependent depth (hooks/, refs/heads/, info/,
+      # ...). A single `repo/.git/**` doublestar covers the whole subtree at any
+      # depth — the v1 vocabulary needed one glob per directory level and still
+      # could not say "and nothing deeper". modified/deleted stay empty, so the
+      # exhaustive-both-ways contract still proves init touched only the .git
+      # tree and created nothing outside it.
+      - run:
+          command: git init -q repo
+      - assert:
+          exit_code: 0
+          changes:
+            created:
+              - "repo/.git/**"
+            modified: []
+            deleted: []


### PR DESCRIPTION
## Summary

Extends the `changes:` entry vocabulary with `**` recursive globs (doublestar semantics) and documents backslash escaping for literal path metacharacters. Closes #76.

## What changed

- **Matching** ([internal/assert/changes.go](internal/assert/changes.go)): `changes:` entries are now matched with `github.com/bmatcuk/doublestar/v4` (already an indirect dep, now direct) instead of `path.Match`. A single `*` still stays within one path segment; `**` crosses `/` at any depth (`site/**` covers the whole tree, `dist/**/*.css` composes with a suffix). A backslash escapes a literal metacharacter (`\[`, `\?`, `\*`), portable because entries are always `/`-separated.
- **Validation** ([internal/loader/validate.go](internal/loader/validate.go)): malformed patterns are rejected at load time via `doublestar.ValidatePattern` (replacing the `path.Match` probe).
- **No behavior change** for existing specs: plain entries and single-level `*` keep their exact current meaning; the exhaustive-both-ways contract is unchanged.
- **Docs**: schema description ([schema/atago.schema.json](schema/atago.schema.json)) and `ChangesAssert` godoc ([internal/spec/spec.go](internal/spec/spec.go)) now document `**` and the escaping rule.

## Pinned semantics

`site/**` matches the bare `site` path itself as well as everything under it (doublestar's native behavior), pinned by a unit test.

## Tests

- Unit ([changes_test.go](internal/assert/changes_test.go)): `**` at depth 0/1/N; `**/*.ext` composition; no spill onto a sibling prefix; bare-prefix semantics; `a\[1\].txt` literal-metachar escaping; unescaped `a[1].txt` still a character class.
- Loader ([loader_test.go](internal/loader/loader_test.go)): `**` entries load; a malformed `site/[unclosed` glob is rejected at load time; existing single-`*` specs load unchanged.
- Self-hosted E2E ([changes.atago.yaml](test/e2e/atago/changes.atago.yaml)): a 3-level generated tree pinned exactly by `out/**` + `modified: []`/`deleted: []`, plus a negative case where a stray file outside `out/` breaks the exhaustive contract.
- Third-party E2E ([git/changes.atago.yaml](test/e2e/thirdparty/git/changes.atago.yaml)): `git init`'s whole `.git` tree pinned by one `repo/.git/**` — the real-world case that motivated this.

## Verification

`go test ./...`, `golangci-lint run`, `make docs` drift guard, and the edited E2E specs all pass.