### PR TITLE
feat(engine): unresolved-variable guard for pty session sends and expects

### DIFF
--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-54 suites · 210 scenarios
+54 suites · 212 scenarios
 ## Contents
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 6 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-54 suites · 208 scenarios
+54 suites · 210 scenarios
 ## Contents
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 6 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
@@ -156,7 +156,7 @@
 - [atago self-hosting / pdf assertion](#atago-self-hosting--pdf-assertion) — 2 scenarios
   - [pdf assertions cover page count, metadata, and text](#scenario-pdf-assertions-cover-page-count-metadata-and-text)
   - [a non-pdf file fails the pdf target](#scenario-a-non-pdf-file-fails-the-pdf-target)
-- [atago self-hosting / pty](#atago-self-hosting--pty) — 7 scenarios
+- [atago self-hosting / pty](#atago-self-hosting--pty) — 8 scenarios
   - [a pty step sees a terminal where a run step sees a pipe](#scenario-a-pty-step-sees-a-terminal-where-a-run-step-sees-a-pipe)
   - [a never-matching expect fails with the pattern in the block](#scenario-a-never-matching-expect-fails-with-the-pattern-in-the-block)
   - [named keys transmit their documented bytes and ctrl-c aborts](#scenario-named-keys-transmit-their-documented-bytes-and-ctrl-c-aborts)
@@ -164,7 +164,8 @@
   - [screen asserts see the final frame where the transcript sees history](#scenario-screen-asserts-see-the-final-frame-where-the-transcript-sees-history)
   - [a screen snapshot round-trips through update and compare](#scenario-a-screen-snapshot-round-trips-through-update-and-compare)
   - [a screen assert without a pty step is a load-time error](#scenario-a-screen-assert-without-a-pty-step-is-a-load-time-error)
-- [atago self-hosting / record (spec skeleton from an observed run)](#atago-self-hosting--record-spec-skeleton-from-an-observed-run) — 12 scenarios
+  - [a send referencing an undefined variable is an execution error, not typed literally](#scenario-a-send-referencing-an-undefined-variable-is-an-execution-error-not-typed-literally)
+- [atago self-hosting / record (spec skeleton from an observed run)](#atago-self-hosting--record-spec-skeleton-from-an-observed-run) — 13 scenarios
   - [record then run round-trips green](#scenario-record-then-run-round-trips-green)
   - [refusing to overwrite without --force](#scenario-refusing-to-overwrite-without---force)
   - [record --pty refuses an existing --out before driving the session](#scenario-record---pty-refuses-an-existing---out-before-driving-the-session)
@@ -177,6 +178,7 @@
   - [record --pty of a no-input command yields a session-less spec that replays green](#scenario-record---pty-of-a-no-input-command-yields-a-session-less-spec-that-replays-green)
   - [a prompt with regex metacharacters is escaped in the generated expect](#scenario-a-prompt-with-regex-metacharacters-is-escaped-in-the-generated-expect)
   - [recorded text containing dollar-brace round-trips as literal text](#scenario-recorded-text-containing-dollar-brace-round-trips-as-literal-text)
+  - [a recorded secret placeholder replays green with the env set and is guarded when unset](#scenario-a-recorded-secret-placeholder-replays-green-with-the-env-set-and-is-guarded-when-unset)
 - [atago self-hosting / reports](#atago-self-hosting--reports) — 5 scenarios
   - [JUnit report is XML with a testsuite and testcase](#scenario-junit-report-is-xml-with-a-testsuite-and-testcase)
   - [GitHub Actions annotations are emitted on failure](#scenario-github-actions-annotations-are-emitted-on-failure)
@@ -2895,6 +2897,32 @@ ${atago} run bad.atago.yaml
 #### Then
 - exit code is `2`
 - stderr contains `requires a preceding pty step`
+### Scenario: a send referencing an undefined variable is an execution error, not typed literally
+_skipped on windows_
+#### Given
+- Fixture file `typo.atago.yaml` is created.
+#### Inputs
+_Fixture `typo.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: typo
+scenarios:
+  - name: typo in a send variable
+    steps:
+      - pty:
+          command: cat
+          timeout: 5s
+          session:
+            - send: "${no_such_var}\n"
+```
+#### When
+```shell
+${atago} run typo.atago.yaml
+```
+#### Then
+- exit code is `4`
+- stdout contains `no variable with that name is defined`, `$${no_such_var}`
 ## atago self-hosting / record (spec skeleton from an observed run)
 Source: `test/e2e/atago/record.atago.yaml`
 ### Scenario: record then run round-trips green
@@ -3064,6 +3092,26 @@ ${atago} run dollar.atago.yaml
 - after `${atago} run dollar.atago.yaml`:
   - exit code is `0`
   - stdout contains `1 passed`
+### Scenario: a recorded secret placeholder replays green with the env set and is guarded when unset
+_skipped on windows_
+#### Given
+- Environment variables are set: ATAGO_SECRET_1.
+#### When
+```shell
+# interactive (pty): ${atago} record --pty --out sec.atago.yaml -- sh -c 'stty -echo; printf "Password: "; read pw; stty echo; printf "\naccepted\n"'
+${atago} run sec.atago.yaml
+${atago} run sec.atago.yaml
+```
+#### Then
+- exit code is `0`
+- file `sec.atago.yaml` contains `${env:ATAGO_SECRET_1}`
+- file `sec.atago.yaml` is checked
+- after `${atago} run sec.atago.yaml`:
+  - exit code is `0`
+  - stdout contains `1 passed`
+- after `${atago} run sec.atago.yaml`:
+  - exit code is `4`
+  - stdout contains `ATAGO_SECRET_1 is not set`
 ## atago self-hosting / reports
 Source: `test/e2e/atago/reports.atago.yaml`
 ### Scenario: JUnit report is XML with a testsuite and testcase

--- a/internal/engine/pty.go
+++ b/internal/engine/pty.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/nao1215/atago/internal/assert"
 	"github.com/nao1215/atago/internal/runner"
@@ -16,6 +17,16 @@ import (
 // compose the process environment (scenario env layered under the step's own,
 // both expanded), and drive the terminal session in the scenario workdir.
 func (e *Engine) runPTY(ctx context.Context, p *spec.PTY, st *store.Store, scenarioEnv map[string]string, workdir string) (*runner.Result, *ptyrun.ExpectFailure, error) {
+	// Guard every session entry against a live unresolved ${name}/${env:NAME}
+	// before any terminal I/O (#78): otherwise st.Expand leaves the reference
+	// verbatim and it would be TYPED into the program (or matched literally by an
+	// expect), so a typo'd store name or a forgotten env: wiring feeds garbage to
+	// the program under test instead of failing at the mistake. Checking all
+	// entries up front guarantees a half-typed secret placeholder never reaches
+	// the child. Escaped $${...} literals are exempt (Unresolved skips them).
+	if err := checkPTYSessionResolved(p.Session, st); err != nil {
+		return nil, nil, err
+	}
 	c := *p
 	c.Command = st.Expand(p.Command)
 	c.Cwd = st.Expand(p.Cwd)
@@ -54,6 +65,43 @@ func (e *Engine) runPTY(ctx context.Context, p *spec.PTY, st *store.Store, scena
 		sandbox = s
 	}
 	return ptyrun.Run(ctx, &c, workdir, runnercmd.BuildEnv(c.Env, c.ClearEnvEnabled(), c.PassEnv, sandbox))
+}
+
+// checkPTYSessionResolved reports the first session entry whose send text or
+// expect pattern carries a live unresolved ${name}/${env:NAME} reference (#78).
+// It mirrors the run.command guard's message — naming the entry, the reference,
+// and the $${...} literal escape — so the fix-forward path is identical. Named
+// keys and the empty-string EOF send have no text to resolve and are skipped.
+func checkPTYSessionResolved(session []spec.PTYAction, st *store.Store) error {
+	for i, a := range session {
+		if err := unresolvedRefError(i, "expect", a.Expect, st); err != nil {
+			return err
+		}
+		if a.Send != nil && a.Send.Text != nil {
+			if err := unresolvedRefError(i, "send", *a.Send.Text, st); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// unresolvedRefError returns an explained error for the first unresolved
+// reference in text, or nil when every reference resolves.
+func unresolvedRefError(idx int, field, text string, st *store.Store) error {
+	names := st.Unresolved(text)
+	if len(names) == 0 {
+		return nil
+	}
+	name := names[0]
+	if envName, isEnv := strings.CutPrefix(name, "env:"); isEnv {
+		return fmt.Errorf(
+			"pty session entry %[1]d (%[2]s) references ${env:%[3]s}, but the environment variable %[3]s is not set; set it or write $${env:%[3]s} for the literal text",
+			idx, field, envName)
+	}
+	return fmt.Errorf(
+		"pty session entry %[1]d (%[2]s) references ${%[3]s}, but no variable with that name is defined (builtins, matrix vars, store, ready.store, env:); define the variable or write $${%[3]s} for the literal text",
+		idx, field, name)
 }
 
 // ptyExpectCheck converts a never-matched session expect into the structured

--- a/internal/engine/pty_test.go
+++ b/internal/engine/pty_test.go
@@ -185,6 +185,122 @@ scenarios:
 	}
 }
 
+// TestEngine_PTY_UnresolvedSendVarErrors: a send referencing a ${name} nothing
+// defines is an explained step error before any I/O, not the literal reference
+// typed into the program (#78) — mirroring the run.command guard so a typo'd
+// store name fails at the mistake, not garbled downstream.
+func TestEngine_PTY_UnresolvedSendVarErrors(t *testing.T) {
+	skipOnWindows(t)
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: v
+scenarios:
+  - name: typo in a send variable
+    steps:
+      - pty:
+          command: cat
+          timeout: 10s
+          session:
+            - send: "${no_such_var}\n"
+`)
+	if res.Status != StatusError {
+		t.Fatalf("status = %s, want error: %+v", res.Status, res.Scenarios)
+	}
+	msg := res.Scenarios[0].Steps[0].ErrMsg
+	if !strings.Contains(msg, "${no_such_var}") || !strings.Contains(msg, "$${no_such_var}") {
+		t.Errorf("error should name the reference and the $${...} literal escape, got %q", msg)
+	}
+}
+
+// TestEngine_PTY_UnresolvedEnvVarErrors: an unset ${env:NAME} in a send fails
+// the same way — a forgotten `env:` wiring must not feed a placeholder to a
+// password prompt (#78).
+func TestEngine_PTY_UnresolvedEnvVarErrors(t *testing.T) {
+	skipOnWindows(t)
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: v
+scenarios:
+  - name: unset env in a send
+    steps:
+      - pty:
+          command: cat
+          timeout: 10s
+          session:
+            - send: "${env:ATAGO_SURELY_UNSET_78}\n"
+`)
+	if res.Status != StatusError {
+		t.Fatalf("status = %s, want error: %+v", res.Status, res.Scenarios)
+	}
+	msg := res.Scenarios[0].Steps[0].ErrMsg
+	if !strings.Contains(msg, "ATAGO_SURELY_UNSET_78") {
+		t.Errorf("error should name the env variable, got %q", msg)
+	}
+}
+
+// TestEngine_PTY_UnresolvedExpectVarErrors: the guard covers expect patterns
+// too — an unresolved reference in an expect would silently match the literal
+// text and pass, so it must fail identically (#78).
+func TestEngine_PTY_UnresolvedExpectVarErrors(t *testing.T) {
+	skipOnWindows(t)
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: v
+scenarios:
+  - name: typo in an expect variable
+    steps:
+      - pty:
+          command: cat
+          timeout: 10s
+          session:
+            - send: "hi\n"
+            - expect: "${no_such_var}"
+`)
+	if res.Status != StatusError {
+		t.Fatalf("status = %s, want error: %+v", res.Status, res.Scenarios)
+	}
+	msg := res.Scenarios[0].Steps[0].ErrMsg
+	if !strings.Contains(msg, "${no_such_var}") {
+		t.Errorf("error should name the reference, got %q", msg)
+	}
+}
+
+// TestEngine_PTY_EscapedLiteralSendTypesLiteral: a $${...} escaped reference in
+// a send still types the literal ${...} into the program (this is how recorded
+// sessions carry literal `${`), so the guard must not touch it (#78).
+func TestEngine_PTY_EscapedLiteralSendTypesLiteral(t *testing.T) {
+	skipOnWindows(t)
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: v
+scenarios:
+  - name: escaped literal is typed verbatim
+    steps:
+      - pty:
+          command: cat
+          timeout: 10s
+          session:
+            - send: "$${literal}\n"
+            - expect: '\$\{literal\}'
+            - send: ""
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "${literal}"
+`)
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed: %+v", res.Status, res.Scenarios[0].Steps)
+	}
+}
+
 // TestEngine_PTY_NamedKeys proves named keys transmit their documented xterm
 // bytes (#26): `cat -v` renders the down arrow it received as ^[[B, ctrl-d
 // ends the stream, and a trap-based shell observes ctrl-c as SIGINT.

--- a/schema/atago.schema.json
+++ b/schema/atago.schema.json
@@ -506,7 +506,7 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "description": "Exactly one of expect (wait until the transcript matches the regexp) or send (write to the terminal; \"\" sends EOF/^D; {key: enter} presses a named key, #26).",
+            "description": "Exactly one of expect (wait until the transcript matches the regexp) or send (write to the terminal; \"\" sends EOF/^D; {key: enter} presses a named key, #26). ${name}/${env:NAME} references in a send or expect are expanded against the store; a reference nothing resolves fails the step before any terminal I/O (#78) — write $${name} for literal text.",
             "properties": {
               "expect": { "type": "string" },
               "send": {

--- a/test/e2e/atago/pty.atago.yaml
+++ b/test/e2e/atago/pty.atago.yaml
@@ -186,3 +186,36 @@ scenarios:
           exit_code: 2
           stderr:
             contains: "requires a preceding pty step"
+
+  - name: a send referencing an undefined variable is an execution error, not typed literally
+    skip:
+      os: windows
+    steps:
+      # #78: a pty session entry that references a ${name} nothing defines must
+      # fail the run with the same fix-forward guard a no-shell run.command
+      # produces — otherwise st.Expand leaves the reference verbatim and the
+      # literal `${no_such_var}` is TYPED into the program, so a typo'd store
+      # name feeds garbage instead of failing at the mistake. The run errors
+      # (exit 4) and the message names the reference and the $${...} escape.
+      - fixture:
+          file: typo.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: typo
+            scenarios:
+              - name: typo in a send variable
+                steps:
+                  - pty:
+                      command: cat
+                      timeout: 5s
+                      session:
+                        - send: "${no_such_var}\n"
+      - run:
+          command: ${atago} run typo.atago.yaml
+      - assert:
+          exit_code: 4
+          stdout:
+            contains:
+              - "no variable with that name is defined"
+              - "$${no_such_var}"

--- a/test/e2e/atago/record.atago.yaml
+++ b/test/e2e/atago/record.atago.yaml
@@ -294,3 +294,55 @@ scenarios:
           exit_code: 0
           stdout:
             contains: "1 passed"
+
+  - name: a recorded secret placeholder replays green with the env set and is guarded when unset
+    skip:
+      os: windows
+    steps:
+      # #69 records echo-off (secret) input as a live ${env:ATAGO_SECRET_n}
+      # placeholder — the one send that MUST stay a live reference. #78 adds the
+      # unresolved-variable guard for pty sessions, so this placeholder path has
+      # two contracts: with the variable SET it replays green, and with it UNSET
+      # the run fails loudly instead of typing the literal placeholder into the
+      # password prompt. An OUTER pty step hand-drives the recorder against a
+      # prompt that turns terminal echo off; the read value is never echoed, so
+      # the secret never lands in the generated spec.
+      - pty:
+          shell: true
+          command: '${atago} record --pty --out sec.atago.yaml -- sh -c ''stty -echo; printf "Password: "; read pw; stty echo; printf "\naccepted\n"'''
+          timeout: 20s
+          session:
+            - expect: "Password:"
+            - send: "hunter2\n"
+            - expect: "accepted"
+      - assert:
+          exit_code: 0
+      # The generated send is a live env placeholder, and the typed secret is not
+      # recorded anywhere in the spec.
+      - assert:
+          file:
+            path: sec.atago.yaml
+            contains: "${env:ATAGO_SECRET_1}"
+      - assert:
+          file:
+            path: sec.atago.yaml
+            not_contains: "hunter2"
+      # With the secret variable set, the placeholder expands and the spec
+      # replays green.
+      - run:
+          shell: true
+          env:
+            ATAGO_SECRET_1: hunter2
+          command: ${atago} run sec.atago.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "1 passed"
+      # With it unset, the #78 guard fires (exit 4) instead of typing the literal
+      # ${env:ATAGO_SECRET_1} into the prompt.
+      - run:
+          command: ${atago} run sec.atago.yaml
+      - assert:
+          exit_code: 4
+          stdout:
+            contains: "ATAGO_SECRET_1 is not set"


### PR DESCRIPTION
## Summary

Makes a pty session entry that references an undefined `${name}` (or unset `${env:NAME}`) fail the step with the same clear, fix-forward error a no-shell `run.command` produces today, instead of silently typing (or matching) the literal reference text. Closes #78.

## Motivation

`run.command` has an unresolved-variable guard; a pty session had none. `send: "${SURELY_UNSET}\n"` typed the literal `${SURELY_UNSET}` into the program and the scenario passed. A typo'd store name or a forgotten `env:` wiring therefore fed garbage to the program under test and failed later (or worse, passed) — far from the mistake. It also matters for `record --pty`: generated specs use `${env:ATAGO_SECRET_n}` placeholders for redacted secrets, so a user who forgets to set the secret variable previously got the placeholder typed into a password prompt silently.

## What changed

- **[internal/engine/pty.go](internal/engine/pty.go)**: `runPTY` now calls `checkPTYSessionResolved` before any terminal I/O. Each `send:` text and `expect:` pattern is resolved against the store; the first live unresolved `${name}`/`${env:NAME}` fails the step with a message naming the entry index, the field (send/expect), the reference, and the `$${...}` literal escape — mirroring the `run.command` message.
- Escaped `$${...}` literals (how recorded sessions carry literal `${`), named-key sends, and the empty-string EOF send are unaffected.
- Checking all entries up front guarantees a half-typed secret placeholder never reaches the child.
- **Docs**: the pty `session` schema description ([schema/atago.schema.json](schema/atago.schema.json)) documents the guard.

## Tests

- Engine ([pty_test.go](internal/engine/pty_test.go)): unresolved store var in a send fails naming the reference and `$${...}` escape; unresolved `${env:NAME}` in a send fails; an unresolved `expect:` fails identically; `$${literal}` in a send still types the literal `${literal}` (pinned with cat echo). A defined variable keeps expanding (existing `TestEngine_PTY_StoreAndVariablesFlow`).
- Self-hosted E2E (POSIX):
  - [pty.atago.yaml](test/e2e/atago/pty.atago.yaml): a typo'd send variable run via `${atago} run` exits **4** with the guard message.
  - [record.atago.yaml](test/e2e/atago/record.atago.yaml): the `record --pty` secret-placeholder flow replays **green** with `ATAGO_SECRET_1` set, and the same generated spec exits **4** (guard) when it is unset — the placeholder value never lands in the spec.

## Verification

`go test ./...`, `golangci-lint run`, and `make docs` drift guard all pass.

## Out of scope

Expansion-behavior changes for run/http/assert fields (already guarded or intentionally verbatim) and load-time validation of variable references (store values only exist at run time).