### PR TITLE
fix(engine): guard unresolved variables for a named cmd runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- The unresolved-variable guard now fires for a named `cmd` runner, not only the
+  default (unnamed) local runner. A no-shell run executes its command as argv, so
+  a typo like `run: {runner: local, command: "echo ${typo}"}` leaked the literal
+  `${typo}` into argv and ran a garbled command instead of erroring with the
+  reference named. Any local (non-ssh) run is now guarded; only an ssh runner,
+  where a remote shell may expand it, stays exempt.
 - A service `ready.delay` is now bounded by `ready.timeout`, as the docs promise
   ("Timeout bounds the readiness wait"). The delay branch waited the full
   duration regardless of the timeout, so `delay: 30s` with `timeout: 500ms`

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -541,8 +541,11 @@ func (e *Engine) runScenario(ctx context.Context, scenarioIdx int, sc *spec.Scen
 			// still expand it — but a local run without `shell: true`
 			// has no shell, so nothing could ever expand it and the literal text
 			// would leak into argv. That is almost always a typo; error with the
-			// reference named instead of running a garbled command (#UX).
-			if !step.Run.ShellEnabled() && step.Run.Runner == "" {
+			// reference named instead of running a garbled command (#UX). A named
+			// cmd runner runs the command as local argv too, so it is guarded like
+			// the default runner; only an ssh runner (remote, where a remote shell
+			// may expand it) is exempt.
+			if !step.Run.ShellEnabled() && !isSSHRunner(step.Run.Runner, rc.runners) {
 				if names := st.Unresolved(step.Run.Command); len(names) > 0 {
 					if envName, isEnv := strings.CutPrefix(names[0], "env:"); isEnv {
 						sr.ErrMsg = fmt.Sprintf(
@@ -798,6 +801,14 @@ func (e *Engine) probeSucceeds(ctx context.Context, command string) bool {
 		return false
 	}
 	return res.ExitCode == 0
+}
+
+// isSSHRunner reports whether a run step's named runner is an ssh runner, which
+// executes remotely where a remote shell may still expand a ${name}. An empty
+// name is the default local cmd runner, and an unknown name is not ssh; both run
+// the command as local argv, so the unresolved-variable guard applies to them.
+func isSSHRunner(name string, runners map[string]spec.Runner) bool {
+	return name != "" && runners[name].Type == "ssh"
 }
 
 // runStep executes a run step, applying retry/until polling when requested. It

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -398,6 +398,38 @@ func TestProbeSucceeds_BoundedByTimeout(t *testing.T) {
 	}
 }
 
+// TestEngine_UnresolvedVarErrorsForNamedCmdRunner is a regression: the
+// unresolved-${name} guard fires for any local (non-ssh) run, not just an
+// unnamed one. A named cmd runner executes the command as argv the same as the
+// default runner, so a typo'd ${name} would otherwise leak into argv and run a
+// garbled command instead of erroring with the reference named. Only an ssh
+// runner (remote, where a remote shell may expand it) is exempt.
+func TestEngine_UnresolvedVarErrorsForNamedCmdRunner(t *testing.T) {
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: s
+runners:
+  local:
+    type: cmd
+scenarios:
+  - name: a typo in a named cmd runner errors instead of running literally
+    steps:
+      - run:
+          runner: local
+          command: "echo ${typo}"
+`)
+	if res.Status != StatusError {
+		t.Fatalf("status = %s, want error (unresolved ${typo} must not run literally through a named cmd runner): %+v",
+			res.Status, res.Scenarios)
+	}
+	msg := res.Scenarios[0].Steps[0].ErrMsg
+	if !strings.Contains(msg, "typo") || !strings.Contains(msg, "no variable with that name") {
+		t.Errorf("error = %q, want it to name the unresolved ${typo}", msg)
+	}
+}
+
 // parityScenarios builds a spec with n scenarios cycling passed/failed/skipped so
 // the parallel scheduler has real mixed outcomes to interleave.
 func parityScenarios(n int) string {


### PR DESCRIPTION
## What

The unresolved-`${name}` guard for a no-shell run only fired when the run named no runner.

A local run without `shell: true` tokenizes its command into argv, so a `${name}` that nothing defines cannot be expanded and leaks into argv verbatim — almost always a typo. The guard errors with the reference named instead of running a garbled command. But its condition was `runner == ""`, so a named `cmd` runner — `run: {runner: local, command: "echo ${typo}"}` — slipped past it and ran `echo ${typo}` literally. A named cmd runner executes as local argv exactly like the default runner; only an ssh runner is different (its command runs under a remote shell that may expand it).

## Fix

The guard now fires for any local (non-ssh) run — the default runner and any named cmd runner — and exempts only ssh runners, matching the loader's own `runnerIsSSH` condition (which already guards the no-shell shell-operator hint the same way). Added an `isSSHRunner` helper.

## Test

`TestEngine_UnresolvedVarErrorsForNamedCmdRunner` runs `echo ${typo}` through a named `cmd` runner and asserts the scenario errors with the unresolved reference named. It passed (ran literally) on the old code.