### PR TITLE
feat(loader): layer defaults.run's environment family onto pty steps

### DIFF
--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-54 suites · 208 scenarios
+54 suites · 209 scenarios
 ## Contents
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 6 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
@@ -36,9 +36,10 @@
 - [atago self-hosting / db runner](#atago-self-hosting--db-runner) — 2 scenarios
   - [query workflow (create, insert, select, row assert, value binding) passes](#scenario-query-workflow-create-insert-select-row-assert-value-binding-passes)
   - [a query against an undeclared runner fails validation (exit 2)](#scenario-a-query-against-an-undeclared-runner-fails-validation-exit-2)
-- [atago self-hosting / top-level defaults](#atago-self-hosting--top-level-defaults) — 3 scenarios
+- [atago self-hosting / top-level defaults](#atago-self-hosting--top-level-defaults) — 4 scenarios
   - [defaults.run.shell applies to every run step without repeating it](#scenario-defaultsrunshell-applies-to-every-run-step-without-repeating-it)
   - [defaults.scenario.env is merged and an explicit scenario env wins](#scenario-defaultsscenarioenv-is-merged-and-an-explicit-scenario-env-wins)
+  - [defaults.run.sandbox_home governs a run step and a pty step alike (POSIX)](#scenario-defaultsrunsandbox_home-governs-a-run-step-and-a-pty-step-alike-posix)
   - [an unsupported defaults field is a load-time error (exit 2)](#scenario-an-unsupported-defaults-field-is-a-load-time-error-exit-2)
 - [atago self-hosting / dir assertion](#atago-self-hosting--dir-assertion) — 2 scenarios
   - [directory/tree assertions cover a multi-file generator](#scenario-directorytree-assertions-cover-a-multi-file-generator)
@@ -846,6 +847,42 @@ scenarios:
 #### When
 ```shell
 ${atago} run env.atago.yaml
+```
+#### Then
+- exit code is `0`
+- stdout contains `1 passed`
+### Scenario: defaults.run.sandbox_home governs a run step and a pty step alike (POSIX)
+_skipped on windows_
+#### Given
+- Fixture file `sandbox.atago.yaml` is created.
+#### Inputs
+_Fixture `sandbox.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: shared-sandbox
+defaults:
+  run:
+    shell: true
+    sandbox_home: true
+scenarios:
+  - name: a run step writes and a pty step reads under one sandbox home
+    steps:
+      - run:
+          command: 'mkdir -p "$XDG_CONFIG_HOME/mytool" && printf editor=vim > "$XDG_CONFIG_HOME/mytool/config"'
+      - assert:
+          exit_code: 0
+      - pty:
+          shell: true
+          command: 'cat "$XDG_CONFIG_HOME/mytool/config"'
+          session:
+            - expect: 'editor=vim'
+      - assert:
+… (truncated, 6 more lines)
+```
+#### When
+```shell
+${atago} run sandbox.atago.yaml
 ```
 #### Then
 - exit code is `0`

--- a/internal/engine/sandbox_home_test.go
+++ b/internal/engine/sandbox_home_test.go
@@ -75,6 +75,46 @@ scenarios:
 	}
 }
 
+// TestEngine_SandboxHome_DefaultsRunGovernsPTY proves defaults.run's sandbox
+// family (clear_env + sandbox_home) layers onto a pty step, so a shared
+// hermetic default governs interactive steps too (#77): the pty child sees the
+// sandbox HOME under ${workdir}/.atago-home, never the host home, even though
+// only defaults.run — not the pty step — declares the family. Mirrors
+// TestEngine_SandboxHome_ClearEnvComposition for the pty path.
+func TestEngine_SandboxHome_DefaultsRunGovernsPTY(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("HOME/XDG family and pty steps are POSIX-only")
+	}
+	t.Setenv("HOME", "/definitely/not/the/sandbox")
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: sandbox
+defaults:
+  run:
+    clear_env: true
+    pass_env: [PATH, HOME]
+    sandbox_home: true
+scenarios:
+  - name: a shared default sandboxes a pty child's home
+    steps:
+      - pty:
+          shell: true
+          command: 'printf "HOME=[%s]\n" "$HOME"'
+          session:
+            - expect: 'HOME='
+      - assert:
+          stdout:
+            contains: /.atago-home]
+      - assert:
+          stdout:
+            not_contains: /definitely/not/the/sandbox
+`)
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed: %+v", res.Status, res.Scenarios[0].Steps)
+	}
+}
+
 // TestEngine_SandboxHome_IsolatedBetweenScenarios proves each scenario gets its
 // own workdir and therefore its own isolated home: a file written in one
 // scenario is not visible in the next (#71).

--- a/internal/loader/defaults.go
+++ b/internal/loader/defaults.go
@@ -36,12 +36,22 @@ func applyDefaults(s *spec.Spec) {
 				if sc.Steps[j].Run != nil {
 					mergeRunDefaults(d.Run, sc.Steps[j].Run)
 				}
+				// A pty step carries the same environment surface as a run step
+				// (env/clear_env/pass_env/sandbox_home), so defaults.run layers
+				// that shared subset onto it too (#77) — without it, a shared
+				// sandbox_home would leave pty children on the host home.
+				if sc.Steps[j].PTY != nil {
+					mergePTYDefaults(d.Run, sc.Steps[j].PTY)
+				}
 			}
 			// Teardown steps are steps too: shared run defaults (shell, env, ...)
 			// apply so cleanup does not need to re-declare them.
 			for j := range sc.Teardown {
 				if sc.Teardown[j].Run != nil {
 					mergeRunDefaults(d.Run, sc.Teardown[j].Run)
+				}
+				if sc.Teardown[j].PTY != nil {
+					mergePTYDefaults(d.Run, sc.Teardown[j].PTY)
 				}
 			}
 		}
@@ -93,6 +103,27 @@ func mergeRunDefaults(def, r *spec.Run) {
 	// `clear_env: false` does not inherit the default allowlist (#16).
 	if r.PassEnv == nil && r.ClearEnvEnabled() {
 		r.PassEnv = def.PassEnv
+	}
+}
+
+// mergePTYDefaults layers defaults.run's environment-shaping subset beneath an
+// authored pty step (#77). Only env/clear_env/pass_env/sandbox_home cross over —
+// a pty step shares exactly that environment surface with a run step. Run-only
+// fields (runner, shell, cwd, timeout, stdin, redirects, retry) do NOT leak:
+// shell/cwd exist on pty with their own semantics and stay per-step until a
+// future defaults.pty. The merge rules mirror mergeRunDefaults exactly.
+func mergePTYDefaults(def *spec.Run, p *spec.PTY) {
+	p.Env = mergeStringMap(def.Env, p.Env)
+	if p.ClearEnv == nil {
+		p.ClearEnv = def.ClearEnv
+	}
+	if p.SandboxHome == nil {
+		p.SandboxHome = def.SandboxHome
+	}
+	// pass_env is meaningless without clear_env, so a pty step that authored
+	// `clear_env: false` does not inherit the default allowlist (#16).
+	if p.PassEnv == nil && p.ClearEnvEnabled() {
+		p.PassEnv = def.PassEnv
 	}
 }
 

--- a/internal/loader/defaults_test.go
+++ b/internal/loader/defaults_test.go
@@ -160,6 +160,85 @@ scenarios:
 	}
 }
 
+// TestApplyDefaults_PTYEnvFamily proves defaults.run's environment-shaping
+// subset (env, clear_env, pass_env, sandbox_home) layers onto pty steps the
+// same way it does onto run steps (#77): the environment surface of a pty step
+// is identical to a run step's, so a shared defaults.run.sandbox_home must not
+// leave pty children on the host home. Run-only fields (shell, cwd, runner) do
+// NOT leak — pty owns its shell/cwd semantics — and authored pointer values win.
+func TestApplyDefaults_PTYEnvFamily(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: sample
+defaults:
+  run:
+    shell: true
+    cwd: /run-only
+    clear_env: true
+    pass_env: [PATH, HOME]
+    sandbox_home: true
+    env:
+      SHARED: from-default
+      OVERRIDE: default
+scenarios:
+  - name: pty inherits the env family
+    steps:
+      - pty:
+          command: wizard
+          env:
+            OVERRIDE: own
+      - pty:
+          command: wizard
+          sandbox_home: false
+          clear_env: false
+`
+	s, err := LoadBytes("sample.atago.yaml", []byte(src))
+	if err != nil {
+		t.Fatalf("LoadBytes() error = %v", err)
+	}
+	p0 := s.Scenarios[0].Steps[0].PTY
+	if p0 == nil {
+		t.Fatal("step 0 is not a pty step")
+	}
+	if !p0.ClearEnvEnabled() {
+		t.Error("step 0: defaults.run.clear_env did not reach the pty step")
+	}
+	if !p0.SandboxHomeEnabled() {
+		t.Error("step 0: defaults.run.sandbox_home did not reach the pty step")
+	}
+	if got := p0.PassEnv; len(got) != 2 || got[0] != "PATH" || got[1] != "HOME" {
+		t.Errorf("step 0: pass_env = %v, want default [PATH HOME]", got)
+	}
+	if got := p0.Env["SHARED"]; got != "from-default" {
+		t.Errorf("step 0: env[SHARED] = %q, want the default to fill", got)
+	}
+	if got := p0.Env["OVERRIDE"]; got != "own" {
+		t.Errorf("step 0: env[OVERRIDE] = %q, want the authored value to win", got)
+	}
+	// Run-only fields must not leak onto a pty step: pty owns shell/cwd.
+	if p0.Shell != nil {
+		t.Errorf("step 0: defaults.run.shell leaked onto the pty step (shell=%v)", *p0.Shell)
+	}
+	if p0.Cwd != "" {
+		t.Errorf("step 0: defaults.run.cwd leaked onto the pty step (cwd=%q)", p0.Cwd)
+	}
+
+	// Authored pointer values win over the default.
+	p1 := s.Scenarios[0].Steps[1].PTY
+	if p1.SandboxHomeEnabled() {
+		t.Error("step 1: authored sandbox_home: false must beat the default")
+	}
+	if p1.ClearEnvEnabled() {
+		t.Error("step 1: authored clear_env: false must beat the default")
+	}
+	// pass_env is not inherited without an effective clear_env (mirrors run).
+	if got := p1.PassEnv; len(got) != 0 {
+		t.Errorf("step 1: pass_env = %v, want none (clear_env is off)", got)
+	}
+}
+
 // TestValidate_PassEnvRequiresClearEnv proves pass_env without clear_env: true
 // is a load-time validation error with a positioned message (#16).
 func TestValidate_PassEnvRequiresClearEnv(t *testing.T) {

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -32,7 +32,10 @@ type Spec struct {
 // Defaults holds the top-level `defaults:` block. Each fragment is
 // merged into the concrete model at load time to cut repetition without adding a
 // runtime model: `run` layers under every `run` step, `scenario.env` under every
-// scenario env, and `service` under every service.
+// scenario env, and `service` under every service. The environment-shaping
+// subset of `run` (env, clear_env, pass_env, sandbox_home) also layers onto
+// `pty` steps — a pty step shares that surface — while run-only fields (runner,
+// shell, cwd, timeout, stdin, redirects, retry) never reach pty steps (#77).
 //
 // Merge rules (applied by the loader): an explicitly-authored value always wins;
 // maps shallow-merge (the authored key wins per key); a nil pointer / empty

--- a/schema/atago.schema.json
+++ b/schema/atago.schema.json
@@ -80,7 +80,7 @@
       "properties": {
         "run": {
           "type": "object",
-          "description": "Layered beneath every `run` step. `command` and `retry` are per-step and rejected here.",
+          "description": "Layered beneath every `run` step. `command` and `retry` are per-step and rejected here. The environment-shaping subset (`env`, `clear_env`, `pass_env`, `sandbox_home`) also layers onto `pty` steps, which share the same environment surface (#77); the run-only fields (`runner`, `shell`, `cwd`, `timeout`, `stdin`, redirects) stay per-step and never reach pty steps.",
           "additionalProperties": false,
           "properties": {
             "runner": { "type": "string" },

--- a/test/e2e/atago/defaults.atago.yaml
+++ b/test/e2e/atago/defaults.atago.yaml
@@ -70,6 +70,52 @@ scenarios:
           stdout:
             contains: "1 passed"
 
+  - name: defaults.run.sandbox_home governs a run step and a pty step alike (POSIX)
+    skip:
+      os: windows
+    steps:
+      # #77: the environment-shaping subset of defaults.run (here sandbox_home)
+      # must layer onto pty steps too — they share a run step's environment
+      # surface. A single defaults.run.sandbox_home: true isolates the home for
+      # BOTH steps: the run step writes config under the sandboxed XDG home and
+      # the pty step reads it back from the SAME .atago-home, proving the default
+      # reached the interactive step instead of leaving it on the host home.
+      - fixture:
+          file: sandbox.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: shared-sandbox
+            defaults:
+              run:
+                shell: true
+                sandbox_home: true
+            scenarios:
+              - name: a run step writes and a pty step reads under one sandbox home
+                steps:
+                  - run:
+                      command: 'mkdir -p "$XDG_CONFIG_HOME/mytool" && printf editor=vim > "$XDG_CONFIG_HOME/mytool/config"'
+                  - assert:
+                      exit_code: 0
+                  - pty:
+                      shell: true
+                      command: 'cat "$XDG_CONFIG_HOME/mytool/config"'
+                      session:
+                        - expect: 'editor=vim'
+                  - assert:
+                      exit_code: 0
+                  # Both steps shared the one deterministic isolated home.
+                  - assert:
+                      file:
+                        path: .atago-home/.config/mytool/config
+                        contains: editor=vim
+      - run:
+          command: ${atago} run sandbox.atago.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "1 passed"
+
   - name: an unsupported defaults field is a load-time error (exit 2)
     steps:
       - fixture:


### PR DESCRIPTION
## Summary

Makes `defaults.run`'s environment-shaping fields (`env`, `clear_env`, `pass_env`, `sandbox_home`) layer onto `pty:` steps the same way they layer onto `run:` steps. Closes #77.

## Motivation

A pty step carries the same environment surface as a run step, but `applyDefaults` merged `defaults.run` into run steps only — so a spec declaring `defaults: {run: {sandbox_home: true}}` got an isolated home for every run step while its pty steps silently kept the **host** home. That is the exact one-machine-passes-elsewhere-fails divergence the hermetic keys exist to kill (and the direction the #71 design named as "shareable via defaults.run" for run/pty steps).

## What changed

- **[internal/loader/defaults.go](internal/loader/defaults.go)**: new `mergePTYDefaults` layers only `env`/`clear_env`/`pass_env`/`sandbox_home` beneath an authored pty step, wired into `applyDefaults` for both steps and teardown. Merge rules mirror `mergeRunDefaults` exactly — authored value wins; `pass_env` is not inherited without an effective `clear_env`.
- **Run-only fields do not leak**: `runner`, `shell`, `cwd`, `timeout`, `stdin`, redirects, `retry` stay per-step. `shell`/`cwd` exist on pty with their own semantics and keep defaulting only from a (future) `defaults.pty`.
- **Docs**: schema `defaults.run` description ([schema/atago.schema.json](schema/atago.schema.json)) and the `Defaults` godoc ([internal/spec/spec.go](internal/spec/spec.go)) document the layered subset.

## Tests

- Loader unit ([defaults_test.go](internal/loader/defaults_test.go)): the sandbox family reaches a pty step; authored `sandbox_home: false`/`clear_env: false` beat the default; `pass_env` not inherited without clear_env; run-only `shell`/`cwd` do not leak.
- Engine integration ([sandbox_home_test.go](internal/engine/sandbox_home_test.go)): with `defaults.run: {clear_env: true, sandbox_home: true}` a pty child sees the sandbox HOME, not the host home (POSIX-gated), mirroring the existing run-step composition test.
- Self-hosted E2E ([defaults.atago.yaml](test/e2e/atago/defaults.atago.yaml)): one `defaults.run.sandbox_home: true` governs a run step (writes config) and a pty step (reads it back) under the same `.atago-home`.

## Verification

`go test ./...`, `golangci-lint run`, and `make docs` drift guard all pass.

## Out of scope

Layering defaults onto suite.setup/teardown steps (a separate, pre-existing gap) and any new `defaults.pty` block.