### PR TITLE
test(e2e): add an htop third-party spec exercising the pty screen surface

### DIFF
--- a/.github/workflows/thirdparty.yml
+++ b/.github/workflows/thirdparty.yml
@@ -52,6 +52,11 @@ jobs:
           - name: fzf
             dir: ./test/e2e/thirdparty/fzf
             install: go install github.com/junegunn/fzf@latest
+          # htop drives the pty runner's alternate-screen rendering and named
+          # function keys; from apt where the runner image lacks it.
+          - name: htop
+            dir: ./test/e2e/thirdparty/htop
+            install: command -v htop >/dev/null || (sudo apt-get update && sudo apt-get install -y htop)
           - name: redis
             dir: ./test/e2e/thirdparty/redis
             install: command -v redis-server >/dev/null || (sudo apt-get update && sudo apt-get install -y redis-server redis-tools)

--- a/test/e2e/thirdparty/htop/htop.atago.yaml
+++ b/test/e2e/thirdparty/htop/htop.atago.yaml
@@ -1,0 +1,76 @@
+version: "1"
+
+suite:
+  name: htop (third-party CLI, full-screen TUI testbed)
+
+# htop is the archetype of a FULL-SCREEN TUI: it switches to the alternate
+# screen buffer, paints meters and a process table with cursor moves and
+# colors, and restores the primary screen when it quits. That makes it the
+# real-world testbed for the pty runner's screen rendering (#27) that fzf — a
+# partial-screen finder — does not reach: the vt100 emulator must track the
+# alternate-screen switch to render the live frame, and a full-screen program
+# must run and quit cleanly under the pty. Every scenario probes for htop first
+# so the suite skips cleanly where it is absent; the interactive scenarios are
+# POSIX-only (the pty runner does not support Windows).
+scenarios:
+  - name: version prints a semantic version
+    only:
+      command: htop --version
+    steps:
+      - run:
+          command: htop --version
+      - assert:
+          exit_code: 0
+          stdout:
+            matches: "^htop [0-9]+\\.[0-9]+"
+
+  - name: the finder loads its function-key bar and quits on q
+    only:
+      command: htop --version
+    skip:
+      os: windows
+    steps:
+      # htop paints on the alternate screen; the transcript still carries the
+      # rendered text, so `expect` waits for the F10 quit label to prove the UI
+      # loaded. `q` quits, htop restores the primary screen, and the process
+      # exits 0 — the full clean lifecycle of an alt-screen TUI under the pty
+      # runner.
+      - pty:
+          command: htop
+          cols: 100
+          rows: 30
+          timeout: 20s
+          session:
+            - expect: "F10"
+            - send: "q"
+      - assert:
+          exit_code: 0
+
+  - name: the rendered screen shows the live meters and column header
+    only:
+      command: htop --version
+    skip:
+      os: windows
+    steps:
+      # The `screen:` assertion replays the transcript through the vt100
+      # emulator and pins what the user actually SEES. htop must still be on its
+      # alternate screen for the frame to hold its UI: quitting would restore
+      # the (empty) primary screen, so this scenario deliberately does NOT send
+      # q — the per-step timeout ends it while htop is live, and the assertion
+      # checks the final rendered frame rather than the exit code.
+      - pty:
+          command: htop
+          cols: 100
+          rows: 30
+          timeout: 4s
+          session:
+            - expect: "F10"
+      - assert:
+          screen:
+            contains: "CPU%"
+      - assert:
+          screen:
+            contains: "Command"
+      - assert:
+          screen:
+            contains: "F10"


### PR DESCRIPTION
## What

Adds a third-party E2E for htop, a full-screen TUI. htop switches to the alternate screen buffer, paints CPU/memory meters and a process table with cursor moves and colors, and restores the primary screen on quit. That reaches a part of the pty runner the existing fzf spec (a partial-screen finder) does not: the vt100 emulator's alternate-screen tracking (#27), needed to render a live full-screen frame.

## Scenarios

Each probes for htop first (`only: {command: htop --version}`) and skips Windows (the pty runner is POSIX-only):

- version prints a semantic version (non-interactive contract).
- the UI loads and quits cleanly on `q` — the full alt-screen lifecycle, exit 0.
- the rendered `screen:` shows the live meters and column header. htop must still be on its alternate screen for the frame to hold its UI (quitting restores the empty primary screen), so this scenario drives to the per-step timeout rather than asserting an exit code.

Added to the daily `thirdparty.yml` matrix, installed from apt. I dispatched the matrix on this branch to verify: atago rendered htop's alternate screen correctly and drove the lifecycle in the CI container — no defect surfaced. An earlier F2/Esc named-key navigation scenario was dropped because htop's function-key handling is terminfo/version-sensitive (it passed locally on htop 3.4.1 but the runner's build did not accept the SS3 F2 sequence), which made that scenario unreliable rather than revealing an atago defect; named keys stay covered by the deterministic pty example and unit tests.

Because this touches a workflow file, it will be merged via git rather than `gh pr merge` (the token lacks the workflow scope).