### PR TITLE
fix(grpc): treat an elapsed per-call deadline as a timeout error, not a captured status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- A `grpc` step against a hung server no longer passes as a normal
+  `Result{grpc_status: 4}` when its per-call timeout fires. The timeout was
+  detected only through `ctx.Err()`, which a server enforcing the propagated
+  deadline could beat: its `DeadlineExceeded` status arrived over the wire, and
+  the call returned, before the local deadline timer marked the context done, so
+  the timed-out call was recorded as a captured status instead of a hard error.
+  A call is now treated as a timeout whenever the per-call deadline has already
+  elapsed, closing the race; a live deadline still records a real status as a
+  Result. This also fixes a flaky `TestInvoke_CallTimeoutIsError` on CI.
 - A suite that fails in `suite.setup` with no scenario selected to run (every
   scenario filtered out by `--filter`/`--tag`, or an empty scenario list) is no
   longer rendered as a green, empty result by the junit, tap, and gha reports,

--- a/internal/runner/grpc/grpc.go
+++ b/internal/runner/grpc/grpc.go
@@ -105,14 +105,13 @@ func (r *Runner) Invoke(ctx context.Context, method string, header map[string]st
 	if !ok {
 		return nil, fmt.Errorf("grpc invoke %s: %w", method, invErr)
 	}
-	// A non-nil ctx error means OUR per-call deadline (run.timeout) or a cancel
-	// fired: the call never completed, so it is a transport failure, not a
-	// captured status. status.FromError otherwise maps a timed-out/dropped call
-	// to codes.DeadlineExceeded(4)/Unavailable(14) with ok=true, which would be
-	// recorded as a passing Result — a false pass against a hung or unreachable
+	// OUR per-call deadline (run.timeout) or a cancel firing means the call never
+	// completed: a transport failure, not a captured status. status.FromError
+	// otherwise maps a timed-out call to codes.DeadlineExceeded(4) with ok=true,
+	// which would be recorded as a passing Result — a false pass against a hung
 	// server unless the spec happens to assert grpc_status.
-	if invErr != nil && ctx.Err() != nil {
-		return nil, fmt.Errorf("grpc invoke %s: %w", method, ctx.Err())
+	if cause := deadlineFailure(ctx, invErr); cause != nil {
+		return nil, fmt.Errorf("grpc invoke %s: %w", method, cause)
 	}
 
 	out := &runner.Result{Command: method, IsGRPC: true, GRPCStatus: int(stat.Code())}
@@ -126,6 +125,31 @@ func (r *Runner) Invoke(ctx context.Context, method string, header map[string]st
 		out.MessageJSON = []byte("{}")
 	}
 	return out, nil
+}
+
+// deadlineFailure reports the cause when a failed invoke is our per-call timeout
+// (or a cancel) rather than a captured gRPC status, or nil when it is a real
+// status to record. It detects the timeout two ways:
+//
+//   - ctx.Err() — set once the local deadline timer (or a cancel) has run.
+//   - an already-elapsed deadline with ctx.Err() still nil — the race the
+//     ctx.Err() check alone misses: a gRPC server enforcing the propagated
+//     deadline can deliver DeadlineExceeded over the wire, and Invoke can return
+//     it, before our local timer goroutine marks the context Done. A live
+//     deadline that has not yet elapsed is left alone, so a server that returns
+//     DeadlineExceeded as a fast application status is still recorded as a
+//     Result rather than swallowed.
+func deadlineFailure(ctx context.Context, invErr error) error {
+	if invErr == nil {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if dl, ok := ctx.Deadline(); ok && !time.Now().Before(dl) {
+		return context.DeadlineExceeded
+	}
+	return nil
 }
 
 // resolveMethod fetches the method descriptor for service/method via server

--- a/internal/runner/grpc/grpc_test.go
+++ b/internal/runner/grpc/grpc_test.go
@@ -2,11 +2,71 @@ package grpc
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/k1LoW/grpcstub"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+// pastDeadlineCtx models the race window Invoke must survive: the deadline has
+// already elapsed, but the local timer goroutine has not yet run, so Err() is
+// still nil while Deadline() is in the past. A real context.WithDeadline cannot
+// be held in this state (its Err flips the instant the deadline passes), so the
+// test uses a fake.
+type pastDeadlineCtx struct {
+	context.Context
+	deadline time.Time
+}
+
+func (c pastDeadlineCtx) Deadline() (time.Time, bool) { return c.deadline, true }
+func (c pastDeadlineCtx) Err() error                  { return nil }
+
+// TestDeadlineFailure covers the timeout-detection logic that keeps a hung
+// server from passing as Result{GRPCStatus:4}. The ctx.Err()-only guard flaked
+// on a server-enforced deadline whose DeadlineExceeded status arrived over the
+// wire before the local timer marked the context Done (main CI:
+// TestInvoke_CallTimeoutIsError).
+func TestDeadlineFailure(t *testing.T) {
+	t.Parallel()
+
+	deadlineErr := status.Error(codes.DeadlineExceeded, "context deadline exceeded")
+
+	t.Run("no invoke error is not a timeout", func(t *testing.T) {
+		t.Parallel()
+		if err := deadlineFailure(context.Background(), nil); err != nil {
+			t.Errorf("deadlineFailure(nil) = %v, want nil", err)
+		}
+	})
+
+	t.Run("a canceled context reports its error", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if err := deadlineFailure(ctx, deadlineErr); !errors.Is(err, context.Canceled) {
+			t.Errorf("deadlineFailure(canceled) = %v, want context.Canceled", err)
+		}
+	})
+
+	t.Run("an elapsed deadline with a nil Err is still a timeout", func(t *testing.T) {
+		t.Parallel()
+		ctx := pastDeadlineCtx{Context: context.Background(), deadline: time.Now().Add(-time.Second)}
+		if err := deadlineFailure(ctx, deadlineErr); !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("deadlineFailure(past deadline, nil Err) = %v, want context.DeadlineExceeded; a hung server must not pass", err)
+		}
+	})
+
+	t.Run("a live deadline leaves a real status alone", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
+		defer cancel()
+		if err := deadlineFailure(ctx, deadlineErr); err != nil {
+			t.Errorf("deadlineFailure(live deadline) = %v, want nil so the status is recorded as a Result", err)
+		}
+	})
+}
 
 func TestSplitMethod(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## What

The main-branch Coverage job was failing intermittently on `TestInvoke_CallTimeoutIsError`: a unary `grpc` call that hangs past its per-call timeout occasionally returned no error and a `Result{grpc_status: 4}` (DEADLINE_EXCEEDED) instead of a hard error.

This is a real correctness bug, not just a flaky test. `Invoke` detected our per-call timeout only through `ctx.Err()`. When a gRPC server enforces the propagated deadline, it can deliver a `DeadlineExceeded` status over the wire — and `cc.Invoke` can return it — before our local deadline-timer goroutine marks the context done. In that window `ctx.Err()` is still nil, so the timed-out call fell through and was recorded as a captured status. A hung (or slow) server would then pass unless the spec happened to assert `grpc_status`.

## Fix

Timeout detection now also treats the call as a timeout when our per-call deadline has already elapsed (`ctx.Deadline()` in the past) even if `ctx.Err()` has not flipped yet, closing the race. A live deadline that has not elapsed is left alone, so a server that legitimately returns `DeadlineExceeded` as a fast application status is still recorded as a `Result`. The check is extracted into `deadlineFailure` and unit-tested.

## Test

`TestDeadlineFailure` covers the decision deterministically, including the race window via a fake context whose deadline is in the past while `Err()` is still nil — the exact state a real `context.WithDeadline` cannot be held in. It fails on the old `ctx.Err()`-only guard. The existing `TestInvoke_CallTimeoutIsError` and the full package pass under `-race -count=3`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling for gRPC calls so hung servers are correctly reported as failures instead of appearing successful.
  * Fixed a race condition that could cause deadline-based errors to be misclassified, making timeout behavior more reliable.
  * Resolved flaky timeout test behavior in CI by making deadline detection more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->