### PR TITLE
refactor: remove dead SignalNameList and Dir.Root

### DIFF
--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -25,9 +25,6 @@ type Dir struct {
 // the --artifacts-dir flag, so an unset flag yields a nil *Dir.
 func NewDir(root string) *Dir { return &Dir{root: filepath.Clean(root)} }
 
-// Root reports the absolute-or-relative root the Dir writes under.
-func (d *Dir) Root() string { return d.root }
-
 // Write stores content at relPath (a slash-separated path relative to the root)
 // and returns the same relPath for embedding in reports. Parent directories are
 // created as needed. Write is safe for concurrent use across distinct relPaths,

--- a/internal/engine/signal.go
+++ b/internal/engine/signal.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	servicerunner "github.com/nao1215/atago/internal/runner/service"
@@ -61,10 +60,3 @@ func findServiceProc(name string, scenarioServices, suiteServices []*servicerunn
 	}
 	return nil
 }
-
-// signalNames is the accepted signal set (#23), shared with the loader's
-// validation message.
-var signalNames = []string{"TERM", "INT", "HUP", "USR1", "USR2", "KILL"}
-
-// SignalNameList renders the accepted signal names for error messages.
-func SignalNameList() string { return strings.Join(signalNames, ", ") }


### PR DESCRIPTION
## What

`golang.org/x/tools/cmd/deadcode -test ./...` reports two unreachable functions:

- `engine.SignalNameList` (and its `signalNames` slice). Its comment claims it is "shared with the loader's validation message", but the loader validates signal names through `spec.ValidSignalName` and spells the accepted set out inline; nothing calls `SignalNameList`. The comment was stale and the function dead.
- `artifact.(*Dir).Root`. Never called; report paths are built from the relative paths `Write` returns, not from the root.

Both live in `internal/` packages, so neither is part of any public API.

## Why

Dead code invites drift — the stale "shared with the loader" comment is exactly that. Removing it keeps `deadcode` clean so a future genuinely-unused function stands out.

Verified: `go build ./...`, `go vet`, package tests, and `golangci-lint` all pass, and `deadcode -test ./...` now reports nothing.