### PR TITLE
test(e2e): drive fzf with named keys and assert its rendered screen

### DIFF
--- a/test/e2e/thirdparty/fzf/fzf.atago.yaml
+++ b/test/e2e/thirdparty/fzf/fzf.atago.yaml
@@ -99,18 +99,19 @@ scenarios:
     skip:
       os: windows
     steps:
-      # -m enables multi-select; ctrl-a (sent as the raw byte \x01 — a named
-      # key like {key: ctrl-a} does not exist yet, see #26) selects every
-      # match and Enter accepts them all.
+      # -m enables multi-select; ctrl-a selects every match and Enter accepts
+      # them all — sent as named keys ({key: ctrl-a} / {key: enter}, #26) so a
+      # real program's key handling proves the named-key sequences, not just the
+      # raw bytes.
       - pty:
           shell: true
           command: printf 'apple\nbanana\ncherry\n' | fzf -m --bind ctrl-a:select-all > pick.txt
           timeout: 20s
           session:
             - expect: "3/3"
-            - send: "\x01"
+            - send: {key: ctrl-a}
             - expect: "\\(3\\)"   # the (3) selection counter appears
-            - send: "\r"
+            - send: {key: enter}
       - assert:
           exit_code: 0
           file:
@@ -126,14 +127,42 @@ scenarios:
     skip:
       os: windows
     steps:
-      # ESC (raw \x1b — named keys are #26) aborts; fzf documents exit 130
-      # for that, mirroring a SIGINT'd shell job.
+      # Esc ({key: esc}, #26) aborts; fzf documents exit 130 for that,
+      # mirroring a SIGINT'd shell job.
       - pty:
           shell: true
           command: printf 'apple\nbanana\ncherry\n' | fzf
           timeout: 20s
           session:
             - expect: "3/3"
-            - send: "\x1b"
+            - send: {key: esc}
       - assert:
           exit_code: 130
+
+  - name: the finder screen narrows to the typed query
+    only:
+      command: fzf --version
+    skip:
+      os: windows
+    steps:
+      # The `screen:` assertion replays the transcript through the vt100
+      # emulator and checks what the finder actually SHOWS. Typing a query
+      # narrows the visible list; fzf stays on its full screen (no Enter), so
+      # the per-step timeout ends the step while the finder is live and the
+      # rendered frame still holds the narrowed list.
+      - pty:
+          shell: true
+          command: printf 'apple\nbanana\ncherry\n' | fzf
+          cols: 80
+          rows: 20
+          timeout: 5s
+          session:
+            - expect: "3/3"
+            - send: "ban"
+            - expect: "1/3"
+      - assert:
+          screen:
+            contains: banana
+      - assert:
+          screen:
+            not_contains: cherry


### PR DESCRIPTION
## What

Strengthens the fzf third-party spec on two axes, and corrects a stale comment.

Named keys: the multi-select and abort scenarios sent ctrl-a / Enter / Esc as raw bytes (`\x01`, `\r`, `\x1b`) with a comment claiming a named key like `{key: ctrl-a}` did not exist yet. It does (#26), so the sends now use `{key: ctrl-a}` / `{key: enter}` / `{key: esc}`. The bytes are identical, but the change proves a real program accepts atago's named-key sequences and removes the incorrect comment. These keys are single control bytes, terminfo-independent, so they behave the same everywhere.

Screen surface: the existing scenarios drive fzf through the transcript and assert on the selection written to a file — they never touch the rendered screen. A new scenario adds it: typing a query narrows the finder, and the `screen:` assertion replays the transcript through the vt100 emulator and checks the live frame shows the surviving match and drops the filtered-out line. fzf stays on its full screen (no Enter), so the per-step timeout ends the step while the finder is live.

atago drove and rendered fzf correctly in every case; this adds the screen angle the spec lacked and keeps the named-key documentation accurate.