### PR TITLE
fix(service): bound ready.delay by ready.timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- A service `ready.delay` is now bounded by `ready.timeout`, as the docs promise
+  ("Timeout bounds the readiness wait"). The delay branch waited the full
+  duration regardless of the timeout, so `delay: 30s` with `timeout: 500ms`
+  stalled for 30 seconds instead of failing fast — a CI-hang hazard. A delay
+  longer than the timeout now fails at the timeout with a message naming the
+  misconfiguration; a delay within the timeout is unchanged.
 - `defaults.run.timeout` now bounds `http`, `query`, and `grpc` steps, not just
   `run` steps. The precedence chain (step > runner > defaults.run > suite >
   built-in 60s) documents these steps as members, but the http and connection

--- a/internal/runner/service/service.go
+++ b/internal/runner/service/service.go
@@ -172,6 +172,14 @@ func (p *Proc) waitReady(ctx context.Context, r *spec.Ready, workdir string) (st
 		if err != nil {
 			return "", fmt.Errorf("invalid ready.delay %q: %w", r.Delay, err)
 		}
+		// Timeout is the ceiling on any readiness wait (documented on ready), so a
+		// delay longer than the timeout can never be reached — wait only up to the
+		// timeout and report the misconfiguration instead of stalling for the full
+		// delay (a CI-hang hazard). A non-positive timeout means "unbounded".
+		wait, cappedByTimeout := d, false
+		if timeout > 0 && timeout < d {
+			wait, cappedByTimeout = timeout, true
+		}
 		select {
 		case <-ctx.Done():
 			return "", ctx.Err()
@@ -181,7 +189,10 @@ func (p *Proc) waitReady(ctx context.Context, r *spec.Ready, workdir string) (st
 			// this, a command that crashes (e.g. `exit 3`) during the delay was
 			// reported READY and the scenario ran against a dead peer.
 			return "", errExitedEarly
-		case <-time.After(d):
+		case <-time.After(wait):
+			if cappedByTimeout {
+				return "", fmt.Errorf("timed out after %s waiting for readiness (ready.delay %s exceeds ready.timeout)", timeout, r.Delay)
+			}
 			// Delay elapsed with the process still running — unless it exited in the
 			// same instant; check once more so a crash at the boundary is not missed.
 			select {

--- a/internal/runner/service/service_test.go
+++ b/internal/runner/service/service_test.go
@@ -136,6 +136,30 @@ func TestStart_DelayReadyDetectsEarlyExit(t *testing.T) {
 	}
 }
 
+// TestStart_DelayBoundedByTimeout is a regression: ready.timeout must bound the
+// ready.delay wait, as the docs promise ("Timeout bounds the readiness wait").
+// A delay longer than the timeout was waited out in full — a spec with
+// delay: 5s, timeout: 100ms stalled for 5 seconds, a CI-hang hazard.
+func TestStart_DelayBoundedByTimeout(t *testing.T) {
+	skipWindows(t)
+	wd := t.TempDir()
+	svc := &spec.Service{
+		Name:    "slow",
+		Shell:   spec.Bool(true),
+		Command: sleepCmd(5), // stays alive well past both the delay and the timeout
+		Ready:   &spec.Ready{Delay: "5s", Timeout: "100ms"},
+	}
+	start := time.Now()
+	_, _, err := Start(context.Background(), svc, wd)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("Start() error = nil, want a readiness timeout (delay exceeds timeout)")
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("Start waited %s; ready.timeout 100ms must bound the 5s ready.delay", elapsed)
+	}
+}
+
 // TestStart_BarePortReadyRejected is a regression: a host-less ready.port must
 // fail fast with a clear message, not swallow "missing port in address" and run
 // to the full readiness timeout.


### PR DESCRIPTION
## What

A service `ready.delay` was not bounded by `ready.timeout`.

The `ready` docs promise "Timeout bounds the readiness wait", and the file, port, and log probes honor it (they poll up to the timeout). But the delay branch waited its full duration with a plain `time.After(delay)`, ignoring the timeout. So a spec with `delay: 30s` and `timeout: 500ms` stalled for 30 seconds before the service was reported ready — a CI-hang hazard, and a contract violation.

## Fix

The delay now waits only up to the timeout. A delay longer than the timeout can never be reached, so it fails at the timeout with a message naming the misconfiguration (`ready.delay ... exceeds ready.timeout`), matching how the other probes report a readiness timeout. A delay within the timeout is unchanged, and the existing early-exit detection (a process that crashes during the delay is not ready) is preserved. A non-positive timeout means unbounded.

## Test

`TestStart_DelayBoundedByTimeout` starts a long-lived service with `delay: 5s` and `timeout: 100ms` and asserts `Start` returns a readiness error in well under 2 seconds. It waited the full 5s on the old code.