### PR TITLE
docs(examples): show extending host env vars with ${env:NAME} (#115)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Every feature has a commented, runnable spec under [examples/](examples/). The e
 | [store_and_variables](examples/store_and_variables.atago.yaml) | capturing values into `${name}`, `${workdir}`, `${env:NAME}` host-environment reads, the `$${...}` literal escape |
 | [teardown](examples/teardown.atago.yaml) | cleanup steps that always run — pass or fail — sharing the scenario's variables |
 | [hermetic_env](examples/hermetic_env.atago.yaml) | `clear_env: true` starts commands from an empty environment, `pass_env` re-admits an allowlist of host variables, `sandbox_home: true` isolates HOME and per-OS config/cache dirs |
+| [extend_host_env](examples/extend_host_env.atago.yaml) | extend an inherited variable in a scenario `env:` value with `${env:NAME}` (e.g. `PATH: "${workdir}/stub:${env:PATH}"`) instead of replacing it — put a stub binary earlier on PATH while real tools still resolve |
 | [timeouts](examples/timeouts.atago.yaml) | the built-in 60s default step timeout, `suite.timeout`, per-step overrides, and the `timeout: "0"` escape hatch |
 | [stdin](examples/stdin.atago.yaml) | stdin sources: inline text, `stdin: {file: ...}` from a workdir file, and binary input via `stdin: {base64: ...}` |
 | [matrix](examples/matrix.atago.yaml) | one template scenario expanded per parameter row |

--- a/drift_test.go
+++ b/drift_test.go
@@ -233,6 +233,7 @@ var exampleSpecs = map[string]bool{ // path -> hermetic (run, not just validate)
 	"examples/defaults.atago.yaml":            true,
 	"examples/dir_tree.atago.yaml":            true,
 	"examples/duration.atago.yaml":            true,
+	"examples/extend_host_env.atago.yaml":     true,
 	"examples/files_and_fixtures.atago.yaml":  true,
 	"examples/grpc.atago.yaml":                false,
 	"examples/hermetic_env.atago.yaml":        true,

--- a/examples/extend_host_env.atago.yaml
+++ b/examples/extend_host_env.atago.yaml
@@ -1,0 +1,69 @@
+version: "1"
+suite:
+  name: extend-host-env
+# A scenario's env: values are ${name}-expanded, and ${env:NAME} reads the
+# launcher's own environment — so a value can EXTEND an inherited variable
+# instead of replacing it. The classic case: put a stub binary earlier on PATH
+# while keeping the real toolchain resolvable. ${env:NAME} is opt-in: a bare
+# ${NAME} (no env: prefix) is left literal, so existing suites are unaffected.
+scenarios:
+  # Prepend a stub dir to PATH: the stub wins, and the inherited PATH still
+  # resolves real tools — impossible if PATH could only be replaced.
+  - name: extend PATH with a stub directory, keeping the inherited PATH
+    skip:
+      os: windows # POSIX PATH syntax (":" separator, sh, command -v)
+    env:
+      PATH: "${workdir}/stub:${env:PATH}"
+    steps:
+      - fixture:
+          file: stub/foo
+          content: |
+            #!/bin/sh
+            echo stubbed-foo
+          mode: "0755"
+      - run:
+          shell: true
+          command: command -v foo # resolves to the stub, not any system foo
+      - assert:
+          stdout:
+            contains: /stub/foo
+      - run:
+          shell: true
+          command: foo
+      - assert:
+          stdout:
+            equals: stubbed-foo
+      - run:
+          shell: true
+          command: command -v sh # a real tool from the inherited PATH still resolves
+      - assert:
+          exit_code: 0
+
+  # Opt-in guard: a bare ${NAME} without the env: prefix stays literal, so
+  # ${env:PATH} never silently changes the meaning of an existing value.
+  - name: "a bare ${NAME} without env: prefix is left literal"
+    skip:
+      os: windows
+    env:
+      LITERAL: "keep:${NOT_DEFINED}"
+    steps:
+      - run:
+          command: printenv LITERAL
+      - assert:
+          stdout:
+            equals: "keep:${NOT_DEFINED}"
+
+  # An unset host variable is left literal (the same unresolved-variable policy
+  # as a bare ${NAME}), so a typo'd or absent host var stays visible instead of
+  # collapsing to a silent empty segment.
+  - name: an unset host variable is left literal, not silently blank
+    skip:
+      os: windows
+    env:
+      MAYBE: "a:${env:DEFINITELY_NOT_SET_XYZ}:b"
+    steps:
+      - run:
+          command: printenv MAYBE
+      - assert:
+          stdout:
+            equals: "a:${env:DEFINITELY_NOT_SET_XYZ}:b"


### PR DESCRIPTION
## Summary

Closes #115.

The capability #115 asks for — extending an inherited env var (the classic "prepend a stub dir to `PATH`, keep the rest") — **already works** via the `${env:NAME}` syntax. A scenario's `env:` values are `${name}`-expanded, and `${env:NAME}` reads the launcher's environment, so:

```yaml
env:
  PATH: "${workdir}/stub:${env:PATH}"   # stub wins; the inherited PATH still resolves real tools
```

#115 concluded it was impossible after trying `${PATH}`, `${env.PATH}`, and `$PATH` — none of which is the supported **colon** form `${env:PATH}`. So this is a discoverability gap, not a missing feature: no new syntax is added.

## Change

- **`examples/extend_host_env.atago.yaml`** — a hermetic example (POSIX-gated) that also serves as the regression test the issue asked for. `TestExamples_HermeticRunGreen` runs it in CI, so it can't silently break. It covers:
  - **extend/stub-wins**: prepend `${workdir}/stub` to `PATH`; `command -v foo` resolves to the stub, the stub runs, and a real tool (`sh`) from the inherited `PATH` still resolves.
  - **opt-in guard**: a bare `${NAME}` (no `env:` prefix) stays literal, so existing suites are unaffected.
  - **unresolved policy**: an unset `${env:NAME}` is left literal (not silently blanked), consistent with the bare-`${NAME}` policy.
- Registered in `exampleSpecs` (drift_test.go) and linked from the README examples table.

The design already satisfies the issue's own opt-in/determinism requirements: `${env:NAME}` is explicit and a bare `${PATH}` is never silently changed.

## Tests

`go test ./... -count=1` passes; the new example runs green through the real engine on POSIX (skipped on Windows via an OS gate, as its `:` separator / `sh` / `command -v` are POSIX).
