### PR TITLE
fix(record): escape only genuine variable references so a recorded spec replays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- `atago record` no longer generates a spec that cannot replay when the observed
+  command or output carries a `${` not followed by a valid variable name (a tool
+  that prints `${1}`, `${}`, or `${ }`). The recorder escaped every `${` to
+  `$${` unconditionally, but the replay expander only restores `$${<valid-name>}`
+  — so `$${1}` stayed literal and the generated `contains`/`command`/file-path
+  matcher could never match the real `${1}`. Escaping now mirrors the expander
+  exactly (only genuine references are escaped), so the recorded spec replays
+  green. The same fix covers `atago record --pty` transcripts and sends.
 - A `grpc` step against a hung server no longer passes as a normal
   `Result{grpc_status: 4}` when its per-call timeout fires. The timeout was
   detected only through `ctx.Err()`, which a server enforcing the propagated

--- a/internal/record/record.go
+++ b/internal/record/record.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/goccy/go-yaml"
 	"github.com/nao1215/atago/internal/loader"
+	"github.com/nao1215/atago/internal/store"
 )
 
 // maxFileAsserts caps the generated file.exists asserts so a command that
@@ -102,16 +103,18 @@ func Generate(obs Observation, opts Options) ([]byte, error) {
 	return out, nil
 }
 
-// escapeVarRefs rewrites every "${" in observed text as the documented "$${"
-// literal escape. Recorded commands, output anchors, file paths, and typed
-// pty input are RAW text — any ${...} in them is literal — but the engine
-// expands ${name} in run.command, assert values, and pty sends at replay (and
-// rejects an unresolved reference in a no-shell command), so an unescaped
-// reference would make the generated spec diverge from, or fail to replay,
-// the recorded run. The uniform rewrite round-trips: the expander turns
-// "$${" back into the literal "${" the tool actually saw.
+// escapeVarRefs escapes the variable references in observed text so the
+// generated spec replays it verbatim. Recorded commands, output anchors, file
+// paths, and typed pty input are RAW text — any ${...} in them is literal — but
+// the engine expands ${name} in run.command, assert values, and pty sends at
+// replay (and rejects an unresolved reference in a no-shell command), so an
+// unescaped reference would make the generated spec diverge from, or fail to
+// replay, the recorded run. store.Escape is the exact inverse of the expander:
+// it escapes only what the expander would act on, so a ${ not followed by a
+// valid name (e.g. a tool that prints ${1}) is left alone rather than turned
+// into a $${1} that the expander never restores and that could never match.
 func escapeVarRefs(s string) string {
-	return strings.ReplaceAll(s, "${", "$${")
+	return store.Escape(s)
 }
 
 // firstLine returns the first non-empty line, trimmed.

--- a/internal/record/record_test.go
+++ b/internal/record/record_test.go
@@ -1,10 +1,12 @@
 package record
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/nao1215/atago/internal/engine"
 	"github.com/nao1215/atago/internal/loader"
 )
 
@@ -181,6 +183,50 @@ func TestGenerate_ControlBytesRoundTrip(t *testing.T) {
 		Stdout:   []byte("ab\n"),
 	}, Options{SuiteName: "demo"}); err != nil {
 		t.Errorf("Generate(multi-line command) failed: %v", err)
+	}
+}
+
+// TestGenerate_RecordRunRoundTrip is the metamorphic law for record (#30): a
+// spec generated from an observed run must itself replay green. The other tests
+// check the generated text and that it loads; this replays the generated spec
+// through the real engine against the same command and asserts it passes. The
+// dollar-brace-digit case is the regression: a tool whose output carries a ${
+// not followed by a valid name (${1}) produced a contains matcher that could
+// never match, because the escape blindly wrote ${1} as $${1} but the expander
+// only restores $${<valid-name>}.
+func TestGenerate_RecordRunRoundTrip(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		obs  Observation
+	}{
+		{"plain echo", Observation{Command: "echo hello", ExitCode: 0, Stdout: []byte("hello\n")}},
+		{"nonzero exit", Observation{Command: "false", ExitCode: 1}},
+		{"shell pipe", Observation{Command: "echo abc | grep b", Shell: true, ExitCode: 0, Stdout: []byte("abc\n")}},
+		{"literal valid var ref", Observation{Command: "echo ${x}", ExitCode: 0, Stdout: []byte("${x}\n")}},
+		{"tab output", Observation{Command: `printf 'a\tb\n'`, Shell: true, ExitCode: 0, Stdout: []byte("a\tb\n")}},
+		{"leading whitespace line", Observation{Command: `printf '   indented\n'`, Shell: true, ExitCode: 0, Stdout: []byte("   indented\n")}},
+		{"hash in output", Observation{Command: "echo '# not a comment'", Shell: true, ExitCode: 0, Stdout: []byte("# not a comment\n")}},
+		// The command text has no ${ of its own, so the observed ${1} is
+		// independent of it — the escape must still leave a matcher that replays.
+		{"dollar-brace-digit output", Observation{Command: "printf '$'; printf '{1}\\n'", Shell: true, ExitCode: 0, Stdout: []byte("${1}\n")}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out, err := Generate(tc.obs, Options{SuiteName: "rt"})
+			if err != nil {
+				t.Fatalf("Generate: %v", err)
+			}
+			s, err := loader.LoadBytes("rt.atago.yaml", out)
+			if err != nil {
+				t.Fatalf("load generated: %v\n%s", err, out)
+			}
+			res := engine.New().Run(context.Background(), s, "rt.atago.yaml")
+			if res.Status != engine.StatusPassed {
+				t.Errorf("recorded spec did not replay green: status=%s\n--- spec ---\n%s", res.Status, out)
+			}
+		})
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -82,6 +82,20 @@ func (s *Store) Expand(in string) string {
 	})
 }
 
