### PR TITLE
fix: harden pty/TUI, grpc, service, ssh, and rerun-failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,46 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- A `pty` step now exports `TERM=xterm-256color` by default (overridable via
+  `env: {TERM: ...}`). Without a sane TERM, full-screen TUIs (less, vim, htop)
+  print "terminal is not fully functional" and refuse to draw, so a pty/screen
+  assertion never saw the real UI; the default matches the vt10x screen emulator
+  and is deterministic regardless of the host's own TERM.
+- A `pty` `expect` now scans only the transcript AFTER the previous match, so a
+  recurring pattern (any shell prompt) waits for its NEXT occurrence instead of
+  matching the stale earlier one. Previously every expect re-scanned the whole
+  transcript, so a second `expect "PROMPT> "` matched instantly and the session
+  raced ahead — a false pass for exactly the interactive flows the feature
+  exists for.
+- A `pty` step now surfaces a parent-context cancellation (Ctrl-C / suite
+  cancel) as an execution error instead of a spurious expect failure or a benign
+  timeout, so the scenario stops rather than asserting against a killed terminal
+  (matching the command runner, #30).
+- The gRPC runner treats a call that times out or drops (our per-call deadline
+  fired) as a transport error, not a passing result. `status.FromError` maps a
+  client-deadline `DeadlineExceeded`/`Unavailable` to `ok=true`, which was
+  recorded as a normal Result and passed against a hung or unreachable server
+  unless the spec happened to assert `grpc_status`.
+- `grpc` `method` accepts the fully-qualified `/pkg.Service/Method` form (a
+  single leading slash) and rejects a method with more than one internal slash,
+  instead of silently mis-parsing `/pkg.Service/Method` as service
+  `/pkg.Service` and failing later with a confusing reflection error.
+- A `service` `ready.delay` probe now fails if the process exits during the
+  delay window, instead of reporting the (dead) service ready and running the
+  scenario against a dead peer — matching the file/port/log probes.
+- A host-less `service` `ready.port` (e.g. `9997` instead of `:9997` /
+  `127.0.0.1:9997`) now fails fast with a clear message instead of swallowing
+  "missing port in address" and running to the full readiness timeout.
+- The SSH runner no longer mangles a bracketed IPv6 host: `[::1]` resolves to
+  `[::1]:22` rather than the malformed `[[::1]]:22`, and a trailing-colon host
+  (`host:`) gains the default port instead of dialing an empty one.
+- `atago run --rerun-failed` no longer reports a false green — and no longer
+  deletes the recorded failures — when the recorded scenario names no longer
+  match the specs (renamed or removed while still broken). It warns, keeps the
+  state, and exits non-zero so the still-failing work is not silently forgotten.
+- `atago doc` rejects `--out` combined with `--split-by-spec` instead of
+  silently ignoring `--out` (the split branch only writes into `--out-dir`).
+
 - The HTTP runner now re-enforces the network allowlist on every redirect hop.
   An allowed host could 3xx-redirect the client onto a denied host and the
   default client would follow it, silently defeating

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-54 suites · 213 scenarios
+55 suites · 217 scenarios
 ## Contents
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 6 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
@@ -258,6 +258,11 @@
   - [a step timeout beats the suite timeout and the hint says run.timeout](#scenario-a-step-timeout-beats-the-suite-timeout-and-the-hint-says-runtimeout)
   - [timeout zero disables a short suite bound](#scenario-timeout-zero-disables-a-short-suite-bound)
   - [an invalid suite.timeout is a load-time error](#scenario-an-invalid-suitetimeout-is-a-load-time-error)
+- [atago self-hosting / tui](#atago-self-hosting--tui) — 4 scenarios
+  - [a pty step exports a usable TERM by default](#scenario-a-pty-step-exports-a-usable-term-by-default)
+  - [an explicit TERM overrides the default](#scenario-an-explicit-term-overrides-the-default)
+  - [an expect does not re-match a consumed pattern](#scenario-an-expect-does-not-re-match-a-consumed-pattern)
+  - [less -X renders a real pager onto the screen](#scenario-less--x-renders-a-real-pager-onto-the-screen)
 - [atago self-hosting / verbose](#atago-self-hosting--verbose) — 4 scenarios
   - [verbose shows a passing scenario's command, output, and verdicts](#scenario-verbose-shows-a-passing-scenarios-command-output-and-verdicts)
   - [without --verbose the trace is absent](#scenario-without---verbose-the-trace-is-absent)
@@ -4699,6 +4704,72 @@ ${atago} run bad.atago.yaml
 #### Then
 - exit code is `2`
 - stderr contains `suite.timeout`
+## atago self-hosting / tui
+Source: `test/e2e/atago/tui.atago.yaml`
+### Scenario: a pty step exports a usable TERM by default
+_skipped on windows_
+#### When
+```shell
+# interactive (pty): echo "TERM=[$TERM]"
+```
+#### Then
+- exit code is `0`
+- stdout contains `TERM=[xterm-256color]`
+### Scenario: an explicit TERM overrides the default
+_skipped on windows_
+#### When
+```shell
+# interactive (pty): echo "TERM=[$TERM]"
+```
+#### Then
+- exit code is `0`
+- stdout contains `TERM=[vt100]`
+### Scenario: an expect does not re-match a consumed pattern
+_skipped on windows_
+#### Given
+- Fixture file `inner.atago.yaml` is created.
+#### Inputs
+_Fixture `inner.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: inner
+scenarios:
+  - name: stale expect must not re-match
+    steps:
+      - pty:
+          shell: true
+          command: 'printf "AAA\n"'
+          timeout: 1s
+          session:
+            - expect: "AAA"
+            - expect: "AAA"
+```
+#### When
+```shell
+${atago} run inner.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `1 failed`
+### Scenario: less -X renders a real pager onto the screen
+_skipped on windows_
+#### Given
+- Fixture file `page.txt` is created.
+#### Inputs
+_Fixture `page.txt`:_
+```text
+Alpha line
+Beta line
+Gamma line
+```
+#### When
+```shell
+# interactive (pty): less -X page.txt
+```
+#### Then
+- rendered screen contains `Alpha line`
+- rendered screen contains `Gamma line`
 ## atago self-hosting / verbose
 Source: `test/e2e/atago/verbose.atago.yaml`
 ### Scenario: verbose shows a passing scenario's command, output, and verdicts

--- a/examples/pty.atago.yaml
+++ b/examples/pty.atago.yaml
@@ -8,7 +8,18 @@ version: "1"
 # the transcript matches the regexp; a `send` types into the terminal (include
 # "\n" to press enter; an empty send: "" transmits EOF, i.e. Ctrl-D). The
 # whole session is bounded by `timeout` (default 30s) — a prompt that never
-# appears fails loudly instead of hanging.
+# appears fails loudly instead of hanging. Each `expect` scans only the
+# transcript AFTER the previous match, so a recurring prompt (`$ `) waits for
+# its NEXT occurrence rather than matching a stale earlier one.
+#
+# The child runs with TERM=xterm-256color by default (matching the vt10x screen
+# emulator, #27), so full-screen TUIs (less, vim, htop) actually draw — override
+# with `env: {TERM: ...}` if a program needs a specific terminal type. Note: a
+# TUI that uses the alternate screen buffer (most of them) RESTORES the primary
+# screen when it exits cleanly, so a `screen:` assertion after a clean quit sees
+# a blank screen. To assert a live TUI, capture it while it is still displayed
+# (e.g. keep output on the primary screen, or let a short `timeout` end the step
+# while the UI is up).
 # POSIX-only for now; on Windows the step reports a clear execution error.
 # Runs green as-is on Linux/macOS: atago run examples/pty.atago.yaml
 

--- a/internal/cli/doc.go
+++ b/internal/cli/doc.go
@@ -39,6 +39,13 @@ func docCmd(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "atago doc: --out-dir requires --split-by-spec")
 		return ExitConfig
 	}
+	if *split && *out != "" {
+		// The split branch writes into --out-dir and never honors --out; rejecting
+		// the combination stops a silently-ignored --out (the file is never
+		// written and no docs land where the user asked).
+		fmt.Fprintln(stderr, "atago doc: --out and --split-by-spec are mutually exclusive (--split-by-spec writes one file per spec into --out-dir)")
+		return ExitConfig
+	}
 
 	targets := fs.Args()
 	if len(targets) == 0 {

--- a/internal/cli/features_test.go
+++ b/internal/cli/features_test.go
@@ -344,6 +344,44 @@ func TestRerunFailed_RecordsAndReruns(t *testing.T) {
 	})
 }
 
+// TestRerunFailed_NoMatchKeepsStateAndWarns is a regression: when the recorded
+// failing scenario no longer exists in the spec (renamed/removed while still
+// broken), --rerun-failed must NOT report a false green and must NOT clear the
+// recorded failures — otherwise the still-failing work is silently forgotten.
+func TestRerunFailed_NoMatchKeepsStateAndWarns(t *testing.T) {
+	dir := t.TempDir()
+	writeSpec(t, dir, "s.atago.yaml", twoScenarioSpec)
+	withWorkdir(t, dir, func() {
+		// First run records the failing "fails" scenario.
+		var out, errb bytes.Buffer
+		if got := Main([]string{"run", "."}, &out, &errb); got != ExitFailures {
+			t.Fatalf("first run exit = %d, want %d (stderr=%s)", got, ExitFailures, errb.String())
+		}
+		// Rename the failing scenario so the recorded name no longer matches, but
+		// keep the spec path (and keep it broken).
+		renamed := strings.ReplaceAll(twoScenarioSpec, "name: fails", "name: fails-renamed")
+		writeSpec(t, dir, "s.atago.yaml", renamed)
+
+		out.Reset()
+		errb.Reset()
+		got := Main([]string{"run", "--rerun-failed", "."}, &out, &errb)
+		if got == ExitOK {
+			t.Errorf("exit = %d (ExitOK); a rerun that matched no recorded failure must not greenlight", got)
+		}
+		if !strings.Contains(errb.String(), "no recorded failing scenarios matched") {
+			t.Errorf("stderr = %q, want the no-match warning", errb.String())
+		}
+		// The recorded failures must survive so a later, correct rerun can find them.
+		st, err := loadRerunState()
+		if err != nil {
+			t.Fatalf("rerun state was removed or unreadable: %v", err)
+		}
+		if len(st.Failed) != 1 || st.Failed[0].Scenario != "fails" {
+			t.Errorf("recorded failures = %+v, want the original 'fails' preserved", st.Failed)
+		}
+	})
+}
+
 func TestRerunFailed_NothingRecorded(t *testing.T) {
 	dir := t.TempDir()
 	writeSpec(t, dir, "s.atago.yaml", passingSpec)

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -168,13 +168,32 @@ func runCmd(args []string, stdout, stderr io.Writer) int {
 		progress.Done()
 	}
 
+	// Scenarios that actually executed. A Select can exclude every scenario in a
+	// loaded suite — most importantly a --rerun-failed whose recorded scenario
+	// names no longer exist in the specs (renamed or removed while still broken).
+	ranScenarios := 0
+	for _, r := range results {
+		ranScenarios += len(r.Scenarios)
+	}
+	// A --rerun-failed run that matched NOTHING verified nothing, yet the recorded
+	// failures are still real: greenlighting it and clearing the state would
+	// silently forget still-failing work. Warn loudly, keep the state, and do not
+	// exit green.
+	rerunMatchedNothing := *rerunFailed && ranScenarios == 0 && ctx.Err() == nil
+	if rerunMatchedNothing {
+		fmt.Fprintln(stderr, "atago run: warning: no recorded failing scenarios matched the current specs (renamed or removed?); the recorded failures were kept, not cleared")
+		exit = worseExit(exit, ExitConfig)
+	}
+
 	// Record this run's failing scenarios for a later `--rerun-failed` (#64). The
 	// state reflects exactly the scenarios that ran: failures are recorded and a
 	// fully-green run clears the file. It is only rewritten when at least one suite
-	// loaded, so a run where every spec failed to parse leaves prior state intact.
-	// Writing is best-effort — a read-only checkout must not fail the run — so a
-	// write error is a warning, not a fatal exit.
-	if len(results) > 0 {
+	// loaded, so a run where every spec failed to parse leaves prior state intact;
+	// and a --rerun-failed that matched no scenario must NOT clear the file, or the
+	// still-failing work it could not map would be forgotten. Writing is
+	// best-effort — a read-only checkout must not fail the run — so a write error
+	// is a warning, not a fatal exit.
+	if len(results) > 0 && !rerunMatchedNothing {
 		if err := saveRerunState(collectFailures(results)); err != nil {
 			fmt.Fprintf(stderr, "atago run: could not update %s: %v\n", rerunStatePath(), err)
 		}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -178,8 +178,10 @@ func runCmd(args []string, stdout, stderr io.Writer) int {
 	// A --rerun-failed run that matched NOTHING verified nothing, yet the recorded
 	// failures are still real: greenlighting it and clearing the state would
 	// silently forget still-failing work. Warn loudly, keep the state, and do not
-	// exit green.
-	rerunMatchedNothing := *rerunFailed && ranScenarios == 0 && ctx.Err() == nil
+	// exit green. Require at least one suite to have LOADED, so this stays about a
+	// scenario-name mismatch — when every spec fails to parse, the load errors
+	// (already printed) are the real story, not a "renamed or removed" scenario.
+	rerunMatchedNothing := *rerunFailed && len(results) > 0 && ranScenarios == 0 && ctx.Err() == nil
 	if rerunMatchedNothing {
 		fmt.Fprintln(stderr, "atago run: warning: no recorded failing scenarios matched the current specs (renamed or removed?); the recorded failures were kept, not cleared")
 		exit = worseExit(exit, ExitConfig)

--- a/internal/cli/subcommands_test.go
+++ b/internal/cli/subcommands_test.go
@@ -58,6 +58,25 @@ func TestDocCmd_NoFiles(t *testing.T) {
 	}
 }
 
+// TestDocCmd_OutWithSplitRejected is a regression: --out and --split-by-spec are
+// contradictory (split writes into --out-dir), so passing both must fail loudly
+// instead of silently ignoring --out.
+func TestDocCmd_OutWithSplitRejected(t *testing.T) {
+	dir := t.TempDir()
+	p := writeSpec(t, dir, "ok.atago.yaml", passingSpec)
+	var out, errb bytes.Buffer
+	got := Main([]string{"doc", "--out", filepath.Join(dir, "ignored.md"), "--split-by-spec", "--out-dir", filepath.Join(dir, "d"), p}, &out, &errb)
+	if got != ExitConfig {
+		t.Fatalf("exit = %d, want %d (mutually-exclusive flags)", got, ExitConfig)
+	}
+	if !strings.Contains(errb.String(), "mutually exclusive") {
+		t.Errorf("stderr = %q, want a mutually-exclusive message", errb.String())
+	}
+	if _, err := os.Stat(filepath.Join(dir, "ignored.md")); !os.IsNotExist(err) {
+		t.Errorf("the ignored --out file was written despite the rejected combination")
+	}
+}
+
 func TestManifestCmd_Stdout(t *testing.T) {
 	dir := t.TempDir()
 	p := writeSpec(t, dir, "ok.atago.yaml", passingSpec)

--- a/internal/engine/pty.go
+++ b/internal/engine/pty.go
@@ -37,6 +37,17 @@ func (e *Engine) runPTY(ctx context.Context, p *spec.PTY, st *store.Store, scena
 	for k, v := range st.ExpandMap(p.Env) { // step env overrides scenario env
 		merged[k] = v
 	}
+	// A pty step drives a REAL terminal, and full-screen TUIs (less, vim, htop —
+	// anything ncurses/termios) consult $TERM to decide whether to draw at all:
+	// an unset or "dumb" TERM makes them refuse full-screen mode ("terminal is
+	// not fully functional") or fall back to line mode, so a pty/screen assertion
+	// can never see the real UI. atago renders the transcript through an
+	// xterm-compatible vt10x emulator, so default TERM to xterm-256color unless
+	// the spec set it — giving deterministic behavior regardless of the host's
+	// own TERM (unset in CI, tmux/screen locally).
+	if _, ok := merged["TERM"]; !ok {
+		merged["TERM"] = "xterm-256color"
+	}
 	c.Env = merged
 	if len(p.Session) > 0 {
 		c.Session = make([]spec.PTYAction, len(p.Session))

--- a/internal/engine/pty_test.go
+++ b/internal/engine/pty_test.go
@@ -119,6 +119,64 @@ scenarios:
 	}
 }
 
+// TestEngine_PTY_ExpectDoesNotRematchStale is a regression: each expect scans
+// only the transcript AFTER the previous match, so a pattern that appeared once
+// is not matched again from the stale buffer. "AAA" is printed exactly once, so
+// the second expect for it must NOT match and the step times out. With the
+// pre-fix whole-transcript match, the second expect matched the stale "AAA"
+// instantly and the step passed falsely. (printf, not cat+send, so terminal echo
+// does not duplicate the pattern.)
+func TestEngine_PTY_ExpectDoesNotRematchStale(t *testing.T) {
+	skipOnWindows(t)
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: s
+scenarios:
+  - name: a once-only pattern is not re-matched
+    steps:
+      - pty:
+          shell: true
+          command: 'printf "AAA\n"'
+          timeout: 1s
+          session:
+            - expect: "AAA"
+            - expect: "AAA"
+`)
+	if res.Status != StatusFailed {
+		t.Fatalf("status = %s, want failed (the second AAA expect must not match the stale one): %+v", res.Status, res.Scenarios)
+	}
+}
+
+// TestEngine_PTY_ExpectMatchesEachRecurringOccurrence proves the offset does not
+// over-consume: when a pattern genuinely recurs, consecutive expects match the
+// successive occurrences in order, so a normal prompt/response loop still passes.
+func TestEngine_PTY_ExpectMatchesEachRecurringOccurrence(t *testing.T) {
+	skipOnWindows(t)
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: s
+scenarios:
+  - name: two occurrences match two expects
+    steps:
+      - pty:
+          shell: true
+          command: 'printf "TICK\nTICK\n"'
+          timeout: 5s
+          session:
+            - expect: "TICK"
+            - expect: "TICK"
+      - assert:
+          exit_code: 0
+`)
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed: %+v", res.Status, res.Scenarios)
+	}
+}
+
 // TestEngine_PTY_SeesSuiteEnv proves suite.env reaches pty commands like it
 // reaches run steps (CodeRabbit finding on #12: the pty step dropped it).
 func TestEngine_PTY_SeesSuiteEnv(t *testing.T) {
@@ -140,6 +198,63 @@ scenarios:
           exit_code: 0
           stdout:
             contains: flag=from-suite-env
+`)
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed: %+v", res.Status, res.Scenarios)
+	}
+}
+
+// TestEngine_PTY_SetsDefaultTERM proves a pty step exports TERM=xterm-256color
+// by default. Without a sane TERM, full-screen TUIs (less, vim, htop) refuse to
+// draw ("terminal is not fully functional"), so a pty/screen assertion can never
+// see the real UI. atago renders through an xterm-compatible vt10x emulator, so
+// the default TERM matches the emulator and is deterministic regardless of the
+// host's own TERM (unset in CI, tmux/screen locally).
+func TestEngine_PTY_SetsDefaultTERM(t *testing.T) {
+	skipOnWindows(t)
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: s
+scenarios:
+  - name: pty exports a usable TERM
+    steps:
+      - pty:
+          shell: true
+          command: echo "TERM=[$TERM]"
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "TERM=[xterm-256color]"
+`)
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed: %+v", res.Status, res.Scenarios)
+	}
+}
+
+// TestEngine_PTY_RespectsExplicitTERM proves an author-set TERM wins over the
+// default, so a spec can pin a specific terminal type when a program's behavior
+// depends on it.
+func TestEngine_PTY_RespectsExplicitTERM(t *testing.T) {
+	skipOnWindows(t)
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: s
+scenarios:
+  - name: explicit TERM wins
+    steps:
+      - pty:
+          shell: true
+          command: echo "TERM=[$TERM]"
+          env:
+            TERM: dumb
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "TERM=[dumb]"
 `)
 	if res.Status != StatusPassed {
 		t.Fatalf("status = %s, want passed: %+v", res.Status, res.Scenarios)

--- a/internal/runner/cmd/cmd.go
+++ b/internal/runner/cmd/cmd.go
@@ -219,11 +219,14 @@ func CommandLine(command string, shell bool) (string, []string, error) {
 	return fields[0], fields[1:], nil
 }
 
-// splitArgv tokenizes a no-shell command into argv fields. POSIX uses shell
-// word-splitting rules (quotes and backslash escapes); Windows uses
-// windowsFields, where a backslash is an ordinary path character — POSIX
-// backslash-escape semantics would corrupt every C:\ path (e.g. the expanded
-// ${atago} binary path).
+// splitArgv tokenizes a no-shell command into argv fields. On POSIX it uses
+// go-shellwords for quote handling; note its backslash escapes are C-style, not
+// sh-style — `\t`/`\n` become a real tab/newline (sh would drop the backslash
+// and keep the letter), and a trailing `\` is an error rather than a line
+// continuation. Quote your command or set shell: true if you need a literal
+// backslash. Windows uses windowsFields, where a backslash is an ordinary path
+// character — sh backslash-escape semantics would corrupt every C:\ path (e.g.
+// the expanded ${atago} binary path).
 func splitArgv(command string) ([]string, error) {
 	if runtime.GOOS == "windows" {
 		return windowsFields(command)

--- a/internal/runner/cmd/cmd.go
+++ b/internal/runner/cmd/cmd.go
@@ -118,7 +118,7 @@ func (r *Runner) Run(ctx context.Context, run *spec.Run, workdir string) (*runne
 	// instead of asserting against the killed result (issue #30).
 	if err := ctx.Err(); err != nil {
 		res.ExitCode = -1
-		return res, fmt.Errorf("run %q cancelled: %w", run.Command, err)
+		return res, fmt.Errorf("run %q canceled: %w", run.Command, err)
 	}
 
 	var exitErr *exec.ExitError

--- a/internal/runner/grpc/grpc.go
+++ b/internal/runner/grpc/grpc.go
@@ -105,6 +105,15 @@ func (r *Runner) Invoke(ctx context.Context, method string, header map[string]st
 	if !ok {
 		return nil, fmt.Errorf("grpc invoke %s: %w", method, invErr)
 	}
+	// A non-nil ctx error means OUR per-call deadline (run.timeout) or a cancel
+	// fired: the call never completed, so it is a transport failure, not a
+	// captured status. status.FromError otherwise maps a timed-out/dropped call
+	// to codes.DeadlineExceeded(4)/Unavailable(14) with ok=true, which would be
+	// recorded as a passing Result — a false pass against a hung or unreachable
+	// server unless the spec happens to assert grpc_status.
+	if invErr != nil && ctx.Err() != nil {
+		return nil, fmt.Errorf("grpc invoke %s: %w", method, ctx.Err())
+	}
 
 	out := &runner.Result{Command: method, IsGRPC: true, GRPCStatus: int(stat.Code())}
 	if stat.Code() == codes.OK {
@@ -149,11 +158,17 @@ func (r *Runner) resolveMethod(ctx context.Context, service, method string) (pro
 	return nil, fmt.Errorf("grpc service %q not found in the reflected schema", service)
 }
 
-// splitMethod parses "pkg.Service/Method" into its service and method parts.
+// splitMethod parses "pkg.Service/Method" into its service and method parts. A
+// single leading slash is tolerated (the fully-qualified "/pkg.Service/Method"
+// form gRPC itself uses), but there must be exactly one internal slash — using
+// strings.LastIndex would silently accept "/pkg.Service/Method" as service
+// "/pkg.Service" and "a/b/c" as service "a/b", then fail later with a confusing
+// reflection error instead of a clear format message.
 func splitMethod(method string) (string, string, error) {
-	i := strings.LastIndex(method, "/")
-	if i <= 0 || i == len(method)-1 {
+	m := strings.TrimPrefix(method, "/")
+	i := strings.IndexByte(m, '/')
+	if i <= 0 || i == len(m)-1 || strings.Contains(m[i+1:], "/") {
 		return "", "", fmt.Errorf("grpc method %q must be in the form pkg.Service/Method", method)
 	}
-	return method[:i], method[i+1:], nil
+	return m[:i], m[i+1:], nil
 }

--- a/internal/runner/grpc/grpc_test.go
+++ b/internal/runner/grpc/grpc_test.go
@@ -18,9 +18,14 @@ func TestSplitMethod(t *testing.T) {
 	}{
 		{in: "pkg.Service/Method", svc: "pkg.Service", method: "Method"},
 		{in: "a.b.c.Svc/Do", svc: "a.b.c.Svc", method: "Do"},
+		// A single leading slash (the fully-qualified gRPC form) is tolerated.
+		{in: "/pkg.Service/Method", svc: "pkg.Service", method: "Method"},
 		{in: "NoSlash", wantErr: true},
 		{in: "/Method", wantErr: true},
 		{in: "Svc/", wantErr: true},
+		// More than one internal slash is a malformed method, not a nested service.
+		{in: "a/b/c", wantErr: true},
+		{in: "/pkg.Service/Method/extra", wantErr: true},
 		{in: "", wantErr: true},
 	}
 	for _, tt := range tests {
@@ -38,6 +43,32 @@ func TestSplitMethod(t *testing.T) {
 		if svc != tt.svc || method != tt.method {
 			t.Errorf("splitMethod(%q) = %q, %q; want %q, %q", tt.in, svc, method, tt.svc, tt.method)
 		}
+	}
+}
+
+// TestInvoke_CallTimeoutIsError is a regression: a unary call that hangs past
+// the per-call timeout must be a hard error, not a passing Result. status.From
+// Error maps a client-deadline DeadlineExceeded to ok=true, which would
+// otherwise be recorded as a normal Result{GRPCStatus:4} and pass against a hung
+// server unless the spec happened to assert grpc_status.
+func TestInvoke_CallTimeoutIsError(t *testing.T) {
+	t.Parallel()
+	ts := grpcstub.NewServer(t, "testdata/greeter.proto")
+	t.Cleanup(func() { ts.Close() })
+	ts.Method("SayHello").Handler(func(_ *grpcstub.Request) *grpcstub.Response {
+		time.Sleep(2 * time.Second) // longer than the client's per-call timeout
+		return grpcstub.NewResponse()
+	})
+
+	r, err := Open(Config{Target: ts.Addr(), Timeout: 300 * time.Millisecond})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+
+	out, err := r.Invoke(context.Background(), "atago.test.Greeter/SayHello", nil, []byte(`{"name":"x"}`))
+	if err == nil {
+		t.Fatalf("Invoke against a hung handler returned no error; got Result %+v (a timed-out call must be an error, not a passing status)", out)
 	}
 }
 

--- a/internal/runner/grpc/grpc_test.go
+++ b/internal/runner/grpc/grpc_test.go
@@ -52,7 +52,11 @@ func TestSplitMethod(t *testing.T) {
 // otherwise be recorded as a normal Result{GRPCStatus:4} and pass against a hung
 // server unless the spec happened to assert grpc_status.
 func TestInvoke_CallTimeoutIsError(t *testing.T) {
-	t.Parallel()
+	// NOT parallel: grpcstub.NewServer registers the proto into the global
+	// protoregistry with a check-then-register that races another grpcstub server
+	// spun up in parallel (TestInvoke_RepeatedReflectionCallsSucceed), panicking
+	// with "file already registered". Running sequentially, the first registration
+	// wins and the second is skipped.
 	ts := grpcstub.NewServer(t, "testdata/greeter.proto")
 	t.Cleanup(func() { ts.Close() })
 	ts.Method("SayHello").Handler(func(_ *grpcstub.Request) *grpcstub.Response {

--- a/internal/runner/ptyrun/ptyrun_unix.go
+++ b/internal/runner/ptyrun/ptyrun_unix.go
@@ -173,22 +173,45 @@ func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runne
 
 	// Drive the session in order. expect polls the transcript; send writes to
 	// the terminal; an empty send transmits EOF (^D).
+	//
+	// matchOffset is the byte index just past the previously matched expect: each
+	// expect scans only transcript[matchOffset:], so a pattern that recurs (any
+	// shell prompt) waits for its NEXT occurrence instead of matching the stale
+	// earlier one. Without it, a second `expect "PROMPT> "` matches the first
+	// prompt already in the buffer and the session races ahead — a false pass for
+	// exactly the interactive flows this feature exists for.
+	matchOffset := 0
 	for i, a := range p.Session {
 		if expects[i] != nil {
 			matched := false
-			for !matched {
-				if expects[i].Match(snapshot()) {
+			for {
+				if loc := expects[i].FindIndex(snapshot()[matchOffset:]); loc != nil {
+					matchOffset += loc[1]
 					matched = true
 					break
 				}
 				select {
 				case <-ctx.Done():
+					// One last check: bytes may have landed in the final poll
+					// window before the deadline fired.
+					if loc := expects[i].FindIndex(snapshot()[matchOffset:]); loc != nil {
+						matchOffset += loc[1]
+						matched = true
+					}
 				case <-time.After(pollInterval):
 					continue
 				}
 				break
 			}
 			if !matched {
+				// A parent-context cancellation (Ctrl-C / suite cancel) is an
+				// execution error that must stop the scenario, not an expect
+				// failure the engine asserts against — mirroring the cmd runner's
+				// cancel/timeout split (#30). Only a genuine session-budget timeout
+				// (DeadlineExceeded) becomes an ExpectFailure.
+				if errors.Is(ctx.Err(), context.Canceled) {
+					return failHard(fmt.Errorf("pty %q cancelled: %w", p.Command, ctx.Err()))
+				}
 				return abort(&ExpectFailure{Pattern: a.Expect, Transcript: string(snapshot())})
 			}
 			continue
@@ -208,6 +231,11 @@ func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runne
 	case waitErr := <-waitCh:
 		return finish(false, waitErr, nil)
 	case <-ctx.Done():
+		// A parent cancellation is a hard error; a session-budget timeout is a
+		// normal timed-out result (#30).
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return failHard(fmt.Errorf("pty %q cancelled: %w", p.Command, ctx.Err()))
+		}
 		return abort(nil)
 	}
 }

--- a/internal/runner/ptyrun/ptyrun_unix.go
+++ b/internal/runner/ptyrun/ptyrun_unix.go
@@ -171,6 +171,14 @@ func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runne
 		return nil, nil, err
 	}
 
+	// canceledResult surfaces a parent-context cancellation (Ctrl-C / suite
+	// cancel) as a hard execution error, so the engine stops the scenario instead
+	// of asserting against a killed terminal — mirroring the cmd runner's
+	// cancel/timeout split (#30). Shared by both ctx.Done() sites below.
+	canceledResult := func() (*runner.Result, *ExpectFailure, error) {
+		return failHard(fmt.Errorf("pty %q canceled: %w", p.Command, ctx.Err()))
+	}
+
 	// Drive the session in order. expect polls the transcript; send writes to
 	// the terminal; an empty send transmits EOF (^D).
 	//
@@ -204,13 +212,11 @@ func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runne
 				break
 			}
 			if !matched {
-				// A parent-context cancellation (Ctrl-C / suite cancel) is an
-				// execution error that must stop the scenario, not an expect
-				// failure the engine asserts against — mirroring the cmd runner's
-				// cancel/timeout split (#30). Only a genuine session-budget timeout
+				// A parent-context cancellation is an execution error that must stop
+				// the scenario; only a genuine session-budget timeout
 				// (DeadlineExceeded) becomes an ExpectFailure.
 				if errors.Is(ctx.Err(), context.Canceled) {
-					return failHard(fmt.Errorf("pty %q canceled: %w", p.Command, ctx.Err()))
+					return canceledResult()
 				}
 				return abort(&ExpectFailure{Pattern: a.Expect, Transcript: string(snapshot())})
 			}
@@ -234,7 +240,7 @@ func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runne
 		// A parent cancellation is a hard error; a session-budget timeout is a
 		// normal timed-out result (#30).
 		if errors.Is(ctx.Err(), context.Canceled) {
-			return failHard(fmt.Errorf("pty %q canceled: %w", p.Command, ctx.Err()))
+			return canceledResult()
 		}
 		return abort(nil)
 	}

--- a/internal/runner/ptyrun/ptyrun_unix.go
+++ b/internal/runner/ptyrun/ptyrun_unix.go
@@ -210,7 +210,7 @@ func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runne
 				// cancel/timeout split (#30). Only a genuine session-budget timeout
 				// (DeadlineExceeded) becomes an ExpectFailure.
 				if errors.Is(ctx.Err(), context.Canceled) {
-					return failHard(fmt.Errorf("pty %q cancelled: %w", p.Command, ctx.Err()))
+					return failHard(fmt.Errorf("pty %q canceled: %w", p.Command, ctx.Err()))
 				}
 				return abort(&ExpectFailure{Pattern: a.Expect, Transcript: string(snapshot())})
 			}
@@ -234,7 +234,7 @@ func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runne
 		// A parent cancellation is a hard error; a session-budget timeout is a
 		// normal timed-out result (#30).
 		if errors.Is(ctx.Err(), context.Canceled) {
-			return failHard(fmt.Errorf("pty %q cancelled: %w", p.Command, ctx.Err()))
+			return failHard(fmt.Errorf("pty %q canceled: %w", p.Command, ctx.Err()))
 		}
 		return abort(nil)
 	}

--- a/internal/runner/service/service.go
+++ b/internal/runner/service/service.go
@@ -167,10 +167,23 @@ func (p *Proc) waitReady(ctx context.Context, r *spec.Ready, workdir string) (st
 			return "", fmt.Errorf("invalid ready.delay %q: %w", r.Delay, err)
 		}
 		select {
-		case <-time.After(d):
-			return "", nil
 		case <-ctx.Done():
 			return "", ctx.Err()
+		case <-p.done:
+			// The process exited during the delay window: it is not ready, matching
+			// how the file/port/log probes detect an early exit via p.done. Without
+			// this, a command that crashes (e.g. `exit 3`) during the delay was
+			// reported READY and the scenario ran against a dead peer.
+			return "", fmt.Errorf("service exited before it became ready")
+		case <-time.After(d):
+			// Delay elapsed with the process still running — unless it exited in the
+			// same instant; check once more so a crash at the boundary is not missed.
+			select {
+			case <-p.done:
+				return "", fmt.Errorf("service exited before it became ready")
+			default:
+				return "", nil
+			}
 		}
 	case r.File != "":
 		path, err := security.ResolveWorkdirPath("service.ready.file", workdir, r.File)
@@ -179,6 +192,13 @@ func (p *Proc) waitReady(ctx context.Context, r *spec.Ready, workdir string) (st
 		}
 		return p.waitFile(ctx, path, r.Store, timeout)
 	case r.Port != "":
+		// A bare port ("9997") makes every dial fail with "missing port in
+		// address", which the probe swallows and then runs to the full timeout —
+		// a slow, misleading failure. Reject a host-less value up front with a
+		// clear message (":9997" for any host, "127.0.0.1:9997" for loopback).
+		if _, _, err := net.SplitHostPort(r.Port); err != nil {
+			return "", fmt.Errorf("invalid ready.port %q (use host:port, e.g. 127.0.0.1:8080 or :8080): %w", r.Port, err)
+		}
 		dialer := net.Dialer{Timeout: pollInterval}
 		return "", p.poll(ctx, timeout, func() bool {
 			conn, err := dialer.DialContext(ctx, "tcp", r.Port)

--- a/internal/runner/service/service.go
+++ b/internal/runner/service/service.go
@@ -8,6 +8,7 @@ package service
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -20,6 +21,11 @@ import (
 	"github.com/nao1215/atago/internal/security"
 	"github.com/nao1215/atago/internal/spec"
 )
+
+// errExitedEarly is the readiness failure when the service process exits before
+// its probe (delay/file/port/log) succeeds. Shared so every wait path words it
+// identically.
+var errExitedEarly = errors.New("service exited before it became ready")
 
 // defaultReadyTimeout bounds a readiness probe when the spec omits one.
 const defaultReadyTimeout = 5 * time.Second
@@ -174,13 +180,13 @@ func (p *Proc) waitReady(ctx context.Context, r *spec.Ready, workdir string) (st
 			// how the file/port/log probes detect an early exit via p.done. Without
 			// this, a command that crashes (e.g. `exit 3`) during the delay was
 			// reported READY and the scenario ran against a dead peer.
-			return "", fmt.Errorf("service exited before it became ready")
+			return "", errExitedEarly
 		case <-time.After(d):
 			// Delay elapsed with the process still running — unless it exited in the
 			// same instant; check once more so a crash at the boundary is not missed.
 			select {
 			case <-p.done:
-				return "", fmt.Errorf("service exited before it became ready")
+				return "", errExitedEarly
 			default:
 				return "", nil
 			}
@@ -257,7 +263,7 @@ func (p *Proc) poll(ctx context.Context, timeout time.Duration, check func() boo
 			if check() {
 				return nil
 			}
-			return fmt.Errorf("service exited before it became ready")
+			return errExitedEarly
 		case <-deadline.C:
 			return fmt.Errorf("timed out after %s waiting for readiness", timeout)
 		case <-ctx.Done():

--- a/internal/runner/service/service_test.go
+++ b/internal/runner/service/service_test.go
@@ -115,6 +115,51 @@ func TestStart_ReadinessErrorOmitsEmptyOutput(t *testing.T) {
 	}
 }
 
+// TestStart_DelayReadyDetectsEarlyExit is a regression: a `ready.delay` service
+// whose command exits during the delay window must fail readiness, not be
+// reported ready — otherwise the scenario runs against a dead peer. The
+// file/port/log probes already detect early exit; the delay branch did not.
+func TestStart_DelayReadyDetectsEarlyExit(t *testing.T) {
+	wd := t.TempDir()
+	svc := &spec.Service{
+		Name:    "crasher",
+		Shell:   spec.Bool(true),
+		Command: "exit 3", // exits immediately, well within the delay
+		Ready:   &spec.Ready{Delay: "2s"},
+	}
+	_, _, err := Start(context.Background(), svc, wd)
+	if err == nil {
+		t.Fatal("Start() error = nil, want 'exited before it became ready'")
+	}
+	if !strings.Contains(err.Error(), "exited before it became ready") {
+		t.Errorf("error = %v, want it to report the early exit", err)
+	}
+}
+
+// TestStart_BarePortReadyRejected is a regression: a host-less ready.port must
+// fail fast with a clear message, not swallow "missing port in address" and run
+// to the full readiness timeout.
+func TestStart_BarePortReadyRejected(t *testing.T) {
+	wd := t.TempDir()
+	svc := &spec.Service{
+		Name:    "svc",
+		Shell:   spec.Bool(true),
+		Command: sleepCmd(5),
+		Ready:   &spec.Ready{Port: "9997", Timeout: "5s"}, // no host
+	}
+	start := time.Now()
+	_, _, err := Start(context.Background(), svc, wd)
+	if err == nil {
+		t.Fatal("Start() error = nil, want an invalid-port error")
+	}
+	if !strings.Contains(err.Error(), "invalid ready.port") {
+		t.Errorf("error = %v, want it to name the invalid ready.port", err)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("took %s; a bare port must fail fast, not run to the readiness timeout", elapsed)
+	}
+}
+
 // On a readiness failure, Start returns the stopped Proc so the caller can still
 // read its captured output to preserve it as a log artifact (#51).
 func TestStart_ReadinessFailureReturnsProcForLogCapture(t *testing.T) {

--- a/internal/runner/ssh/ssh.go
+++ b/internal/runner/ssh/ssh.go
@@ -170,9 +170,23 @@ func hostKeyCallback(knownHosts string, insecure bool) (ssh.HostKeyCallback, err
 	return cb, nil
 }
 
+// withDefaultPort appends the default SSH port 22 when addr carries none. It
+// must handle a bare IPv6 literal without mangling it: net.JoinHostPort on an
+// already-bracketed "[::1]" would double-bracket it ("[[::1]]:22"), and a
+// trailing-colon "host:" parses as a present-but-empty port that must still get
+// the default.
 func withDefaultPort(addr string) string {
-	if _, _, err := net.SplitHostPort(addr); err == nil {
-		return addr
+	if host, port, err := net.SplitHostPort(addr); err == nil {
+		if port != "" {
+			return addr
+		}
+		return net.JoinHostPort(host, "22") // "host:" → "host:22"
 	}
-	return net.JoinHostPort(addr, "22")
+	// No port present. Strip surrounding brackets from a bracketed IPv6 literal
+	// so JoinHostPort re-wraps it exactly once.
+	host := addr
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		host = host[1 : len(host)-1]
+	}
+	return net.JoinHostPort(host, "22")
 }

--- a/internal/runner/ssh/ssh_test.go
+++ b/internal/runner/ssh/ssh_test.go
@@ -9,6 +9,14 @@ func TestWithDefaultPort(t *testing.T) {
 		"example.com:2222": "example.com:2222",
 		"127.0.0.1":        "127.0.0.1:22",
 		"127.0.0.1:22":     "127.0.0.1:22",
+		// IPv6 literals must not be double-bracketed, and a bracketed literal
+		// without a port must gain one.
+		"::1":        "[::1]:22",
+		"[::1]":      "[::1]:22",
+		"[::1]:2222": "[::1]:2222",
+		"[fe80::1]":  "[fe80::1]:22",
+		// A trailing-colon host has an empty port that must still get the default.
+		"host:": "host:22",
 	}
 	for in, want := range cases {
 		if got := withDefaultPort(in); got != want {

--- a/test/e2e/atago/tui.atago.yaml
+++ b/test/e2e/atago/tui.atago.yaml
@@ -1,0 +1,95 @@
+version: "1"
+
+# pty/TUI behavior against the real terminal (#8, #27): a pty step must export a
+# usable TERM so full-screen programs draw, and each expect must consume its
+# match so a recurring prompt is not matched from stale history. POSIX-only.
+
+suite:
+  name: atago self-hosting / tui
+
+scenarios:
+  # A pty child gets TERM=xterm-256color by default — without it, ncurses/termios
+  # programs refuse full-screen mode ("terminal is not fully functional").
+  - name: a pty step exports a usable TERM by default
+    skip:
+      os: windows
+    steps:
+      - pty:
+          shell: true
+          command: 'echo "TERM=[$TERM]"'
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "TERM=[xterm-256color]"
+
+  # An author-set TERM wins over the default.
+  - name: an explicit TERM overrides the default
+    skip:
+      os: windows
+    steps:
+      - pty:
+          shell: true
+          command: 'echo "TERM=[$TERM]"'
+          env:
+            TERM: vt100
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "TERM=[vt100]"
+
+  # Each expect scans only the transcript after the previous match: "AAA" is
+  # printed once, so a second expect for it must NOT match the stale one and the
+  # session must time out (proving it cannot race ahead on a recurring prompt).
+  - name: an expect does not re-match a consumed pattern
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: inner.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: inner
+            scenarios:
+              - name: stale expect must not re-match
+                steps:
+                  - pty:
+                      shell: true
+                      command: 'printf "AAA\n"'
+                      timeout: 1s
+                      session:
+                        - expect: "AAA"
+                        - expect: "AAA"
+      - run:
+          command: ${atago} run inner.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains: "1 failed"
+
+  # A REAL third-party TUI pager: less -X keeps its output on the primary screen,
+  # so after quitting the rendered screen still shows the file. (less using the
+  # alternate screen would restore a blank primary screen on exit — documented in
+  # examples/pty.atago.yaml.) Gated on less being installed.
+  - name: less -X renders a real pager onto the screen
+    skip:
+      os: windows
+    only:
+      command: command -v less
+    steps:
+      - fixture:
+          file: page.txt
+          content: "Alpha line\nBeta line\nGamma line\n"
+      - pty:
+          command: less -X page.txt
+          rows: 10
+          cols: 40
+          session:
+            - expect: "Alpha line"
+            - send: "q"
+      - assert:
+          screen:
+            contains: "Alpha line"
+      - assert:
+          screen:
+            contains: "Gamma line"


### PR DESCRIPTION
## Summary

A third bug-hunting pass, this time over the runner packages (`ptyrun`, `cmd`, `grpc`, `service`, `ssh`, `browser`, `mock`) and `cli`, driven partly by adding **real third-party TUI tests** — which immediately surfaced two pty gaps. No new features; every fix ships with a regression test. `go build`, `go test ./...`, `go vet`, and `golangci-lint` are green.

## pty / TUI (found by testing a real pager)

Testing `less` through a `pty` step failed two ways, both now fixed:

- **No `TERM` was set**, so full-screen TUIs printed `WARNING: terminal is not fully functional` and refused to draw — a pty/`screen` assertion never saw the real UI. A pty child now exports `TERM=xterm-256color` by default (matching the vt10x screen emulator), overridable via `env: {TERM: ...}`, deterministic regardless of the host's TERM (unset in CI, tmux/screen locally).
- **`expect` re-scanned the whole cumulative transcript**, so a recurring pattern (any shell prompt) matched a *stale* earlier occurrence and the session raced ahead — a false pass for interactive flows. Each `expect` now scans only the transcript after the previous match.
- A parent-context **cancellation** (Ctrl-C / suite cancel) during a pty step is now an execution error, not a spurious expect failure/timeout (mirrors the cmd runner, #30).
- Documented the **alt-screen-restore caveat** (a TUI that uses the alternate screen buffer and quits cleanly leaves a blank final screen) in `examples/pty.atago.yaml`, and added a real `less -X` pager to the e2e suite (gated on `less` being installed).

## grpc

- A call that **times out or drops** (our per-call deadline fired) is now a transport error, not a passing `Result`. `status.FromError` maps a client-deadline `DeadlineExceeded`/`Unavailable` to `ok=true`, which was recorded as a normal result and passed against a hung/unreachable server unless the spec asserted `grpc_status`.
- `method` accepts the fully-qualified `/pkg.Service/Method` form and rejects extra internal slashes, instead of mis-parsing `/pkg.Service/Method` as service `/pkg.Service`.

## service

- `ready.delay` now **fails if the process exits during the delay window** (matching the file/port/log probes), instead of reporting a dead service ready.
- A host-less `ready.port` (`9997` vs `:9997`) **fails fast** with a clear message instead of swallowing "missing port in address" and running to the full timeout.

## ssh

- `withDefaultPort` no longer double-brackets an IPv6 literal (`[::1]` → `[::1]:22`, not `[[::1]]:22`) and supplies a port for a trailing-colon host.

## cli

- `--rerun-failed` no longer reports a **false green** — and no longer **deletes the recorded failures** — when the recorded scenario names no longer match the specs (renamed/removed while still broken). It warns, keeps the state, and exits non-zero.
- `doc` rejects `--out` combined with `--split-by-spec` instead of silently ignoring `--out`.
- Corrected the `splitArgv` comment: `shell: false` uses C-style (not sh) backslash escapes.

## Testing

`go build ./...`, `go test ./...`, `go vet ./...`, `golangci-lint run` — all green. New regression tests accompany every fix, including a real-TUI e2e (`test/e2e/atago/tui.atago.yaml`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved terminal/PTY behavior for full-screen apps, including a better default `TERM` and support for overriding it.
  * Added clearer SSH host handling for IPv6 and addresses with missing ports.

* **Bug Fixes**
  * Fixed repeated prompt matching so `expect` steps advance through new output instead of reusing stale matches.
  * Improved cancellation and timeout handling so interrupted or dropped runs fail correctly.
  * Tightened readiness checks for services and gRPC calls, with faster and clearer failures.
  * Fixed `--rerun-failed` and documentation output flag handling edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->