### PR TITLE
fix(spec): make exit_code, stdin, and send YAML marshal round-trip

### DIFF
--- a/internal/spec/roundtrip_test.go
+++ b/internal/spec/roundtrip_test.go
@@ -1,0 +1,133 @@
+package spec
+
+import (
+	"math/rand"
+	"reflect"
+	"testing"
+	"testing/quick"
+
+	"github.com/goccy/go-yaml"
+)
+
+// Three spec fields decode several authoring shapes through a custom
+// UnmarshalYAML (a scalar or one of a few mappings). Marshaling them back must
+// emit a shape the same unmarshaler accepts, or a loaded spec cannot be written
+// out and re-read — the round-trip a future canonicalizer/formatter would rely
+// on. These tests pin that marshal/unmarshal symmetry per type; the default
+// struct marshal breaks it (it writes fields like `equals`/`inline`/`text` the
+// unmarshaler rejects or silently drops).
+
+func TestExitCode_YAMLRoundTrip(t *testing.T) {
+	t.Parallel()
+	cases := map[string]ExitCode{
+		"equals zero":     {Equals: intp(0)},
+		"equals nonzero":  {Equals: intp(2)},
+		"equals negative": {Equals: intp(-1)},
+		"not":             {Not: intp(1)},
+		"in pair":         {In: []int{0, 2}},
+		"in single":       {In: []int{127}},
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := marshalReload(t, in)
+			if !reflect.DeepEqual(in, got) {
+				t.Errorf("exit_code round-trip:\n in  = %+v\n got = %+v", in, got)
+			}
+		})
+	}
+}
+
+// TestExitCode_YAMLRoundTrip_Property fuzzes the integer forms with a fixed seed:
+// any equals/not/in built from arbitrary ints must survive marshal→unmarshal.
+func TestExitCode_YAMLRoundTrip_Property(t *testing.T) {
+	t.Parallel()
+	f := func(n int, form uint8) bool {
+		var in ExitCode
+		switch form % 3 {
+		case 0:
+			in.Equals = &n
+		case 1:
+			in.Not = &n
+		default:
+			in.In = []int{n, n + 1}
+		}
+		return reflect.DeepEqual(in, marshalReloadNoT(in))
+	}
+	if err := quick.Check(f, &quick.Config{MaxCount: 500, Rand: rand.New(rand.NewSource(1))}); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestStdin_YAMLRoundTrip(t *testing.T) {
+	t.Parallel()
+	cases := map[string]Stdin{
+		"inline plain":    {Inline: "hello"},
+		"inline empty":    {Inline: ""},
+		"inline unicode":  {Inline: "日本語 \t emoji 💥 line1\nline2"},
+		"inline yamlmeta": {Inline: "- : # * & [x]"},
+		"file":            {File: "input.txt", mapped: true},
+		"base64":          {Base64: "aGVsbG8=", mapped: true},
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := marshalReload(t, in)
+			if !reflect.DeepEqual(in, got) {
+				t.Errorf("stdin round-trip:\n in  = %+v\n got = %+v", in, got)
+			}
+		})
+	}
+}
+
+func TestPTYSend_YAMLRoundTrip(t *testing.T) {
+	t.Parallel()
+	// A lone carriage return is deliberately not exercised: YAML normalizes bare
+	// CRs in scalars, so no marshaler could round-trip one — that key press is
+	// authored as {key: enter}, which is covered below.
+	cases := map[string]PTYSend{
+		"text plain":     {Text: strp("yes")},
+		"text empty":     {Text: strp("")},
+		"text multiline": {Text: strp("line1\nline2")},
+		"text escape":    {Text: strp("\x01\x1b[A")},
+		"key enter":      {Key: "enter"},
+		"key ctrl-c":     {Key: "ctrl-c"},
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := marshalReload(t, in)
+			if !reflect.DeepEqual(in, got) {
+				t.Errorf("send round-trip:\n in  = %+v\n got = %+v", in, got)
+			}
+		})
+	}
+}
+
+// marshalReload marshals v to YAML and decodes it back into a fresh T, failing
+// the test on any encode/decode error. It is how each round-trip case checks
+// that a value survives a write-then-read cycle.
+func marshalReload[T any](t *testing.T, v T) T {
+	t.Helper()
+	b, err := yaml.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal %+v: %v", v, err)
+	}
+	var got T
+	if err := yaml.Unmarshal(b, &got); err != nil {
+		t.Fatalf("reload %q: %v", b, err)
+	}
+	return got
+}
+
+// marshalReloadNoT is the property-test variant: it returns the zero value on
+// any error so quick.Check reports the offending input via a false result.
+func marshalReloadNoT[T any](v T) T {
+	var got T
+	b, err := yaml.Marshal(v)
+	if err != nil {
+		return got
+	}
+	_ = yaml.Unmarshal(b, &got)
+	return got
+}

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -676,6 +676,17 @@ func (p *PTYSend) UnmarshalYAML(unmarshal func(any) error) error {
 	return nil
 }
 