+// Escape rewrites text so that Expand returns it verbatim: it prefixes an extra
+// `$` onto exactly the references Expand acts on — a live `${name}` becomes the
+// literal `$${name}`, and an already-escaped `$${name}` becomes `$$${name}` —
+// while a `${` that Expand ignores (one not followed by a valid name, e.g.
+// `${1}` or `${}`) is left untouched, because Expand would already pass it
+// through. It is the exact inverse Expand relies on, so raw observed text (a
+// recorded command, output anchor, or typed pty input) can be embedded in a spec
+// without being re-expanded at replay. A blind `${`→`$${` rewrite is wrong: the
+// expander only unescapes `$${<valid-name>}`, so `$${1}` would never round-trip
+// back to the observed `${1}`.
+func Escape(s string) string {
+	return varRef.ReplaceAllStringFunc(s, func(m string) string { return "$" + m })
+}
+
 // Unresolved returns the names of ${name} references in in that no stored
 // variable resolves, and of ${env:NAME} references whose environment variable
 // is not set. Escaped $${name} literals are not reported — the author

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,6 +1,10 @@
 package store
 
-import "testing"
+import (
+	"math/rand"
+	"testing"
+	"testing/quick"
+)
 
 func TestGet(t *testing.T) {
 	t.Parallel()
@@ -83,6 +87,57 @@ func TestExpandMap(t *testing.T) {
 	out := s.ExpandMap(map[string]string{"GOBIN": "${dir}/bin"})
 	if out["GOBIN"] != "/tmp/x/bin" {
 		t.Errorf("GOBIN = %q, want /tmp/x/bin", out["GOBIN"])
+	}
+}
+
+// TestEscapeExpandRoundTrip proves store.Escape is the exact inverse of Expand:
+// Expand(Escape(x)) == x for any observed text. record relies on this to embed a
+// raw recorded command/output/pty-send in a spec without it being re-expanded at
+// replay. A blind ${→$${ rewrite broke it for a ${ not followed by a valid name
+// (e.g. a tool that prints ${1}): the expander only unescapes $${<valid-name>},
+// so $${1} never round-tripped back to ${1}.
+func TestEscapeExpandRoundTrip(t *testing.T) {
+	t.Parallel()
+	s := New()
+	s.Set("name", "Alice")
+	s.Set("user_id", "42")
+	cases := []string{
+		"plain text with no refs",
+		"live ${name} reference",
+		"unknown ${missing} reference",
+		"${user_id} and ${name} together",
+		"already escaped $${name}",
+		"double escaped $$${user_id}",
+		"digit name ${1}",
+		"leading-digit name ${9zzz}",
+		"empty name ${}",
+		"space in name ${ x}",
+		"unclosed ${name",
+		"env ref ${env:PATH}",
+		"bare pid $$ and price $$5",
+		"adjacent ${name}${user_id}",
+		"mixed ${name}/${1}/$${user_id}/${}",
+		"dollar-brace-digit output val=${1} end",
+	}
+	for _, in := range cases {
+		if got := s.Expand(Escape(in)); got != in {
+			t.Errorf("Expand(Escape(%q)) = %q, want %q (round-trip broken)", in, got, in)
+		}
+	}
+}
+
+// TestEscapeExpandRoundTrip_Quick fuzzes the same inverse law over random inputs
+// with a fixed seed, so a future change to the reference grammar that breaks the
+// escape/expand symmetry is caught.
+func TestEscapeExpandRoundTrip_Quick(t *testing.T) {
+	t.Parallel()
+	s := New()
+	s.Set("a", "X")
+	s.Set("name", "Alice")
+	roundTrips := func(in string) bool { return s.Expand(Escape(in)) == in }
+	cfg := &quick.Config{Rand: rand.New(rand.NewSource(1)), MaxCount: 3000}
+	if err := quick.Check(roundTrips, cfg); err != nil {
+		t.Errorf("escape/expand round-trip law broken: %v", err)
 	}
 }
 


### PR DESCRIPTION
## What

`atago record` generates a spec that cannot replay green when the observed command or output carries a `${` that is not a valid variable reference — a tool that prints `${1}`, `${}`, or `${ }`.

The recorder escaped every `${` to `$${` with a blind string replace, so the generated `contains`/`command`/file-path matcher held `$${1}`. But the replay expander only restores `$${<valid-name>}` back to `${...}`; `$${1}` (invalid name) stays literal. So the matcher `$${1}` was compared against the real output `${1}` and never matched — the recorded spec failed to replay.

## Fix

The escape must be the exact inverse of the expander. This adds `store.Escape` next to `store.Expand` (where the reference grammar already lives) that escapes only the references the expander acts on — a live `${name}` becomes `$${name}`, an already-escaped `$${name}` becomes `$$${name}`, and a `${` the expander ignores is left untouched. `record` (including `record --pty` transcripts and sends) routes through it instead of the blind replace.

## Test

- `store.TestEscapeExpandRoundTrip` plus a `testing/quick` property test assert `Expand(Escape(x)) == x` for arbitrary text.
- `record.TestGenerate_RecordRunRoundTrip` replays a generated spec through the real engine and asserts it passes, including the `${1}` regression that failed before the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed replay issues when recorded output contains `${...}`-style text with invalid variable names, so `atago record` and `atago record --pty` now replay these cases correctly.
* **Tests**
  * Added coverage to verify recorded specs round-trip successfully through generation, loading, and replay.
* **Documentation**
  * Updated the changelog with the latest replay fix details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->