### PR TITLE
fix(report): mark a flaky scenario as a passing ok point in TAP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- The TAP report now emits a passing `ok` point for a flaky scenario (one that
+  failed and then passed under `--retry-failed`), matching the exit code and the
+  console, gha, and junit reports, which all treat a recovered scenario as green.
+  TAP previously fell through to `not ok`, so a CI step consuming the TAP stream
+  read the run as failed even though atago exited 0; the recovery now stays
+  visible in the point's diagnostic instead of flipping the verdict.
+
 ## [0.3.1] - 2026-07-05
 
 A bug-fix release — correctness and UX hardening across the assertion engine,

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -184,6 +184,98 @@ func TestRender_TAP(t *testing.T) {
 	}
 }
 
+// flakyResults builds a suite whose single scenario failed once and then passed
+// on retry (#29). atago treats a recovered scenario as green: the process exits 0
+// (exitForSuite), the console verdict stays PASSED, gha warns instead of erroring,
+// and junit records it as a passed testcase. Every report format must agree on
+// that verdict, so a flaky scenario is a pass and never a failure.
+func flakyResults() []*engine.SuiteResult {
+	return []*engine.SuiteResult{{
+		Suite:    "s1",
+		Status:   engine.StatusPassed,
+		Duration: 3 * time.Millisecond,
+		Scenarios: []engine.ScenarioResult{
+			{Name: "flake", Status: engine.StatusFlaky, Attempts: 2, Duration: time.Millisecond, Steps: []engine.StepResult{
+				{Kind: "assert", Checks: []*assert.CheckResult{{OK: true}}},
+			}},
+		},
+	}}
+}
+
+// TestRender_FlakyIsGreenAcrossFormats is a metamorphic parity check: a scenario
+// that recovered on retry (StatusFlaky) reads as a pass in every report format,
+// matching the exit code and the console verdict. TAP fell through to a `not ok`
+// point, contradicting the green verdict the same run reported everywhere else.
+func TestRender_FlakyIsGreenAcrossFormats(t *testing.T) {
+	t.Parallel()
+
+	t.Run("tap marks a flaky scenario ok, not failed", func(t *testing.T) {
+		t.Parallel()
+		var b bytes.Buffer
+		if err := Render(&b, FormatTAP, flakyResults()); err != nil {
+			t.Fatal(err)
+		}
+		out := b.String()
+		if strings.Contains(out, "not ok") {
+			t.Errorf("TAP reported a flaky scenario as failed; a recovered scenario is green:\n%s", out)
+		}
+		if !strings.Contains(out, "ok 1 - s1 / flake") {
+			t.Errorf("TAP should mark the flaky scenario as an ok point:\n%s", out)
+		}
+		// Green for the verdict, but the recovery stays visible, matching gha's
+		// warning and junit's flakyFailure element.
+		if !strings.Contains(out, "flaky: passed after 2 attempts") {
+			t.Errorf("TAP should keep the flaky recovery visible in a diagnostic:\n%s", out)
+		}
+	})
+
+	t.Run("junit counts a flaky scenario as passed", func(t *testing.T) {
+		t.Parallel()
+		var b bytes.Buffer
+		if err := Render(&b, FormatJUnit, flakyResults()); err != nil {
+			t.Fatal(err)
+		}
+		var root junitTestsuites
+		if err := xml.Unmarshal(b.Bytes(), &root); err != nil {
+			t.Fatalf("JUnit output is not valid XML: %v\n%s", err, b.String())
+		}
+		if root.Tests != 1 || root.Failures != 0 || root.Errors != 0 || root.Skipped != 0 {
+			t.Errorf("counts = tests %d failures %d errors %d skipped %d, want 1/0/0/0",
+				root.Tests, root.Failures, root.Errors, root.Skipped)
+		}
+	})
+
+	t.Run("gha warns instead of erroring on a flaky scenario", func(t *testing.T) {
+		t.Parallel()
+		var b bytes.Buffer
+		if err := Render(&b, FormatGHA, flakyResults()); err != nil {
+			t.Fatal(err)
+		}
+		out := b.String()
+		if strings.Contains(out, "::error") {
+			t.Errorf("gha emitted an error annotation for a flaky (green) scenario:\n%s", out)
+		}
+		if !strings.Contains(out, "::warning title=s1 / flake::") {
+			t.Errorf("gha should warn on a flaky scenario:\n%s", out)
+		}
+	})
+
+	t.Run("console verdict stays PASSED with a flaky scenario", func(t *testing.T) {
+		t.Parallel()
+		var b bytes.Buffer
+		if err := Render(&b, FormatConsole, flakyResults()); err != nil {
+			t.Fatal(err)
+		}
+		out := b.String()
+		if strings.Contains(out, "FAILED") {
+			t.Errorf("console verdict flipped to FAILED for a flaky (green) scenario:\n%s", out)
+		}
+		if !strings.Contains(out, "1 flaky") {
+			t.Errorf("console should surface the flaky count:\n%s", out)
+		}
+	})
+}
+
 func TestProgress_Markers(t *testing.T) {
 	t.Parallel()
 	var b bytes.Buffer

--- a/internal/report/tap.go
+++ b/internal/report/tap.go
@@ -33,6 +33,13 @@ func writeTAP(w io.Writer, results []*engine.SuiteResult) error {
 				fmt.Fprintf(&b, "ok %d - %s\n", n, name)
 			case engine.StatusSkipped:
 				fmt.Fprintf(&b, "ok %d - %s # SKIP %s\n", n, name, tapInline(sc.SkipReason))
+			case engine.StatusFlaky:
+				// A scenario that failed and then passed on retry (#29) is green
+				// for the verdict, matching the exit code, console, gha, and
+				// junit. Emit a passing point so a TAP consumer agrees, and keep
+				// the recovery visible in the diagnostic rather than hiding it.
+				fmt.Fprintf(&b, "ok %d - %s\n", n, name)
+				writeTAPDiagnostic(&b, fmt.Sprintf("flaky: passed after %d attempts", sc.Attempts), detailText(sc))
 			case engine.StatusFailed:
 				fmt.Fprintf(&b, "not ok %d - %s\n", n, name)
 				writeTAPDiagnostic(&b, firstFailureMessage(sc), detailText(sc))


### PR DESCRIPTION
## Summary

The TAP report contradicted every other format on a flaky scenario. A scenario that failed and then passed under `--retry-failed` (StatusFlaky) is green everywhere else: the process exits 0 (`exitForSuite`), the console verdict stays PASSED, gha emits `::warning::` rather than `::error::`, and junit records the testcase as passed. TAP had no `case StatusFlaky` and fell through to `not ok`, so a CI step consuming the TAP stream saw the run as failed even though atago itself reported success. This is a report-format parity defect: the same run yields opposite verdicts depending on the chosen format.

## Changes

- `internal/report/tap.go`: add a `StatusFlaky` case to `writeTAP` that emits a passing `ok` point and records the recovery in the point's YAML diagnostic (`flaky: passed after N attempts`), mirroring junit's `flakyFailure` element and gha's warning.
- `internal/report/report_test.go`: add `TestRender_FlakyIsGreenAcrossFormats`, a metamorphic parity check asserting a flaky scenario reads as green in TAP, junit, gha, and console. The TAP subtest reproduces the bug (it saw `not ok` before the fix); the other three already passed and pin the oracle.
- `CHANGELOG.md`: note the fix under Unreleased.

## Design Decisions

TAP 13 has no standard directive for a flaky test, so the fix follows atago's existing "green for the verdict, never hidden" convention (#29): the point is `ok` so consumers agree with the exit code, and the recovery stays visible in the diagnostic instead of flipping the verdict to a failure. The regression lives at the report-package level because the defect is pure rendering logic and that layer is deterministic; reproducing it through a real flaky run would require non-deterministic retry state, which does not belong in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Flaky scenarios that recover after retries now show as passing in TAP output.
  * Retry details are preserved in diagnostics, including how many attempts were needed.
  * Cross-format reporting is now consistent: JUnit, GHA, and console outputs also reflect recovered flaky runs as successful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->