### PR TITLE
fix(engine): time-bound skip/only probe commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project follows [Semantic Versioning](https://semver.org/).
   stalled for 30 seconds instead of failing fast — a CI-hang hazard. A delay
   longer than the timeout now fails at the timeout with a message naming the
   misconfiguration; a delay within the timeout is unchanged.
+- A `skip.command` / `only.command` probe is now time-bounded (30s). The probe
+  ran unbounded, so a hanging probe (`sleep 9999`, an unreachable health check)
+  stalled the sequential selection phase and with it the whole run. A probe that
+  exceeds the bound is treated as "did not succeed".
 - `defaults.run.timeout` now bounds `http`, `query`, and `grpc` steps, not just
   `run` steps. The precedence chain (step > runner > defaults.run > suite >
   built-in 60s) documents these steps as members, but the http and connection

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -94,11 +94,20 @@ type Engine struct {
 	// assertions write durable sidecar files for review tooling (#48, the
 	// --artifacts-dir flag). Nil disables artifact export.
 	Artifacts *artifact.Dir
+
+	// probeTimeout bounds a skip/only probe command so a hanging probe cannot
+	// stall the (sequential) selection phase. Zero means unbounded.
+	probeTimeout time.Duration
 }
+
+// defaultProbeTimeout bounds a skip/only probe command: quick checks like
+// `command -v tool` need far less, but a generous ceiling still stops a
+// pathological probe (`sleep 9999`) from hanging the selection phase.
+const defaultProbeTimeout = 30 * time.Second
 
 // New returns an Engine with the default command runner.
 func New() *Engine {
-	return &Engine{cmd: runnercmd.New(), builtins: builtinVars()}
+	return &Engine{cmd: runnercmd.New(), builtins: builtinVars(), probeTimeout: defaultProbeTimeout}
 }
 
 // builtinVars are variables seeded into every scenario's store. ${atago} is the
@@ -773,6 +782,13 @@ func (e *Engine) skipReason(ctx context.Context, sc *spec.Scenario) (string, boo
 // tool. The probe runs in a throwaway temp dir so it cannot touch the cwd; if
 // that dir cannot be created it falls back to the process cwd.
 func (e *Engine) probeSucceeds(ctx context.Context, command string) bool {
+	// A probe is a quick selection check, not a step, so bound it: a hanging
+	// probe would otherwise stall the sequential selection phase indefinitely.
+	if e.probeTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, e.probeTimeout)
+		defer cancel()
+	}
 	dir, err := os.MkdirTemp("", "atago-probe-")
 	if err == nil {
 		defer os.RemoveAll(dir)

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -377,6 +377,27 @@ scenarios:
 	}
 }
 
+// TestProbeSucceeds_BoundedByTimeout is a regression: a skip/only probe command
+// must be time-bounded so a hanging probe (e.g. `sleep 9999`) cannot stall the
+// sequential selection phase and, with it, the whole run.
+func TestProbeSucceeds_BoundedByTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX sleep as the hanging probe")
+	}
+	t.Parallel()
+	e := New()
+	e.probeTimeout = 100 * time.Millisecond
+	start := time.Now()
+	ok := e.probeSucceeds(context.Background(), "sleep 30")
+	elapsed := time.Since(start)
+	if ok {
+		t.Error("a hanging probe timed out and must not count as succeeded")
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("probeSucceeds ran %s; a probe must be bounded by the probe timeout", elapsed)
+	}
+}
+
 // parityScenarios builds a spec with n scenarios cycling passed/failed/skipped so
 // the parallel scheduler has real mixed outcomes to interleave.
 func parityScenarios(n int) string {


### PR DESCRIPTION
## What

A `skip.command` / `only.command` probe ran unbounded.

`probeSucceeds` ran the probe through the cmd runner with no timeout, so a hanging probe — `sleep 9999`, or a health check against an unreachable service — stalled the selection phase. Selection runs sequentially before the workers start, so one hanging probe hangs the entire run, not just its scenario.

## Fix

Bound the probe with a 30s ceiling — far more than a real check like `command -v tool` needs, but enough to stop a pathological probe. A probe that exceeds the bound is killed by the context deadline and counts as "did not succeed" (so `only:` skips and `skip:` runs, matching the existing "probe that cannot start counts as a failure" behavior). The bound is an unexported engine field defaulting to 30s so the regression test can drive it short.

## Test

`TestProbeSucceeds_BoundedByTimeout` sets the probe timeout to 100ms and runs `sleep 30`, asserting `probeSucceeds` returns false in well under 2 seconds. It ran the full 30s on the old code.