### PR TITLE
chore(release): prepare v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-07-05
+
+A bug-fix release hardening the runners and the reporters. No new features.
+
+Highlights: a `query`/`db` SELECT preceded by a SQL comment no longer misroutes
+to ExecContext and drops its rows; `atago record` escapes only genuine variable
+references, so a recorded spec whose output carries a literal `${1}` replays
+green; and a hung `grpc` server no longer passes on a per-call timeout. Reporting
+is steadier too — a suite that errors in `suite.setup` with nothing selected is
+no longer a green empty junit/tap/gha result, and TAP marks a recovered flaky
+scenario `ok`.
+
 ### Fixed
 
 - A `query`/`db` step whose SELECT is preceded by a SQL comment (a `-- ...` line
@@ -15,7 +27,6 @@ and this project follows [Semantic Versioning](https://semver.org/).
   commented SELECT looked like a non-row statement and its result set was lost.
   Comments outside string literals are now stripped before classification; a
   comment marker inside a quoted value is still treated as data.
-
 - `atago record` no longer generates a spec that cannot replay when the observed
   command or output carries a `${` not followed by a valid variable name (a tool
   that prints `${1}`, `${}`, or `${ }`). The recorder escaped every `${` to


### PR DESCRIPTION
Prepare the v0.3.2 release. This seals the current Unreleased entries under a dated `## [0.3.2]` heading with a short summary, matching the v0.3.1 format; no code changes.

v0.3.2 is a bug-fix release across the db and grpc runners, record, the loader, and the reporters:

- db: a SELECT preceded by a SQL comment no longer misroutes to ExecContext and drops its rows.
- record: escaping now mirrors the expander, so a recorded spec whose output carries a literal `${1}` (a `${` not followed by a valid name) replays green; covers `record --pty` too.
- grpc: a hung server no longer passes on a per-call timeout when the deadline status arrives over the wire before the local timer fires.
- loader: an empty spec file reports a clear message instead of a bare `EOF`.
- report: a suite that errors in `suite.setup` with nothing selected is no longer a green empty junit/tap/gha result; the console verdict reads FAILED. TAP marks a recovered flaky scenario as a passing `ok` point.

After merge, tag `v0.3.2` on the merge commit to trigger the Release workflow.