### PR TITLE
build(coverage): combine unit and self-hosted E2E coverage into cover.out

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,15 +17,15 @@ permissions:
   pull-requests: write
 
 jobs:
-  unit_test:
-    name: Unit test (linux)
+  coverage:
+    name: Coverage (unit + e2e)
 
     strategy:
       matrix:
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -34,11 +34,15 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: "1"
+          go-version-file: "go.mod"
           check-latest: true
 
-      - name: Run tests with coverage report output
-        run: go test -cover -coverpkg=./... -coverprofile=cover.out ./...
+      # Combines unit-test coverage with self-hosted E2E coverage (E2E runs a
+      # `go build -cover` atago and collects covdata via GOCOVERDIR), then
+      # merges both into cover.out. git is preinstalled on the runner, which is
+      # all the atago + git E2E suites need.
+      - name: Run combined unit + E2E coverage
+        run: make coverage
 
       - uses: k1LoW/octocov-action@b3b6ee60482a667950f87553abf1df63217235d9 # v1.5.1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ coverage.txt
 profile.cov
 cover.html
 
+# `make coverage` scratch: raw covdata (unit + e2e), the cover binary, and the
+# merged dir. The final cover.out / cover.html are the only kept artifacts.
+.coverage/
+
 # Dependency directories (remove the comment below to include it)
 # vendor/
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,14 @@ make e2e
 ```
 
 `make vet` runs `go vet` and `make fmt` formats the Go sources. `make test` also
-generates `cover.out` and `cover.html` locally.
+generates `cover.out` and `cover.html` locally (unit tests only).
+
+`make coverage` reports the fuller picture: it combines unit-test coverage with
+the self-hosted E2E coverage. The E2E half runs a `go build -cover` atago binary
+and collects its runtime coverage via `GOCOVERDIR`, then merges both into the
+same `cover.out` (`go tool cover -func` prints the total; `cover.html` is the
+HTML report). Scratch data lives under `.coverage/` (gitignored). This is the
+heavier target used by the Coverage CI job; `make test` / `make e2e` stay fast.
 
 `make e2e` builds the binary and runs atago against its own self-hosted specs in
 `test/e2e/atago/` plus the git suite in `test/e2e/thirdparty/git/`. atago is also

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test clean vet fmt lint tools release-smoke e2e thirdparty dogfood dogfood-iso8583tool dogfood-jose dogfood-career dogfood-gup dogfood-mimixbox dogfood-mobilepkg demo docs site help
+.PHONY: build test coverage clean vet fmt lint tools release-smoke e2e thirdparty dogfood dogfood-iso8583tool dogfood-jose dogfood-career dogfood-gup dogfood-mimixbox dogfood-mobilepkg demo docs site help
 
 APP         = atago
 VERSION     = $(shell git describe --tags --always --dirty 2>/dev/null)
@@ -25,11 +25,14 @@ build: ## Build binary
 	env GO111MODULE=on CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO_BUILD) $(GO_LDFLAGS) -o $(APP) .
 
 clean: ## Clean project artifacts
-	-rm -rf $(APP) cover.out cover.html dist
+	-rm -rf $(APP) cover.out cover.html dist .coverage
 
 test: ## Run tests with coverage output
 	env GOOS=$(GOOS) $(GO_TEST) -cover -coverpkg=./... -coverprofile=cover.out $(GO_PKGROOT)
 	$(GO_TOOL) cover -html=cover.out -o cover.html
+
+coverage: ## Combine unit + self-hosted E2E coverage into cover.out / cover.html (uses a `go build -cover` atago; scratch under .coverage/)
+	env PARALLEL=$(PARALLEL) bash ./scripts/coverage.sh
 
 vet: ## Run go vet
 	$(GO_VET) $(GO_PACKAGES)

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+# Combine unit-test coverage with self-hosted E2E coverage into a single
+# cover.out. Unit tests report line coverage, but they never exercise the real
+# atago binary the way an end user does; the self-hosted E2E specs do. Go 1.20+
+# lets us instrument a built binary (`go build -cover`) and collect its runtime
+# coverage via GOCOVERDIR, so we can merge "what the tests cover" with "what a
+# real run covers" and get one honest number.
+#
+# This is intentionally a separate, heavier target: `make test` / `make e2e`
+# stay fast. Everything lands under .coverage/ (gitignored) except the final
+# cover.out / cover.html, which are the same artifacts `make test` already
+# produces so octocov and local tooling need no changes.
+#
+# Override scenario concurrency with PARALLEL (defaults to 8, matching `make e2e`).
+set -eu
+
+cd "$(CDPATH= cd "$(dirname "$0")/.." && pwd)"
+root="$(pwd)"
+cov="${root}/.coverage"
+parallel="${PARALLEL:-8}"
+
+rm -rf "${cov}"
+mkdir -p "${cov}/unit" "${cov}/e2e" "${cov}/bin" "${cov}/merged"
+
+# 1. Unit-test coverage as raw covdata (GOCOVERDIR form) so it can be merged
+#    with the E2E covdata below. -covermode=atomic must match the binary build.
+echo ">> unit coverage -> ${cov}/unit"
+go test -count=1 -cover -covermode=atomic -coverpkg=./... ./... \
+	-args -test.gocoverdir="${cov}/unit"
+
+# 2. Coverage-instrumented atago binary. E2E must run THIS, not dist/atago.
+echo ">> building coverage-instrumented atago -> ${cov}/bin/atago-cover"
+go build -cover -covermode=atomic -coverpkg=./... -o "${cov}/bin/atago-cover" .
+
+# 3. Self-hosted E2E via the instrumented binary. ${atago} inside the specs is
+#    os.Executable(), i.e. this same cover binary, so every atago-on-atago child
+#    is also instrumented. GOCOVERDIR is inherited by those children (the specs
+#    that invoke ${atago} do not use clear_env), so each writes its own covdata.
+echo ">> e2e coverage -> ${cov}/e2e"
+GOCOVERDIR="${cov}/e2e" \
+	"${cov}/bin/atago-cover" run --parallel "${parallel}" \
+	./test/e2e/atago ./test/e2e/thirdparty/git
+
+# 4. Merge the raw covdata and render the combined text profile + reports.
+echo ">> merging unit + e2e covdata -> cover.out"
+go tool covdata merge -i="${cov}/unit,${cov}/e2e" -o="${cov}/merged"
+go tool covdata textfmt -i="${cov}/merged" -o="${root}/cover.out"
+
+go tool cover -func=cover.out | tail -n 1
+go tool cover -html=cover.out -o cover.html
+echo ">> wrote cover.out and cover.html (unit + e2e combined)"


### PR DESCRIPTION
## What

`make coverage` now reports **unit + self-hosted E2E** coverage combined into a single `cover.out`, instead of unit-tests only.

Unit tests never exercise the real atago binary the way an end user does; the self-hosted E2E specs do. Go 1.20+ lets us instrument a built binary (`go build -cover`) and collect its runtime coverage via `GOCOVERDIR`, so we merge "what the tests cover" with "what a real run covers" into one honest number.

## How

New `scripts/coverage.sh` (driven by `make coverage`):

1. Collect unit coverage as raw covdata (`go test ... -args -test.gocoverdir=.coverage/unit`).
2. Build a coverage-instrumented atago (`go build -cover -covermode=atomic -coverpkg=./... -o .coverage/bin/atago-cover`).
3. Run the self-hosted E2E suite with that binary and `GOCOVERDIR=.coverage/e2e`. `${atago}` inside specs is `os.Executable()`, i.e. the same cover binary, so every atago-on-atago child is instrumented too and inherits `GOCOVERDIR`.
4. `go tool covdata merge` + `textfmt` → `cover.out`; `go tool cover -func` prints the total; `cover.html` is the HTML report.

## Notes

- `make test` / `make e2e` are unchanged and stay fast. Coverage combining is isolated to the new `make coverage` target.
- Scratch data lives under `.coverage/` (gitignored); the final `cover.out` / `cover.html` are the only kept artifacts, so octocov needs no changes.
- The Coverage CI job now runs `make coverage`.

## Result

- unit-only: **82.9%**
- unit + E2E combined: **85.8%** (+2.9pt), no `GOCOVERDIR not set` warnings across all 225 scenarios.

## Verified

- `make test` passes (unchanged)
- `make e2e` passes (unchanged)
- `make coverage` generates combined `cover.out` + `cover.html`; `go tool cover -func=cover.out` succeeds
- No atago DSL / user-facing coverage feature added