### PR TITLE
test(cli): pin which scenario statuses --rerun-failed records

### DIFF
--- a/internal/cli/features_test.go
+++ b/internal/cli/features_test.go
@@ -9,8 +9,49 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/nao1215/atago/internal/engine"
 	"github.com/nao1215/atago/internal/loader"
 )
+
+// TestCollectFailures_ClassifiesStatuses pins which scenario outcomes are
+// recorded for --rerun-failed: only failed and errored scenarios are, in a
+// deterministic order. A flaky scenario (one that recovered on retry, #29) is
+// green and must NOT be recorded, or the red-green loop would keep re-running a
+// scenario that already passes; passed and skipped are likewise excluded.
+func TestCollectFailures_ClassifiesStatuses(t *testing.T) {
+	t.Parallel()
+	results := []*engine.SuiteResult{
+		{SpecPath: "b.atago.yaml", Scenarios: []engine.ScenarioResult{
+			{Name: "passes", Status: engine.StatusPassed},
+			{Name: "errs", Status: engine.StatusError},
+			{Name: "flakes", Status: engine.StatusFlaky},
+		}},
+		{SpecPath: "a.atago.yaml", Scenarios: []engine.ScenarioResult{
+			{Name: "fails", Status: engine.StatusFailed},
+			{Name: "skipped", Status: engine.StatusSkipped},
+		}},
+		nil, // a nil suite result (e.g. a spec that failed to load) is skipped
+	}
+	got := collectFailures(results)
+
+	want := []failedEntry{
+		{SpecPath: "b.atago.yaml", Scenario: "errs"},
+		{SpecPath: "a.atago.yaml", Scenario: "fails"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("collectFailures = %+v, want only the failed/errored entries %+v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("entry %d = %+v, want %+v (order follows results, statuses filtered)", i, got[i], want[i])
+		}
+	}
+	for _, e := range got {
+		if e.Scenario == "flakes" || e.Scenario == "passes" || e.Scenario == "skipped" {
+			t.Errorf("collectFailures recorded a non-failing scenario %q; the rerun loop would never converge", e.Scenario)
+		}
+	}
+}
 
 // --- #62 completion --------------------------------------------------------
 


### PR DESCRIPTION
## What

Iteration 5 of a five-part bug hunt (the --rerun-failed state machine via state-transition testing). `collectFailures` decides which scenarios the rerun state remembers, and the important, subtle rule is that a flaky scenario — one that failed and then recovered on retry (#29) — is green and must NOT be recorded. If it were, `--rerun-failed` would keep re-running a scenario that already passes and the red-green loop would never converge. Passed and skipped are excluded too; only failed and errored are recorded, in a deterministic order.

The spec-driven rerun tests cover the round trip but cannot easily stage a deterministically flaky scenario, so this adds a direct unit test of the classification and ordering.

The classifier was already correct, so this captures the invariant as a regression. Test-only, no production change.