+// MarshalYAML emits the same shape UnmarshalYAML accepts — the scalar text form,
+// or the {key: <name>} mapping — so a loaded send round-trips back to a loadable
+// spec. Without it the default struct marshal writes a `text:` key the custom
+// unmarshaler rejects.
+func (p PTYSend) MarshalYAML() (any, error) {
+	if p.Text != nil {
+		return *p.Text, nil
+	}
+	return map[string]string{"key": p.Key}, nil
+}
+
 // ptyKeySequences maps each named key (#26) to the xterm byte sequence it
 // transmits. Documented bytes: enter=\r, tab=\t, esc=\x1b, space=" ",
 // backspace=\x7f (DEL, the modern erase), delete=\x1b[3~, arrows
@@ -1112,6 +1123,24 @@ func (s *Stdin) UnmarshalYAML(unmarshal func(any) error) error {
 	return nil
 }
 
+// MarshalYAML emits the scalar inline form or the {file}/{base64} mapping the
+// author used, mirroring UnmarshalYAML so a loaded stdin round-trips. The
+// default struct marshal would instead write an `inline:` key the unmarshaler
+// rejects.
+func (s Stdin) MarshalYAML() (any, error) {
+	if s.mapped {
+		m := make(map[string]string, 1)
+		if s.File != "" {
+			m["file"] = s.File
+		}
+		if s.Base64 != "" {
+			m["base64"] = s.Base64
+		}
+		return m, nil
+	}
+	return s.Inline, nil
+}
+
 // ExitCode accepts a bare integer, {not: <int>}, or {in: [<int>, ...]} (#19).
 // The `in` set is the contract shape real CLIs document (grep's 0/1,
 // terraform plan -detailed-exitcode's 0/2): membership in an accepted set.
@@ -1152,6 +1181,24 @@ func (e *ExitCode) UnmarshalYAML(b []byte) error {
 	e.Not = m.Not
 	e.In = m.In
 	return nil
+}
+
+// MarshalYAML emits the same shape UnmarshalYAML accepts — a bare integer, a
+// {not: <int>} map, or an {in: [<int>, ...]} map — so a loaded exit_code
+// round-trips. The default struct marshal writes all three fields at once
+// (equals/not/in), and the unmarshaler's inner mapping decode then silently
+// drops `equals` and rejects the empty `in`, losing the assertion.
+func (e ExitCode) MarshalYAML() (any, error) {
+	switch {
+	case e.Equals != nil:
+		return *e.Equals, nil
+	case e.Not != nil:
+		return map[string]int{"not": *e.Not}, nil
+	case len(e.In) > 0:
+		return map[string][]int{"in": e.In}, nil
+	default:
+		return nil, nil
+	}
 }
 
 // StreamAssert matches a captured text stream (stdout/stderr/body). One matcher.


### PR DESCRIPTION
The exit_code, stdin, and send spec fields each decode several authoring shapes through a custom UnmarshalYAML — a scalar, or one of a few mappings — but none had a matching MarshalYAML. So the default struct marshal emitted field names the unmarshaler rejects or silently drops, and a loaded spec could not be written back out and re-read.

The worst case is exit_code: marshaling ExitCode{Equals: 0} wrote equals, not, and in at once, and the unmarshaler's inner mapping decode then dropped equals and rejected the empty in list, so the assertion was lost entirely. stdin round-tripped an inline value to an inline: key its unmarshaler rejects, and send wrote a text: key its unmarshaler rejects.

No production path marshals a whole spec today (record.go marshals only individual scalar strings), so this was latent rather than user-reachable, but the marshal/unmarshal asymmetry is a correctness defect the moment a canonicalizer, formatter, or spec dump reads a loaded spec back.

This adds a MarshalYAML to each type that emits exactly the shape its UnmarshalYAML accepts, plus a per-type round-trip test and a fixed-seed property check over exit_code's integer forms that pin the symmetry. A lone carriage return in send text is intentionally not exercised: YAML normalizes bare CRs in scalars, so no marshaler could round-trip one, and that key press is authored as {key: enter}.