### PR TITLE
fix(report): surface a suite-setup failure with no scenarios instead of a green report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- A suite that fails in `suite.setup` with no scenario selected to run (every
+  scenario filtered out by `--filter`/`--tag`, or an empty scenario list) is no
+  longer rendered as a green, empty result by the junit, tap, and gha reports,
+  and the console verdict now reads FAILED. The run already exits non-zero and
+  the console/json output showed the failure, but junit emitted `tests="0"`, tap
+  a bare `1..0` plan, and gha no error annotation, so a CI step gating on those
+  reports read the errored suite as passing. Each format now surfaces the setup
+  failure as a failing entry.
 - The TAP report now emits a passing `ok` point for a flaky scenario (one that
   failed and then passed under `--retry-failed`), matching the exit code and the
   console, gha, and junit reports, which all treat a recovered scenario as green.

--- a/internal/report/console.go
+++ b/internal/report/console.go
@@ -10,9 +10,12 @@ import (
 
 // writeSummary prints the final tally line. The uppercase status word
 // (PASSED/FAILED) anchors the line and is part of the stable output contract.
-func writeSummary(b *strings.Builder, color bool, c engine.Counts, total int, d time.Duration) {
+func writeSummary(b *strings.Builder, color bool, c engine.Counts, total int, d time.Duration, hardFail bool) {
 	status, code := "PASSED", cGreen
-	if c.Failed > 0 || c.Errored > 0 {
+	// hardFail covers a suite that errored before producing any scenario row (#7):
+	// the counts are all zero, but the verdict must still read FAILED to match the
+	// non-zero exit code and the SUITE SETUP FAILED block printed above.
+	if c.Failed > 0 || c.Errored > 0 || hardFail {
 		status, code = "FAILED", cRed
 	}
 	plural := "scenarios"

--- a/internal/report/gha.go
+++ b/internal/report/gha.go
@@ -32,6 +32,15 @@ func writeGHA(w io.Writer, results []*engine.SuiteResult) error {
 					ghaEscapeProp(res.Suite+" / "+sc.Name), ghaEscapeData(fmt.Sprintf("flaky: passed after %d attempts", sc.Attempts)))
 			}
 		}
+		// A suite that errored before any scenario ran (#7) surfaces its cause as
+		// an error annotation, so the Actions UI is never silent for a non-zero
+		// exit that produced no scenario rows.
+		if suiteErroredWithoutScenarios(res) {
+			for _, p := range suiteFailurePoints(res) {
+				fmt.Fprintf(&b, "::error title=%s::%s\n",
+					ghaEscapeProp(res.Suite+" / "+p.name), ghaEscapeData(p.message))
+			}
+		}
 		c := res.Counts()
 		agg.Passed += c.Passed
 		agg.Failed += c.Failed

--- a/internal/report/junit.go
+++ b/internal/report/junit.go
@@ -78,6 +78,20 @@ func buildJUnit(results []*engine.SuiteResult) junitTestsuites {
 			ts.Testcases = append(ts.Testcases, tc)
 			ts.Tests++
 		}
+		// A suite that errored before producing any scenario row (a suite.setup
+		// failure with nothing selected, #7) has no testcase to carry the error;
+		// synthesize one so the suite is never a green empty <testsuite> while the
+		// process exits non-zero.
+		if suiteErroredWithoutScenarios(res) {
+			for _, p := range suiteFailurePoints(res) {
+				ts.Testcases = append(ts.Testcases, junitTestcase{
+					Name:  p.name,
+					Error: &junitMessage{Message: p.message, Body: p.body},
+				})
+				ts.Errors++
+				ts.Tests++
+			}
+		}
 		root.Suites = append(root.Suites, ts)
 		root.Tests += ts.Tests
 		root.Failures += ts.Failures

--- a/internal/report/render.go
+++ b/internal/report/render.go
@@ -21,6 +21,7 @@ func Render(w io.Writer, f Format, results []*engine.SuiteResult) error {
 		var agg engine.Counts
 		var total int
 		var dur time.Duration
+		hardFail := false
 		for _, res := range results {
 			for i := range res.Scenarios {
 				writeDetail(&b, color, res.Suite, &res.Scenarios[i])
@@ -36,8 +37,13 @@ func Render(w io.Writer, f Format, results []*engine.SuiteResult) error {
 			agg.Flaky += c.Flaky
 			total += len(res.Scenarios)
 			dur += res.Duration
+			// A suite that errored before producing any scenario row (#7) has
+			// zero counts; force the summary verdict to FAILED regardless.
+			if suiteErroredWithoutScenarios(res) {
+				hardFail = true
+			}
 		}
-		writeSummary(&b, color, agg, total, dur)
+		writeSummary(&b, color, agg, total, dur, hardFail)
 		_, err := io.WriteString(w, b.String())
 		return err
 	case FormatJSON:

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -2,6 +2,86 @@
 // : console, JSON, JUnit XML, and GitHub Actions annotations.
 package report
 
+import (
+	"strings"
+
+	"github.com/nao1215/atago/internal/engine"
+)
+
+// suiteErroredWithoutScenarios reports a suite that failed or errored before it
+// produced any scenario row: a suite.setup failure (#7) with nothing selected to
+// run (all scenarios filtered out, or an empty scenario list), or a
+// suite-runtime creation failure. exitForSuite maps such a suite to a non-zero
+// code and console/JSON show the cause, but with no scenario rows the
+// junit/tap/gha bodies would otherwise render an all-green empty suite that
+// contradicts the exit code — so those formats synthesize a failure entry from
+// suiteFailurePoints, and the console summary reads FAILED.
+func suiteErroredWithoutScenarios(res *engine.SuiteResult) bool {
+	return len(res.Scenarios) == 0 &&
+		(res.Status == engine.StatusFailed || res.Status == engine.StatusError)
+}
+
+// suiteFailurePoint is a synthetic failure entry for a suite that errored
+// without scenarios: one per recorded suite.setup failure, or a single generic
+// entry when no setup detail was captured (the runtime-creation path).
+type suiteFailurePoint struct {
+	name    string // point/testcase name, e.g. "service setup"
+	message string // one-line failure message
+	body    string // optional detail block
+}
+
+// suiteFailurePoints builds the entries junit/tap/gha emit for a suite that
+// errored without scenarios. It mirrors the suite.setup failures JSON already
+// reports (setup_failures) and the console already shows (SUITE SETUP FAILED).
+func suiteFailurePoints(res *engine.SuiteResult) []suiteFailurePoint {
+	var pts []suiteFailurePoint
+	for _, f := range suiteStepFailures(res.Suite, res.Setup) {
+		pts = append(pts, suiteFailurePoint{
+			name:    f.Step,
+			message: suiteFailureMessage(f),
+			body:    suiteFailureBody(f),
+		})
+	}
+	if len(pts) == 0 {
+		// The runtime-creation path records its message on a would-be scenario,
+		// not res.Setup; with nothing selected there is no detail to show. Emit
+		// one generic point so the failure is never rendered green.
+		pts = append(pts, suiteFailurePoint{name: setupPhaseLabel, message: "suite errored before any scenario ran"})
+	}
+	return pts
+}
+
+// suiteFailureMessage picks the most informative one-line message from a
+// suite-level failure record.
+func suiteFailureMessage(f jsonFailure) string {
+	switch {
+	case f.Error != "":
+		return f.Error
+	case f.Hint != "":
+		return f.Hint
+	case f.Expected != "" || f.Actual != "":
+		return "expected " + f.Expected + ", got " + f.Actual
+	default:
+		return f.Step
+	}
+}
+
+// suiteFailureBody renders the multi-line detail block for a suite-level
+// failure, matching the console/junit failure body shape.
+func suiteFailureBody(f jsonFailure) string {
+	var parts []string
+	if f.Expected != "" {
+		parts = append(parts, "Expected: "+f.Expected)
+	}
+	if f.Actual != "" {
+		parts = append(parts, "Actual: "+f.Actual)
+	}
+	if f.Hint != "" {
+		parts = append(parts, "Hint: "+f.Hint)
+	}
+	return strings.Join(parts, "\n")
+}
+
 // Format names a built-in report format.
 type Format string
 

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -276,6 +276,134 @@ func TestRender_FlakyIsGreenAcrossFormats(t *testing.T) {
 	})
 }
 
+// suiteSetupErrorEmpty builds a suite that errored in suite.setup (#7) with no
+// scenario rows — the shape the engine produces when suite.setup fails and
+// nothing was selected to run (all scenarios filtered out, or an empty scenario
+// list). exitForSuite maps StatusError to a non-zero code, and console/JSON both
+// show the failure, so no report format may render this as a green suite.
+func suiteSetupErrorEmpty() []*engine.SuiteResult {
+	return []*engine.SuiteResult{{
+		Suite:     "s1",
+		Status:    engine.StatusError,
+		Scenarios: nil,
+		Setup: []engine.StepResult{
+			{Index: 0, Kind: "", Setup: true, ErrMsg: `service "api" not ready: timed out after 5s`},
+		},
+	}}
+}
+
+// TestRender_SuiteSetupErrorEmptyIsNotGreen is a metamorphic parity check: a
+// suite that errored before producing any scenario row exits non-zero, so every
+// report format must surface the failure. Regression: junit reported
+// tests=0/errors=0, tap emitted a bare "1..0" plan, gha emitted no error
+// annotation, and the console verdict read PASSED — each contradicting the
+// non-zero exit code and the JSON "error" status.
+func TestRender_SuiteSetupErrorEmptyIsNotGreen(t *testing.T) {
+	t.Parallel()
+
+	t.Run("junit records an error testcase, not an empty green suite", func(t *testing.T) {
+		t.Parallel()
+		var b bytes.Buffer
+		if err := Render(&b, FormatJUnit, suiteSetupErrorEmpty()); err != nil {
+			t.Fatal(err)
+		}
+		var root junitTestsuites
+		if err := xml.Unmarshal(b.Bytes(), &root); err != nil {
+			t.Fatalf("JUnit output is not valid XML: %v\n%s", err, b.String())
+		}
+		if root.Errors == 0 && root.Failures == 0 {
+			t.Errorf("junit rendered a green suite (errors=%d failures=%d tests=%d) for a setup-errored suite:\n%s",
+				root.Errors, root.Failures, root.Tests, b.String())
+		}
+		if root.Tests == 0 {
+			t.Errorf("junit tests=0 for a setup-errored suite; the failure has no testcase:\n%s", b.String())
+		}
+		if !strings.Contains(b.String(), "not ready") {
+			t.Errorf("junit should carry the setup failure message:\n%s", b.String())
+		}
+	})
+
+	t.Run("tap emits a not-ok point, not a bare 1..0 plan", func(t *testing.T) {
+		t.Parallel()
+		var b bytes.Buffer
+		if err := Render(&b, FormatTAP, suiteSetupErrorEmpty()); err != nil {
+			t.Fatal(err)
+		}
+		out := b.String()
+		if !strings.Contains(out, "not ok") {
+			t.Errorf("tap emitted no failing point for a setup-errored suite:\n%s", out)
+		}
+		if strings.Contains(out, "1..0") {
+			t.Errorf("tap emitted an empty 1..0 plan for a setup-errored suite:\n%s", out)
+		}
+		// The plan count must equal the number of emitted points.
+		points := strings.Count(out, "\nok ") + strings.Count(out, "\nnot ok ")
+		if !strings.Contains(out, "1.."+itoa(points)) {
+			t.Errorf("tap plan does not match the %d emitted points:\n%s", points, out)
+		}
+	})
+
+	t.Run("gha emits an error annotation", func(t *testing.T) {
+		t.Parallel()
+		var b bytes.Buffer
+		if err := Render(&b, FormatGHA, suiteSetupErrorEmpty()); err != nil {
+			t.Fatal(err)
+		}
+		out := b.String()
+		if !strings.Contains(out, "::error") {
+			t.Errorf("gha emitted no error annotation for a setup-errored suite:\n%s", out)
+		}
+	})
+
+	t.Run("console verdict reads FAILED", func(t *testing.T) {
+		t.Parallel()
+		var b bytes.Buffer
+		if err := Render(&b, FormatConsole, suiteSetupErrorEmpty()); err != nil {
+			t.Fatal(err)
+		}
+		out := b.String()
+		// The summary line's verdict word (not the SUITE SETUP FAILED block) must
+		// read FAILED, matching the non-zero exit code.
+		if !strings.Contains(out, "FAILED  0 scenarios") {
+			t.Errorf("console summary verdict read PASSED for a setup-errored suite:\n%s", out)
+		}
+		if strings.Contains(out, "PASSED  0 scenarios") {
+			t.Errorf("console summary verdict must not read PASSED for a setup-errored suite:\n%s", out)
+		}
+		if !strings.Contains(out, "SUITE SETUP FAILED") {
+			t.Errorf("console should show the setup failure block:\n%s", out)
+		}
+	})
+
+	t.Run("json reports an error status with setup_failures", func(t *testing.T) {
+		t.Parallel()
+		var b bytes.Buffer
+		if err := Render(&b, FormatJSON, suiteSetupErrorEmpty()); err != nil {
+			t.Fatal(err)
+		}
+		out := b.String()
+		if !strings.Contains(out, `"status": "error"`) {
+			t.Errorf("json should report the suite status as error:\n%s", out)
+		}
+		if !strings.Contains(out, "setup_failures") {
+			t.Errorf("json should carry setup_failures:\n%s", out)
+		}
+	})
+}
+
+// itoa avoids the strconv import churn for the small counts this test uses.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
 func TestProgress_Markers(t *testing.T) {
 	t.Parallel()
 	var b bytes.Buffer

--- a/internal/report/tap.go
+++ b/internal/report/tap.go
@@ -18,6 +18,11 @@ func writeTAP(w io.Writer, results []*engine.SuiteResult) error {
 	total := 0
 	for _, res := range results {
 		total += len(res.Scenarios)
+		// A suite that errored before any scenario ran (#7) still contributes a
+		// failing point, so the plan is never a bare "1..0" for a non-zero exit.
+		if suiteErroredWithoutScenarios(res) {
+			total += len(suiteFailurePoints(res))
+		}
 	}
 	b.WriteString("TAP version 13\n")
 	fmt.Fprintf(&b, "1..%d\n", total)
@@ -48,6 +53,13 @@ func writeTAP(w io.Writer, results []*engine.SuiteResult) error {
 				writeTAPDiagnostic(&b, firstErrorMessage(sc), detailText(sc))
 			default:
 				fmt.Fprintf(&b, "not ok %d - %s\n", n, name)
+			}
+		}
+		if suiteErroredWithoutScenarios(res) {
+			for _, p := range suiteFailurePoints(res) {
+				n++
+				fmt.Fprintf(&b, "not ok %d - %s\n", n, tapDescription(res.Suite, p.name))
+				writeTAPDiagnostic(&b, p.message, p.body)
 			}
 		}
 	}


### PR DESCRIPTION
## What

A suite that fails in `suite.setup` while no scenario is selected to run — every scenario filtered out by `--filter`/`--tag`, or an empty scenario list — produced no scenario rows. The junit, tap, and gha reports render entirely off those rows, so they showed a green, empty suite even though the run exits non-zero (`ExitExec`) and the console/json output already surfaced the failure.

Concretely, for such a run junit emitted `tests="0" errors="0"`, tap a bare `1..0` plan, gha no error annotation, and the console summary verdict read `PASSED`. A CI step gating on any of those reports read the errored suite as passing, contradicting both the exit code and the json `"status": "error"`.

## Fix

The report layer now recognizes a suite that errored or failed before producing any scenario row and surfaces the cause in each format:

- junit emits an error `<testcase>` per recorded `suite.setup` failure (`tests`/`errors` count it).
- tap emits a `not ok` point (and the `1..N` plan counts it).
- gha emits an `::error` annotation.
- the console summary verdict reads `FAILED`.

json and the console detail block already showed the failure, so they are unchanged. The synthesis is gated on zero scenario rows, so the common setup-failure case (scenarios present and already errored) is untouched.

## Test

`TestRender_SuiteSetupErrorEmptyIsNotGreen` is a metamorphic parity check: a suite the exit code calls errored must not render green in any format. It fails on the old code across junit, tap, gha, and the console verdict.

Verified end to end with `atago run --filter <no-match> --report junit|tap|gha` against a spec whose `suite.setup` fails: exit 4, and every format now shows the failure.