### PR TITLE
docs: center the atago logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/nao1215/atago)](https://goreportcard.com/report/github.com/nao1215/atago)
 ![GitHub](https://img.shields.io/github/license/nao1215/atago)
 
-<img src="./doc/img/atago-logo.jpg" alt="atago logo" width="400" />
+<p align="center">
+  <img src="./doc/img/atago-logo.jpg" alt="atago logo" width="400" />
+</p>
 
 atago tests real CLI behavior from plain YAML: commands, files, snapshots, services, and interactive terminals. It runs your actual binary — in any language — and asserts what a user observes. No test code, no shell DSL.
 


### PR DESCRIPTION
## Overview

Center the atago logo under the `# atago` heading by wrapping it in a `<p align="center">` block.

## Notes

Documentation-only change; no code or behavior affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved the README’s top-of-page logo layout by centering the existing logo image for a cleaner presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->