### PR TITLE
fix(loader): report an empty spec file clearly instead of a bare EOF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project follows [Semantic Versioning](https://semver.org/).
   A call is now treated as a timeout whenever the per-call deadline has already
   elapsed, closing the race; a live deadline still records a real status as a
   Result. This also fixes a flaky `TestInvoke_CallTimeoutIsError` on CI.
+- Loading an empty spec file (empty, whitespace-only, or comments only) now
+  reports `spec is empty: expected a YAML document with version, suite, and
+  scenarios` instead of the bare decoder `EOF`, which named neither the file's
+  problem nor what a spec needs.
 - A suite that fails in `suite.setup` with no scenario selected to run (every
   scenario filtered out by `--filter`/`--tag`, or an empty scenario list) is no
   longer rendered as a green, empty result by the junit, tap, and gha reports,

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -54,6 +55,12 @@ func LoadBytes(path string, data []byte) (*spec.Spec, error) {
 	var s spec.Spec
 	dec := yaml.NewDecoder(bytes.NewReader(data), yaml.Strict())
 	if err := dec.Decode(&s); err != nil {
+		// An empty document (empty file, whitespace, or comments only) decodes to
+		// io.EOF, whose bare "EOF" tells the user nothing. Name the problem and
+		// what a spec needs instead.
+		if errors.Is(err, io.EOF) {
+			return nil, &Error{Path: path, Kind: KindParse, Msg: "spec is empty: expected a YAML document with version, suite, and scenarios"}
+		}
 		return nil, &Error{Path: path, Kind: KindParse, Msg: formatYAMLError(err)}
 	}
 	// Record each scenario's authored index before matrix expansion, so every

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -313,6 +313,26 @@ func TestLoadBytes_Errors(t *testing.T) {
 			wantKind: KindParse,
 		},
 		{
+			// An empty file previously surfaced the raw decoder "EOF", which tells
+			// the user nothing. It now names the problem and what a spec needs.
+			name:     "empty file",
+			src:      "",
+			wantKind: KindParse,
+			wantMsg:  "spec is empty",
+		},
+		{
+			name:     "whitespace-only file",
+			src:      "   \n\t\n  ",
+			wantKind: KindParse,
+			wantMsg:  "spec is empty",
+		},
+		{
+			name:     "comments-only file",
+			src:      "# just a comment\n# nothing else\n",
+			wantKind: KindParse,
+			wantMsg:  "spec is empty",
+		},
+		{
 			name:     "unknown field is strict-rejected",
 			src:      "version: \"1\"\nsuite:\n  name: x\nbogus: true\nscenarios:\n  - name: a\n    steps:\n      - run:\n          command: echo",
 			wantKind: KindParse,


### PR DESCRIPTION
## What

Running atago against an empty spec file printed only:

```
myspec.atago.yaml: EOF
```

which names neither the file's problem nor what a spec needs. The same bare `EOF` appeared for a whitespace-only or comments-only file, since goccy's decoder returns `io.EOF` when there is no document node.

## Fix

`LoadBytes` now detects the empty-document case (`errors.Is(err, io.EOF)`) and reports:

```
myspec.atago.yaml: spec is empty: expected a YAML document with version, suite, and scenarios
```

Other parse and validation errors are unchanged — they already carry position and did-you-mean context.

## Test

`TestLoadBytes_Errors` gains empty-file, whitespace-only, and comments-only cases, each asserting the friendly message. They fail on the old bare-`EOF` behavior. Verified end to end with `atago run` against all three inputs.

Found while auditing the loader's broken-YAML UX; the other malformed-input errors (unknown field with did-you-mean, tab, wrong type, misspelled matcher) already read well.