### PR TITLE
fix(engine): apply defaults.run.timeout to http, query, and grpc steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `defaults.run.timeout` now bounds `http`, `query`, and `grpc` steps, not just
+  `run` steps. The precedence chain (step > runner > defaults.run > suite >
+  built-in 60s) documents these steps as members, but the http and connection
+  config builders passed an empty defaults.run level, so a spec relying on
+  `defaults.run.timeout` to bound a slow request or query silently fell through
+  to `suite.timeout` or the 60s default.
+
 ## [0.3.2] - 2026-07-05
 
 A bug-fix release hardening the runners and the reporters. No new features.

--- a/internal/engine/conn.go
+++ b/internal/engine/conn.go
@@ -18,9 +18,10 @@ import (
 // wantType is the required runner.Type; open builds and opens the typed
 // connection from the runner definition and its parsed timeout. defaultBounded
 // opts the runner family into the step-timeout precedence chain (#17): query
-// and grpc steps fall back to suite.timeout and the built-in 60s default when
-// the runner declares no timeout, while ssh and browser keep their historical
-// "empty means unbounded" behavior (their long-lived sessions are not steps).
+// and grpc steps fall back to defaults.run.timeout, then suite.timeout, then the
+// built-in 60s default when the runner declares no timeout, while ssh and
+// browser keep their historical "empty means unbounded" behavior (their
+// long-lived sessions are not steps).
 func resolveConn[T io.Closer](
 	name, stepVerb, wantType string,
 	rc runConfig,
@@ -41,7 +42,7 @@ func resolveConn[T io.Closer](
 	}
 	timeoutStr := rdef.Timeout
 	if defaultBounded {
-		timeoutStr, _ = resolveTimeout("", rdef.Timeout, "", rc.suiteTimeout)
+		timeoutStr, _ = resolveTimeout("", rdef.Timeout, rc.defaultsRunTimeout, rc.suiteTimeout)
 	}
 	var timeout time.Duration
 	if timeoutStr != "" {

--- a/internal/engine/http.go
+++ b/internal/engine/http.go
@@ -96,8 +96,9 @@ func resolveHTTPConfig(h *spec.HTTP, st *store.Store, rc runConfig) (httprunner.
 		runnerTimeout = r.Timeout
 	}
 	// http requests join the step-timeout precedence chain (#17): runner
-	// timeout > suite.timeout > built-in 60s ("0" disables).
-	timeoutStr, _ := resolveTimeout("", runnerTimeout, "", rc.suiteTimeout)
+	// timeout > defaults.run.timeout > suite.timeout > built-in 60s ("0"
+	// disables). An http step has no step-level timeout of its own.
+	timeoutStr, _ := resolveTimeout("", runnerTimeout, rc.defaultsRunTimeout, rc.suiteTimeout)
 	d, err := time.ParseDuration(timeoutStr)
 	if err != nil {
 		return cfg, fmt.Errorf("runner %q has invalid timeout %q: %w", h.Runner, timeoutStr, err)

--- a/internal/engine/timeout_test.go
+++ b/internal/engine/timeout_test.go
@@ -3,7 +3,56 @@ package engine
 import (
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/nao1215/atago/internal/spec"
+	"github.com/nao1215/atago/internal/store"
 )
+
+// TestResolveHTTPConfig_DefaultsRunTimeout proves an http step honors
+// defaults.run.timeout when it declares no runner or step timeout (#17). The
+// suite comment puts http in the same precedence chain as run, but the config
+// builder dropped the defaults.run level, so an http step fell straight through
+// to suite.timeout / the built-in 60s.
+func TestResolveHTTPConfig_DefaultsRunTimeout(t *testing.T) {
+	t.Parallel()
+	cfg, err := resolveHTTPConfig(&spec.HTTP{Path: "/"}, store.New(), runConfig{defaultsRunTimeout: "150ms"})
+	if err != nil {
+		t.Fatalf("resolveHTTPConfig: %v", err)
+	}
+	if cfg.Timeout != 150*time.Millisecond {
+		t.Errorf("cfg.Timeout = %s, want 150ms (defaults.run.timeout must bound an http step)", cfg.Timeout)
+	}
+}
+
+// fakeCloser is a no-op io.Closer for the resolveConn timeout test.
+type fakeCloser struct{}
+
+func (fakeCloser) Close() error { return nil }
+
+// TestResolveConn_DefaultsRunTimeout proves query/grpc connections honor
+// defaults.run.timeout when the runner declares none (#17). resolveConn opted
+// into the precedence chain but passed an empty defaults.run level, so these
+// steps skipped defaults.run and used suite.timeout / the built-in 60s instead.
+func TestResolveConn_DefaultsRunTimeout(t *testing.T) {
+	t.Parallel()
+	rc := runConfig{
+		defaultsRunTimeout: "150ms",
+		runners:            map[string]spec.Runner{"db": {Type: "db", DSN: "sqlite::memory:"}},
+	}
+	var got time.Duration
+	_, err := resolveConn("db", "query step", "db", rc, map[string]fakeCloser{}, true,
+		func(_ spec.Runner, timeout time.Duration) (fakeCloser, error) {
+			got = timeout
+			return fakeCloser{}, nil
+		})
+	if err != nil {
+		t.Fatalf("resolveConn: %v", err)
+	}
+	if got != 150*time.Millisecond {
+		t.Errorf("open received timeout %s, want 150ms (defaults.run.timeout must bound a query/grpc step)", got)
+	}
+}
 
 // TestResolveTimeout proves the five-level precedence chain (#17): step >
 // runner > defaults.run > suite > built-in 60s, with an explicit "0" at any


### PR DESCRIPTION
## What

`defaults.run.timeout` was ignored by `http`, `query`, and `grpc` steps.

The step-timeout precedence chain is documented (on `suite.timeout` and in the loader) as step > runner > defaults.run > suite > built-in 60s, and it names run, http, query, and grpc as members. But the http config builder (`resolveHTTPConfig`) and the shared connection builder (`resolveConn`, used by query and grpc) called `resolveTimeout` with an empty string for the defaults.run level. So a spec that set `defaults.run.timeout` to bound a slow request or query fell straight through to `suite.timeout` — or, with no suite timeout, the built-in 60s — instead of the configured bound.

## Fix

Pass `rc.defaultsRunTimeout` as the defaults.run argument in both builders, and correct the two stale precedence comments.

## Test

`TestResolveHTTPConfig_DefaultsRunTimeout` asserts the http config resolves to `defaults.run.timeout` when no runner/step timeout is set; `TestResolveConn_DefaultsRunTimeout` uses a fake opener to capture the timeout passed to a query/grpc connection. Both fail on the old code (they resolve to the 60s default) and pass after the fix.