### PR TITLE
fix(db): strip SQL comments before classifying a statement's routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- A `query`/`db` step whose SELECT is preceded by a SQL comment (a `-- ...` line
+  or a `/* ... */` block) no longer misroutes to ExecContext and returns no rows.
+  The statement classifier read the leading verb without stripping comments, so a
+  commented SELECT looked like a non-row statement and its result set was lost.
+  Comments outside string literals are now stripped before classification; a
+  comment marker inside a quoted value is still treated as data.
+
 - `atago record` no longer generates a spec that cannot replay when the observed
   command or output carries a `${` not followed by a valid variable name (a tool
   that prints `${1}`, `${}`, or `${ }`). The recorder escaped every `${` to

--- a/internal/runner/db/db.go
+++ b/internal/runner/db/db.go
@@ -148,7 +148,7 @@ func normalizeValue(v any) any {
 // isRowReturning reports whether a statement yields a result set and so should be
 // run with QueryContext rather than ExecContext.
 func isRowReturning(query string) bool {
-	head := strings.ToUpper(strings.TrimSpace(query))
+	head := strings.ToUpper(strings.TrimSpace(stripSQLComments(query)))
 	// A WITH (CTE) statement is only row-returning when its main statement is a
 	// SELECT/VALUES (or it has RETURNING). A data-modifying CTE like
 	// `WITH x AS (...) INSERT/UPDATE/DELETE ...` without RETURNING must run through
@@ -162,6 +162,50 @@ func isRowReturning(query string) bool {
 		}
 	}
 	return hasReturningKeyword(head)
+}
+
+// stripSQLComments replaces SQL comments outside string/identifier literals with
+// a single space, so the statement classifier sees the real leading verb. A `--`
+// line comment runs to end of line; a `/* */` block comment to its close (an
+// unterminated one to end of input). Quoted regions are skipped with the same
+// rule as the keyword scans, so a `--` or `/*` inside a string literal stays as
+// data. A commented `SELECT` was otherwise misrouted to ExecContext, losing its
+// rows.
+func stripSQLComments(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); {
+		c := s[i]
+		switch {
+		case c == '\'' || c == '"' || c == '`':
+			j := skipQuoted(s, i)
+			b.WriteString(s[i:j])
+			i = j
+		case c == '-' && i+1 < len(s) && s[i+1] == '-':
+			j := i + 2
+			for j < len(s) && s[j] != '\n' {
+				j++
+			}
+			b.WriteByte(' ')
+			i = j
+		case c == '/' && i+1 < len(s) && s[i+1] == '*':
+			j := i + 2
+			for j+1 < len(s) && (s[j] != '*' || s[j+1] != '/') {
+				j++
+			}
+			if j+1 < len(s) {
+				j += 2 // consume the closing */
+			} else {
+				j = len(s) // unterminated block comment
+			}
+			b.WriteByte(' ')
+			i = j
+		default:
+			b.WriteByte(c)
+			i++
+		}
+	}
+	return b.String()
 }
 
 // hasReturningKeyword reports whether head contains a RETURNING keyword OUTSIDE

--- a/internal/runner/db/db_test.go
+++ b/internal/runner/db/db_test.go
@@ -129,6 +129,44 @@ func TestRunner_Query_ModifyingCTE(t *testing.T) {
 	}
 }
 
+// TestRunner_Query_CommentedSelect is a regression: a SELECT preceded by a SQL
+// comment must still route through QueryContext and return its rows. A leading
+// comment hid the SELECT verb, misrouting the statement to ExecContext, which
+// returns no rows — so the row assertion saw nothing.
+func TestRunner_Query_CommentedSelect(t *testing.T) {
+	t.Parallel()
+	cfg, err := Resolve("", "sqlite::memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, err := Open(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = r.Close() }()
+
+	ctx := context.Background()
+	if _, err := r.Query(ctx, "CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := r.Query(ctx, "INSERT INTO t (name) VALUES ('alice')"); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	for _, q := range []string{
+		"-- fetch the row\nSELECT id, name FROM t",
+		"/* preamble */ SELECT id, name FROM t",
+	} {
+		sel, err := r.Query(ctx, q)
+		if err != nil {
+			t.Fatalf("query %q: %v", q, err)
+		}
+		if !strings.Contains(string(sel.RowsJSON), `"name":"alice"`) {
+			t.Errorf("commented SELECT %q returned no rows: RowsJSON=%q (misrouted to Exec?)", q, sel.RowsJSON)
+		}
+	}
+}
+
 func TestRunner_Query_SyntaxError(t *testing.T) {
 	t.Parallel()
 	cfg, _ := Resolve("", "sqlite::memory:")
@@ -163,6 +201,17 @@ func TestIsRowReturning(t *testing.T) {
 		"INSERT INTO logs (msg) VALUES ('order RETURNING to sender')":    false,
 		"UPDATE t SET note = 'see RETURNING policy' WHERE id = 1":        false,
 		"WITH x AS (SELECT 1) INSERT INTO logs VALUES ('a RETURNING b')": false,
+		// A leading or embedded SQL comment must not hide the main verb: a
+		// commented SELECT was misrouted to Exec, losing its rows.
+		"-- fetch users\nSELECT 1":              true,
+		"/* preamble */ SELECT 1":               true,
+		"SELECT/* inline */1":                   true,
+		"-- note\nINSERT INTO t VALUES (1)":     false,
+		"/* c */ WITH x AS (SELECT 1) SELECT 1": true,
+		// A comment marker inside a string literal is data, not a comment: it must
+		// not be stripped, and the statement still routes to Exec.
+		"INSERT INTO logs (msg) VALUES ('a -- b')": false,
+		"INSERT INTO logs (msg) VALUES ('a /* b')": false,
 	}
 	for q, want := range cases {
 		if got := isRowReturning(q); got != want {


### PR DESCRIPTION
## What

A `query`/`db` step whose SELECT is preceded by a SQL comment returned no rows. `isRowReturning` classified the statement (SELECT/WITH → QueryContext vs INSERT/UPDATE/DDL → ExecContext) by reading the leading verb, but did not strip comments first. So `-- fetch users\nSELECT ...` or `/* preamble */ SELECT ...` did not match the SELECT prefix, fell through to the RETURNING scan, and was misrouted to ExecContext — which returns no rows, so the row assertion saw nothing.

## Fix

Strip SQL comments outside string/identifier literals before classification, replacing each comment with a space (so `SELECT/*x*/1` still reads as a SELECT). A `--` or `/*` inside a quoted value is skipped with the same rule the RETURNING scan already uses, so a comment marker in a data value stays as data and the statement still routes correctly.

## Test

- `TestIsRowReturning` gains leading/embedded comment cases and quoted-comment-marker cases.
- `TestRunner_Query_CommentedSelect` runs a commented SELECT through the real sqlite driver and asserts the rows come back.