### PR TITLE
chore(release): prepare v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.4] - 2026-07-05
+
+A bug-fix release that bounds and guards the run engine. No new features.
+
+Highlights: `defaults.run.timeout` now bounds `http`, `query`, and `grpc` steps,
+not just `run` steps; a `skip.command` / `only.command` probe and a service
+`ready.delay` are both time-bounded so a hanging probe or an over-long delay
+fails fast instead of stalling the whole run; and the unresolved-variable guard
+now fires for a named `cmd` runner, so a typo cannot leak `${...}` into argv and
+run a garbled command.
+
 ### Fixed
 
 - The unresolved-variable guard now fires for a named `cmd` runner, not only the


### PR DESCRIPTION
Cuts v0.3.4, a bug-fix release that bounds and guards the run engine. No new features.

The release ships the fixes accumulated since v0.3.2: defaults.run.timeout now bounds http, query, and grpc steps rather than only run steps; a skip.command / only.command probe and a service ready.delay are both time-bounded so a hanging probe or an over-long delay fails fast instead of stalling the whole run; and the unresolved-variable guard now fires for a named cmd runner, so a typo cannot leak a literal variable reference into argv and run a garbled command.

This branch only moves the accumulated Unreleased entries under a dated 0.3.4 heading with a summary; the fixes themselves already landed on main. Internal hardening merged alongside (report cross-format count-parity and hostile-char tests, exit_code/stdin/send YAML marshal round-trip symmetry, and scenario-selection set-algebra tests) carries no user-facing change and is not listed.