### PR TITLE
chore(release): prepare v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-07-05
+
+A bug-fix release — correctness and UX hardening across the assertion engine,
+the loader, and every runner (command, pty/TUI, HTTP, gRPC, database, SSH,
+background services), plus the record/snapshot/report tooling. No new features.
+
+Highlights: two security fixes (an HTTP redirect could follow an allowed host
+onto a denied one, bypassing `permissions.network.allow`; a `mode`/`mtime`-only
+fixture could follow a planted symlink and re-permission a file outside the
+workdir), and pty/TUI fixes that make real full-screen programs testable at last
+(a usable default `TERM`, and an `expect` that no longer matches a stale earlier
+prompt and races the session ahead).
+
 ### Fixed
 
 - A `pty` step now exports `TERM=xterm-256color` by default (overridable via


### PR DESCRIPTION
## v0.3.1 — bug-fix release

Correctness and UX hardening across the assertion engine, the loader, and every runner (command, pty/TUI, HTTP, gRPC, database, SSH, background services), plus the record/snapshot/report tooling. **No new features.** Every fix landed with a regression test (merged via #85 and #86).

### Highlights

**Security**
- The HTTP runner re-checks the network allowlist on every redirect hop — an allowed host could 3xx-redirect the client onto a denied host and bypass `permissions.network.allow`.
- A `mode`/`mtime`-only `fixture` refuses a planted symlink at the destination — `chmod`/`chtimes` follow symlinks and could re-permission a file outside the workdir.

**pty / TUI** (found by testing a real pager)
- A pty child now exports `TERM=xterm-256color` by default, so full-screen TUIs actually draw instead of printing "terminal is not fully functional".
- `expect` scans only the transcript after the previous match, so a recurring prompt waits for its next occurrence instead of matching a stale earlier one and racing the session ahead.
- A pty cancellation surfaces as an execution error, not a spurious expect failure.

**Correctness**
- `json`/`yaml` `equals` no longer treats different numeric strings (`"1.2.3"` vs `"1.2.9"`) as equal; numeric coercion handles unsigned integers; `length` counts characters, not bytes.
- Secret masking is longest-first (a short secret that is a substring of a longer one no longer leaks the remainder).
- gRPC: a timed-out/dropped call is a transport error, not a passing status; `method` accepts the fully-qualified `/pkg.Service/Method` form.
- service: `ready.delay` fails on early exit; a host-less `ready.port` fails fast.
- ssh: `withDefaultPort` stops mangling IPv6 literals (`[::1]` → `[::1]:22`).
- snapshot normalization strips private-mode/OSC escapes and folds CRLF in the stored golden; `line: N` addresses a trailing blank line.
- `atago record` escapes control bytes so tab/newline output round-trips instead of corrupting the generated spec.

**CLI / validation**
- `--rerun-failed` no longer greenlights or clears recorded failures when the recorded scenarios no longer match.
- Load-time guards: empty-string `contains`, `store.from` selector syntax, `store.name`/`matrix` keys shadowing built-ins, `doc --out` + `--split-by-spec`.

**Docs**
- Regenerated the stale `snapshot.gif` (still showed the pre-rename `b3spec`); documented the pty alt-screen caveat; added `not_equals` / `min_count` / `max_count` examples and a real-TUI (`less -X`) e2e.

See the [CHANGELOG](CHANGELOG.md) for the full list.