### PR TITLE
test: raise coverage to 94% and fix render/expansion bugs it surfaced

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,11 +1,10 @@
 coverage:
   paths:
     - cover.out
-  acceptable: 80%
-  exclude:
-    # The process entrypoint just wires os.Args into cli.Main; it has no logic
-    # worth a test and is exercised end-to-end by the binary itself.
-    - "github.com/nao1215/atago/main.go"
+  # cover.out is the merged unit + self-hosted E2E profile (make coverage), so
+  # main.go is exercised by the real binary and needs no exclude; every package
+  # is measured against one honest number.
+  acceptable: 90%
   badge:
     path: doc/coverage.svg
 diff:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- PDF text extraction now decodes octal `\ddd`, `\b`, `\f`, and backslash-newline
+  line-continuation escapes in literal strings (ISO 32000), so a `pdf: {text:
+  {...}}` assertion matches non-ASCII text as written by pandoc/LaTeX/wkhtmltopdf
+  instead of seeing the literal escape sequence (e.g. `caf\351` now yields the
+  byte for `é`, not `caf351`).
+- The `screen` assertion's failure box measures line width and padding in runes,
+  not bytes, so a rendered pty/TUI screen with box-drawing characters or CJK text
+  frames with an aligned right border instead of a ragged one.
+- A store step capturing a JSON `null` (`from.stdout.json`) now returns a clear
+  error instead of storing Go's `"<nil>"` string into the variable, so a null
+  field can no longer masquerade as a captured value.
+- Browser `cdp` upload and download actions now expand `${name}` references in
+  their file path, capture directory, and selectors, matching every other cdp
+  action; a stored or `${workdir}`-derived path previously reached the browser
+  literally.
+- `atago explain` and `atago doc` now render an HTTP header `matches:` regexp
+  matcher; it was silently dropped, hiding a security-relevant header constraint
+  from the generated summaries.
+- The shared variable walk (`explain`/`manifest`/`doc`) now counts `${name}`
+  references in `fixture.from`, HTTP/gRPC header values and JSON bodies, assert
+  matcher arguments, a service `ready` probe, and a store file-source path — every
+  field the engine expands — so the "Variables used" summary no longer
+  under-reports them.
+
 ## [0.3.4] - 2026-07-05
 
 A bug-fix release that bounds and guards the run engine. No new features.

--- a/internal/assert/assert_test.go
+++ b/internal/assert/assert_test.go
@@ -1,6 +1,11 @@
 package assert
 
 import (
+	"bytes"
+	"compress/zlib"
+	"image"
+	"image/color"
+	"image/png"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -8,8 +13,11 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
+	"github.com/nao1215/atago/internal/fsdelta"
 	"github.com/nao1215/atago/internal/runner"
+	"github.com/nao1215/atago/internal/runner/mock"
 	"github.com/nao1215/atago/internal/spec"
 )
 
@@ -738,5 +746,1138 @@ func TestCheck_File_ExistsUnreadable(t *testing.T) {
 	got = Check(&spec.Assert{File: &spec.FileAssert{Path: target, Exists: boolp(true)}}, nil, Env{Workdir: dir})
 	if got.OK {
 		t.Fatalf("unreadable path with exists:true should fail; hint=%s", got.Hint)
+	}
+}
+
+// TestBorderedScreen_MultibyteAligns is a regression test for a width bug in the
+// screen-assert failure box: it measured line width and padding in bytes, so a
+// rendered TUI screen containing box-drawing characters (─│┌, 3 bytes each) or
+// CJK text produced a ragged right border — exactly the screens atago's pty/TUI
+// assertions exist to check. Every framed content row must have the same rune
+// width so the closing "|" column lines up.
+func TestBorderedScreen_MultibyteAligns(t *testing.T) {
+	t.Parallel()
+	// An ASCII line and a multibyte line of different byte lengths but knowable
+	// rune widths. Byte-based padding would give these rows different rune widths.
+	screen := "abc\n日本\n┌──┐"
+	out := borderedScreen(screen)
+
+	lines := strings.Split(out, "\n")
+	if len(lines) < 3 {
+		t.Fatalf("bordered output has too few lines:\n%s", out)
+	}
+	// The top bar sets the box width; every subsequent row (content rows and the
+	// bottom bar) must match it rune-for-rune.
+	want := utf8.RuneCountInString(lines[0])
+	for i, l := range lines {
+		if got := utf8.RuneCountInString(l); got != want {
+			t.Errorf("row %d rune width = %d, want %d (ragged border)\nrow: %q\nfull:\n%s", i, got, want, l, out)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// pdf.go: inflate, readPDFString, unescapePDFByte, metadataActual, parsePDF
+// ---------------------------------------------------------------------------
+
+// TestInflate_RoundTripAndError exercises the FlateDecode success path (a real
+// zlib stream) and the raw-stream error path (a non-Flate stream returns an
+// error so parsePDF keeps the raw bytes).
+func TestInflate_RoundTripAndError(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	zw := zlib.NewWriter(&buf)
+	payload := []byte("BT (Compressed body) Tj ET")
+	if _, err := zw.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	// Prepend stray CR/LF so we exercise the TrimLeft in inflate.
+	compressed := append([]byte("\r\n"), buf.Bytes()...)
+	out, err := inflate(compressed)
+	if err != nil {
+		t.Fatalf("inflate valid zlib: %v", err)
+	}
+	if !bytes.Equal(out, payload) {
+		t.Errorf("inflate roundtrip = %q, want %q", out, payload)
+	}
+
+	if _, err := inflate([]byte("this is not zlib data at all")); err == nil {
+		t.Error("inflate on raw (non-zlib) bytes must return an error so the caller keeps raw bytes")
+	}
+	// Empty input must not panic and must error.
+	if _, err := inflate(nil); err == nil {
+		t.Error("inflate(nil) should error, not silently succeed")
+	}
+}
+
+// TestReadPDFString_Escapes covers unescapePDFByte (all mapped escapes plus the
+// default passthrough) and balanced/nested/unbalanced parentheses.
+func TestReadPDFString_Escapes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		lit  string
+		want string
+	}{
+		{"plain", `(hello)`, "hello"},
+		{"newline-escape", `(a\nb)`, "a\nb"},
+		{"tab-escape", `(a\tb)`, "a\tb"},
+		{"cr-escape", `(a\rb)`, "a\rb"},
+		{"escaped-paren", `(a\)b)`, "a)b"},
+		{"escaped-open-paren", `(a\(b)`, "a(b"},
+		{"escaped-backslash", `(a\\b)`, `a\b`},
+		{"default-passthrough", `(a\zb)`, "azb"}, // \z is not special -> literal z
+		{"nested-balanced", `(a (b) c)`, "a (b) c"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := decodePDFString([]byte(tt.lit)); got != tt.want {
+				t.Errorf("decodePDFString(%q) = %q, want %q", tt.lit, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestReadPDFString_Boundaries feeds out-of-range / non-paren openings and a
+// trailing backslash so the function never panics.
+func TestReadPDFString_Boundaries(t *testing.T) {
+	t.Parallel()
+	data := []byte(`(abc)`)
+	if _, ok := readPDFString(data, -1); ok {
+		t.Error("negative open index must return false")
+	}
+	if _, ok := readPDFString(data, len(data)); ok {
+		t.Error("open index at len must return false")
+	}
+	if _, ok := readPDFString([]byte("xyz"), 0); ok {
+		t.Error("a non-'(' opening byte must return false")
+	}
+	// Trailing backslash with no following byte: must not panic.
+	if _, ok := readPDFString([]byte(`(ab\`), 0); !ok {
+		t.Error("unterminated string is read leniently and returns true")
+	}
+	// Unbalanced open paren: lenient parser returns what it has.
+	if s, ok := readPDFString([]byte(`(unclosed`), 0); !ok || s != "unclosed" {
+		t.Errorf("unbalanced literal = %q ok=%v", s, ok)
+	}
+}
+
+// TestParsePDF_Compressed proves parsePDF extracts text from a FlateDecode
+// content stream, exercising the inflate branch inside parsePDF.
+func TestParsePDF_Compressed(t *testing.T) {
+	t.Parallel()
+	var zbuf bytes.Buffer
+	zw := zlib.NewWriter(&zbuf)
+	if _, err := zw.Write([]byte("BT (Zlib hidden text) Tj ET")); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	var pdf bytes.Buffer
+	pdf.WriteString("%PDF-1.5\n1 0 obj\n<< /Type /Page >>\nendobj\n4 0 obj\n<< /Length 99 /Filter /FlateDecode >>\nstream\n")
+	pdf.Write(zbuf.Bytes())
+	pdf.WriteString("\nendstream\nendobj\n%%EOF\n")
+
+	doc := parsePDF(pdf.Bytes())
+	if !strings.Contains(doc.text, "Zlib hidden text") {
+		t.Errorf("compressed text not extracted: %q", doc.text)
+	}
+}
+
+// TestParsePDF_Malformed feeds garbage / truncated bodies (after the header,
+// which checkPDF requires) and asserts parsePDF never panics and returns a
+// zero-ish doc.
+func TestParsePDF_Malformed(t *testing.T) {
+	t.Parallel()
+	inputs := [][]byte{
+		[]byte("%PDF-1.4\n"),
+		[]byte("%PDF-1.4\nstream\n"),                    // truncated stream, no endstream
+		[]byte("%PDF-1.4\nstream\n\xff\xfe\nendstream"), // binary garbage stream
+		[]byte("%PDF-1.4\n/Type /Page /Title ("),        // dangling metadata literal
+		append([]byte("%PDF-1.4\n"), bytes.Repeat([]byte{0x00}, 512)...),
+	}
+	for i, in := range inputs {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("parsePDF panicked on input %d: %v", i, r)
+				}
+			}()
+			_ = parsePDF(in)
+		}()
+	}
+}
+
+// TestCheckPDF_PageBoundaries hits the min/max off-by-one edges and the
+// metadataActual "field not present" branch.
+func TestCheckPDF_PageBoundaries(t *testing.T) {
+	t.Parallel()
+	wd := writePDF(t, minimalPDF) // 1 page
+	// min == pages passes, min == pages+1 fails.
+	if cr := checkPDFOK(t, wd, &spec.PDFAssert{Path: "doc.pdf", MinPages: ptrInt(1)}); !cr.OK {
+		t.Errorf("min 1 on a 1-page PDF should pass: %+v", cr)
+	}
+	if cr := checkPDFOK(t, wd, &spec.PDFAssert{Path: "doc.pdf", MinPages: ptrInt(2)}); cr.OK {
+		t.Error("min 2 on a 1-page PDF must fail")
+	}
+	// max == pages passes, max == pages-1 fails.
+	if cr := checkPDFOK(t, wd, &spec.PDFAssert{Path: "doc.pdf", MaxPages: ptrInt(1)}); !cr.OK {
+		t.Errorf("max 1 on a 1-page PDF should pass: %+v", cr)
+	}
+	if cr := checkPDFOK(t, wd, &spec.PDFAssert{Path: "doc.pdf", MaxPages: ptrInt(0)}); cr.OK {
+		t.Error("max 0 on a 1-page PDF must fail")
+	}
+	// A metadata field absent from the doc reports "field not present".
+	cr := checkPDFOK(t, wd, &spec.PDFAssert{Path: "doc.pdf", Metadata: map[string]string{"subject": "anything"}})
+	if cr.OK {
+		t.Fatal("absent metadata field must fail")
+	}
+	if !strings.Contains(cr.Actual, "field not present") {
+		t.Errorf("Actual = %q, want it to say the field is not present", cr.Actual)
+	}
+}
+
+func TestMetadataActual(t *testing.T) {
+	t.Parallel()
+	if got := metadataActual("", false); got != "field not present" {
+		t.Errorf("metadataActual(_, false) = %q", got)
+	}
+	if got := metadataActual("value", true); got != "value" {
+		t.Errorf("metadataActual present = %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// screen.go: checkScreen, borderedScreen
+// ---------------------------------------------------------------------------
+
+func TestCheckScreen_NoPTY(t *testing.T) {
+	t.Parallel()
+	sa := &spec.StreamAssert{Contains: spec.StringList{"x"}}
+	if cr := checkScreen(sa, nil, Env{}); cr.OK {
+		t.Error("screen assert with no result should not pass")
+	}
+	if cr := checkScreen(sa, &runner.Result{IsPTY: false}, Env{}); cr.OK {
+		t.Error("screen assert with a non-pty result should not pass")
+	}
+}
+
+func TestCheckScreen_PassAndFail(t *testing.T) {
+	t.Parallel()
+	res := &runner.Result{IsPTY: true, Screen: []byte("hello\nworld")}
+	if cr := checkScreen(&spec.StreamAssert{Contains: spec.StringList{"world"}}, res, Env{}); !cr.OK {
+		t.Errorf("matching screen should pass: %+v", cr)
+	}
+	fail := checkScreen(&spec.StreamAssert{Contains: spec.StringList{"absent"}}, res, Env{})
+	if fail.OK {
+		t.Fatal("non-matching screen should fail")
+	}
+	if !strings.Contains(fail.Actual, "+---") || !strings.Contains(fail.Actual, "| hello") {
+		t.Errorf("failure Actual should be a bordered screen, got:\n%s", fail.Actual)
+	}
+	if fail.ArtifactKind != "screen" {
+		t.Errorf("ArtifactKind = %q, want screen", fail.ArtifactKind)
+	}
+	if !bytes.Equal(fail.ArtifactActual, res.Screen) {
+		t.Error("ArtifactActual should carry the raw screen bytes")
+	}
+}
+
+func TestBorderedScreen(t *testing.T) {
+	t.Parallel()
+	// Ragged lines: the border width follows the widest line and every row is
+	// right-padded to it, so trailing whitespace stays visible.
+	out := borderedScreen("ab\nabcd\n")
+	lines := strings.Split(out, "\n")
+	width := len(lines[0])
+	for _, l := range lines {
+		if len(l) != width {
+			t.Errorf("uneven border row %q (len %d != %d)", l, len(l), width)
+		}
+	}
+	// Single empty screen must not panic and still frames a zero-width box.
+	_ = borderedScreen("")
+}
+
+// ---------------------------------------------------------------------------
+// jsonmatch.go: toFloat, jsonMatches, single, opSymbol, applyJSONMatch, checkYAML
+// ---------------------------------------------------------------------------
+
+func TestToFloat_AllKinds(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		in     any
+		wantOK bool
+		want   float64
+	}{
+		{"int", int(3), true, 3},
+		{"int8", int8(-3), true, -3},
+		{"int16", int16(300), true, 300},
+		{"int32", int32(-9), true, -9},
+		{"int64", int64(1 << 40), true, float64(int64(1) << 40)},
+		{"uint", uint(7), true, 7},
+		{"uint8", uint8(255), true, 255},
+		{"uint16", uint16(65535), true, 65535},
+		{"uint32", uint32(1), true, 1},
+		{"uint64-huge", uint64(1) << 62, true, float64(uint64(1) << 62)},
+		{"float32", float32(1.5), true, 1.5},
+		{"float64", float64(2.25), true, 2.25},
+		{"numeric-string", "42", true, 42},
+		{"trimmed-string", "  3.5  ", true, 3.5},
+		{"non-numeric-string", "abc", false, 0},
+		{"version-string-not-a-float", "1.2.3", false, 0}, // #: full-consume guard
+		{"trailing-junk", "3abc", false, 0},
+		{"bool-not-numeric", true, false, 0},
+		{"nil-not-numeric", nil, false, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := toFloat(tt.in)
+			if ok != tt.wantOK {
+				t.Fatalf("toFloat(%v) ok = %v, want %v", tt.in, ok, tt.wantOK)
+			}
+			if ok && got != tt.want {
+				t.Errorf("toFloat(%v) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOpSymbol(t *testing.T) {
+	t.Parallel()
+	for op, sym := range map[string]string{"gt": ">", "gte": ">=", "lt": "<", "lte": "<=", "weird": "weird"} {
+		if got := opSymbol(op); got != sym {
+			t.Errorf("opSymbol(%q) = %q, want %q", op, got, sym)
+		}
+	}
+}
+
+// TestJSONCompare_Metamorphic proves gt and lt can never both pass for the same
+// value/threshold, and that a non-numeric selected value fails cleanly.
+func TestJSONCompare_Metamorphic(t *testing.T) {
+	t.Parallel()
+	data := []byte(`{"n": 5, "s": "hello"}`)
+	gt := checkJSON("d", "stdout", data, &spec.JSONAssert{Path: "$.n", Gt: f64p(5)})
+	lt := checkJSON("d", "stdout", data, &spec.JSONAssert{Path: "$.n", Lt: f64p(5)})
+	if gt.OK && lt.OK {
+		t.Error("gt 5 and lt 5 must not both pass for value 5")
+	}
+	// gte 5 and lte 5 both pass (boundary) — that is correct, not contradictory.
+	gte := checkJSON("d", "stdout", data, &spec.JSONAssert{Path: "$.n", Gte: f64p(5)})
+	lte := checkJSON("d", "stdout", data, &spec.JSONAssert{Path: "$.n", Lte: f64p(5)})
+	if !gte.OK || !lte.OK {
+		t.Error("gte 5 and lte 5 should both pass at the boundary")
+	}
+	// Non-numeric node cannot be compared.
+	if cr := checkJSON("d", "stdout", data, &spec.JSONAssert{Path: "$.s", Gt: f64p(0)}); cr.OK {
+		t.Error("gt on a string value must fail")
+	}
+}
+
+func TestJSONMatches_Errors(t *testing.T) {
+	t.Parallel()
+	data := []byte(`{"v": "abc123"}`)
+	if cr := checkJSON("d", "stdout", data, &spec.JSONAssert{Path: "$.v", Matches: strp(`\d+`)}); !cr.OK {
+		t.Errorf("matches digits should pass: %+v", cr)
+	}
+	if cr := checkJSON("d", "stdout", data, &spec.JSONAssert{Path: "$.v", Matches: strp(`^zzz$`)}); cr.OK {
+		t.Error("non-matching pattern should fail")
+	}
+	if cr := checkJSON("d", "stdout", data, &spec.JSONAssert{Path: "$.v", Matches: strp(`(`)}); cr.OK {
+		t.Error("invalid regexp should fail, not panic")
+	}
+}
+
+func TestSingle_ZeroAndMultiple(t *testing.T) {
+	t.Parallel()
+	data := []byte(`{"a": [1, 2, 3]}`)
+	// Zero matches.
+	if cr := checkJSON("d", "stdout", data, &spec.JSONAssert{Path: "$.missing", Equals: 1}); cr.OK {
+		t.Error("no-match path should fail via single()")
+	}
+	// Multiple matches (wildcard) → single() rejects.
+	cr := checkJSON("d", "stdout", data, &spec.JSONAssert{Path: "$.a[*]", Equals: 1})
+	if cr.OK {
+		t.Fatal("multiple matches should fail single()")
+	}
+	if !strings.Contains(cr.Actual, "matches") {
+		t.Errorf("Actual = %q, want it to report the match count", cr.Actual)
+	}
+}
+
+func TestApplyJSONMatch_NoMatcherAndBadPath(t *testing.T) {
+	t.Parallel()
+	if cr := checkJSON("d", "stdout", []byte(`{"a":1}`), &spec.JSONAssert{Path: "$.a"}); cr.OK {
+		t.Error("a matcher with no operator must fail")
+	}
+	if cr := checkJSON("d", "stdout", []byte(`{"a":1}`), &spec.JSONAssert{Path: "$[", Equals: 1}); cr.OK {
+		t.Error("an invalid JSON path must fail, not panic")
+	}
+}
+
+func TestCheckYAML(t *testing.T) {
+	t.Parallel()
+	yamlData := []byte("name: Ada\nage: 42\n")
+	if cr := checkYAML("d", "stdout", yamlData, &spec.JSONAssert{Path: "$.name", Equals: "Ada"}); !cr.OK {
+		t.Errorf("yaml equals should pass: %+v", cr)
+	}
+	if cr := checkYAML("d", "stdout", []byte("   \n"), &spec.JSONAssert{Path: "$.name", Equals: "Ada"}); cr.OK {
+		t.Error("empty YAML should fail")
+	}
+	if cr := checkYAML("d", "stdout", []byte("a: [b, c"), &spec.JSONAssert{Path: "$.a", Length: intp(2)}); cr.OK {
+		t.Error("malformed YAML should fail, not panic")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// dir.go: dirStatActual error branch, count boundaries, glob error
+// ---------------------------------------------------------------------------
+
+func TestCheckDir_CountBoundaries(t *testing.T) {
+	t.Parallel()
+	wd := makeTree(t) // site has 3 direct entries
+	// min == n passes, min == n+1 fails.
+	if cr := checkDirOK(t, wd, &spec.DirAssert{Path: "site", MinCount: ptrInt(3)}); !cr.OK {
+		t.Errorf("min 3 should pass: %+v", cr)
+	}
+	if cr := checkDirOK(t, wd, &spec.DirAssert{Path: "site", MinCount: ptrInt(4)}); cr.OK {
+		t.Error("min 4 must fail on 3 entries")
+	}
+	// max == n passes, max == n-1 fails.
+	if cr := checkDirOK(t, wd, &spec.DirAssert{Path: "site", MaxCount: ptrInt(3)}); !cr.OK {
+		t.Errorf("max 3 should pass: %+v", cr)
+	}
+	if cr := checkDirOK(t, wd, &spec.DirAssert{Path: "site", MaxCount: ptrInt(2)}); cr.OK {
+		t.Error("max 2 must fail on 3 entries")
+	}
+}
+
+// TestCheckDir_CountOnMissing hits the dirStatActual error branch: a count
+// constraint on a non-existent directory (no exists field) reports the stat
+// error rather than "not a directory".
+func TestCheckDir_CountOnMissing(t *testing.T) {
+	t.Parallel()
+	wd := makeTree(t)
+	cr := checkDirOK(t, wd, &spec.DirAssert{Path: "does-not-exist", Count: ptrInt(0)})
+	if cr.OK {
+		t.Fatal("count on a missing dir must fail")
+	}
+	if cr.Actual == "not a directory" || cr.Actual == "" {
+		t.Errorf("Actual = %q, want the underlying stat error", cr.Actual)
+	}
+}
+
+func TestCheckDir_GlobInvalid(t *testing.T) {
+	t.Parallel()
+	wd := makeTree(t)
+	cr := checkDirOK(t, wd, &spec.DirAssert{Path: "site", Glob: "["})
+	if cr.OK {
+		t.Error("an invalid glob pattern must fail, not match")
+	}
+	if !strings.Contains(cr.Hint, "invalid glob") {
+		t.Errorf("Hint = %q, want it to flag the invalid glob", cr.Hint)
+	}
+}
+
+func TestDirStatActual(t *testing.T) {
+	t.Parallel()
+	if got := dirStatActual(nil, os.ErrNotExist); got != os.ErrNotExist.Error() {
+		t.Errorf("err branch = %q", got)
+	}
+	// A regular file's FileInfo → "not a directory".
+	f := filepath.Join(t.TempDir(), "x")
+	if err := os.WriteFile(f, []byte("y"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := dirStatActual(info, nil); got != "not a directory" {
+		t.Errorf("not-a-dir branch = %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// file.go: not_contains, executable, exists:false, default, readFile error
+// ---------------------------------------------------------------------------
+
+func writeWorkFile(t *testing.T, name, body string, mode os.FileMode) string {
+	t.Helper()
+	wd := t.TempDir()
+	if err := os.WriteFile(filepath.Join(wd, name), []byte(body), mode); err != nil {
+		t.Fatal(err)
+	}
+	return wd
+}
+
+func checkFileOK(t *testing.T, wd string, f *spec.FileAssert) *CheckResult {
+	t.Helper()
+	return Check(&spec.Assert{File: f}, nil, Env{Workdir: wd})
+}
+
+func TestCheckFile_ExistsFalseAndDefault(t *testing.T) {
+	t.Parallel()
+	wd := writeWorkFile(t, "a.txt", "hi", 0o600)
+	if cr := checkFileOK(t, wd, &spec.FileAssert{Path: "missing.txt", Exists: boolp(false)}); !cr.OK {
+		t.Errorf("exists:false on a missing file should pass: %+v", cr)
+	}
+	if cr := checkFileOK(t, wd, &spec.FileAssert{Path: "a.txt", Exists: boolp(false)}); cr.OK {
+		t.Error("exists:false on a present file must fail")
+	}
+	// No matcher set → hint.
+	if cr := checkFileOK(t, wd, &spec.FileAssert{Path: "a.txt"}); cr.OK {
+		t.Error("a file assertion with no field must fail")
+	}
+}
+
+func TestCheckFile_NotContains(t *testing.T) {
+	t.Parallel()
+	wd := writeWorkFile(t, "a.txt", "hello world", 0o600)
+	if cr := checkFileOK(t, wd, &spec.FileAssert{Path: "a.txt", NotContains: spec.StringList{"absent"}}); !cr.OK {
+		t.Errorf("not_contains absent should pass: %+v", cr)
+	}
+	present := checkFileOK(t, wd, &spec.FileAssert{Path: "a.txt", NotContains: spec.StringList{"world"}})
+	if present.OK {
+		t.Error("not_contains present should fail")
+	}
+	if present.ArtifactKind != "file" {
+		t.Errorf("ArtifactKind = %q, want file", present.ArtifactKind)
+	}
+	// Reading a missing file for a contains check surfaces a read error.
+	if cr := checkFileOK(t, wd, &spec.FileAssert{Path: "missing.txt", Contains: spec.StringList{"x"}}); cr.OK {
+		t.Error("contains on a missing file must fail to read")
+	}
+}
+
+func TestCheckFile_Executable(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows ignores POSIX executable bits, so a 0755 file is not observably executable")
+	}
+	wd := writeWorkFile(t, "run.sh", "#!/bin/sh\n", 0o755)
+	if err := os.WriteFile(filepath.Join(wd, "plain.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if cr := checkFileOK(t, wd, &spec.FileAssert{Path: "run.sh", Executable: boolp(true)}); !cr.OK {
+		t.Errorf("executable:true on a 0755 file should pass: %+v", cr)
+	}
+	if cr := checkFileOK(t, wd, &spec.FileAssert{Path: "plain.txt", Executable: boolp(false)}); !cr.OK {
+		t.Errorf("executable:false on a 0600 file should pass: %+v", cr)
+	}
+	if cr := checkFileOK(t, wd, &spec.FileAssert{Path: "plain.txt", Executable: boolp(true)}); cr.OK {
+		t.Error("executable:true on a non-exec file must fail")
+	}
+	// Stat error on a missing file.
+	if cr := checkFileOK(t, wd, &spec.FileAssert{Path: "missing", Executable: boolp(true)}); cr.OK {
+		t.Error("executable on a missing file must fail")
+	}
+}
+
+func TestExistenceAndExecutabilityWords(t *testing.T) {
+	t.Parallel()
+	if existence(true) != "exist" || existence(false) != "not exist" {
+		t.Error("existence phrasing wrong")
+	}
+	if executability(true) != "be" || executability(false) != "not be" {
+		t.Error("executability phrasing wrong")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// http.go: grpc_status, dbRows/grpcMessage/cdpValue, header value matchers
+// ---------------------------------------------------------------------------
+
+func TestCheckGRPCStatus(t *testing.T) {
+	t.Parallel()
+	if cr := checkGRPCStatus(intp(0), nil); cr.OK {
+		t.Error("grpc_status with no result must fail")
+	}
+	if cr := checkGRPCStatus(intp(0), &runner.Result{IsGRPC: false}); cr.OK {
+		t.Error("grpc_status without a gRPC call must fail")
+	}
+	res := &runner.Result{IsGRPC: true, GRPCStatus: 5}
+	if cr := checkGRPCStatus(intp(5), res); !cr.OK {
+		t.Errorf("matching grpc status should pass: %+v", cr)
+	}
+	if cr := checkGRPCStatus(intp(0), res); cr.OK {
+		t.Error("mismatched grpc status must fail")
+	}
+}
+
+func TestCapturedBytesHelpers(t *testing.T) {
+	t.Parallel()
+	if dbRows(nil) != nil || grpcMessage(nil) != nil || cdpValue(nil) != nil || httpBody(nil) != nil {
+		t.Error("captured-bytes helpers should return nil for a nil result")
+	}
+	res := &runner.Result{
+		RowsJSON:    []byte(`[{"id":1}]`),
+		MessageJSON: []byte(`{"ok":true}`),
+		CDPValue:    []byte("value"),
+		Body:        []byte("body"),
+	}
+	if string(dbRows(res)) != `[{"id":1}]` {
+		t.Error("dbRows mismatch")
+	}
+	if string(grpcMessage(res)) != `{"ok":true}` {
+		t.Error("grpcMessage mismatch")
+	}
+	if string(cdpValue(res)) != "value" {
+		t.Error("cdpValue mismatch")
+	}
+	if string(httpBody(res)) != "body" {
+		t.Error("httpBody mismatch")
+	}
+}
+
+func TestCheckHeaderValue_AllMatchers(t *testing.T) {
+	t.Parallel()
+	h := func(m *spec.HeaderMatch) *CheckResult {
+		return checkHeaderValue(m, "application/json; charset=utf-8", "response")
+	}
+	if cr := h(&spec.HeaderMatch{Name: "Content-Type", Equals: strp("application/json; charset=utf-8")}); !cr.OK {
+		t.Errorf("equals should pass: %+v", cr)
+	}
+	if cr := h(&spec.HeaderMatch{Name: "Content-Type", Equals: strp("text/plain")}); cr.OK {
+		t.Error("equals mismatch must fail")
+	}
+	if cr := h(&spec.HeaderMatch{Name: "Content-Type", Contains: strp("json")}); !cr.OK {
+		t.Errorf("contains should pass: %+v", cr)
+	}
+	if cr := h(&spec.HeaderMatch{Name: "Content-Type", Contains: strp("xml")}); cr.OK {
+		t.Error("contains mismatch must fail")
+	}
+	if cr := h(&spec.HeaderMatch{Name: "Content-Type", Matches: strp(`^application/`)}); !cr.OK {
+		t.Errorf("matches should pass: %+v", cr)
+	}
+	if cr := h(&spec.HeaderMatch{Name: "Content-Type", Matches: strp(`^text/`)}); cr.OK {
+		t.Error("matches mismatch must fail")
+	}
+	if cr := h(&spec.HeaderMatch{Name: "Content-Type", Matches: strp(`(`)}); cr.OK {
+		t.Error("invalid regexp must fail, not panic")
+	}
+	// No matcher set → hint.
+	if cr := h(&spec.HeaderMatch{Name: "Content-Type"}); cr.OK {
+		t.Error("a header match with no matcher must fail")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// mock.go: checkMock, mockFilterLabel, plural, summarizeRecords
+// ---------------------------------------------------------------------------
+
+func mockEnv(records map[string][]mock.Record) Env {
+	return Env{MockRecords: func(name string) ([]mock.Record, bool) {
+		r, ok := records[name]
+		return r, ok
+	}}
+}
+
+func TestCheckMock_NoServerAndNilProvider(t *testing.T) {
+	t.Parallel()
+	if cr := checkMock(&spec.MockAssert{Name: "api"}, Env{}); cr.OK {
+		t.Error("mock assert with no provider must fail")
+	}
+	env := mockEnv(map[string][]mock.Record{})
+	if cr := checkMock(&spec.MockAssert{Name: "unknown"}, env); cr.OK {
+		t.Error("mock assert for an unknown server must fail")
+	}
+}
+
+func TestCheckMock_CountAndFilter(t *testing.T) {
+	t.Parallel()
+	records := []mock.Record{
+		{Method: "GET", Path: "/a", Status: 200},
+		{Method: "POST", Path: "/a", Status: 201},
+		{Method: "GET", Path: "/b", Status: 200},
+	}
+	env := mockEnv(map[string][]mock.Record{"api": records})
+
+	// Exact count over all routes.
+	if cr := checkMock(&spec.MockAssert{Name: "api", Count: intp(3)}, env); !cr.OK {
+		t.Errorf("count 3 (any route) should pass: %+v", cr)
+	}
+	// Wrong count reports the summary of recorded requests.
+	wrong := checkMock(&spec.MockAssert{Name: "api", Count: intp(2)}, env)
+	if wrong.OK {
+		t.Fatal("count 2 must fail")
+	}
+	if !strings.Contains(wrong.Actual, "GET /a -> 200") {
+		t.Errorf("Actual should summarize recorded requests, got:\n%s", wrong.Actual)
+	}
+	// Filter by method+path.
+	if cr := checkMock(&spec.MockAssert{Name: "api", Method: "get", Path: "/a", Count: intp(1)}, env); !cr.OK {
+		t.Errorf("GET /a count 1 should pass: %+v", cr)
+	}
+	// Without count: at least one match required.
+	if cr := checkMock(&spec.MockAssert{Name: "api", Path: "/b"}, env); !cr.OK {
+		t.Errorf("path /b (>=1) should pass: %+v", cr)
+	}
+	if cr := checkMock(&spec.MockAssert{Name: "api", Path: "/zzz"}, env); cr.OK {
+		t.Error("no request for /zzz must fail")
+	}
+}
+
+func TestCheckMock_HeaderAndBody(t *testing.T) {
+	t.Parallel()
+	rec := mock.Record{Method: "POST", Path: "/ingest", Status: 200, Body: []byte(`{"k":"v"}`)}
+	rec.Header = map[string][]string{"X-Token": {"secret"}}
+	env := mockEnv(map[string][]mock.Record{"api": {rec}})
+
+	pass := checkMock(&spec.MockAssert{
+		Name:   "api",
+		Header: &spec.HeaderMatch{Name: "X-Token", Equals: strp("secret")},
+		Body:   &spec.StreamAssert{Contains: spec.StringList{`"k":"v"`}},
+	}, env)
+	if !pass.OK {
+		t.Errorf("matching header+body should pass: %+v", pass)
+	}
+	// Header mismatch surfaces as failure.
+	if cr := checkMock(&spec.MockAssert{Name: "api", Header: &spec.HeaderMatch{Name: "X-Token", Equals: strp("nope")}}, env); cr.OK {
+		t.Error("header mismatch must fail")
+	}
+	// Body mismatch surfaces as failure.
+	if cr := checkMock(&spec.MockAssert{Name: "api", Body: &spec.StreamAssert{Contains: spec.StringList{"absent"}}}, env); cr.OK {
+		t.Error("body mismatch must fail")
+	}
+}
+
+func TestMockFilterLabelAndPlural(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		m    *spec.MockAssert
+		want string
+	}{
+		{&spec.MockAssert{}, "(any route)"},
+		{&spec.MockAssert{Path: "/x"}, "for /x"},
+		{&spec.MockAssert{Method: "get"}, "for GET"},
+		{&spec.MockAssert{Method: "post", Path: "/y"}, "for POST /y"},
+	}
+	for _, c := range cases {
+		if got := mockFilterLabel(c.m); got != c.want {
+			t.Errorf("mockFilterLabel = %q, want %q", got, c.want)
+		}
+	}
+	if plural("request", 1) != "request" || plural("request", 0) != "requests" || plural("request", 2) != "requests" {
+		t.Error("plural wrong")
+	}
+	if summarizeRecords(nil) != "  (no requests recorded)" {
+		t.Error("empty summarizeRecords wrong")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// changes.go: describeChangesExpected with all three categories
+// ---------------------------------------------------------------------------
+
+func TestDescribeChangesExpected(t *testing.T) {
+	t.Parallel()
+	c := &spec.ChangesAssert{Created: list("a"), Modified: list("b"), Deleted: list("c")}
+	got := describeChangesExpected(c)
+	for _, want := range []string{"created [a]", "modified [b]", "deleted [c]"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("describeChangesExpected = %q, want it to contain %q", got, want)
+		}
+	}
+	if describeChangesExpected(&spec.ChangesAssert{}) != "" {
+		t.Error("an empty changes assert should describe as empty string")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// image.go: isSVG, format on garbage, similar_to on undecodable data
+// ---------------------------------------------------------------------------
+
+func TestIsSVG(t *testing.T) {
+	t.Parallel()
+	if !isSVG([]byte(`<?xml version="1.0"?>` + "\n" + `<svg xmlns="http://www.w3.org/2000/svg"></svg>`)) {
+		t.Error("an SVG with an XML declaration should be detected")
+	}
+	if !isSVG([]byte("<svg></svg>")) {
+		t.Error("a bare <svg should be detected")
+	}
+	if isSVG([]byte("<html><body></body></html>")) {
+		t.Error("HTML must not be detected as SVG")
+	}
+	// A large blob whose "<svg" would sit past the 1024-byte scan window.
+	big := append(bytes.Repeat([]byte(" "), 2000), []byte("<svg")...)
+	if isSVG(big) {
+		t.Error("an <svg past the 1024-byte head window must not be detected")
+	}
+}
+
+func TestCheckImage_FormatUnknown(t *testing.T) {
+	t.Parallel()
+	wd := t.TempDir()
+	writeImage(t, wd, "junk.png", []byte("not an image at all"))
+	cr := Check(&spec.Assert{Image: &spec.ImageAssert{Path: "junk.png", Format: "png"}}, nil, Env{Workdir: wd})
+	if cr.OK {
+		t.Fatal("garbage bytes should not match format png")
+	}
+	if !strings.Contains(cr.Actual, "unknown") {
+		t.Errorf("Actual = %q, want it to say unknown", cr.Actual)
+	}
+}
+
+// TestCheckImage_SimilarTo_Undecodable proves an undecodable actual image fails
+// cleanly (no panic) and still attaches image artifacts.
+func TestCheckImage_SimilarTo_Undecodable(t *testing.T) {
+	t.Parallel()
+	wd := t.TempDir()
+	baseline := makePNG(t, 2, 2, color.RGBA{R: 255, A: 255})
+	writeImage(t, wd, "base.png", baseline)
+	writeImage(t, wd, "actual.png", []byte("\x89PNG\r\n\x1a\ntruncated"))
+	cr := Check(&spec.Assert{Image: &spec.ImageAssert{Path: "actual.png", SimilarTo: "base.png"}},
+		nil, Env{Workdir: wd, SpecDir: wd})
+	if cr.OK {
+		t.Fatal("an undecodable actual image must fail similar_to")
+	}
+	if cr.ArtifactKind != "image" {
+		t.Errorf("ArtifactKind = %q, want image", cr.ArtifactKind)
+	}
+}
+
+func TestMeanPixelDiff_IdenticalAndDifferent(t *testing.T) {
+	t.Parallel()
+	red := image.NewNRGBA(image.Rect(0, 0, 4, 4))
+	blue := image.NewNRGBA(image.Rect(0, 0, 4, 4))
+	for y := 0; y < 4; y++ {
+		for x := 0; x < 4; x++ {
+			red.SetNRGBA(x, y, color.NRGBA{R: 255, A: 255})
+			blue.SetNRGBA(x, y, color.NRGBA{B: 255, A: 255})
+		}
+	}
+	if d := meanPixelDiff(red, red); d != 0 {
+		t.Errorf("identical images diff = %v, want 0", d)
+	}
+	d := meanPixelDiff(red, blue)
+	if d <= 0 || d > 1 {
+		t.Errorf("different images diff = %v, want in (0,1]", d)
+	}
+	// Heatmap of two different images encodes to a valid PNG the same size.
+	hm := renderDiffHeatmap(red, blue)
+	img, err := png.Decode(bytes.NewReader(hm))
+	if err != nil {
+		t.Fatalf("heatmap not a valid PNG: %v", err)
+	}
+	if img.Bounds().Dx() != 4 || img.Bounds().Dy() != 4 {
+		t.Errorf("heatmap size = %v, want 4x4", img.Bounds())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// stream.go: excerpt truncation, line selector out of range, splitLines
+// ---------------------------------------------------------------------------
+
+func TestExcerpt_Truncation(t *testing.T) {
+	t.Parallel()
+	short := "small"
+	if excerpt(short) != short {
+		t.Error("short strings pass through unchanged")
+	}
+	long := strings.Repeat("a", excerptLimit+50)
+	got := excerpt(long)
+	if !strings.HasSuffix(got, "... (truncated)") {
+		t.Error("long strings get a truncation marker")
+	}
+	if len(got) >= len(long) {
+		t.Error("truncated excerpt should be shorter than the input")
+	}
+}
+
+func TestCheckStream_LineOutOfRange(t *testing.T) {
+	t.Parallel()
+	sa := &spec.StreamAssert{Line: intp(9), Contains: spec.StringList{"x"}}
+	cr := checkStream("stdout", sa, []byte("only one line\n"), true, Env{})
+	if cr.OK {
+		t.Fatal("selecting line 9 of a 1-line stream must fail")
+	}
+	if !strings.Contains(cr.Hint, "out of range") {
+		t.Errorf("Hint = %q, want an out-of-range message", cr.Hint)
+	}
+	// A deliberate trailing blank line stays addressable.
+	if _, ok := selectLine("a\n\n", 2); !ok {
+		t.Error("a deliberate trailing blank line should be addressable as line 2")
+	}
+	if got := countLines(""); got != 0 {
+		t.Errorf("countLines(empty) = %d, want 0", got)
+	}
+	if got := countLines("\n"); got != 1 {
+		t.Errorf("countLines(single newline) = %d, want 1", got)
+	}
+}
+
+// TestStreamMatchers_Metamorphic proves a matcher and its negation never both
+// pass on the same data (contains/not_contains, matches/not_matches,
+// equals/not_equals).
+func TestStreamMatchers_Metamorphic(t *testing.T) {
+	t.Parallel()
+	data := []byte("The quick brown fox\n")
+	pairs := []struct {
+		name string
+		pos  *spec.StreamAssert
+		neg  *spec.StreamAssert
+	}{
+		{"contains", &spec.StreamAssert{Contains: spec.StringList{"quick"}}, &spec.StreamAssert{NotContains: spec.StringList{"quick"}}},
+		{"contains-absent", &spec.StreamAssert{Contains: spec.StringList{"zzz"}}, &spec.StreamAssert{NotContains: spec.StringList{"zzz"}}},
+		{"matches", &spec.StreamAssert{Matches: strp(`fox`)}, &spec.StreamAssert{NotMatches: strp(`fox`)}},
+		{"equals", &spec.StreamAssert{Equals: strp("The quick brown fox\n")}, &spec.StreamAssert{NotEquals: strp("The quick brown fox\n")}},
+	}
+	for _, p := range pairs {
+		pos := checkStream("stdout", p.pos, data, true, Env{})
+		neg := checkStream("stdout", p.neg, data, true, Env{})
+		if pos.OK == neg.OK {
+			t.Errorf("%s: a matcher and its negation returned the same verdict (both %v)", p.name, pos.OK)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// tree.go: hashFile error, walkTree error, ignoredPath patterns
+// ---------------------------------------------------------------------------
+
+func TestHashFile_Error(t *testing.T) {
+	t.Parallel()
+	if _, err := hashFile(filepath.Join(t.TempDir(), "nope")); err == nil {
+		t.Error("hashFile on a missing path must error")
+	}
+}
+
+func TestWalkTree_MissingDir(t *testing.T) {
+	t.Parallel()
+	if _, err := walkTree(filepath.Join(t.TempDir(), "absent"), nil); err == nil {
+		t.Error("walkTree on a missing dir must error")
+	}
+}
+
+func TestIgnoredPath(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		rel    string
+		ignore []string
+		want   bool
+	}{
+		{"node_modules", []string{"node_modules/**"}, true},
+		{"node_modules/pkg/x.js", []string{"node_modules/**"}, true},
+		{"src/main.go", []string{"node_modules/**"}, false},
+		{"a/b/c.log", []string{"*.log"}, true}, // basename match for /-less pattern
+		{"a/b/c.txt", []string{"*.log"}, false},
+		{"dist/app.js", []string{"dist/*.js"}, true}, // full-path path.Match
+		{"deep/dist/app.js", []string{"dist/*.js"}, false},
+	}
+	for _, tt := range tests {
+		if got := ignoredPath(tt.rel, tt.ignore); got != tt.want {
+			t.Errorf("ignoredPath(%q, %v) = %v, want %v", tt.rel, tt.ignore, got, tt.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// assert.go: CheckAll no targets, checkTarget default, streamBytes stderr,
+// checkExitCode no result / default
+// ---------------------------------------------------------------------------
+
+func TestCheckAll_NoTargets(t *testing.T) {
+	t.Parallel()
+	results := CheckAll(&spec.Assert{}, nil, Env{})
+	if len(results) != 1 || results[0].OK {
+		t.Errorf("an assert with no targets should yield one failing result, got %+v", results)
+	}
+}
+
+func TestStreamBytes_Stderr(t *testing.T) {
+	t.Parallel()
+	res := &runner.Result{Stdout: []byte("OUT"), Stderr: []byte("ERR")}
+	if string(streamBytes(res, "stdout")) != "OUT" {
+		t.Error("streamBytes stdout mismatch")
+	}
+	if string(streamBytes(res, "stderr")) != "ERR" {
+		t.Error("streamBytes stderr mismatch")
+	}
+	if streamBytes(nil, "stdout") != nil {
+		t.Error("streamBytes(nil) should be nil")
+	}
+}
+
+func TestCheckExitCode_NoResultAndDefault(t *testing.T) {
+	t.Parallel()
+	if cr := checkExitCode(&spec.ExitCode{Equals: intp(0)}, nil); cr.OK {
+		t.Error("exit_code with no result must fail")
+	}
+	// An exit_code with no operator set falls to the default hint.
+	if cr := checkExitCode(&spec.ExitCode{}, &runner.Result{ExitCode: 0}); cr.OK {
+		t.Error("exit_code with no operator must fail")
+	}
+}
+
+// TestCheckTarget_AllFamilies drives every remaining target family through the
+// public Check entry point so the checkTarget switch is exercised end-to-end.
+func TestCheckTarget_AllFamilies(t *testing.T) {
+	t.Parallel()
+	// DB rows.
+	db := &runner.Result{IsDB: true, RowsJSON: []byte(`[{"id":1}]`)}
+	if cr := Check(&spec.Assert{Rows: &spec.StreamAssert{JSON: &spec.JSONAssert{Path: "$[0].id", Equals: 1}}}, db, Env{}); !cr.OK {
+		t.Errorf("rows target should pass: %+v", cr)
+	}
+	// gRPC status + message.
+	g := &runner.Result{IsGRPC: true, GRPCStatus: 0, MessageJSON: []byte(`{"ok":true}`)}
+	if cr := Check(&spec.Assert{GRPCStatus: intp(0)}, g, Env{}); !cr.OK {
+		t.Errorf("grpc_status target should pass: %+v", cr)
+	}
+	if cr := Check(&spec.Assert{Message: &spec.StreamAssert{Contains: spec.StringList{`"ok":true`}}}, g, Env{}); !cr.OK {
+		t.Errorf("message target should pass: %+v", cr)
+	}
+	// CDP value.
+	cdp := &runner.Result{IsCDP: true, CDPValue: []byte("Ready")}
+	if cr := Check(&spec.Assert{Value: &spec.StreamAssert{Equals: strp("Ready")}}, cdp, Env{}); !cr.OK {
+		t.Errorf("value target should pass: %+v", cr)
+	}
+	// Screen.
+	pty := &runner.Result{IsPTY: true, Screen: []byte("menu")}
+	if cr := Check(&spec.Assert{Screen: &spec.StreamAssert{Contains: spec.StringList{"menu"}}}, pty, Env{}); !cr.OK {
+		t.Errorf("screen target should pass: %+v", cr)
+	}
+	// Duration.
+	dur := &runner.Result{Duration: 5 * time.Millisecond}
+	if cr := Check(&spec.Assert{Duration: &spec.DurationAssert{LT: "1s"}}, dur, Env{}); !cr.OK {
+		t.Errorf("duration target should pass: %+v", cr)
+	}
+	// Changes.
+	ch := &runner.Result{Changes: &fsdelta.Delta{Created: []string{"out.txt"}}}
+	if cr := Check(&spec.Assert{Changes: &spec.ChangesAssert{Created: list("out.txt")}}, ch, Env{}); !cr.OK {
+		t.Errorf("changes target should pass: %+v", cr)
+	}
+	// Image + Dir + PDF + Mock via Check so their checkTarget cases run.
+	wd := t.TempDir()
+	writeImage(t, wd, "p.png", makePNG(t, 3, 3, color.RGBA{A: 255}))
+	if cr := Check(&spec.Assert{Image: &spec.ImageAssert{Path: "p.png", Format: "png"}}, nil, Env{Workdir: wd}); !cr.OK {
+		t.Errorf("image target should pass: %+v", cr)
+	}
+	if cr := Check(&spec.Assert{Dir: &spec.DirAssert{Path: ".", Exists: boolp(true)}}, nil, Env{Workdir: wd}); !cr.OK {
+		t.Errorf("dir target should pass: %+v", cr)
+	}
+	pwd := writePDF(t, minimalPDF)
+	if cr := Check(&spec.Assert{PDF: &spec.PDFAssert{Path: "doc.pdf", Pages: ptrInt(1)}}, nil, Env{Workdir: pwd}); !cr.OK {
+		t.Errorf("pdf target should pass: %+v", cr)
+	}
+	menv := mockEnv(map[string][]mock.Record{"api": {{Method: "GET", Path: "/", Status: 200}}})
+	if cr := Check(&spec.Assert{Mock: &spec.MockAssert{Name: "api"}}, nil, menv); !cr.OK {
+		t.Errorf("mock target should pass: %+v", cr)
+	}
+}
+
+// TestCheckDirRecursive_FailureBranches hits the recursive not_contains,
+// file-count off-by-one, and glob-no-match failure branches (#25). Counts in
+// recursive mode are over FILES only, so a directory does not inflate the count.
+func TestCheckDirRecursive_FailureBranches(t *testing.T) {
+	t.Parallel()
+	wd := makeTree(t) // site: index.html, about.html, assets/app.css -> 3 files, 1 dir
+	rec := func(d *spec.DirAssert) *CheckResult {
+		d.Recursive = true
+		return checkDirOK(t, wd, d)
+	}
+	// not_contains a path that is present -> fail.
+	if cr := rec(&spec.DirAssert{Path: "site", NotContains: []string{"index.html"}}); cr.OK {
+		t.Error("recursive not_contains of a present path must fail")
+	}
+	// Exactly 3 files (dirs excluded) passes; 4 fails; 2 fails.
+	if cr := rec(&spec.DirAssert{Path: "site", Count: ptrInt(3)}); !cr.OK {
+		t.Errorf("recursive count 3 files should pass: %+v", cr)
+	}
+	if cr := rec(&spec.DirAssert{Path: "site", Count: ptrInt(4)}); cr.OK {
+		t.Error("recursive count 4 must fail (only 3 files, dir not counted)")
+	}
+	if cr := rec(&spec.DirAssert{Path: "site", MinCount: ptrInt(4)}); cr.OK {
+		t.Error("recursive min 4 must fail")
+	}
+	if cr := rec(&spec.DirAssert{Path: "site", MaxCount: ptrInt(2)}); cr.OK {
+		t.Error("recursive max 2 must fail")
+	}
+	// glob matching nothing in the tree -> fail.
+	if cr := rec(&spec.DirAssert{Path: "site", Glob: "*.pdf"}); cr.OK {
+		t.Error("recursive glob *.pdf must fail (no match)")
+	}
+	// glob matching a nested basename -> pass.
+	if cr := rec(&spec.DirAssert{Path: "site", Glob: "*.css"}); !cr.OK {
+		t.Errorf("recursive glob *.css should match assets/app.css: %+v", cr)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// snapshot.go: missing, update, mismatch, path escape
+// ---------------------------------------------------------------------------
+
+func TestCheckSnapshot_Lifecycle(t *testing.T) {
+	t.Parallel()
+	specDir := t.TempDir()
+	env := Env{SpecDir: specDir, Workdir: specDir}
+
+	// Missing snapshot.
+	miss := checkSnapshot("d", "stdout", "snap.txt", []byte("hello\n"), env)
+	if miss.OK || !strings.Contains(miss.Actual, "missing") {
+		t.Errorf("missing snapshot should fail with 'missing': %+v", miss)
+	}
+
+	// Update writes it.
+	up := checkSnapshot("d", "stdout", "snap.txt", []byte("hello\n"), Env{SpecDir: specDir, Workdir: specDir, UpdateSnapshots: true})
+	if !up.OK {
+		t.Fatalf("update should pass: %+v", up)
+	}
+	if _, err := os.Stat(filepath.Join(specDir, "snap.txt")); err != nil {
+		t.Fatalf("snapshot file not written: %v", err)
+	}
+
+	// Now a match passes.
+	if cr := checkSnapshot("d", "stdout", "snap.txt", []byte("hello\n"), env); !cr.OK {
+		t.Errorf("matching snapshot should pass: %+v", cr)
+	}
+	// And a mismatch fails with artifacts.
+	mismatch := checkSnapshot("d", "stdout", "snap.txt", []byte("changed\n"), env)
+	if mismatch.OK {
+		t.Fatal("changed data should mismatch the snapshot")
+	}
+	if mismatch.ArtifactKind != "snapshot" {
+		t.Errorf("ArtifactKind = %q, want snapshot", mismatch.ArtifactKind)
+	}
+
+	// A snapshot path escaping the spec dir is rejected.
+	if cr := checkSnapshot("d", "stdout", "../escape.txt", []byte("x"), env); cr.OK {
+		t.Error("a snapshot path escaping the spec dir must be rejected")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Fuzz-style smoke: feed detectImageFormat and parsePDF a batch of adversarial
+// byte patterns and assert they never panic.
+// ---------------------------------------------------------------------------
+
+func TestParsersNeverPanicOnGarbage(t *testing.T) {
+	t.Parallel()
+	seeds := [][]byte{
+		nil, {}, {0x00}, {0xff, 0xd8}, {'B', 'M'},
+		[]byte("RIFF"), []byte("GIF8"), []byte("<svg"),
+		bytes.Repeat([]byte{0xff}, 100),
+		[]byte("\x89PNG\r\n\x1a\n"),
+	}
+	for i, s := range seeds {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("panic on seed %d: %v", i, r)
+				}
+			}()
+			_ = detectImageFormat(s)
+			_ = isBMP(s)
+			_ = isAVIF(s)
+			_ = isSVG(s)
+			_ = parsePDF(append([]byte("%PDF-1.4\n"), s...))
+		}()
 	}
 }

--- a/internal/assert/pdf.go
+++ b/internal/assert/pdf.go
@@ -211,8 +211,34 @@ func readPDFString(data []byte, open int) (string, bool) {
 		c := data[i]
 		switch c {
 		case '\\':
-			if i+1 < len(data) {
-				b.WriteByte(unescapePDFByte(data[i+1]))
+			if i+1 >= len(data) {
+				break // trailing backslash: nothing to escape
+			}
+			nc := data[i+1]
+			switch {
+			case nc >= '0' && nc <= '7':
+				// Octal escape \ddd (1–3 digits): the canonical way PDFs encode a
+				// non-ASCII byte in a literal string. Consume up to three octal
+				// digits and emit the resulting byte.
+				val := 0
+				n := 0
+				for n < 3 && i+1 < len(data) && data[i+1] >= '0' && data[i+1] <= '7' {
+					val = val*8 + int(data[i+1]-'0')
+					i++
+					n++
+				}
+				b.WriteByte(byte(val))
+			case nc == '\n':
+				// Backslash-newline is a line continuation: both bytes are dropped.
+				i++
+			case nc == '\r':
+				// Same, tolerating a CRLF line ending after the backslash.
+				i++
+				if i+1 < len(data) && data[i+1] == '\n' {
+					i++
+				}
+			default:
+				b.WriteByte(unescapePDFByte(nc))
 				i++
 			}
 		case '(':
@@ -247,7 +273,12 @@ func unescapePDFByte(c byte) byte {
 		return '\r'
 	case 't':
 		return '\t'
+	case 'b':
+		return '\b'
+	case 'f':
+		return '\f'
 	default:
+		// \( \) \\ and any other escaped byte pass through literally.
 		return c
 	}
 }

--- a/internal/assert/pdf_test.go
+++ b/internal/assert/pdf_test.go
@@ -145,3 +145,38 @@ func indexOf(s, sub string) int {
 	}
 	return -1
 }
+
+// TestDecodePDFString_Escapes pins PDF literal-string decoding (ISO 32000
+// §7.3.4.2) as used by the `pdf: {text: {...}}` assertion. Beyond the \n \r \t
+// already handled, PDFs written by common generators (pandoc, LaTeX, wkhtmltopdf)
+// escape non-ASCII bytes as octal \ddd and use \b \f and backslash-newline line
+// continuations. Decoding those wrong makes a valid pdf text assertion silently
+// fail to match, so each case here is a correctness guard, not cosmetics.
+func TestDecodePDFString_Escapes(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		lit  string
+		want string
+	}{
+		{"plain", "(hello)", "hello"},
+		{"newline-tab", "(a\\nb\\tc)", "a\nb\tc"},
+		// \351 is octal for 0xE9 — 'é' in Latin-1/PDFDocEncoding. It must decode to
+		// that single byte, not the literal text "351".
+		{"octal-latin1", "(caf\\351)", "caf\xe9"},
+		{"octal-short", "(\\7a)", "\x07a"},
+		{"octal-three", "(\\101\\102\\103)", "ABC"},
+		// \b and \f are defined escapes.
+		{"backspace-formfeed", "(x\\by\\fz)", "x\by\fz"},
+		// Escaped parentheses and backslash pass through literally.
+		{"escaped-parens", "(a\\(b\\)c\\\\d)", "a(b)c\\d"},
+		// A backslash immediately before a newline is a line continuation: it and
+		// the newline vanish, joining the two source lines.
+		{"line-continuation", "(line1\\\nline2)", "line1line2"},
+	}
+	for _, c := range cases {
+		if got := decodePDFString([]byte(c.lit)); got != c.want {
+			t.Errorf("%s: decodePDFString(%q) = %q, want %q", c.name, c.lit, got, c.want)
+		}
+	}
+}

--- a/internal/assert/screen.go
+++ b/internal/assert/screen.go
@@ -2,6 +2,7 @@ package assert
 
 import (
 	"strings"
+	"unicode/utf8"
 
 	"github.com/nao1215/atago/internal/runner"
 	"github.com/nao1215/atago/internal/spec"
@@ -29,20 +30,23 @@ func checkScreen(sa *spec.StreamAssert, res *runner.Result, env Env) *CheckResul
 }
 
 // borderedScreen frames the rendered screen so trailing spaces and width are
-// visible in failure output.
+// visible in failure output. Width and padding are measured in runes, not bytes:
+// a pty/TUI screen routinely contains box-drawing characters (─│┌, 3 bytes each)
+// and CJK text, and a byte-based measure would pad those rows short and produce a
+// ragged right border in exactly the screens this assertion exists to check.
 func borderedScreen(screen string) string {
 	lines := strings.Split(screen, "\n")
 	width := 0
 	for _, l := range lines {
-		if len(l) > width {
-			width = len(l)
+		if n := utf8.RuneCountInString(l); n > width {
+			width = n
 		}
 	}
 	var b strings.Builder
 	bar := "+" + strings.Repeat("-", width+2) + "+"
 	b.WriteString(bar + "\n")
 	for _, l := range lines {
-		b.WriteString("| " + l + strings.Repeat(" ", width-len(l)) + " |\n")
+		b.WriteString("| " + l + strings.Repeat(" ", width-utf8.RuneCountInString(l)) + " |\n")
 	}
 	b.WriteString(bar)
 	return b.String()

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -4,10 +4,15 @@ import (
 	"bytes"
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/nao1215/atago/internal/engine"
+	"github.com/nao1215/atago/internal/manifest"
 )
 
 func writeSpec(t *testing.T, dir, name, body string) string {
@@ -416,4 +421,997 @@ func TestMain_VersionAndUnknown(t *testing.T) {
 	if got := Main([]string{"bogus"}, &out, &errb); got != ExitConfig {
 		t.Errorf("unknown exit = %d, want %d", got, ExitConfig)
 	}
+}
+
+// errWriter is an io.Writer that always fails, to exercise the output-write
+// error branches that a bytes.Buffer never triggers.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) { return 0, errors.New("boom") }
+
+// --- exit-code logic: exitForSuite -----------------------------------------
+
+// TestExitForSuite_Precedence pins the per-suite result -> exit code mapping.
+// This is exit-code logic and a prime spot for an inverted branch, so every
+// status is exercised, including the default (unknown status) and the
+// security-violation override that must win over any status.
+func TestExitForSuite_Precedence(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		res  *engine.SuiteResult
+		want int
+	}{
+		{"passed", &engine.SuiteResult{Status: engine.StatusPassed}, ExitOK},
+		{"skipped", &engine.SuiteResult{Status: engine.StatusSkipped}, ExitOK},
+		{"flaky", &engine.SuiteResult{Status: engine.StatusFlaky}, ExitOK},
+		{"failed", &engine.SuiteResult{Status: engine.StatusFailed}, ExitFailures},
+		{"error", &engine.SuiteResult{Status: engine.StatusError}, ExitExec},
+		{"unknown", &engine.SuiteResult{Status: engine.Status("weird")}, ExitInternal},
+		// A security violation outranks the generic status entirely.
+		{"security over passed", &engine.SuiteResult{Status: engine.StatusPassed, SecurityViolation: true}, ExitSecurity},
+		{"security over error", &engine.SuiteResult{Status: engine.StatusError, SecurityViolation: true}, ExitSecurity},
+		{"security over failed", &engine.SuiteResult{Status: engine.StatusFailed, SecurityViolation: true}, ExitSecurity},
+	}
+	for _, c := range cases {
+		if got := exitForSuite(c.res); got != c.want {
+			t.Errorf("%s: exitForSuite = %d, want %d", c.name, got, c.want)
+		}
+	}
+}
+
+// TestWorseExit_MonotonicAndCommutative exhaustively checks the exit-code
+// aggregator over every ordered pair of the seven exit codes. It asserts two
+// independent properties that would each expose an inverted comparison:
+//  1. worseExit returns the code with the higher documented severity;
+//  2. it is commutative (order of the two suites must not change the verdict).
+func TestWorseExit_MonotonicAndCommutative(t *testing.T) {
+	t.Parallel()
+	// An independent severity ladder mirroring worseExit's documented contract:
+	// security is most severe, then internal, exec, parse, config, failures, ok.
+	sev := map[int]int{
+		ExitOK:       0,
+		ExitFailures: 1,
+		ExitConfig:   2,
+		ExitParse:    3,
+		ExitExec:     4,
+		ExitInternal: 5,
+		ExitSecurity: 6,
+	}
+	codes := []int{ExitOK, ExitFailures, ExitConfig, ExitParse, ExitExec, ExitInternal, ExitSecurity}
+	for _, a := range codes {
+		for _, b := range codes {
+			got := worseExit(a, b)
+			// Property 1: the winner is the more severe input.
+			wantSev := sev[a]
+			if sev[b] > wantSev {
+				wantSev = sev[b]
+			}
+			if sev[got] != wantSev {
+				t.Errorf("worseExit(%d,%d) = %d (sev %d), want a code of severity %d", a, b, got, sev[got], wantSev)
+			}
+			// Property 2: commutativity.
+			if rev := worseExit(b, a); sev[rev] != sev[got] {
+				t.Errorf("worseExit not commutative: (%d,%d)=%d but (%d,%d)=%d", a, b, got, b, a, rev)
+			}
+		}
+	}
+	// Spot-check the documented ladder directly so the intent is legible.
+	if worseExit(ExitFailures, ExitOK) != ExitFailures {
+		t.Error("a failure must outrank a pass")
+	}
+	if worseExit(ExitExec, ExitFailures) != ExitExec {
+		t.Error("an exec error must outrank a failure")
+	}
+	if worseExit(ExitSecurity, ExitInternal) != ExitSecurity {
+		t.Error("a security violation must outrank an internal error")
+	}
+	if worseExit(ExitParse, ExitConfig) != ExitParse {
+		t.Error("a spec parse error must outrank a CLI config error")
+	}
+}
+
+// --- pure record helpers ----------------------------------------------------
+
+func TestSplitCSV(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{"   ", nil},
+		{",,", nil},
+		{"a", []string{"a"}},
+		{"a,b,c", []string{"a", "b", "c"}},
+		{" a , b ,, c ", []string{"a", "b", "c"}},
+	}
+	for _, c := range cases {
+		if got := splitCSV(c.in); !reflect.DeepEqual(got, c.want) {
+			t.Errorf("splitCSV(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestSuiteNameFor(t *testing.T) {
+	t.Parallel()
+	cases := []struct{ in, want string }{
+		{"echo", "echo"},
+		{"/usr/bin/grep", "grep"},
+		{"tool.exe", "tool"},
+		{"a.b.exe", "a.b"},
+		{"", "recorded"},
+		{".", "recorded"},
+		{"dir/", "dir"},
+	}
+	for _, c := range cases {
+		if got := suiteNameFor(c.in); got != c.want {
+			t.Errorf("suiteNameFor(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestCountLines(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"", 0},
+		{"\n\n", 0},
+		{"one", 1},
+		{"one\ntwo\n", 2},
+		{"one\n\n  \nthree", 2}, // blank / whitespace-only lines are not counted
+	}
+	for _, c := range cases {
+		if got := countLines([]byte(c.in)); got != c.want {
+			t.Errorf("countLines(%q) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+func TestPlainPOSIXWord(t *testing.T) {
+	t.Parallel()
+	plain := []string{"abc", "ABC123", "a/b.c-d_e", "path/to.file", "user@host", "k=v", "50%", "a,b", "+x", ":port"}
+	for _, s := range plain {
+		if !plainPOSIXWord(s) {
+			t.Errorf("plainPOSIXWord(%q) = false, want true", s)
+		}
+	}
+	notPlain := []string{"", "a b", "a$b", "a|b", "a'b", `a"b`, "a>b", "a;b", "a*b", `a\b`}
+	for _, s := range notPlain {
+		if plainPOSIXWord(s) {
+			t.Errorf("plainPOSIXWord(%q) = true, want false", s)
+		}
+	}
+}
+
+func TestShellJoin_Dispatches(t *testing.T) {
+	t.Parallel()
+	// shellJoin picks the platform tokenizer; on the test host it must produce a
+	// non-empty command that keeps the plain leading word verbatim.
+	got := shellJoin([]string{"echo", "plain"})
+	if !strings.HasPrefix(got, "echo ") {
+		t.Errorf("shellJoin = %q, want it to start with the verbatim plain word", got)
+	}
+}
+
+func TestListFiles(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub", "deep")
+	if err := os.MkdirAll(sub, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	for _, rel := range []string{"z.txt", "a.txt"} {
+		if err := os.WriteFile(filepath.Join(dir, rel), []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(sub, "b.txt"), []byte("y"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := listFiles(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"a.txt", "sub/deep/b.txt", "z.txt"} // sorted, slash-separated
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("listFiles = %v, want %v", got, want)
+	}
+}
+
+// --- list gate rendering ----------------------------------------------------
+
+func TestGateTokens(t *testing.T) {
+	t.Parallel()
+	if got := gateTokens("only", nil); got != nil {
+		t.Errorf("gateTokens(nil) = %v, want nil", got)
+	}
+	// All three condition fields render, sorted, with the given kind prefix.
+	got := gateTokens("only", &manifest.Condition{OS: "linux", Env: "CI", Command: "git"})
+	want := []string{"only:command", "only:env=CI", "only:os=linux"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("gateTokens = %v, want %v", got, want)
+	}
+	// skip kind and a single field.
+	if got := gateTokens("skip", &manifest.Condition{Env: "DEBUG"}); !reflect.DeepEqual(got, []string{"skip:env=DEBUG"}) {
+		t.Errorf("skip env gate = %v", got)
+	}
+}
+
+func TestScenarioGates_OnlyAndSkip(t *testing.T) {
+	t.Parallel()
+	sc := manifest.Scenario{
+		Only: &manifest.Condition{OS: "linux"},
+		Skip: &manifest.Condition{Env: "CI"},
+	}
+	got := scenarioGates(sc)
+	want := []string{"only:os=linux", "skip:env=CI"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("scenarioGates = %v, want %v", got, want)
+	}
+	// No conditions -> no gates.
+	if got := scenarioGates(manifest.Scenario{}); got != nil {
+		t.Errorf("scenarioGates(empty) = %v, want nil", got)
+	}
+}
+
+// --- rerun state round-trip -------------------------------------------------
+
+// TestRerunState_RoundTrip proves save then load returns the same failures,
+// sorted deterministically, and that an empty save clears the file.
+func TestRerunState_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	withWorkdir(t, dir, func() {
+		// Intentionally unsorted input; saveRerunState must normalize it.
+		in := []failedEntry{
+			{SpecPath: "b.atago.yaml", Scenario: "z"},
+			{SpecPath: "a.atago.yaml", Scenario: "y"},
+			{SpecPath: "a.atago.yaml", Scenario: "x"},
+		}
+		if err := saveRerunState(in); err != nil {
+			t.Fatal(err)
+		}
+		st, err := loadRerunState()
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := []failedEntry{
+			{SpecPath: "a.atago.yaml", Scenario: "x"},
+			{SpecPath: "a.atago.yaml", Scenario: "y"},
+			{SpecPath: "b.atago.yaml", Scenario: "z"},
+		}
+		if !reflect.DeepEqual(st.Failed, want) {
+			t.Errorf("loaded failures = %+v, want sorted %+v", st.Failed, want)
+		}
+		if st.SchemaVersion != RerunStateSchemaVersion {
+			t.Errorf("schema_version = %q, want %q", st.SchemaVersion, RerunStateSchemaVersion)
+		}
+		// specPaths dedups and sorts.
+		if got := st.specPaths(); !reflect.DeepEqual(got, []string{"a.atago.yaml", "b.atago.yaml"}) {
+			t.Errorf("specPaths = %v", got)
+		}
+		// selectSet has one identity per entry.
+		if got := st.selectSet(); len(got) != 3 {
+			t.Errorf("selectSet size = %d, want 3", len(got))
+		}
+
+		// An empty save removes the file (a fully-green run clears state).
+		if err := saveRerunState(nil); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := os.Stat(rerunStatePath()); !os.IsNotExist(err) {
+			t.Errorf("empty saveRerunState did not remove the state file (err=%v)", err)
+		}
+		// Loading a missing file is not an error: empty state with schema set.
+		st, err = loadRerunState()
+		if err != nil {
+			t.Fatalf("loadRerunState on missing file errored: %v", err)
+		}
+		if len(st.Failed) != 0 || st.selectSet() != nil {
+			t.Errorf("missing-file state should be empty, got %+v", st)
+		}
+	})
+}
+
+// TestLoadRerunState_Corrupt proves a garbled state file surfaces a clean error
+// rather than silently degrading to "nothing recorded".
+func TestLoadRerunState_Corrupt(t *testing.T) {
+	dir := t.TempDir()
+	withWorkdir(t, dir, func() {
+		if err := os.MkdirAll(rerunStateDir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(rerunStatePath(), []byte("{ this is not json"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := loadRerunState(); err == nil {
+			t.Error("loadRerunState on corrupt JSON returned nil error")
+		}
+	})
+}
+
+// TestRunCmd_CorruptRerunStateExitsConfig proves `run --rerun-failed` reports a
+// clean ExitConfig (not a panic or false green) when the state file is corrupt.
+func TestRunCmd_CorruptRerunStateExitsConfig(t *testing.T) {
+	dir := t.TempDir()
+	writeSpec(t, dir, "s.atago.yaml", passingSpec)
+	withWorkdir(t, dir, func() {
+		if err := os.MkdirAll(rerunStateDir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(rerunStatePath(), []byte("not json"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		var out, errb bytes.Buffer
+		if got := Main([]string{"run", "--rerun-failed", "."}, &out, &errb); got != ExitConfig {
+			t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitConfig, errb.String())
+		}
+		if !strings.Contains(errb.String(), "cannot read") {
+			t.Errorf("stderr = %q, want a cannot-read message", errb.String())
+		}
+	})
+}
+
+// --- Main dispatch / usage --------------------------------------------------
+
+func TestMain_NoArgsShowsUsage(t *testing.T) {
+	t.Parallel()
+	var out, errb bytes.Buffer
+	if got := Main(nil, &out, &errb); got != ExitConfig {
+		t.Fatalf("exit = %d, want %d", got, ExitConfig)
+	}
+	if !strings.Contains(errb.String(), "atago <command>") {
+		t.Errorf("stderr = %q, want usage", errb.String())
+	}
+}
+
+func TestMain_HelpAndVersionVariants(t *testing.T) {
+	t.Parallel()
+	for _, arg := range []string{"help", "-h", "--help"} {
+		var out, errb bytes.Buffer
+		if got := Main([]string{arg}, &out, &errb); got != ExitOK {
+			t.Errorf("%s exit = %d, want 0", arg, got)
+		}
+		if !strings.Contains(out.String(), "atago <command>") {
+			t.Errorf("%s: usage not on stdout: %q", arg, out.String())
+		}
+	}
+	for _, arg := range []string{"version", "-version", "--version"} {
+		var out, errb bytes.Buffer
+		if got := Main([]string{arg}, &out, &errb); got != ExitOK {
+			t.Errorf("%s exit = %d, want 0", arg, got)
+		}
+		if !strings.Contains(out.String(), "atago ") {
+			t.Errorf("%s: version not on stdout: %q", arg, out.String())
+		}
+	}
+}
+
+func TestSnapshotCmd_BadInvocation(t *testing.T) {
+	t.Parallel()
+	for _, args := range [][]string{{"snapshot"}, {"snapshot", "bogus"}} {
+		var out, errb bytes.Buffer
+		if got := Main(args, &out, &errb); got != ExitConfig {
+			t.Errorf("%v exit = %d, want %d", args, got, ExitConfig)
+		}
+		if !strings.Contains(errb.String(), "Usage: atago snapshot update") {
+			t.Errorf("%v: stderr = %q, want usage", args, errb.String())
+		}
+	}
+}
+
+// --- run argument parsing ---------------------------------------------------
+
+func TestRunCmd_ArgParsingErrors(t *testing.T) {
+	dir := t.TempDir()
+	p := writeSpec(t, dir, "ok.atago.yaml", passingSpec)
+	cases := []struct {
+		name    string
+		args    []string
+		wantMsg string
+	}{
+		{"unknown report", []string{"run", "--report", "xml", p}, "unknown --report"},
+		{"mutually exclusive repeat/retry", []string{"run", "--repeat", "2", "--retry-failed", "2", p}, "mutually exclusive"},
+		{"negative repeat", []string{"run", "--repeat", "-1", p}, "must be >= 0"},
+		{"negative retry", []string{"run", "--retry-failed", "-1", p}, "must be >= 0"},
+		{"unknown flag", []string{"run", "--no-such-flag", p}, ""},
+		{"nonexistent target", []string{"run", filepath.Join(dir, "missing")}, "cannot access"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var out, errb bytes.Buffer
+			if got := Main(c.args, &out, &errb); got != ExitConfig {
+				t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitConfig, errb.String())
+			}
+			if c.wantMsg != "" && !strings.Contains(errb.String(), c.wantMsg) {
+				t.Errorf("stderr = %q, want %q", errb.String(), c.wantMsg)
+			}
+		})
+	}
+}
+
+// TestRunCmd_CIFlagAndParallel exercises the --ci and --parallel>1 branches of
+// runCmd (setting NO_COLOR and the shared scenario semaphore).
+func TestRunCmd_CIFlagAndParallel(t *testing.T) {
+	// t.Setenv registers cleanup to restore NO_COLOR after --ci overwrites it.
+	t.Setenv("NO_COLOR", os.Getenv("NO_COLOR"))
+	dir := t.TempDir()
+	writeSpec(t, dir, "a.atago.yaml", passingSpec)
+	writeSpec(t, dir, "b.atago.yaml", passingSpec)
+	var out, errb bytes.Buffer
+	if got := Main([]string{"run", "--ci", "--parallel", "2", dir}, &out, &errb); got != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitOK, errb.String())
+	}
+	if os.Getenv("NO_COLOR") != "1" {
+		t.Errorf("--ci did not set NO_COLOR=1 (got %q)", os.Getenv("NO_COLOR"))
+	}
+}
+
+// --- doc / manifest / list error and split paths ----------------------------
+
+func TestDocCmd_FlagCombinations(t *testing.T) {
+	dir := t.TempDir()
+	p := writeSpec(t, dir, "ok.atago.yaml", passingSpec)
+	cases := []struct {
+		name    string
+		args    []string
+		wantMsg string
+	}{
+		{"split without out-dir", []string{"doc", "--split-by-spec", p}, "requires --out-dir"},
+		{"out-dir without split", []string{"doc", "--out-dir", filepath.Join(dir, "d"), p}, "requires --split-by-spec"},
+		{"nonexistent target", []string{"doc", filepath.Join(dir, "missing")}, "cannot access"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var out, errb bytes.Buffer
+			if got := Main(c.args, &out, &errb); got != ExitConfig {
+				t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitConfig, errb.String())
+			}
+			if !strings.Contains(errb.String(), c.wantMsg) {
+				t.Errorf("stderr = %q, want %q", errb.String(), c.wantMsg)
+			}
+		})
+	}
+}
+
+// TestDocCmd_SplitBySpec exercises writeSplitDocs: one file per spec plus an
+// index.md written into --out-dir, with a confirmation on stdout.
+func TestDocCmd_SplitBySpec(t *testing.T) {
+	dir := t.TempDir()
+	writeSpec(t, dir, "one.atago.yaml", passingSpec)
+	writeSpec(t, dir, "two.atago.yaml", passingSpec)
+	outDir := filepath.Join(dir, "docs")
+	var out, errb bytes.Buffer
+	if got := Main([]string{"doc", "--split-by-spec", "--out-dir", outDir, dir}, &out, &errb); got != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitOK, errb.String())
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "index.md")); err != nil {
+		t.Errorf("index.md not written: %v", err)
+	}
+	if !strings.Contains(out.String(), "Wrote") {
+		t.Errorf("stdout = %q, want a Wrote confirmation", out.String())
+	}
+	// At least the two per-spec docs plus index.md should exist.
+	entries, err := os.ReadDir(outDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) < 3 {
+		t.Errorf("out-dir has %d files, want at least 3 (2 specs + index.md)", len(entries))
+	}
+}
+
+// TestDocCmd_OutWriteError proves a failed write to --out reports a config error
+// rather than panicking (the parent directory does not exist).
+func TestDocCmd_OutWriteError(t *testing.T) {
+	dir := t.TempDir()
+	p := writeSpec(t, dir, "ok.atago.yaml", passingSpec)
+	var out, errb bytes.Buffer
+	bad := filepath.Join(dir, "nope", "out.md")
+	if got := Main([]string{"doc", "--out", bad, p}, &out, &errb); got != ExitConfig {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitConfig, errb.String())
+	}
+}
+
+func TestManifestCmd_ErrorPaths(t *testing.T) {
+	dir := t.TempDir()
+	p := writeSpec(t, dir, "ok.atago.yaml", passingSpec)
+	t.Run("nonexistent target", func(t *testing.T) {
+		var out, errb bytes.Buffer
+		if got := Main([]string{"manifest", filepath.Join(dir, "missing")}, &out, &errb); got != ExitConfig {
+			t.Fatalf("exit = %d, want %d", got, ExitConfig)
+		}
+		if !strings.Contains(errb.String(), "cannot access") {
+			t.Errorf("stderr = %q", errb.String())
+		}
+	})
+	t.Run("out write error", func(t *testing.T) {
+		var out, errb bytes.Buffer
+		bad := filepath.Join(dir, "nope", "m.json")
+		if got := Main([]string{"manifest", "--out", bad, p}, &out, &errb); got != ExitConfig {
+			t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitConfig, errb.String())
+		}
+	})
+}
+
+func TestListCmd_ErrorPaths(t *testing.T) {
+	dir := t.TempDir()
+	t.Run("nonexistent target", func(t *testing.T) {
+		var out, errb bytes.Buffer
+		if got := Main([]string{"list", filepath.Join(dir, "missing")}, &out, &errb); got != ExitConfig {
+			t.Fatalf("exit = %d, want %d", got, ExitConfig)
+		}
+		if !strings.Contains(errb.String(), "cannot access") {
+			t.Errorf("stderr = %q", errb.String())
+		}
+	})
+	t.Run("parse error", func(t *testing.T) {
+		p := writeSpec(t, dir, "bad.atago.yaml", "version: \"1\"\nsuite: {}\nscenarios: []")
+		var out, errb bytes.Buffer
+		if got := Main([]string{"list", p}, &out, &errb); got != ExitParse {
+			t.Fatalf("exit = %d, want %d", got, ExitParse)
+		}
+	})
+}
+
+// TestListCmd_JSONEmptyIsValid proves a spec with no runnable scenario still
+// yields a valid JSON document whose scenarios field is a [] (never null).
+func TestListCmd_JSONEmptyIsValid(t *testing.T) {
+	dir := t.TempDir()
+	// A single scenario carrying an only:os gate that never matches keeps the
+	// suite loadable while producing exactly one row we can round-trip.
+	spec := `version: "1"
+suite:
+  name: gated
+scenarios:
+  - name: only linux
+    only: {os: linux}
+    steps:
+      - run: {shell: true, command: "true"}
+      - assert: {exit_code: 0}
+`
+	p := writeSpec(t, dir, "g.atago.yaml", spec)
+	var out, errb bytes.Buffer
+	if got := Main([]string{"list", "--json", p}, &out, &errb); got != ExitOK {
+		t.Fatalf("exit = %d (stderr=%s)", got, errb.String())
+	}
+	var doc listDocument
+	if err := json.Unmarshal(out.Bytes(), &doc); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out.String())
+	}
+	if len(doc.Scenarios) != 1 || len(doc.Scenarios[0].Gates) != 1 || doc.Scenarios[0].Gates[0] != "only:os=linux" {
+		t.Errorf("gates round-trip failed: %+v", doc.Scenarios)
+	}
+}
+
+// --- explain multi-file partial failure -------------------------------------
+
+// TestExplainCmd_ContinuesPastParseError proves explain reports ExitParse when
+// one spec fails to load but still explains the loadable specs (the loop uses
+// worseExit + continue rather than aborting on the first bad file).
+func TestExplainCmd_ContinuesPastParseError(t *testing.T) {
+	dir := t.TempDir()
+	writeSpec(t, dir, "a-good.atago.yaml", passingSpec)
+	writeSpec(t, dir, "b-bad.atago.yaml", "version: \"1\"\nsuite: {}\nscenarios: []")
+	var out, errb bytes.Buffer
+	if got := Main([]string{"explain", dir}, &out, &errb); got != ExitParse {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitParse, errb.String())
+	}
+	// The good spec was still explained despite the bad sibling.
+	if !strings.Contains(out.String(), "Suite: sample") {
+		t.Errorf("stdout = %q, want the good spec still explained", out.String())
+	}
+}
+
+// --- init argument parsing --------------------------------------------------
+
+func TestInitCmd_ArgParsing(t *testing.T) {
+	dir := t.TempDir()
+	t.Run("help exits ok", func(t *testing.T) {
+		var out, errb bytes.Buffer
+		if got := Main([]string{"init", "-h"}, &out, &errb); got != ExitOK {
+			t.Fatalf("exit = %d, want %d", got, ExitOK)
+		}
+	})
+	t.Run("unknown flag", func(t *testing.T) {
+		var out, errb bytes.Buffer
+		if got := Main([]string{"init", "--no-such-flag"}, &out, &errb); got != ExitConfig {
+			t.Fatalf("exit = %d, want %d", got, ExitConfig)
+		}
+	})
+	t.Run("write error", func(t *testing.T) {
+		var out, errb bytes.Buffer
+		bad := filepath.Join(dir, "nope", "x.atago.yaml")
+		if got := Main([]string{"init", bad}, &out, &errb); got != ExitConfig {
+			t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitConfig, errb.String())
+		}
+	})
+}
+
+// --- record command paths ---------------------------------------------------
+
+func TestRecordCmd_ArgErrors(t *testing.T) {
+	dir := t.TempDir()
+	cases := []struct {
+		name    string
+		args    []string
+		wantMsg string
+	}{
+		{"no command", []string{"record"}, "no command given"},
+		{"snapshot needs out", []string{"record", "--snapshot", "--", "echo", "hi"}, "--snapshot needs --out"},
+		{"snapshot with pty", []string{"record", "--pty", "--snapshot", "--out", filepath.Join(dir, "s.atago.yaml"), "--", "echo", "hi"}, "cannot be combined with --pty"},
+		{"unknown flag", []string{"record", "--no-such-flag"}, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var out, errb bytes.Buffer
+			if got := Main(c.args, &out, &errb); got != ExitConfig {
+				t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitConfig, errb.String())
+			}
+			if c.wantMsg != "" && !strings.Contains(errb.String(), c.wantMsg) {
+				t.Errorf("stderr = %q, want %q", errb.String(), c.wantMsg)
+			}
+		})
+	}
+}
+
+// TestRecordCmd_StdoutHappyPath records a simple command to stdout and checks
+// the generated spec skeleton is emitted, exercising the run/observe/generate
+// path plus shellJoin, listFiles, suiteNameFor, and countLines.
+func TestRecordCmd_StdoutHappyPath(t *testing.T) {
+	var out, errb bytes.Buffer
+	if got := Main([]string{"record", "--", "echo", "hello-record"}, &out, &errb); got != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitOK, errb.String())
+	}
+	if !strings.Contains(out.String(), "version:") || !strings.Contains(out.String(), "echo") {
+		t.Errorf("generated spec on stdout looks wrong:\n%s", out.String())
+	}
+	if !strings.Contains(errb.String(), "recorded:") {
+		t.Errorf("stderr = %q, want a recorded summary", errb.String())
+	}
+}
+
+// TestRecordCmd_OutFileForceAndShell covers writing to --out, the
+// already-exists guard, --force overwrite, and --shell verbatim joining.
+func TestRecordCmd_OutFileForceAndShell(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "gen.atago.yaml")
+
+	var out, errb bytes.Buffer
+	if got := Main([]string{"record", "--out", outPath, "--", "echo", "hi"}, &out, &errb); got != ExitOK {
+		t.Fatalf("first write exit = %d (stderr=%s)", got, errb.String())
+	}
+	if _, err := os.Stat(outPath); err != nil {
+		t.Fatalf("spec not written: %v", err)
+	}
+	if !strings.Contains(errb.String(), "wrote "+outPath) {
+		t.Errorf("stderr = %q, want a wrote confirmation", errb.String())
+	}
+
+	// Second write without --force is refused.
+	out.Reset()
+	errb.Reset()
+	if got := Main([]string{"record", "--out", outPath, "--", "echo", "hi"}, &out, &errb); got != ExitConfig {
+		t.Fatalf("overwrite-without-force exit = %d, want %d", got, ExitConfig)
+	}
+	if !strings.Contains(errb.String(), "already exists") {
+		t.Errorf("stderr = %q, want already-exists", errb.String())
+	}
+
+	// --force overwrites; --shell records the command line verbatim.
+	out.Reset()
+	errb.Reset()
+	if got := Main([]string{"record", "--force", "--shell", "--out", outPath, "--", "echo hi there"}, &out, &errb); got != ExitOK {
+		t.Fatalf("force+shell exit = %d (stderr=%s)", got, errb.String())
+	}
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "shell: true") {
+		t.Errorf("--shell spec missing shell: true:\n%s", data)
+	}
+}
+
+// TestRecordCmd_Snapshot writes a spec plus its stdout golden next to it.
+func TestRecordCmd_Snapshot(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "snap.atago.yaml")
+	var out, errb bytes.Buffer
+	if got := Main([]string{"record", "--snapshot", "--out", outPath, "--", "echo", "snapshot-me"}, &out, &errb); got != ExitOK {
+		t.Fatalf("exit = %d (stderr=%s)", got, errb.String())
+	}
+	golden := filepath.Join(dir, "snapshots", "snap.stdout.txt")
+	if _, err := os.Stat(golden); err != nil {
+		t.Fatalf("snapshot golden not written at %s: %v", golden, err)
+	}
+	data, _ := os.ReadFile(outPath)
+	if !strings.Contains(string(data), "snapshot") {
+		t.Errorf("spec missing snapshot matcher:\n%s", data)
+	}
+}
+
+// --- list writers: nil-scenarios normalization and write errors -------------
+
+// TestWriteListJSON_NilScenariosAndWriteError covers two branches at once: an
+// empty manifest normalizes scenarios to [] (never null in the JSON), and a
+// failing writer surfaces ExitInternal rather than a false success.
+func TestWriteListJSON_NilScenariosAndWriteError(t *testing.T) {
+	t.Parallel()
+	// Success path with a real buffer: empty document -> "scenarios": [].
+	var buf bytes.Buffer
+	if got := writeListJSON(manifest.Document{}, &buf, &buf); got != ExitOK {
+		t.Fatalf("exit = %d, want %d", got, ExitOK)
+	}
+	var doc listDocument
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if doc.Scenarios == nil {
+		t.Error("scenarios serialized as null; want an empty array")
+	}
+	// Failing writer -> ExitInternal.
+	var errb bytes.Buffer
+	if got := writeListJSON(manifest.Document{}, errWriter{}, &errb); got != ExitInternal {
+		t.Errorf("write error exit = %d, want %d", got, ExitInternal)
+	}
+}
+
+// TestWriteListTable_WriteError proves a failed tabwriter flush surfaces
+// ExitInternal.
+func TestWriteListTable_WriteError(t *testing.T) {
+	t.Parallel()
+	var errb bytes.Buffer
+	if got := writeListTable(manifest.Document{}, errWriter{}, &errb); got != ExitInternal {
+		t.Errorf("write error exit = %d, want %d", got, ExitInternal)
+	}
+	if !strings.Contains(errb.String(), "atago list:") {
+		t.Errorf("stderr = %q, want an atago list error", errb.String())
+	}
+}
+
+// --- filesystem error branches for rerun state ------------------------------
+
+// TestSaveRerunState_MkdirError proves an unwritable state dir (here .atago is
+// a regular file, so MkdirAll fails) is returned as an error for the caller to
+// warn about — writes are best-effort and must not panic.
+func TestSaveRerunState_MkdirError(t *testing.T) {
+	dir := t.TempDir()
+	withWorkdir(t, dir, func() {
+		// Occupy the state dir path with a file so MkdirAll(.atago) fails.
+		if err := os.WriteFile(rerunStateDir, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		err := saveRerunState([]failedEntry{{SpecPath: "a", Scenario: "b"}})
+		if err == nil {
+			t.Error("saveRerunState with a file where .atago should be returned nil error")
+		}
+	})
+}
+
+// TestLoadRerunState_ReadErrorSurfaced proves a read error that is not
+// os.IsNotExist is surfaced, not swallowed as empty state. It makes the state
+// path itself a directory, so os.ReadFile fails with a non-NotExist error on
+// every platform (EISDIR on POSIX, an equivalent on Windows) — portable, unlike
+// making .atago a file, whose read error Windows reports as not-exist.
+func TestLoadRerunState_ReadErrorSurfaced(t *testing.T) {
+	dir := t.TempDir()
+	withWorkdir(t, dir, func() {
+		if err := os.MkdirAll(rerunStatePath(), 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := loadRerunState(); err == nil {
+			t.Error("loadRerunState reading a directory as the state file returned nil error")
+		}
+	})
+}
+
+// --- writeSplitDocs mkdir error ---------------------------------------------
+
+// TestDocCmd_SplitMkdirError proves writeSplitDocs reports a config error when
+// --out-dir cannot be created (a file already occupies the path).
+func TestDocCmd_SplitMkdirError(t *testing.T) {
+	dir := t.TempDir()
+	writeSpec(t, dir, "one.atago.yaml", passingSpec)
+	// A regular file at the out-dir path makes MkdirAll fail.
+	fileAsDir := filepath.Join(dir, "outfile")
+	if err := os.WriteFile(fileAsDir, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var out, errb bytes.Buffer
+	if got := Main([]string{"doc", "--split-by-spec", "--out-dir", fileAsDir, filepath.Join(dir, "one.atago.yaml")}, &out, &errb); got != ExitConfig {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitConfig, errb.String())
+	}
+}
+
+// --- manifest default target + parse error ----------------------------------
+
+func TestManifestCmd_NoFilesDefaultDot(t *testing.T) {
+	dir := t.TempDir()
+	withWorkdir(t, dir, func() {
+		var out, errb bytes.Buffer
+		if got := Main([]string{"manifest"}, &out, &errb); got != ExitConfig {
+			t.Fatalf("exit = %d, want %d", got, ExitConfig)
+		}
+		if !strings.Contains(errb.String(), "no *.atago.yaml files found") {
+			t.Errorf("stderr = %q, want no-files message", errb.String())
+		}
+	})
+}
+
+// TestRecordCmd_CommandNotFound proves a command that cannot start reports an
+// execution error (exit 4), not a panic or a spurious success.
+func TestRecordCmd_CommandNotFound(t *testing.T) {
+	var out, errb bytes.Buffer
+	got := Main([]string{"record", "--", "atago-no-such-binary-xyz123"}, &out, &errb)
+	if got != ExitExec {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitExec, errb.String())
+	}
+}
+
+// TestRecordCmd_HelpFlag proves `record -h` prints usage and exits 0.
+func TestRecordCmd_HelpFlag(t *testing.T) {
+	t.Parallel()
+	var out, errb bytes.Buffer
+	if got := Main([]string{"record", "-h"}, &out, &errb); got != ExitOK {
+		t.Fatalf("exit = %d, want %d", got, ExitOK)
+	}
+}
+
+// TestRecordCmd_OutIsDirectory proves that recording over an existing directory
+// path with --force surfaces an execution error (the WriteFile fails) rather
+// than panicking.
+func TestRecordCmd_OutIsDirectory(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "adir")
+	if err := os.MkdirAll(target, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	var out, errb bytes.Buffer
+	if got := Main([]string{"record", "--force", "--out", target, "--", "echo", "hi"}, &out, &errb); got != ExitExec {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitExec, errb.String())
+	}
+}
+
+// TestExplainCmd_NonexistentTarget proves a bad path exits ExitConfig with a
+// helpful message (collectSpecFiles error branch).
+func TestExplainCmd_NonexistentTarget(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	var out, errb bytes.Buffer
+	if got := Main([]string{"explain", filepath.Join(dir, "missing")}, &out, &errb); got != ExitConfig {
+		t.Fatalf("exit = %d, want %d", got, ExitConfig)
+	}
+	if !strings.Contains(errb.String(), "cannot access") {
+		t.Errorf("stderr = %q, want cannot-access", errb.String())
+	}
+}
+
+// TestRunCmd_SaveStateWriteErrorWarns proves a run whose failing-scenario state
+// cannot be persisted (here .atago is occupied by a regular file) still exits on
+// the run's own verdict and only warns about the failed write — persistence is
+// best-effort and must never fail the run.
+func TestRunCmd_SaveStateWriteErrorWarns(t *testing.T) {
+	dir := t.TempDir()
+	writeSpec(t, dir, "fail.atago.yaml", failingSpec)
+	withWorkdir(t, dir, func() {
+		// Block .atago dir creation with a file of the same name.
+		if err := os.WriteFile(rerunStateDir, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		var out, errb bytes.Buffer
+		if got := Main([]string{"run", "fail.atago.yaml"}, &out, &errb); got != ExitFailures {
+			t.Fatalf("exit = %d, want %d (the run's own verdict, stderr=%s)", got, ExitFailures, errb.String())
+		}
+		if !strings.Contains(errb.String(), "could not update") {
+			t.Errorf("stderr = %q, want a best-effort save warning", errb.String())
+		}
+	})
+}
+
+// --- help flags on FlagSet-based subcommands --------------------------------
+
+// TestSubcommands_HelpFlagExitsOK proves `-h` on the flag-parsing subcommands
+// prints usage to stderr and exits 0 (the flag.ErrHelp path), never treating
+// the flag as a spec path.
+func TestSubcommands_HelpFlagExitsOK(t *testing.T) {
+	t.Parallel()
+	for _, cmd := range []string{"run", "doc", "manifest", "list"} {
+		var out, errb bytes.Buffer
+		if got := Main([]string{cmd, "-h"}, &out, &errb); got != ExitOK {
+			t.Errorf("%s -h exit = %d, want %d", cmd, got, ExitOK)
+		}
+	}
+}
+
+// --- default "." target ------------------------------------------------------
+
+// TestSubcommands_DefaultTargetIsDot proves run/doc/list default to the current
+// directory when no path argument is given (parity across the read commands).
+func TestSubcommands_DefaultTargetIsDot(t *testing.T) {
+	for _, cmd := range []string{"run", "doc", "list"} {
+		t.Run(cmd, func(t *testing.T) {
+			dir := t.TempDir()
+			writeSpec(t, dir, "ok.atago.yaml", passingSpec)
+			withWorkdir(t, dir, func() {
+				var out, errb bytes.Buffer
+				if got := Main([]string{cmd}, &out, &errb); got != ExitOK {
+					t.Fatalf("%s (no target) exit = %d, want %d (stderr=%s)", cmd, got, ExitOK, errb.String())
+				}
+			})
+		})
+	}
+}
+
+// --- run --tag / --skip-tag no-match warnings -------------------------------
+
+// TestRunCmd_TagSelectionNoMatchWarns proves a --tag/--skip-tag that selects
+// nothing still exits 0 but warns loudly, mentioning the exact selector — a
+// typo in CI must not greenlight in silence.
+func TestRunCmd_TagSelectionNoMatchWarns(t *testing.T) {
+	dir := t.TempDir()
+	p := writeSpec(t, dir, "ok.atago.yaml", passingSpec)
+	t.Run("tag", func(t *testing.T) {
+		var out, errb bytes.Buffer
+		if got := Main([]string{"run", "--tag", "no-such-tag", p}, &out, &errb); got != ExitOK {
+			t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitOK, errb.String())
+		}
+		if !strings.Contains(errb.String(), `--tag "no-such-tag"`) {
+			t.Errorf("stderr = %q, want a --tag no-match warning", errb.String())
+		}
+	})
+	t.Run("skip-tag", func(t *testing.T) {
+		// skip-tag alone can only remove scenarios; skipping the sole scenario's
+		// (nonexistent) tag keeps it, so pair it with a filter that matches nothing
+		// is not needed — instead assert the skip-tag path is exercised by skipping
+		// a tag the scenario does carry via a tagged spec.
+		tagged := `version: "1"
+suite:
+  name: t
+scenarios:
+  - name: only
+    tags: [slow]
+    steps:
+      - run: {shell: true, command: "exit 0"}
+      - assert: {exit_code: 0}
+`
+		tp := writeSpec(t, dir, "tagged.atago.yaml", tagged)
+		var out, errb bytes.Buffer
+		if got := Main([]string{"run", "--skip-tag", "slow", tp}, &out, &errb); got != ExitOK {
+			t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitOK, errb.String())
+		}
+		if !strings.Contains(errb.String(), `--skip-tag "slow"`) {
+			t.Errorf("stderr = %q, want a --skip-tag no-match warning", errb.String())
+		}
+	})
+}
+
+// --- rerun-failed target intersection is empty ------------------------------
+
+// TestRerunFailed_TargetOutsideRecorded proves that when failures were recorded
+// for one spec but --rerun-failed is pointed at a different (passing) spec, the
+// run reports "nothing under the given targets" and exits 0 without rerunning.
+func TestRerunFailed_TargetOutsideRecorded(t *testing.T) {
+	dir := t.TempDir()
+	writeSpec(t, dir, "fail.atago.yaml", failingSpec)
+	writeSpec(t, dir, "pass.atago.yaml", passingSpec)
+	withWorkdir(t, dir, func() {
+		// Record the failing spec's failure.
+		var out, errb bytes.Buffer
+		if got := Main([]string{"run", "fail.atago.yaml"}, &out, &errb); got != ExitFailures {
+			t.Fatalf("seed run exit = %d, want %d (stderr=%s)", got, ExitFailures, errb.String())
+		}
+		// Rerun, but target only the passing spec: the recorded failure is not
+		// under this target, so nothing reruns.
+		out.Reset()
+		errb.Reset()
+		if got := Main([]string{"run", "--rerun-failed", "pass.atago.yaml"}, &out, &errb); got != ExitOK {
+			t.Fatalf("rerun exit = %d, want %d (stderr=%s)", got, ExitOK, errb.String())
+		}
+		if !strings.Contains(errb.String(), "no previously failed scenarios under the given targets") {
+			t.Errorf("stderr = %q, want the out-of-target note", errb.String())
+		}
+	})
 }

--- a/internal/docgen/describe.go
+++ b/internal/docgen/describe.go
@@ -145,6 +145,12 @@ func describeHeader(h *spec.HeaderMatch) string {
 		return markdown.Code(h.Name) + " contains " + markdown.Code(*h.Contains)
 	case h.Equals != nil:
 		return markdown.Code(h.Name) + " equals " + markdown.Code(*h.Equals)
+	// A header `matches` regexp is a real matcher (the natural shape for auth
+	// headers like "^Bearer "); without this case it fell to the generic "is
+	// checked" and the documented constraint vanished from the doc, so a reviewer
+	// could not see it. Kept in step with explain.describeHeader.
+	case h.Matches != nil:
+		return markdown.Code(h.Name) + " matches " + markdown.Code("/"+*h.Matches+"/")
 	default:
 		return markdown.Code(h.Name) + " is checked"
 	}

--- a/internal/docgen/docgen_test.go
+++ b/internal/docgen/docgen_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/nao1215/atago/internal/explain"
 	"github.com/nao1215/atago/internal/loader"
 	"github.com/nao1215/atago/internal/spec"
 )
@@ -495,4 +496,367 @@ func mustLoadSpec(t *testing.T, path, src string) *spec.Spec {
 		t.Fatalf("load: %v", err)
 	}
 	return s
+}
+
+func strptr(s string) *string   { return &s }
+func intptr(n int) *int         { return &n }
+func boolptr(b bool) *bool      { return &b }
+func f64ptr(f float64) *float64 { return &f }
+
+// oneAssertBullets renders a single assert's Then bullets via the doc renderer.
+func oneAssertBullets(t *testing.T, a *spec.Assert) []string {
+	t.Helper()
+	return describeAsserts(a)
+}
+
+// TestDescribeTarget_MatcherMatrix drives describeTarget/describeStream/
+// jsonMatcher/describeImage/describeDir/describePDF/describeChanges/describeHeader
+// across every matcher and operator shape and pins the rendered phrase. A wrong
+// operator symbol (> vs >=), a dropped matcher, or an off-by-one would show here.
+func TestDescribeTarget_MatcherMatrix(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		a    *spec.Assert
+		want string
+	}{
+		// exit_code shapes
+		{"exit not", &spec.Assert{ExitCode: &spec.ExitCode{Not: intptr(2)}}, "exit code is not `2`"},
+		{"exit in", &spec.Assert{ExitCode: &spec.ExitCode{In: []int{0, 2}}}, "exit code is one of `0`, `2`"},
+		{"exit equals", &spec.Assert{ExitCode: &spec.ExitCode{Equals: intptr(0)}}, "exit code is `0`"},
+		{"exit bare", &spec.Assert{ExitCode: &spec.ExitCode{}}, "exit code is checked"},
+		// status / grpc_status "checked" fallbacks
+		{"status checked", &spec.Assert{Status: nil, Header: nil}, ""}, // placeholder, skipped below
+		// stream matchers (via stdout)
+		{"stdout matches", &spec.Assert{Stdout: &spec.StreamAssert{Matches: strptr("h.+")}}, "stdout matches `/h.+/`"},
+		{"stdout not_matches", &spec.Assert{Stdout: &spec.StreamAssert{NotMatches: strptr("bye")}}, "stdout does not match `/bye/`"},
+		{"stdout yaml", &spec.Assert{Stdout: &spec.StreamAssert{YAML: &spec.JSONAssert{Path: "$.n", Gte: f64ptr(3)}}}, "stdout YAML at `$.n` is `>= 3`"},
+		{"stdout json gt", &spec.Assert{Stdout: &spec.StreamAssert{JSON: &spec.JSONAssert{Path: "$.n", Gt: f64ptr(5)}}}, "stdout at `$.n` is `> 5`"},
+		{"stdout json lt", &spec.Assert{Stdout: &spec.StreamAssert{JSON: &spec.JSONAssert{Path: "$.n", Lt: f64ptr(9)}}}, "stdout at `$.n` is `< 9`"},
+		{"stdout json lte", &spec.Assert{Stdout: &spec.StreamAssert{JSON: &spec.JSONAssert{Path: "$.n", Lte: f64ptr(1)}}}, "stdout at `$.n` is `<= 1`"},
+		{"stdout json equals", &spec.Assert{Stdout: &spec.StreamAssert{JSON: &spec.JSONAssert{Path: "$.n", Equals: "ok"}}}, "stdout at `$.n` equals `ok`"},
+		{"stdout json matches", &spec.Assert{Stdout: &spec.StreamAssert{JSON: &spec.JSONAssert{Path: "$.n", Matches: strptr("y.+")}}}, "stdout at `$.n` matches `/y.+/`"},
+		{"stdout json bare", &spec.Assert{Stdout: &spec.StreamAssert{JSON: &spec.JSONAssert{Path: "$.n"}}}, "stdout at `$.n` is checked"},
+		{"stdout bare", &spec.Assert{Stdout: &spec.StreamAssert{}}, "stdout is checked"},
+		// header matches (regression for the dropped-matcher bug)
+		{"header matches", &spec.Assert{Header: &spec.HeaderMatch{Name: "Authorization", Matches: strptr("^Bearer ")}}, "header `Authorization` matches `/^Bearer /`"},
+		{"header equals", &spec.Assert{Header: &spec.HeaderMatch{Name: "X", Equals: strptr("1")}}, "header `X` equals `1`"},
+		{"header bare", &spec.Assert{Header: &spec.HeaderMatch{Name: "X"}}, "header `X` is checked"},
+		// screen / message / value streams
+		{"screen", &spec.Assert{Screen: &spec.StreamAssert{Contains: spec.StringList{"MENU"}}}, "rendered screen contains `MENU`"},
+		{"message", &spec.Assert{Message: &spec.StreamAssert{Empty: boolptr(true)}}, "message is empty"},
+		{"value", &spec.Assert{Value: &spec.StreamAssert{Empty: boolptr(false)}}, "value is not empty"},
+		// duration
+		{"duration", &spec.Assert{Duration: &spec.DurationAssert{LT: "2s", GTE: "100ms"}}, "completes in under 2s and in at least 100ms"},
+		// changes
+		{"changes", &spec.Assert{Changes: &spec.ChangesAssert{Created: &spec.StringList{"a.txt"}, Modified: &spec.StringList{}}}, "the step changed exactly created `a.txt`, modified nothing"},
+		// mock
+		{"mock", &spec.Assert{Mock: &spec.MockAssert{Name: "api", Method: "get", Path: "/v1", Count: intptr(2)}}, "mock `api` received `GET /v1` exactly 2 time(s)"},
+		{"mock no route", &spec.Assert{Mock: &spec.MockAssert{Name: "api"}}, "mock `api` received a request"},
+		// dir constraints
+		{"dir", &spec.Assert{Dir: &spec.DirAssert{Path: "site", Exists: boolptr(true), Contains: []string{"index.html"}, NotContains: []string{"tmp"}, Count: intptr(3), MinCount: intptr(1), MaxCount: intptr(9), Glob: "*.html", Recursive: true, Snapshot: "tree.snap", Ignore: []string{"*.log"}}},
+			"dir `site` exists, contains `index.html`, does not contain `tmp`, has 3 entries, has >= 1 entries, has <= 9 entries, matches glob `*.html`, tree matches snapshot `tree.snap`, (recursive), ignoring *.log"},
+		{"dir absent", &spec.Assert{Dir: &spec.DirAssert{Path: "gone", Exists: boolptr(false)}}, "dir `gone` does not exist"},
+		{"dir checked", &spec.Assert{Dir: &spec.DirAssert{Path: "d"}}, "dir `d` is checked"},
+		// pdf
+		{"pdf", &spec.Assert{PDF: &spec.PDFAssert{Path: "r.pdf", Pages: intptr(3), MinPages: intptr(1), MaxPages: intptr(9), Metadata: map[string]string{"title": "Q1", "author": "me"}, Text: &spec.StreamAssert{Contains: spec.StringList{"total"}}}},
+			"pdf `r.pdf` 3 pages, >= 1 pages, <= 9 pages, author contains `me`, title contains `Q1`, text contains `total`"},
+		{"pdf checked", &spec.Assert{PDF: &spec.PDFAssert{Path: "e.pdf"}}, "pdf `e.pdf` is checked"},
+		// image min/max dims + no-alpha + similar
+		{"image", &spec.Assert{Image: &spec.ImageAssert{Path: "o.png", MinWidth: intptr(1), MaxWidth: intptr(2), MinHeight: intptr(3), MaxHeight: intptr(4), Alpha: boolptr(false), SimilarTo: "base.png"}},
+			"image `o.png` width >= 1, width <= 2, height >= 3, height <= 4, has no alpha, similar to `base.png`"},
+	}
+	for _, tc := range cases {
+		if tc.name == "status checked" {
+			continue
+		}
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			bullets := oneAssertBullets(t, tc.a)
+			if len(bullets) != 1 {
+				t.Fatalf("expected 1 bullet, got %d: %v", len(bullets), bullets)
+			}
+			if bullets[0] != tc.want {
+				t.Errorf("describe = %q\n           want %q", bullets[0], tc.want)
+			}
+		})
+	}
+}
+
+// TestDescribeTarget_StatusAndGRPCChecked covers the nil-value "is checked"
+// fallbacks that a normal spec (with a value) never reaches.
+func TestDescribeTarget_StatusAndGRPCChecked(t *testing.T) {
+	t.Parallel()
+	if got := describeTarget(&spec.Assert{Status: intptr(0)}, spec.AssertStatus); got == "" {
+		t.Error("status render empty")
+	}
+	// Force the nil-value branches directly (SetTargets would not surface them).
+	if got := describeTarget(&spec.Assert{}, spec.AssertStatus); got != "HTTP status is checked" {
+		t.Errorf("status checked = %q", got)
+	}
+	if got := describeTarget(&spec.Assert{}, spec.AssertGRPCStatus); got != "gRPC status is checked" {
+		t.Errorf("grpc checked = %q", got)
+	}
+	if got := describeTarget(&spec.Assert{}, spec.AssertHeader); got != "header is checked" {
+		t.Errorf("header nil = %q", got)
+	}
+	if got := describeTarget(&spec.Assert{Status: intptr(200)}, spec.AssertStatus); got != "HTTP status is `200`" {
+		t.Errorf("status = %q", got)
+	}
+	if got := describeTarget(&spec.Assert{GRPCStatus: intptr(0)}, spec.AssertGRPCStatus); got != "gRPC status is `0`" {
+		t.Errorf("grpc = %q", got)
+	}
+}
+
+// TestDescribeChanges_Empty covers the "nothing" fallback (all categories nil).
+func TestDescribeChanges_Empty(t *testing.T) {
+	t.Parallel()
+	if got := describeChanges(&spec.ChangesAssert{}); got != "nothing" {
+		t.Errorf("empty changes = %q, want nothing", got)
+	}
+}
+
+// TestDescribeAsserts_InvalidAndMultiTarget covers the no-target fallback and the
+// multi-target expansion (one bullet per set target).
+func TestDescribeAsserts_InvalidAndMultiTarget(t *testing.T) {
+	t.Parallel()
+	if got := describeAsserts(&spec.Assert{}); len(got) != 1 || got[0] != "_(invalid assertion)_" {
+		t.Errorf("empty assert = %v", got)
+	}
+	multi := &spec.Assert{ExitCode: &spec.ExitCode{Equals: intptr(0)}, Stdout: &spec.StreamAssert{Empty: boolptr(true)}}
+	if got := describeAsserts(multi); len(got) != 2 {
+		t.Errorf("multi-target assert = %v, want 2 bullets", got)
+	}
+}
+
+// TestStoreSourceLabel covers every StoreFrom branch.
+func TestStoreSourceLabel(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		st   *spec.Store
+		want string
+	}{
+		{"nil from", &spec.Store{Name: "x"}, "the last result"},
+		{"stdout", &spec.Store{From: &spec.StoreFrom{Stdout: &spec.StreamAssert{}}}, "stdout"},
+		{"body", &spec.Store{From: &spec.StoreFrom{Body: &spec.StreamAssert{}}}, "the response body"},
+		{"file", &spec.Store{From: &spec.StoreFrom{File: &spec.FileAssert{Path: "o.json"}}}, "file o.json"},
+		{"header", &spec.Store{From: &spec.StoreFrom{Header: "ETag"}}, "response header ETag"},
+		{"rows", &spec.Store{From: &spec.StoreFrom{Rows: &spec.StreamAssert{}}}, "the result rows"},
+		{"message", &spec.Store{From: &spec.StoreFrom{Message: &spec.StreamAssert{}}}, "the response message"},
+		{"value", &spec.Store{From: &spec.StoreFrom{Value: &spec.StreamAssert{}}}, "the captured value"},
+		{"empty from", &spec.Store{From: &spec.StoreFrom{}}, "the last result"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := storeSourceLabel(tc.st); got != tc.want {
+				t.Errorf("storeSourceLabel = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestActionLabel covers the query/grpc/cdp/default arms not hit by the run/http
+// path in existing tests.
+func TestActionLabel(t *testing.T) {
+	t.Parallel()
+	id := func(s string) string { return s }
+	q := &spec.Step{Query: &spec.Query{Runner: "d", SQL: "SELECT 1"}}
+	if got := actionLabel(q, id); got != "SELECT 1" {
+		t.Errorf("query label = %q", got)
+	}
+	g := &spec.Step{GRPC: &spec.GRPC{Runner: "g", Method: "Svc/Get"}}
+	if got := actionLabel(g, id); got != "gRPC Svc/Get" {
+		t.Errorf("grpc label = %q", got)
+	}
+	c := &spec.Step{CDP: &spec.CDP{Runner: "b"}}
+	if got := actionLabel(c, id); got != "the browser flow" {
+		t.Errorf("cdp label = %q", got)
+	}
+	if got := actionLabel(&spec.Step{Fixture: &spec.Fixture{File: "x"}}, id); got != "" {
+		t.Errorf("non-action label = %q, want empty", got)
+	}
+}
+
+// TestFirstToken covers the empty-command fallback and a normal token.
+func TestFirstToken(t *testing.T) {
+	t.Parallel()
+	if got := firstToken("   "); got != "   " {
+		t.Errorf("blank cmd = %q, want the input", got)
+	}
+	if got := firstToken("git commit -m x"); got != "git" {
+		t.Errorf("first token = %q, want git", got)
+	}
+}
+
+// TestSplitBaseName sanitizes odd names and covers the empty-stem fallback.
+func TestSplitBaseName(t *testing.T) {
+	t.Parallel()
+	if got := splitBaseName("dir/my spec!.atago.yaml"); got != "my-spec" {
+		t.Errorf("sanitize = %q, want my-spec", got)
+	}
+	if got := splitBaseName("a/plain.atago.yml"); got != "plain" {
+		t.Errorf("yml strip = %q, want plain", got)
+	}
+	// A name that sanitizes to all separators falls back to the "spec" stem.
+	if got := splitBaseName("x/@@@"); got != "spec" {
+		t.Errorf("all-hyphen stem = %q, want spec fallback", got)
+	}
+}
+
+// TestRelPath computes a slash-separated relative link between two dirs.
+func TestRelPath(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	base := filepath.Join(root, "docs")
+	target := filepath.Join(root, "spec", "img.png")
+	got, err := relPath(base, target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "../spec/img.png" {
+		t.Errorf("relPath = %q, want ../spec/img.png", got)
+	}
+}
+
+// TestSnapshotPreview_MissingFallsBack proves an unreadable snapshot yields a
+// label-only block (no body) rather than an error.
+func TestSnapshotPreview_MissingFallsBack(t *testing.T) {
+	t.Parallel()
+	b := snapshotPreview("stdout snapshot", "nope.snap", t.TempDir())
+	if b.body != "" {
+		t.Errorf("missing snapshot should have no body, got %q", b.body)
+	}
+	if !strings.Contains(b.label, "nope.snap") {
+		t.Errorf("label = %q", b.label)
+	}
+}
+
+// TestImageBaselinePreview_Guards covers the early-return guards: no output dir,
+// a ${workdir}-relative baseline, and a missing file.
+func TestImageBaselinePreview_Guards(t *testing.T) {
+	t.Parallel()
+	if _, ok := imageBaselinePreview("base.png", t.TempDir(), ""); ok {
+		t.Error("no output dir must return ok=false")
+	}
+	if _, ok := imageBaselinePreview("${workdir}/out.png", t.TempDir(), t.TempDir()); ok {
+		t.Error("runtime baseline must return ok=false")
+	}
+	if _, ok := imageBaselinePreview("missing.png", t.TempDir(), t.TempDir()); ok {
+		t.Error("missing file must return ok=false")
+	}
+}
+
+// TestTruncatePreview_ByteBudget covers the byte-truncation arm (single long
+// line under the line budget but over the byte budget).
+func TestTruncatePreview_ByteBudget(t *testing.T) {
+	t.Parallel()
+	got := truncatePreview(strings.Repeat("x", previewMaxBytes+50))
+	if !strings.HasSuffix(got, "… (truncated)") {
+		t.Errorf("byte-truncated preview should end with the plain marker:\n%q", got[len(got)-40:])
+	}
+	if len(got) > previewMaxBytes+len("\n… (truncated)")+1 {
+		t.Errorf("byte budget exceeded: %d", len(got))
+	}
+}
+
+// --- differential: explain vs docgen must agree on the shared model ----------
+
+// TestParity_HeaderMatchesRendered is the metamorphic regression: a header
+// `matches` regexp must appear in BOTH the generated doc and the explain output.
+// Before the fix, both silently dropped it (doc: "is checked", explain: name
+// only), hiding a security-relevant auth-header assertion from every reader.
+func TestParity_HeaderMatchesRendered(t *testing.T) {
+	t.Parallel()
+	src := `version: "1"
+suite: {name: h}
+scenarios:
+  - name: auth
+    steps:
+      - http: {method: GET, path: /}
+      - assert:
+          header: {name: Authorization, matches: "^Bearer "}
+`
+	s, err := loader.LoadBytes("h.atago.yaml", []byte(src))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	var doc bytes.Buffer
+	if err := Generate(&doc, []Source{{Path: "h.atago.yaml", Spec: s}}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(doc.String(), "header `Authorization` matches `/^Bearer /`") {
+		t.Errorf("doc dropped the header matches regexp:\n%s", doc.String())
+	}
+	if strings.Contains(doc.String(), "`Authorization` is checked") {
+		t.Errorf("doc still renders the terse 'is checked' for a matches header:\n%s", doc.String())
+	}
+	var exp bytes.Buffer
+	if err := explain.Explain(&exp, s, "h.atago.yaml"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(exp.String(), `"Authorization" matches /^Bearer /`) {
+		t.Errorf("explain dropped the header matches regexp:\n%s", exp.String())
+	}
+}
+
+// TestParity_JSONOperators pins that both renderers agree on the numeric operator
+// symbols (>, >=, <, <=) for a json/yaml value bound — a swapped symbol in either
+// would mislead a reader about the asserted bound.
+func TestParity_JSONOperators(t *testing.T) {
+	t.Parallel()
+	src := `version: "1"
+suite: {name: ops}
+scenarios:
+  - name: bounds
+    steps:
+      - run: {command: metrics}
+      - assert: {stdout: {json: {path: "$.gt", gt: 1}}}
+      - assert: {stdout: {json: {path: "$.gte", gte: 2}}}
+      - assert: {stdout: {json: {path: "$.lt", lt: 3}}}
+      - assert: {stdout: {json: {path: "$.lte", lte: 4}}}
+`
+	s, err := loader.LoadBytes("ops.atago.yaml", []byte(src))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	var doc bytes.Buffer
+	if err := Generate(&doc, []Source{{Path: "ops.atago.yaml", Spec: s}}); err != nil {
+		t.Fatal(err)
+	}
+	var exp bytes.Buffer
+	if err := explain.Explain(&exp, s, "ops.atago.yaml"); err != nil {
+		t.Fatal(err)
+	}
+	d, e := doc.String(), exp.String()
+	// doc uses "is `> 1`"; explain uses "> 1". Both must carry the exact symbol.
+	for _, sym := range []string{"> 1", ">= 2", "< 3", "<= 4"} {
+		if !strings.Contains(d, sym) {
+			t.Errorf("doc missing operator %q:\n%s", sym, d)
+		}
+		if !strings.Contains(e, sym) {
+			t.Errorf("explain missing operator %q:\n%s", sym, e)
+		}
+	}
+}
+
+// TestGenerateSplit_WithOutputDir exercises GenerateSplit's outputDir path and
+// the index generator, plus mdEscape of a suite name with markdown-active chars.
+func TestGenerateSplit_WithOutputDir(t *testing.T) {
+	t.Parallel()
+	a := load(t, "one.atago.yaml", `version: "1"
+suite: {name: "a[1]"}
+scenarios: [{name: s, steps: [{run: {command: "true"}}, {assert: {exit_code: 0}}]}]
+`)
+	index, docs, err := GenerateSplit([]Source{*a}, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(docs) != 1 || docs[0].Name != "one.md" {
+		t.Fatalf("docs = %+v", docs)
+	}
+	if !bytes.Contains(index, []byte("Documents")) {
+		t.Errorf("index missing Documents section:\n%s", index)
+	}
 }

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -2,14 +2,23 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/nao1215/atago/internal/artifact"
 	"github.com/nao1215/atago/internal/assert"
 	"github.com/nao1215/atago/internal/loader"
+	"github.com/nao1215/atago/internal/runner"
+	"github.com/nao1215/atago/internal/security"
+	"github.com/nao1215/atago/internal/spec"
+	"github.com/nao1215/atago/internal/store"
 )
 
 func runSpec(t *testing.T, src string) *SuiteResult {
@@ -754,5 +763,682 @@ scenarios:
 `)
 	if res.Scenarios[0].Status != StatusSkipped {
 		t.Fatalf("status = %s, want skipped", res.Scenarios[0].Status)
+	}
+}
+
+// TestExtractValue_AllBranches exercises every source branch of extractValue,
+// asserting both the "wrong family / no step yet" guards and the happy path for
+// each. These branches (body/header/rows/message/value) were previously
+// unexercised, and each guard is a data-integrity gate: capturing from the wrong
+// result family would store a stale or empty value under a variable name a later
+// step trusts.
+func TestExtractValue_AllBranches(t *testing.T) {
+	t.Parallel()
+
+	jsonSel := &spec.StreamAssert{JSON: &spec.JSONAssert{Path: "$.v"}}
+	body := []byte(`{"v":"hit"}`)
+
+	httpRes := &runner.Result{IsHTTP: true, Body: body, Header: http.Header{"X-Token": {"abc"}}}
+	dbRes := &runner.Result{IsDB: true, RowsJSON: body}
+	grpcRes := &runner.Result{IsGRPC: true, MessageJSON: body}
+	cdpRes := &runner.Result{IsCDP: true, CDPValue: body}
+
+	tests := []struct {
+		name    string
+		from    *spec.StoreFrom
+		current *runner.Result
+		want    string
+		wantErr string // substring; "" means expect success
+	}{
+		{"nil from", nil, httpRes, "", "'from' is required"},
+		{"empty from", &spec.StoreFrom{}, httpRes, "", "must set stdout"},
+
+		{"stdout nil result", &spec.StoreFrom{Stdout: jsonSel}, nil, "", "no command has run"},
+
+		{"body ok", &spec.StoreFrom{Body: jsonSel}, httpRes, "hit", ""},
+		{"body wrong family", &spec.StoreFrom{Body: jsonSel}, dbRes, "", "no HTTP request"},
+		{"body nil result", &spec.StoreFrom{Body: jsonSel}, nil, "", "no HTTP request"},
+
+		{"header ok", &spec.StoreFrom{Header: "X-Token"}, httpRes, "abc", ""},
+		{"header missing", &spec.StoreFrom{Header: "X-Absent"}, httpRes, "", "has no"},
+		{"header wrong family", &spec.StoreFrom{Header: "X-Token"}, dbRes, "", "no HTTP request"},
+
+		{"rows ok", &spec.StoreFrom{Rows: jsonSel}, dbRes, "hit", ""},
+		{"rows wrong family", &spec.StoreFrom{Rows: jsonSel}, httpRes, "", "no query has run"},
+
+		{"message ok", &spec.StoreFrom{Message: jsonSel}, grpcRes, "hit", ""},
+		{"message wrong family", &spec.StoreFrom{Message: jsonSel}, httpRes, "", "no gRPC call"},
+
+		{"value ok", &spec.StoreFrom{Value: jsonSel}, cdpRes, "hit", ""},
+		{"value wrong family", &spec.StoreFrom{Value: jsonSel}, httpRes, "", "no cdp step"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sp := &spec.Store{Name: "x", From: tt.from}
+			got, err := extractValue(sp, tt.current, "")
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("want error containing %q, got value %q", tt.wantErr, got)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error %q, want substring %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestExtractValue_FileNeedsJSONSelector proves a file source without a json
+// selector is a clean error, not a nil-deref.
+func TestExtractValue_FileNeedsJSONSelector(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "f.json"), []byte(`{"v":1}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sp := &spec.Store{Name: "x", From: &spec.StoreFrom{File: &spec.FileAssert{Path: "f.json"}}}
+	_, err := extractValue(sp, &runner.Result{}, dir)
+	if err == nil || !strings.Contains(err.Error(), "needs a json selector") {
+		t.Fatalf("want json-selector error, got %v", err)
+	}
+}
+
+// TestExtractStream_NoSelector proves a stream source that sets neither json nor
+// matches is a clean error.
+func TestExtractStream_NoSelector(t *testing.T) {
+	t.Parallel()
+	_, err := extractStream(&spec.StreamAssert{}, []byte("data"))
+	if err == nil || !strings.Contains(err.Error(), "json or matches") {
+		t.Fatalf("want selector error, got %v", err)
+	}
+}
+
+// TestJSONValue_NullSelectsError is a regression for the bug where a JSON path
+// selecting a null value stored the Go literal string "<nil>" instead of erroring
+// — a Go-ism leaking into a user-visible variable that silently masked "the field
+// was null".
+func TestJSONValue_NullSelectsError(t *testing.T) {
+	t.Parallel()
+	got, err := jsonValue([]byte(`{"token":null}`), "$.token")
+	if err == nil {
+		t.Fatalf("null capture returned %q, want an error", got)
+	}
+	if strings.Contains(got, "<nil>") {
+		t.Fatalf("leaked Go nil literal: %q", got)
+	}
+	if !strings.Contains(err.Error(), "null") {
+		t.Errorf("error %q should mention the null value", err)
+	}
+}
+
+// TestJSONValue_Edges covers the remaining jsonValue paths: invalid JSON, invalid
+// path syntax, a path selecting a container (array/object), and multibyte scalars.
+func TestJSONValue_Edges(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name, data, path, want string
+		wantErr                string
+	}{
+		{"invalid json", `{`, "$.x", "", "invalid JSON"},
+		{"invalid path", `{"x":1}`, "$[", "", "invalid JSON path"},
+		{"multibyte scalar", `{"名前":"太郎"}`, "$.名前", "太郎", ""},
+		{"number int", `{"x":42}`, "$.x", "42", ""},
+		{"bool", `{"x":true}`, "$.x", "true", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := jsonValue([]byte(tt.data), tt.path)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("err = %v, want substring %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil || got != tt.want {
+				t.Fatalf("got %q err %v, want %q", got, err, tt.want)
+			}
+		})
+	}
+}
+
+// TestRegexValue_Edges covers invalid regexp, a multibyte capture, and the
+// documented "no capture group -> whole match" fallback.
+func TestRegexValue_Edges(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name, data, pattern, want string
+		wantErr                   string
+	}{
+		{"invalid regexp", "x", `(`, "", "invalid regexp"},
+		{"multibyte capture", "名前=太郎さん", `名前=(\p{Han}+)`, "太郎", ""},
+		{"no group whole match", "abc123", `[a-z]+`, "abc", ""},
+		{"first group only", "a=1;b=2", `(\w)=(\d)`, "a", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := regexValue([]byte(tt.data), tt.pattern)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("err = %v, want substring %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil || got != tt.want {
+				t.Fatalf("got %q err %v, want %q", got, err, tt.want)
+			}
+		})
+	}
+}
+
+// TestMergedEnv_Precedence proves own wins per key, base-only keys survive, and
+// the empty-base fast path returns own unchanged without mutating either map.
+// An inverted precedence here would silently let a suite-wide default override a
+// scenario's explicit value.
+func TestMergedEnv_Precedence(t *testing.T) {
+	t.Parallel()
+	base := map[string]string{"A": "base", "B": "baseOnly"}
+	own := map[string]string{"A": "own", "C": "ownOnly"}
+	got := mergedEnv(base, own)
+	if got["A"] != "own" {
+		t.Errorf("own must win: A=%q", got["A"])
+	}
+	if got["B"] != "baseOnly" || got["C"] != "ownOnly" {
+		t.Errorf("keys lost: %+v", got)
+	}
+	// Inputs untouched.
+	if base["A"] != "base" || own["A"] != "own" {
+		t.Errorf("inputs mutated: base=%v own=%v", base, own)
+	}
+	// Empty base returns the exact own map (documented no-alloc fast path).
+	if out := mergedEnv(nil, own); len(out) != len(own) {
+		t.Errorf("empty base should return own, got %+v", out)
+	}
+}
+
+// TestExpandHTTP_Fields proves ${name} substitution reaches every
+// user-controllable HTTP field (path, header values, JSON body, raw body,
+// body_file, body_to, form values, file part paths) and leaves the input HTTP
+// spec untouched (expandHTTP returns a copy).
+func TestExpandHTTP_Fields(t *testing.T) {
+	t.Parallel()
+	st := store.New()
+	st.Set("id", "42")
+	st.Set("tok", "secret")
+	st.Set("workdir", "/wd")
+
+	in := &spec.HTTP{
+		Path:     "/users/${id}",
+		Header:   map[string]string{"Authorization": "Bearer ${tok}"},
+		JSON:     map[string]any{"name": "u${id}"},
+		Body:     "raw-${id}",
+		BodyFile: "${workdir}/in.bin",
+		BodyTo:   "${workdir}/out.bin",
+		Form:     map[string]string{"q": "${tok}"},
+		Files:    []spec.FilePart{{Path: "${workdir}/a.png"}},
+	}
+	out := expandHTTP(st, in)
+
+	if out.Path != "/users/42" {
+		t.Errorf("path = %q", out.Path)
+	}
+	if out.Header["Authorization"] != "Bearer secret" {
+		t.Errorf("header = %q", out.Header["Authorization"])
+	}
+	if m, _ := out.JSON.(map[string]any); m["name"] != "u42" {
+		t.Errorf("json = %v", out.JSON)
+	}
+	if out.Body != "raw-42" {
+		t.Errorf("body = %q", out.Body)
+	}
+	if out.BodyFile != "/wd/in.bin" || out.BodyTo != "/wd/out.bin" {
+		t.Errorf("body_file/body_to = %q/%q", out.BodyFile, out.BodyTo)
+	}
+	if out.Form["q"] != "secret" {
+		t.Errorf("form = %q", out.Form["q"])
+	}
+	if out.Files[0].Path != "/wd/a.png" {
+		t.Errorf("file part = %q", out.Files[0].Path)
+	}
+	// Input untouched.
+	if in.Path != "/users/${id}" || in.Files[0].Path != "${workdir}/a.png" {
+		t.Errorf("input mutated: %+v", in)
+	}
+}
+
+// TestExpandService_EnvPrecedence proves a background service's own env overrides
+// the scenario env on a key conflict, and both are ${name}-expanded. An inverted
+// precedence would let a scenario-wide default clobber a service's explicit
+// credential.
+func TestExpandService_EnvPrecedence(t *testing.T) {
+	t.Parallel()
+	st := store.New()
+	st.Set("home", "/wd")
+	svc := &spec.Service{
+		Name:    "db",
+		Command: "${home}/server",
+		Cwd:     "${home}",
+		Env:     map[string]string{"MODE": "service", "PORT": "${home}"},
+	}
+	scenarioEnv := map[string]string{"MODE": "scenario", "SHARED": "${home}/x"}
+	out := expandService(st, scenarioEnv, svc)
+
+	if out.Command != "/wd/server" || out.Cwd != "/wd" {
+		t.Errorf("command/cwd = %q/%q", out.Command, out.Cwd)
+	}
+	if out.Env["MODE"] != "service" {
+		t.Errorf("service env must win: MODE=%q", out.Env["MODE"])
+	}
+	if out.Env["SHARED"] != "/wd/x" {
+		t.Errorf("scenario env not expanded: SHARED=%q", out.Env["SHARED"])
+	}
+	if out.Env["PORT"] != "/wd" {
+		t.Errorf("service env not expanded: PORT=%q", out.Env["PORT"])
+	}
+}
+
+// TestNormalizeHostAndAllowedHosts covers normalizeHost's URL vs bare-host
+// branches and how allowedHosts threads them out of a spec. A full URL must
+// collapse to its host[:port]; a bare host or host:port passes through verbatim
+// so it can match the runner's url.Host comparison.
+func TestNormalizeHostAndAllowedHosts(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		entry, want string
+	}{
+		{"https://example.com", "example.com"},
+		{"https://example.com:8443/path", "example.com:8443"},
+		{"example.com", "example.com"},
+		{"example.com:9000", "example.com:9000"},
+	}
+	for _, tt := range tests {
+		if got := normalizeHost(tt.entry); got != tt.want {
+			t.Errorf("normalizeHost(%q) = %q, want %q", tt.entry, got, tt.want)
+		}
+	}
+
+	// No permissions block -> nil (no restriction).
+	if got := allowedHosts(&spec.Spec{}); got != nil {
+		t.Errorf("allowedHosts with no permissions = %v, want nil", got)
+	}
+	s := &spec.Spec{Permissions: &spec.Permissions{Network: &spec.NetworkPolicy{
+		Allow: []string{"https://api.example.com", "localhost:8080"},
+	}}}
+	got := allowedHosts(s)
+	if len(got) != 2 || got[0] != "api.example.com" || got[1] != "localhost:8080" {
+		t.Errorf("allowedHosts = %v", got)
+	}
+}
+
+// TestServiceLogged proves the duplicate-guard used by the service-log artifact
+// writer: a name already recorded reports true, an unrecorded name false. A false
+// negative here would write a service's log (and its masked secrets) twice.
+func TestServiceLogged(t *testing.T) {
+	t.Parallel()
+	out := &ScenarioResult{ServiceLogs: []ServiceLog{{Name: "api"}, {Name: "db"}}}
+	if !serviceLogged(out, "api") || !serviceLogged(out, "db") {
+		t.Error("recorded services should report logged")
+	}
+	if serviceLogged(out, "cache") {
+		t.Error("unrecorded service should report not logged")
+	}
+	if serviceLogged(&ScenarioResult{}, "api") {
+		t.Error("empty result should report not logged")
+	}
+}
+
+// TestSkipReason covers every gate of skipReason: OS-only/skip, env-only/skip,
+// and the command probe. Each gate is a scenario-selection decision; an inverted
+// gate would run a scenario that should be skipped (or vice versa).
+func TestSkipReason(t *testing.T) {
+	// Not parallel: env-based gates use t.Setenv.
+	e := New()
+	ctx := context.Background()
+	otherOS := "plan9-nonexistent"
+
+	// only.OS pointing at a non-host OS -> skip.
+	if r, skip := e.skipReason(ctx, &spec.Scenario{Only: &spec.Condition{OS: otherOS}}); !skip || !strings.Contains(r, "only on os") {
+		t.Errorf("only.OS mismatch: reason=%q skip=%v", r, skip)
+	}
+	// skip.OS matching the host -> skip.
+	if r, skip := e.skipReason(ctx, &spec.Scenario{Skip: &spec.Condition{OS: runtime.GOOS}}); !skip || !strings.Contains(r, "skip on os") {
+		t.Errorf("skip.OS match: reason=%q skip=%v", r, skip)
+	}
+	// only.OS matching the host -> not skipped.
+	if _, skip := e.skipReason(ctx, &spec.Scenario{Only: &spec.Condition{OS: runtime.GOOS}}); skip {
+		t.Error("only.OS matching host should not skip")
+	}
+
+	// only.Env unset -> skip; set -> run.
+	if r, skip := e.skipReason(ctx, &spec.Scenario{Only: &spec.Condition{Env: "ATAGO_UNSET_XYZ"}}); !skip || !strings.Contains(r, "only when env") {
+		t.Errorf("only.Env unset: reason=%q skip=%v", r, skip)
+	}
+	t.Setenv("ATAGO_SET_XYZ", "1")
+	if _, skip := e.skipReason(ctx, &spec.Scenario{Only: &spec.Condition{Env: "ATAGO_SET_XYZ"}}); skip {
+		t.Error("only.Env set should not skip")
+	}
+	// skip.Env set -> skip.
+	if r, skip := e.skipReason(ctx, &spec.Scenario{Skip: &spec.Condition{Env: "ATAGO_SET_XYZ"}}); !skip || !strings.Contains(r, "skip when env") {
+		t.Errorf("skip.Env set: reason=%q skip=%v", r, skip)
+	}
+
+	// Command probes (POSIX shells only; cmd.exe lacks true/false builtins).
+	if runtime.GOOS != "windows" {
+		// only.Command that fails -> skip.
+		if r, skip := e.skipReason(ctx, &spec.Scenario{Only: &spec.Condition{Command: "exit 1"}}); !skip || !strings.Contains(r, "only when command") {
+			t.Errorf("only.Command fail: reason=%q skip=%v", r, skip)
+		}
+		// skip.Command that succeeds -> skip.
+		if r, skip := e.skipReason(ctx, &spec.Scenario{Skip: &spec.Condition{Command: "exit 0"}}); !skip || !strings.Contains(r, "skip when command") {
+			t.Errorf("skip.Command success: reason=%q skip=%v", r, skip)
+		}
+		// No gates -> run.
+		if _, skip := e.skipReason(ctx, &spec.Scenario{}); skip {
+			t.Error("scenario with no gates should not skip")
+		}
+	}
+}
+
+// TestSuiteSetupFailure covers each branch of the setup-failure summary: empty
+// setup, a step ErrMsg, a failing check, and the no-detail fallback.
+func TestSuiteSetupFailure(t *testing.T) {
+	t.Parallel()
+	if got := suiteSetupFailure(nil); got != suiteSetupLabel+" failed" {
+		t.Errorf("empty setup = %q", got)
+	}
+	errMsg := suiteSetupFailure([]StepResult{{Index: 2, Kind: spec.StepRun, ErrMsg: "boom"}})
+	if !strings.Contains(errMsg, "step 2") || !strings.Contains(errMsg, "boom") {
+		t.Errorf("errmsg branch = %q", errMsg)
+	}
+	checkFail := suiteSetupFailure([]StepResult{{Index: 1, Kind: spec.StepAssert, Checks: []*assert.CheckResult{{OK: false, Desc: "want 200"}}}})
+	if !strings.Contains(checkFail, "want 200") {
+		t.Errorf("check branch = %q", checkFail)
+	}
+	fallback := suiteSetupFailure([]StepResult{{Index: 0, Kind: spec.StepFixture}})
+	if !strings.Contains(fallback, "step 0") || strings.Contains(fallback, ":") {
+		t.Errorf("fallback branch = %q", fallback)
+	}
+}
+
+// TestSuiteResultCounts tallies each status exactly once, proving flaky is a
+// distinct bucket (not folded into passed or failed) — the report's headline
+// numbers depend on it.
+func TestSuiteResultCounts(t *testing.T) {
+	t.Parallel()
+	s := &SuiteResult{Scenarios: []ScenarioResult{
+		{Status: StatusPassed}, {Status: StatusPassed},
+		{Status: StatusFailed},
+		{Status: StatusSkipped},
+		{Status: StatusError},
+		{Status: StatusFlaky},
+	}}
+	c := s.Counts()
+	if c != (Counts{Passed: 2, Failed: 1, Skipped: 1, Errored: 1, Flaky: 1}) {
+		t.Errorf("counts = %+v", c)
+	}
+}
+
+// TestScenarioID proves the identity key is stable and distinguishes same-named
+// scenarios across different spec paths (the --rerun-failed / --select key).
+func TestScenarioID(t *testing.T) {
+	t.Parallel()
+	a := ScenarioID("a.yaml", "login")
+	b := ScenarioID("b.yaml", "login")
+	if a == b {
+		t.Error("same name in different specs must not collide")
+	}
+	if a != ScenarioID("a.yaml", "login") {
+		t.Error("ScenarioID must be deterministic")
+	}
+}
+
+// TestEngineMatches covers each scenario-filter gate: name substring, required
+// tags, excluded tags, and the explicit --select set. A gate that reads inverted
+// would run the wrong subset of scenarios.
+func TestEngineMatches(t *testing.T) {
+	t.Parallel()
+	sc := &spec.Scenario{Name: "login flow", Tags: []string{"smoke", "auth"}}
+
+	if !New().matches(sc, "s.yaml") {
+		t.Error("no filters should match everything")
+	}
+
+	byName := New()
+	byName.FilterName = "login"
+	if !byName.matches(sc, "s.yaml") {
+		t.Error("name substring should match")
+	}
+	byName.FilterName = "logout"
+	if byName.matches(sc, "s.yaml") {
+		t.Error("non-matching name substring should reject")
+	}
+
+	byTag := New()
+	byTag.Tags = []string{"smoke"}
+	if !byTag.matches(sc, "s.yaml") {
+		t.Error("required tag present should match")
+	}
+	byTag.Tags = []string{"nightly"}
+	if byTag.matches(sc, "s.yaml") {
+		t.Error("required tag absent should reject")
+	}
+
+	bySkipTag := New()
+	bySkipTag.SkipTags = []string{"auth"}
+	if bySkipTag.matches(sc, "s.yaml") {
+		t.Error("excluded tag present should reject")
+	}
+
+	bySelect := New()
+	bySelect.Select = map[string]bool{ScenarioID("s.yaml", "login flow"): true}
+	if !bySelect.matches(sc, "s.yaml") {
+		t.Error("selected id should match")
+	}
+	if bySelect.matches(sc, "other.yaml") {
+		t.Error("unselected id (different path) should reject")
+	}
+}
+
+// TestResolveHTTPConfig covers the named-runner resolution branches: the
+// no-runner default (built-in 60s), an unknown runner, a wrong-typed runner, a
+// runner whose base_url is ${name}-expanded, and an invalid runner timeout.
+func TestResolveHTTPConfig(t *testing.T) {
+	t.Parallel()
+	st := store.New()
+	st.Set("host", "example.com")
+
+	rc := runConfig{runners: map[string]spec.Runner{
+		"api":    {Type: "http", BaseURL: "https://${host}", Timeout: "5s"},
+		"dbconn": {Type: "db", DSN: "sqlite:x"},
+		"bad":    {Type: "http", Timeout: "not-a-duration"},
+	}}
+
+	// No runner: default timeout applies, no base_url.
+	cfg, err := resolveHTTPConfig(&spec.HTTP{}, st, rc)
+	if err != nil || cfg.Timeout <= 0 {
+		t.Fatalf("default: cfg=%+v err=%v", cfg, err)
+	}
+
+	// Named http runner: base_url expanded, its timeout used.
+	cfg, err = resolveHTTPConfig(&spec.HTTP{Runner: "api"}, st, rc)
+	if err != nil || cfg.BaseURL != "https://example.com" {
+		t.Fatalf("api: cfg=%+v err=%v", cfg, err)
+	}
+
+	// Unknown runner.
+	if _, err := resolveHTTPConfig(&spec.HTTP{Runner: "ghost"}, st, rc); err == nil || !strings.Contains(err.Error(), "unknown runner") {
+		t.Fatalf("unknown runner err = %v", err)
+	}
+	// Wrong type.
+	if _, err := resolveHTTPConfig(&spec.HTTP{Runner: "dbconn"}, st, rc); err == nil || !strings.Contains(err.Error(), "not an http runner") {
+		t.Fatalf("wrong-type err = %v", err)
+	}
+	// Invalid timeout.
+	if _, err := resolveHTTPConfig(&spec.HTTP{Runner: "bad"}, st, rc); err == nil || !strings.Contains(err.Error(), "invalid timeout") {
+		t.Fatalf("invalid-timeout err = %v", err)
+	}
+}
+
+// TestRunHTTP_UnknownRunnerErrors proves runHTTP surfaces a config error (no
+// request attempted) and does not flag it as a network-policy violation.
+func TestRunHTTP_UnknownRunnerErrors(t *testing.T) {
+	t.Parallel()
+	e := New()
+	rc := runConfig{runners: map[string]spec.Runner{}, masker: security.NewMasker(nil)}
+	_, secViolation, err := e.runHTTP(context.Background(), &spec.HTTP{Runner: "ghost"}, store.New(), rc, t.TempDir())
+	if err == nil || secViolation {
+		t.Fatalf("want plain config error, got err=%v secViolation=%v", err, secViolation)
+	}
+}
+
+// TestMaskCheck_ArtifactPayloads proves the durable artifact payloads (#48) are
+// masked before they can reach a sidecar file — a secret in ArtifactActual /
+// ArtifactExpected must not survive maskCheck. A nil "no expected payload" must
+// stay nil rather than becoming an empty masked slice.
+func TestMaskCheck_ArtifactPayloads(t *testing.T) {
+	t.Parallel()
+	m := security.NewMasker([]string{"s3cret"})
+	cr := &assert.CheckResult{
+		ArtifactActual:   []byte("token=s3cret in body"),
+		ArtifactExpected: nil,
+	}
+	maskCheck(m, cr)
+	if strings.Contains(string(cr.ArtifactActual), "s3cret") {
+		t.Errorf("ArtifactActual leaked secret: %q", cr.ArtifactActual)
+	}
+	if cr.ArtifactExpected != nil {
+		t.Errorf("nil ArtifactExpected became %q; must stay nil", cr.ArtifactExpected)
+	}
+	// nil CheckResult and empty masker are both no-ops (no panic).
+	maskCheck(m, nil)
+	maskCheck(security.NewMasker(nil), &assert.CheckResult{Desc: "s3cret stays"})
+}
+
+// TestWriteArtifacts covers the sidecar writer: it writes actual+expected text
+// and each binary blob for a failed check, records their paths, and is a no-op
+// for passing checks, empty ArtifactKind, or a nil Artifacts dir.
+func TestWriteArtifacts(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	e := New()
+	e.Artifacts = artifact.NewDir(root)
+
+	cr := &assert.CheckResult{
+		OK:               false,
+		ArtifactKind:     "stdout",
+		ArtifactActual:   []byte("actual output"),
+		ArtifactExpected: []byte("expected output"),
+		ArtifactBlobs:    []assert.ArtifactBlob{{Role: "diff", Ext: "png", Data: []byte("PNGDATA")}, {Role: "empty", Ext: "bin", Data: nil}},
+	}
+	e.writeArtifacts(cr, "t.atago.yaml", "scn", 0, 1)
+	if len(cr.ArtifactFiles) != 3 { // actual, expected, diff (empty blob skipped)
+		t.Fatalf("ArtifactFiles = %d, want 3: %+v", len(cr.ArtifactFiles), cr.ArtifactFiles)
+	}
+	for _, f := range cr.ArtifactFiles {
+		if _, err := os.Stat(filepath.Join(root, f.Path)); err != nil {
+			t.Errorf("artifact %q not written: %v", f.Path, err)
+		}
+	}
+
+	// No-op guards.
+	passing := &assert.CheckResult{OK: true, ArtifactKind: "stdout", ArtifactActual: []byte("x")}
+	e.writeArtifacts(passing, "t.atago.yaml", "scn", 0, 0)
+	if len(passing.ArtifactFiles) != 0 {
+		t.Error("passing check should write nothing")
+	}
+	noKind := &assert.CheckResult{OK: false, ArtifactActual: []byte("x")}
+	e.writeArtifacts(noKind, "t.atago.yaml", "scn", 0, 0)
+	if len(noKind.ArtifactFiles) != 0 {
+		t.Error("empty ArtifactKind should write nothing")
+	}
+	// Nil Artifacts dir: no panic, no write.
+	(&Engine{}).writeArtifacts(cr, "t.atago.yaml", "scn", 0, 0)
+}
+
+// TestEngine_LeadingFixtureFailureErrorsScenario proves a leading fixture that
+// cannot be written (its `from` source is missing) errors the scenario before any
+// service or run step executes — the applyLeadingFixtures failure path. The later
+// run step must never run.
+func TestEngine_LeadingFixtureFailureErrorsScenario(t *testing.T) {
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: s
+scenarios:
+  - name: leading fixture fails
+    steps:
+      - fixture:
+          file: config.txt
+          from: this-source-does-not-exist.txt
+      - run:
+          shell: true
+          command: echo unreached
+`)
+	sc := res.Scenarios[0]
+	if sc.Status != StatusError {
+		t.Fatalf("status = %s, want error: %+v", sc.Status, sc.Steps)
+	}
+	for _, st := range sc.Steps {
+		if st.Run != nil && strings.Contains(string(st.Run.Stdout), "unreached") {
+			t.Error("run step executed despite the leading fixture failure")
+		}
+	}
+}
+
+type bughuntCloser struct{ closed bool }
+
+func (f *bughuntCloser) Close() error { f.closed = true; return nil }
+
+// TestResolveConn covers the shared per-runner connection resolver used by the
+// db/grpc/ssh/browser step helpers: cache hit (no re-open), unknown runner,
+// wrong-type runner, invalid timeout, and an open error. A cache miss that
+// re-opened on every step would leak connections; a wrong-type acceptance would
+// run a query against, say, an ssh runner.
+func TestResolveConn(t *testing.T) {
+	t.Parallel()
+	rc := runConfig{runners: map[string]spec.Runner{
+		"db":   {Type: "db", Timeout: "5s"},
+		"bad":  {Type: "db", Timeout: "not-a-duration"},
+		"http": {Type: "http"},
+	}}
+	conns := map[string]*bughuntCloser{}
+	opens := 0
+	open := func(spec.Runner, time.Duration) (*bughuntCloser, error) {
+		opens++
+		return &bughuntCloser{}, nil
+	}
+
+	c1, err := resolveConn("db", "query step", "db", rc, conns, false, open)
+	if err != nil || c1 == nil {
+		t.Fatalf("first resolve: %v", err)
+	}
+	c2, err := resolveConn("db", "query step", "db", rc, conns, false, open)
+	if err != nil || c1 != c2 || opens != 1 {
+		t.Fatalf("cache miss: opens=%d c1==c2=%v", opens, c1 == c2)
+	}
+
+	if _, err := resolveConn("ghost", "query step", "db", rc, conns, false, open); err == nil || !strings.Contains(err.Error(), "unknown runner") {
+		t.Fatalf("unknown runner err = %v", err)
+	}
+	if _, err := resolveConn("http", "query step", "db", rc, conns, false, open); err == nil || !strings.Contains(err.Error(), "not a db runner") {
+		t.Fatalf("wrong-type err = %v", err)
+	}
+	// defaultBounded=false so the raw (invalid) runner timeout is parsed and fails.
+	if _, err := resolveConn("bad", "query step", "db", rc, conns, false, open); err == nil || !strings.Contains(err.Error(), "invalid timeout") {
+		t.Fatalf("invalid-timeout err = %v", err)
+	}
+	openErr := func(spec.Runner, time.Duration) (*bughuntCloser, error) { return nil, errors.New("boom") }
+	if _, err := resolveConn("db", "query step", "db", rc, map[string]*bughuntCloser{}, true, openErr); err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("open error = %v", err)
 	}
 }

--- a/internal/engine/expand.go
+++ b/internal/engine/expand.go
@@ -177,6 +177,23 @@ func expandCDP(st *store.Store, c *spec.CDP) *spec.CDP {
 			at.Name = st.Expand(at.Name)
 			a.Attribute = &at
 		}
+		if a.Upload != nil {
+			// Upload.File is a workdir-relative path; expand it (and the selector)
+			// so a ${workdir}/store-derived file is uploaded, matching what
+			// CollectStepVars reports as a live variable use.
+			up := *a.Upload
+			up.Selector = st.Expand(up.Selector)
+			up.File = st.Expand(up.File)
+			a.Upload = &up
+		}
+		if a.Download != nil {
+			// Download.Dir is a workdir-relative capture directory; expand it (and
+			// the click selector) for the same reason as Upload above.
+			dl := *a.Download
+			dl.Click = st.Expand(dl.Click)
+			dl.Dir = st.Expand(dl.Dir)
+			a.Download = &dl
+		}
 		out.Actions[i] = a
 	}
 	return &out

--- a/internal/engine/expand_test.go
+++ b/internal/engine/expand_test.go
@@ -279,3 +279,38 @@ func indexOf(s, sub string) int {
 	}
 	return -1
 }
+
+// TestExpandCDP_UploadDownload is a regression: a browser upload's file path and
+// selector, and a download's click selector and capture dir, are ${name}
+// references the engine must expand — spec.CollectStepVars already reports them
+// as used, so leaving them literal meant a variable the summaries advertise as
+// live was silently passed to the browser unexpanded. Upload.File and
+// Download.Dir are workdir-relative paths, so a `${workdir}`- or store-derived
+// value that stays literal targets the wrong file.
+func TestExpandCDP_UploadDownload(t *testing.T) {
+	t.Parallel()
+	st := store.New()
+	st.Set("workdir", "/wd")
+	st.Set("field", "#chooser")
+	st.Set("btn", "#dl")
+
+	c := &spec.CDP{Actions: []spec.CDPAction{
+		{Upload: &spec.CDPUpload{Selector: "${field}", File: "${workdir}/in.png"}},
+		{Download: &spec.CDPDownload{Click: "${btn}", Dir: "${workdir}/out"}},
+	}}
+	out := expandCDP(st, c)
+
+	up := out.Actions[0].Upload
+	if up.Selector != "#chooser" || up.File != "/wd/in.png" {
+		t.Errorf("upload not expanded: selector=%q file=%q", up.Selector, up.File)
+	}
+	dl := out.Actions[1].Download
+	if dl.Click != "#dl" || dl.Dir != "/wd/out" {
+		t.Errorf("download not expanded: click=%q dir=%q", dl.Click, dl.Dir)
+	}
+
+	// The input must not be mutated: expansion returns a fresh copy.
+	if c.Actions[0].Upload.File != "${workdir}/in.png" {
+		t.Error("expandCDP mutated the input upload action")
+	}
+}

--- a/internal/engine/store.go
+++ b/internal/engine/store.go
@@ -99,6 +99,13 @@ func jsonValue(data []byte, path string) (string, error) {
 	if len(nodes) != 1 {
 		return "", fmt.Errorf("JSON path %q selected %d values, want exactly 1", path, len(nodes))
 	}
+	// Why: a JSON null selects exactly one node whose Go value is nil, and
+	// fmt.Sprint(nil) yields the literal string "<nil>". Storing that would leak
+	// a Go-ism into a user-visible variable and silently mask "the field was
+	// null" as a captured value. Surface it as a clean error instead.
+	if nodes[0] == nil {
+		return "", fmt.Errorf("JSON path %q selected a null value", path)
+	}
 	return fmt.Sprint(nodes[0]), nil
 }
 

--- a/internal/engine/suite_setup_test.go
+++ b/internal/engine/suite_setup_test.go
@@ -234,3 +234,87 @@ scenarios:
 		t.Errorf("no-block spec recorded setup/teardown results: %+v / %+v", res.Setup, res.Teardown)
 	}
 }
+
+// TestEngine_SuiteSetup_FixtureStoreAssertKinds exercises the fixture, store, and
+// assert step kinds inside suite.setup (not only run/service), covering the
+// per-kind branches of runSuiteSteps that the other suite tests skip. A fixture
+// written in setup lands in ${suitedir} and is visible to scenarios, and a setup
+// assert against a setup run's output participates in the setup verdict.
+func TestEngine_SuiteSetup_FixtureStoreAssertKinds(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: s
+  setup:
+    - fixture:
+        file: seed.txt
+        content: "hello from setup"
+    - run:
+        shell: true
+        command: echo boot-42
+    - assert:
+        exit_code: 0
+        stdout: {contains: boot-42}
+    - store:
+        name: bootid
+        from:
+          stdout:
+            matches: "boot-[0-9]+"
+scenarios:
+  - name: sees the setup store
+    steps:
+      # The fixture/store/assert setup steps above run once before this scenario
+      # regardless of what it does, so they are what exercises runSuiteSteps'
+      # per-kind branches; the scenario just confirms the captured store reached
+      # it with a cross-platform echo (no cat/;, which cmd.exe does not honor).
+      - run: {shell: true, command: "echo id=${bootid}"}
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: id=boot-42
+`
+	s, err := loader.LoadBytes("t.atago.yaml", []byte(src))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	res := New().Run(context.Background(), s, "t.atago.yaml")
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed: %+v", res.Status, res.Scenarios)
+	}
+	if len(res.Setup) != 4 {
+		t.Fatalf("recorded %d setup step results, want 4", len(res.Setup))
+	}
+}
+
+// TestEngine_SuiteSetup_FailingAssertErrsScenarios covers the suite-setup failure
+// path triggered by a failing assert (not a run error): a false setup assertion
+// aborts the suite and errors every scenario, exercising the assert-failure and
+// stop-on-failure branches of runSuiteSteps.
+func TestEngine_SuiteSetup_FailingAssertErrsScenarios(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: s
+  setup:
+    - run: {shell: true, command: echo actual}
+    - assert:
+        stdout: {contains: expected-but-absent}
+scenarios:
+  - name: never runs
+    steps:
+      - run: {shell: true, command: echo unreached}
+`
+	s, err := loader.LoadBytes("t.atago.yaml", []byte(src))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	res := New().Run(context.Background(), s, "t.atago.yaml")
+	if res.Status != StatusError {
+		t.Fatalf("status = %s, want error: %+v", res.Status, res.Scenarios)
+	}
+	if len(res.Scenarios) != 1 || res.Scenarios[0].Status != StatusError {
+		t.Fatalf("scenario should be errored by the setup failure: %+v", res.Scenarios)
+	}
+}

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -424,6 +424,12 @@ func describeHeader(h *spec.HeaderMatch) string {
 		return fmt.Sprintf("%q contains %q", h.Name, *h.Contains)
 	case h.Equals != nil:
 		return fmt.Sprintf("%q equals %q", h.Name, *h.Equals)
+	// A header `matches` regexp is a real matcher (the natural shape for auth
+	// headers like "^Bearer "); without this case it fell to the name-only
+	// default and the documented constraint vanished from the explain output.
+	// Kept in step with docgen.describeHeader.
+	case h.Matches != nil:
+		return fmt.Sprintf("%q matches /%s/", h.Name, *h.Matches)
 	default:
 		return fmt.Sprintf("%q", h.Name)
 	}

--- a/internal/explain/explain_test.go
+++ b/internal/explain/explain_test.go
@@ -565,3 +565,526 @@ scenarios:
 		}
 	}
 }
+
+// TestExplain_SuiteSetupTeardownBlocks exercises explainSuiteBlock across every
+// step kind that suite.setup/teardown accepts (run, service, mock_server,
+// fixture, store, assert). The validator (validateSuiteBlock) permits exactly
+// these kinds, so explain must render each — a dropped kind would hide part of
+// the once-per-suite bootstrap from a reviewer.
+func TestExplain_SuiteSetupTeardownBlocks(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: bootstrap
+  setup:
+    - fixture:
+        file: seed.json
+        content: "{}"
+    - run:
+        command: ./build-helper
+    - store:
+        name: token
+        from:
+          stdout:
+            matches: "tok-[0-9]+"
+    - service:
+        name: broker
+        command: ./broker
+        ready:
+          delay: 50ms
+    - mock_server:
+        name: api
+        routes:
+          - {method: GET, path: /health, body: ok}
+    - assert:
+        exit_code: 0
+  teardown:
+    - run:
+        command: ./cleanup
+    - store:
+        name: bye
+        from:
+          stdout:
+            matches: "bye-[0-9]+"
+scenarios:
+  - name: trivial
+    steps:
+      - run: {command: echo hi}
+      - assert: {exit_code: 0}
+`
+	out := mustExplain(t, src)
+	for _, want := range []string{
+		"Suite setup (runs once before any scenario):",
+		"seed.json (inline content)",
+		"./build-helper",
+		"start suite service \"broker\": ./broker",
+		"mock server api: 1 canned route(s), serves ${api.url}",
+		"store token",
+		"expect exit code is 0",
+		"Suite teardown (always runs after the last scenario):",
+		"./cleanup",
+		"store bye",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("explain suite block missing %q\n--- got ---\n%s", want, out)
+		}
+	}
+}
+
+// TestExplain_SignalStep covers describeSignal for both the fire-and-forget form
+// and the wait form. The default wait timeout rendered here (5s) must match the
+// engine's defaultSignalWait constant; a drift would mislead a reviewer about how
+// long a teardown blocks.
+func TestExplain_SignalStep(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: signals
+scenarios:
+  - name: send signals
+    services:
+      - name: server
+        command: ./server
+        ready:
+          delay: 10ms
+    steps:
+      - run: {command: echo go}
+      - signal:
+          service: server
+          signal: HUP
+      - signal:
+          service: server
+          signal: TERM
+          wait: {}
+      - signal:
+          service: server
+          signal: INT
+          wait:
+            timeout: 2s
+      - assert: {exit_code: 0}
+`
+	out := mustExplain(t, src)
+	for _, want := range []string{
+		"send SIGHUP to service server",
+		"send SIGTERM to service server  [wait up to 5s for exit]",
+		"send SIGINT to service server  [wait up to 2s for exit]",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("explain signal missing %q\n--- got ---\n%s", want, out)
+		}
+	}
+}
+
+// TestExplain_ChangesAssert covers describeChangesExplain: a populated category,
+// an explicitly-empty category ("modified: []" renders "modified nothing"), and
+// the mix. This is the workdir-delta assertion (#70).
+func TestExplain_ChangesAssert(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: delta
+scenarios:
+  - name: workdir changes
+    steps:
+      - run: {command: ./generate}
+      - assert:
+          changes:
+            created: [out.txt, log/run.log]
+            modified: []
+            deleted: [stale.tmp]
+`
+	out := mustExplain(t, src)
+	for _, want := range []string{
+		"changed exactly created out.txt, log/run.log; modified nothing; deleted stale.tmp",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("explain changes missing %q\n--- got ---\n%s", want, out)
+		}
+	}
+}
+
+// TestExplain_MockAssertVariants covers describeMockAssert (#24): a bare "received
+// a request", a method+path filter, and a count. It also exercises describeMockServer
+// via the scenario's mock_servers list.
+func TestExplain_MockAssertVariants(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: mocks
+scenarios:
+  - name: assert against mock
+    mock_servers:
+      - name: up
+        routes:
+          - {method: POST, path: /events, status: 202}
+          - {method: GET, path: /health, body: ok}
+    steps:
+      - run: {command: ./client}
+      - assert:
+          mock:
+            name: up
+      - assert:
+          mock:
+            name: up
+            method: post
+            path: /events
+      - assert:
+          mock:
+            name: up
+            path: /health
+            count: 3
+`
+	out := mustExplain(t, src)
+	for _, want := range []string{
+		"mock server up: 2 canned route(s), serves ${up.url}",
+		"mock up received a request",
+		"mock up received POST /events",
+		"mock up received /health x3",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("explain mock assert missing %q\n--- got ---\n%s", want, out)
+		}
+	}
+}
+
+// TestExplain_DirAssert covers describeDir (#74) across every constraint field so
+// a directory/tree assertion is fully summarized.
+func TestExplain_DirAssert(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: dirs
+scenarios:
+  - name: check a tree
+    steps:
+      - run: {command: ./build}
+      - assert:
+          dir:
+            path: dist
+            exists: true
+            contains: [index.html]
+            not_contains: [.DS_Store]
+            min_count: 1
+            max_count: 100
+            glob: "*.html"
+            recursive: true
+            ignore: [tmp, cache]
+      - assert:
+          dir:
+            path: empty
+            exists: false
+      - assert:
+          dir:
+            path: exact
+            count: 2
+      - assert:
+          dir:
+            path: snap
+            snapshot: tree.snap
+`
+	out := mustExplain(t, src)
+	for _, want := range []string{
+		`dir "dist" exists, contains index.html, does not contain .DS_Store, has >= 1 entries, has <= 100 entries, matches glob *.html, (recursive), ignoring tmp, cache`,
+		`dir "empty" does not exist`,
+		`dir "exact" has 2 entries`,
+		`dir "snap" tree matches snapshot tree.snap`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("explain dir assert missing %q\n--- got ---\n%s", want, out)
+		}
+	}
+}
+
+// TestExplain_PDFAssert covers describePDF (#73) across page-count bounds, sorted
+// metadata, and extracted-text matching.
+func TestExplain_PDFAssert(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: pdfs
+scenarios:
+  - name: check a pdf
+    steps:
+      - run: {command: ./render}
+      - assert:
+          pdf:
+            path: out.pdf
+            pages: 3
+            metadata:
+              Title: Report
+              Author: nao
+            text:
+              contains: Summary
+      - assert:
+          pdf:
+            path: bounded.pdf
+            min_pages: 1
+            max_pages: 10
+`
+	out := mustExplain(t, src)
+	for _, want := range []string{
+		`pdf "out.pdf" 3 pages`,
+		// Metadata keys are sorted, so Author precedes Title regardless of map order.
+		`Author contains "nao", Title contains "Report"`,
+		`text contains "Summary"`,
+		`pdf "bounded.pdf" >= 1 pages, <= 10 pages`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("explain pdf assert missing %q\n--- got ---\n%s", want, out)
+		}
+	}
+}
+
+// TestExplain_ExitCodeInAndNot covers intList (exit code in {…}) and the
+// exit-code "not" / bare forms (#19) in describeTarget.
+func TestExplain_ExitCodeInAndNot(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: codes
+scenarios:
+  - name: exit code sets
+    steps:
+      - run: {command: ./maybe-fail}
+      - assert:
+          exit_code:
+            in: [0, 2, 3]
+`
+	out := mustExplain(t, src)
+	if !strings.Contains(out, "exit code in [0, 2, 3]") {
+		t.Errorf("explain exit-code-in missing\n--- got ---\n%s", out)
+	}
+}
+
+// TestExplain_JSONMatcherOperators covers jsonMatcher for the numeric-bound
+// operators (gte/lt/lte) not exercised elsewhere, so every comparison branch is
+// rendered.
+func TestExplain_JSONMatcherOperators(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: jsonops
+scenarios:
+  - name: numeric bounds
+    steps:
+      - run: {command: echo hi}
+      - assert:
+          stdout:
+            json:
+              path: $.gte
+              gte: 5
+      - assert:
+          stdout:
+            json:
+              path: $.lt
+              lt: 9
+      - assert:
+          stdout:
+            json:
+              path: $.lte
+              lte: 7
+`
+	out := mustExplain(t, src)
+	for _, want := range []string{
+		"$.gte >= 5",
+		"$.lt < 9",
+		"$.lte <= 7",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("explain json operator missing %q\n--- got ---\n%s", want, out)
+		}
+	}
+}
+
+// TestExplain_FixtureBase64AndRunNotes covers describeFixture's base64 branch and
+// describeRun with a timeout and env (the notes path), plus describeStream's
+// empty:true/false via body asserts on an HTTP response.
+func TestExplain_FixtureBase64AndRunNotes(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: misc
+runners:
+  api: {type: http, base_url: "http://127.0.0.1:8080"}
+scenarios:
+  - name: assorted rendering
+    steps:
+      - fixture:
+          file: blob.bin
+          base64: "aGVsbG8="
+      - run:
+          command: ./slow
+          timeout: 30s
+          env:
+            MODE: fast
+      - http:
+          runner: api
+          method: GET
+          path: /health
+      - assert:
+          body:
+            empty: false
+      - assert:
+          body:
+            empty: true
+`
+	out := mustExplain(t, src)
+	for _, want := range []string{
+		"blob.bin (base64 binary)",
+		"./slow  (timeout 30s, env: MODE)",
+		"body is not empty",
+		"body is empty",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("explain misc missing %q\n--- got ---\n%s", want, out)
+		}
+	}
+}
+
+// TestExplain_TeardownStepKinds covers the teardown branch of explainScenario
+// across every step kind teardown accepts (run, http, query, grpc, cdp, fixture,
+// assert, store, signal) plus the http header `matches` matcher (describeHeader)
+// and a stream YAML matcher (describeStream). A teardown block always runs, so a
+// reviewer must see what external cleanup a spec performs.
+func TestExplain_TeardownStepKinds(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: teardowns
+runners:
+  api: {type: http, base_url: "http://127.0.0.1:8080"}
+  d: {type: db, dsn: "sqlite::memory:"}
+  g: {type: grpc, target: "localhost:50051"}
+  web: {type: browser}
+scenarios:
+  - name: rich teardown
+    services:
+      - name: worker
+        command: ./worker
+        ready: {delay: 10ms}
+    steps:
+      - run: {command: echo go}
+      - assert: {exit_code: 0}
+    teardown:
+      - run: {command: ./cleanup}
+      - http: {runner: api, method: DELETE, path: /session}
+      - assert:
+          header:
+            name: X-Trace
+            matches: "^t-[0-9]+$"
+      - assert:
+          body:
+            yaml:
+              path: $.status
+              equals: done
+      - query: {runner: d, sql: "DELETE FROM tmp"}
+      - grpc: {runner: g, method: pkg.Svc/Cleanup}
+      - cdp:
+          runner: web
+          actions:
+            - navigate: http://localhost:8080/logout
+      - fixture: {file: marker.txt, content: bye}
+      - store:
+          name: final
+          from:
+            stdout:
+              matches: "done-[0-9]+"
+      - signal:
+          service: worker
+          signal: TERM
+`
+	out := mustExplain(t, src)
+	for _, want := range []string{
+		"Teardown (always runs):",
+		"./cleanup",
+		"HTTP DELETE /session",
+		`"X-Trace" matches /^t-[0-9]+$/`,
+		"body YAML $.status",
+		"SQL query via d: DELETE FROM tmp",
+		"gRPC pkg.Svc/Cleanup via g",
+		"CDP via web: navigate http://localhost:8080/logout",
+		"marker.txt (inline content)",
+		"store final",
+		"send SIGTERM to service worker",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("explain teardown missing %q\n--- got ---\n%s", want, out)
+		}
+	}
+}
+
+// TestExplain_FileContains covers describeFile's contains branch (a multi-element
+// contains list renders each quoted element).
+func TestExplain_FileContains(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: edges
+scenarios:
+  - name: file contains
+    steps:
+      - run: {command: ./noop}
+      - assert:
+          file:
+            path: log.txt
+            contains: [started, finished]
+`
+	out := mustExplain(t, src)
+	if want := `file "log.txt" contains "started", "finished"`; !strings.Contains(out, want) {
+		t.Errorf("explain file-contains missing %q\n--- got ---\n%s", want, out)
+	}
+}
+
+// TestExplain_RunStdinVariants covers describeRun's stdin-from-file and
+// binary-stdin (base64) note branches (#…): a reviewer must see where a command's
+// stdin comes from.
+func TestExplain_RunStdinVariants(t *testing.T) {
+	t.Parallel()
+	fileSrc := `
+version: "1"
+suite:
+  name: stdinfile
+scenarios:
+  - name: stdin from file
+    steps:
+      - fixture: {file: in.txt, content: "data"}
+      - run:
+          command: cat
+          stdin:
+            file: in.txt
+      - assert: {exit_code: 0}
+`
+	out := mustExplain(t, fileSrc)
+	if !strings.Contains(out, "stdin from file in.txt") {
+		t.Errorf("explain stdin-file missing\n--- got ---\n%s", out)
+	}
+
+	b64Src := `
+version: "1"
+suite:
+  name: stdinb64
+scenarios:
+  - name: binary stdin
+    steps:
+      - run:
+          command: cat
+          stdin:
+            base64: "aGVsbG8="
+      - assert: {exit_code: 0}
+`
+	out = mustExplain(t, b64Src)
+	if !strings.Contains(out, "binary stdin (base64)") {
+		t.Errorf("explain binary-stdin missing\n--- got ---\n%s", out)
+	}
+}

--- a/internal/fsdelta/fsdelta_test.go
+++ b/internal/fsdelta/fsdelta_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
+	"sort"
 	"testing"
 )
 
@@ -98,4 +100,91 @@ func keys(m Snapshot) []string {
 		out = append(out, k)
 	}
 	return out
+}
+
+// TestScan_MissingRootReturnsEmpty covers the os.IsNotExist branch: scanning a
+// root that does not exist yields an empty snapshot and no error, so a step that
+// never created its workdir does not turn a `changes:` assertion into an engine
+// error.
+func TestScan_MissingRootReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	snap, err := Scan(filepath.Join(t.TempDir(), "does-not-exist"))
+	if err != nil {
+		t.Fatalf("Scan(missing) error = %v, want nil", err)
+	}
+	if len(snap) != 0 {
+		t.Errorf("Scan(missing) = %v, want empty snapshot", snap)
+	}
+}
+
+// TestScan_SkipsSymlinks proves symlinks are not tracked (only regular files
+// are), so a symlink cannot be mistaken for a created/modified content file.
+func TestScan_SkipsSymlinks(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is restricted on Windows")
+	}
+	root := t.TempDir()
+	target := filepath.Join(root, "real.txt")
+	if err := os.WriteFile(target, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(root, "link.txt")); err != nil {
+		t.Fatal(err)
+	}
+	snap, err := Scan(root)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if _, ok := snap["link.txt"]; ok {
+		t.Errorf("symlink should not be tracked, snapshot = %v", snap)
+	}
+	if _, ok := snap["real.txt"]; !ok {
+		t.Errorf("regular file should be tracked, snapshot = %v", snap)
+	}
+}
+
+// TestDiff_Antisymmetry is a metamorphic law: swapping the two snapshots turns
+// every Created into a Deleted and vice versa, while the Modified set is
+// unchanged (only its membership flips direction, not the paths). A break here
+// would mean the delta reports the wrong verb for a change.
+func TestDiff_Antisymmetry(t *testing.T) {
+	t.Parallel()
+	pre := Snapshot{"keep": "h", "changed": "old", "onlypre": "x"}
+	post := Snapshot{"keep": "h", "changed": "new", "onlypost": "y"}
+
+	fwd := Diff(pre, post)
+	rev := Diff(post, pre)
+
+	if !reflect.DeepEqual(fwd.Created, rev.Deleted) {
+		t.Errorf("forward Created %v != reverse Deleted %v", fwd.Created, rev.Deleted)
+	}
+	if !reflect.DeepEqual(fwd.Deleted, rev.Created) {
+		t.Errorf("forward Deleted %v != reverse Created %v", fwd.Deleted, rev.Created)
+	}
+	fm, rm := append([]string(nil), fwd.Modified...), append([]string(nil), rev.Modified...)
+	sort.Strings(fm)
+	sort.Strings(rm)
+	if !reflect.DeepEqual(fm, rm) {
+		t.Errorf("Modified set differs by direction: %v vs %v", fm, rm)
+	}
+	if len(fwd.Modified) != 1 || fwd.Modified[0] != "changed" {
+		t.Errorf("Modified = %v, want [changed]", fwd.Modified)
+	}
+}
+
+// TestDiff_EmptySnapshots covers the trivial edges: two empty snapshots produce
+// an all-empty delta, and a scan-against-nothing reports everything created.
+func TestDiff_EmptySnapshots(t *testing.T) {
+	t.Parallel()
+	empty := Snapshot{}
+	if d := Diff(empty, empty); len(d.Created)+len(d.Modified)+len(d.Deleted) != 0 {
+		t.Errorf("Diff(empty,empty) = %+v, want all empty", d)
+	}
+	post := Snapshot{"a": "1", "b": "2"}
+	d := Diff(empty, post)
+	want := []string{"a", "b"}
+	if !reflect.DeepEqual(d.Created, want) || len(d.Modified) != 0 || len(d.Deleted) != 0 {
+		t.Errorf("Diff(empty, post) = %+v, want Created %v", d, want)
+	}
 }

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -2,8 +2,12 @@ package loader
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/goccy/go-yaml"
 )
 
 func TestLoadBytes_Valid(t *testing.T) {
@@ -697,6 +701,412 @@ func TestLoadBytes_Errors(t *testing.T) {
 			if tt.wantMsg != "" && !strings.Contains(lerr.Msg, tt.wantMsg) {
 				t.Errorf("msg = %q, want substring %q", lerr.Msg, tt.wantMsg)
 			}
+		})
+	}
+}
+
+// specSteps assembles a minimal one-scenario spec whose steps are the given
+// flow-style step entries (each is the text after "- " in a steps list). It
+// keeps the many one-off validation cases readable without hand-indenting YAML.
+func specSteps(steps ...string) string {
+	var b strings.Builder
+	b.WriteString("version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps:\n")
+	for _, s := range steps {
+		b.WriteString("      - " + s + "\n")
+	}
+	return b.String()
+}
+
+// mustReject asserts LoadBytes fails with a validation/parse error whose message
+// contains want.
+func mustReject(t *testing.T, name, src, want string) {
+	t.Helper()
+	_, err := LoadBytes("t.atago.yaml", []byte(src))
+	if err == nil {
+		t.Fatalf("%s: LoadBytes() error = nil, want error containing %q", name, want)
+	}
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("%s: error = %q, want substring %q", name, err.Error(), want)
+	}
+}
+
+// mustAccept asserts LoadBytes loads src cleanly.
+func mustAccept(t *testing.T, name, src string) {
+	t.Helper()
+	if _, err := LoadBytes("t.atago.yaml", []byte(src)); err != nil {
+		t.Errorf("%s: LoadBytes() error = %v, want clean load", name, err)
+	}
+}
+
+// TestBugHunt_Rejections drives the validation-error paths — the untrusted-input
+// surface — asserting each malformed spec is rejected with an accurate message.
+func TestBugHunt_Rejections(t *testing.T) {
+	t.Parallel()
+
+	dbRunner := "runners:\n  d: {type: db, dsn: \"sqlite::memory:\"}\n"
+	grpcRunner := "runners:\n  g: {type: grpc, target: \"127.0.0.1:50051\"}\n"
+	browserRunner := "runners:\n  b: {type: browser}\n"
+
+	// withRunner prepends a runners: block to a specSteps body (which has no
+	// runners of its own).
+	withRunner := func(runner, body string) string {
+		// body starts with `version: "1"\nsuite:\n  name: x\n...`; splice the
+		// runner block in after the suite name line.
+		const anchor = "  name: x\n"
+		i := strings.Index(body, anchor) + len(anchor)
+		return body[:i] + runner + body[i:]
+	}
+
+	// scenarioSpec builds a spec whose single scenario has extra scenario-level
+	// blocks (services/mock_servers) plus steps.
+	mockScenario := func(step string) string {
+		return "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n" +
+			"    mock_servers:\n      - name: api\n        routes:\n          - {method: GET, path: /, status: 200}\n" +
+			"    steps:\n      - " + step + "\n"
+	}
+	svcScenario := func(step string) string {
+		return "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n" +
+			"    services:\n      - {name: s, command: sleep 10}\n" +
+			"    steps:\n      - " + step + "\n"
+	}
+	scenarioTop := func(extra, step string) string {
+		return "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    " + extra + "\n    steps:\n      - " + step + "\n"
+	}
+
+	tests := []struct{ name, src, want string }{
+		// ---- store / validateStoreJSONPath / validateStore ----
+		{"store name required", specSteps("store: {from: {header: X-Foo}}"), "store.name is required"},
+		{"store shadows builtin", specSteps("store: {name: workdir, from: {header: X}}"), "shadows a built-in variable"},
+		{"store from required", specSteps("store: {name: v}"), "store.from is required"},
+		{"store from empty", specSteps("store: {name: v, from: {}}"), "must set one of stdout/body/file/header/rows/message/value"},
+		{"store from two sources", specSteps("store: {name: v, from: {header: X, stdout: {json: {path: \"$.a\"}}}}"), "must set exactly one source"},
+		{"store selector no json/matches", specSteps("store: {name: v, from: {stdout: {}}}"), "must set a json path or a matches regexp"},
+		{"store selector bad matches", specSteps("store: {name: v, from: {stdout: {matches: \"a[\"}}}"), "is not a valid regexp"},
+		{"store selector json path required", specSteps("store: {name: v, from: {stdout: {json: {}}}}"), "path is required"},
+		{"store selector bad json path", specSteps("store: {name: v, from: {stdout: {json: {path: \"$[\"}}}}"), "is not a valid JSON path"},
+		{"store file bad json path", specSteps("store: {name: v, from: {file: {path: out.txt, json: {path: \"$.\"}}}}"), "is not a valid JSON path"},
+
+		// ---- validateAssert / validateAssertTarget ----
+		{"assert no target", specSteps("assert: {}"), "must set at least one assertion target"},
+
+		// ---- validateExitCode ----
+		{"exit_code none set", specSteps("assert: {exit_code: {}}"), "must be an int, {not: int}, or {in: [int, ...]}"},
+		{"exit_code two forms", specSteps("assert: {exit_code: {not: 1, in: [2]}}"), "set exactly one of a bare int, not, or in"},
+		{"exit_code in empty", specSteps("assert: {exit_code: {in: []}}"), "in must list at least one accepted exit code"},
+		{"exit_code in dup", specSteps("assert: {exit_code: {in: [0, 0]}}"), "in lists 0 more than once"},
+
+		// ---- validateStream ----
+		{"stream no matcher", specSteps("assert: {stdout: {}}"), "must set exactly one matcher"},
+		{"stream two matchers", specSteps("assert: {stdout: {contains: a, equals: b}}"), "must set exactly one matcher, but set"},
+		{"stream line with snapshot", specSteps("assert: {stdout: {line: 1, snapshot: snap}}"), "line cannot be combined with json/yaml/snapshot"},
+		{"stream contains empty list", specSteps("assert: {stdout: {contains: []}}"), "contains must not be empty"},
+		{"stream contains empty element", specSteps("assert: {stdout: {contains: [\"\"]}}"), "is an empty string"},
+
+		// ---- validateFile ----
+		{"file path required", specSteps("assert: {file: {exists: true}}"), "file.path is required"},
+		{"file no matcher", specSteps("assert: {file: {path: out.txt}}"), "must set one of exists/contains/not_contains/executable/json/snapshot"},
+		{"file two matchers", specSteps("assert: {file: {path: out.txt, exists: true, snapshot: s}}"), "must set exactly one of exists/contains/not_contains/executable/json/snapshot"},
+		{"file not_contains empty", specSteps("assert: {file: {path: out.txt, not_contains: []}}"), "not_contains must not be empty"},
+
+		// ---- validateHeaderMatch ----
+		{"header name required", specSteps("assert: {header: {equals: text/html}}"), "header.name is required"},
+		{"header no matcher", specSteps("assert: {header: {name: Content-Type}}"), "must set one of contains/equals/matches"},
+		{"header two matchers", specSteps("assert: {header: {name: X, contains: a, equals: b}}"), "must set exactly one of contains/equals/matches"},
+		{"header bad matches", specSteps("assert: {header: {name: X, matches: \"a[\"}}"), "is not a valid regexp"},
+
+		// ---- validateJSON ----
+		{"json path required", specSteps("assert: {stdout: {json: {equals: 1}}}"), "json.path is required"},
+		{"json no matcher", specSteps("assert: {stdout: {json: {path: \"$.a\"}}}"), "must set one of equals/matches/length/gt/gte/lt/lte"},
+		{"json two matchers", specSteps("assert: {stdout: {json: {path: \"$.a\", equals: 1, length: 2}}}"), "must set exactly one of equals/matches/length/gt/gte/lt/lte"},
+		{"json bad matches", specSteps("assert: {stdout: {json: {path: \"$.a\", matches: \"a[\"}}}"), "is not a valid regexp"},
+
+		// ---- validateMockAssert ----
+		{"mock name required", specSteps("assert: {mock: {count: 1}}"), "mock.name is required"},
+		{"mock undeclared", specSteps("assert: {mock: {name: nope, count: 1}}"), "is not a declared mock server"},
+		{"mock count negative", mockScenario("assert: {mock: {name: api, count: -1}}"), "count must be >= 0"},
+		{"mock count zero with matcher", mockScenario("assert: {mock: {name: api, count: 0, header: {name: X, equals: y}}}"), "count: 0 cannot be combined"},
+		{"mock header invalid", mockScenario("assert: {mock: {name: api, header: {name: X}}}"), "must set one of contains/equals/matches"},
+		{"mock body invalid", mockScenario("assert: {mock: {name: api, body: {}}}"), "must set exactly one matcher"},
+
+		// ---- validateCondition ----
+		{"skip bad os", scenarioTop("skip: {os: solaris}", "run: {command: echo}"), "skip.os \"solaris\" is invalid"},
+		{"only bad os", scenarioTop("only: {os: bsd}", "run: {command: echo}"), "only.os \"bsd\" is invalid"},
+
+		// ---- validateStep ----
+		{"step no action", specSteps("{}"), "step must set exactly one of fixture/run/http/query/grpc/cdp/assert/store/pty/signal (got none)"},
+		{"step two actions", specSteps("{run: {command: x}, store: {name: v, from: {header: X}}}"), "step must set exactly one action, but set"},
+		{"query missing runner", withRunner(dbRunner, specSteps("query: {sql: \"SELECT 1\"}")), "query.runner is required"},
+		{"query missing sql", withRunner(dbRunner, specSteps("query: {runner: d}")), "query.sql is required"},
+		{"grpc missing runner", withRunner(grpcRunner, specSteps("grpc: {method: m}")), "grpc.runner is required"},
+		{"grpc missing method", withRunner(grpcRunner, specSteps("grpc: {runner: g}")), "grpc.method is required"},
+		{"cdp missing runner", withRunner(browserRunner, specSteps("cdp: {actions: [{navigate: \"https://x\"}]}")), "cdp.runner is required"},
+		{"cdp empty actions", withRunner(browserRunner, specSteps("cdp: {runner: b, actions: []}")), "cdp.actions must contain at least one action"},
+		{"service step in scenario", specSteps("service: {name: s, command: x}"), "service steps are only allowed in suite.setup"},
+
+		// ---- validateCDPActions ----
+		{"cdp no action key", withRunner(browserRunner, specSteps("cdp: {runner: b, actions: [{}]}")), "sets no recognized action"},
+		{"cdp multiple actions", withRunner(browserRunner, specSteps("cdp: {runner: b, actions: [{navigate: x, click: \"#a\"}]}")), "sets multiple actions"},
+		{"cdp press incomplete", withRunner(browserRunner, specSteps("cdp: {runner: b, actions: [{press: {selector: \"#a\"}}]}")), "press requires selector and key"},
+		{"cdp select incomplete", withRunner(browserRunner, specSteps("cdp: {runner: b, actions: [{select: {value: v}}]}")), "select requires a selector"},
+		{"cdp screenshot incomplete", withRunner(browserRunner, specSteps("cdp: {runner: b, actions: [{screenshot: {}}]}")), "screenshot requires a path"},
+		{"cdp attribute incomplete", withRunner(browserRunner, specSteps("cdp: {runner: b, actions: [{attribute: {selector: \"#a\"}}]}")), "attribute requires selector and name"},
+		{"cdp send_keys incomplete", withRunner(browserRunner, specSteps("cdp: {runner: b, actions: [{send_keys: {value: hi}}]}")), "send_keys requires a selector"},
+		{"cdp upload incomplete", withRunner(browserRunner, specSteps("cdp: {runner: b, actions: [{upload: {selector: \"#a\"}}]}")), "upload requires selector and file"},
+		{"cdp download incomplete", withRunner(browserRunner, specSteps("cdp: {runner: b, actions: [{download: {}}]}")), "download requires a click selector"},
+
+		// ---- validateFixture ----
+		{"fixture file required", specSteps("fixture: {content: hi}"), "fixture.file is required"},
+		{"fixture two sources", specSteps("fixture: {file: a.txt, content: x, base64: eA==}"), "set only one of content, base64, from, or symlink"},
+		{"fixture symlink with mode", specSteps("fixture: {file: a, symlink: b, mode: \"0644\"}"), "mode cannot be applied to a symlink"},
+		{"fixture bad mode", specSteps("fixture: {file: a, mode: \"999\"}"), "is not an octal file mode"},
+		{"fixture bad mtime", specSteps("fixture: {file: a, mtime: nope}"), "is not an RFC3339 timestamp"},
+
+		// ---- validateSignal ----
+		{"signal service required", svcScenario("signal: {signal: TERM}"), "signal.service is required"},
+		{"signal undeclared", svcScenario("signal: {service: nope, signal: TERM}"), "is not a declared service"},
+		{"signal signal required", svcScenario("signal: {service: s}"), "signal.signal is required"},
+		{"signal bad name", svcScenario("signal: {service: s, signal: BOGUS}"), "is not an accepted signal"},
+		{"signal wait bad duration", svcScenario("signal: {service: s, signal: TERM, wait: {timeout: abc}}"), "is not a valid duration"},
+		{"signal wait nonpositive", svcScenario("signal: {service: s, signal: TERM, wait: {timeout: \"-1s\"}}"), "must be positive"},
+
+		// ---- validatePTY ----
+		{"pty command required", specSteps("pty: {session: [{expect: hi}]}"), "pty.command is required"},
+		{"pty bad timeout", specSteps("pty: {command: sh, timeout: abc}"), "is not a valid duration"},
+		{"pty nonpositive timeout", specSteps("pty: {command: sh, timeout: \"-1s\"}"), "must be positive"},
+		{"pty size overflow", specSteps("pty: {command: sh, rows: 70000}"), "rows/cols must be between 0 and 65535"},
+		{"pty expect and send", specSteps("pty: {command: sh, session: [{expect: hi, send: x}]}"), "set exactly one of expect/send (got both)"},
+		{"pty neither expect nor send", specSteps("pty: {command: sh, session: [{}]}"), "set exactly one of expect/send"},
+		{"pty bad expect regexp", specSteps("pty: {command: sh, session: [{expect: \"a[\"}]}"), "is not a valid regexp"},
+		{"pty bad send key", specSteps("pty: {command: sh, session: [{send: {key: BOGUS}}]}"), "is not a supported key"},
+
+		// ---- validateMockRoutes (scenario) ----
+		{"route method required", "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    mock_servers:\n      - name: m\n        routes:\n          - {path: /}\n    steps:\n      - run: {command: echo}\n", "method is required"},
+		{"route path required", "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    mock_servers:\n      - name: m\n        routes:\n          - {method: GET}\n    steps:\n      - run: {command: echo}\n", "path is required"},
+		{"route path no slash", "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    mock_servers:\n      - name: m\n        routes:\n          - {method: GET, path: foo}\n    steps:\n      - run: {command: echo}\n", "must start with \"/\""},
+		{"route two payloads", "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    mock_servers:\n      - name: m\n        routes:\n          - {method: GET, path: /, body: hi, body_file: f.txt}\n    steps:\n      - run: {command: echo}\n", "set at most one of json/body/body_file"},
+		{"route bad status", "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    mock_servers:\n      - name: m\n        routes:\n          - {method: GET, path: /, status: 700}\n    steps:\n      - run: {command: echo}\n", "is not a valid HTTP status"},
+		{"route bad delay", "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    mock_servers:\n      - name: m\n        routes:\n          - {method: GET, path: /, delay: xyz}\n    steps:\n      - run: {command: echo}\n", "is not a valid duration"},
+
+		// ---- validateSuiteBlock ----
+		{"suite http rejected", "version: \"1\"\nsuite:\n  name: x\n  setup:\n    - http: {runner: api, method: GET, path: /}\nrunners:\n  api: {type: http, base_url: \"http://127.0.0.1:1\"}\nscenarios:\n  - name: a\n    steps:\n      - run: {command: echo}\n", "steps are per-scenario"},
+		{"suite service in teardown", "version: \"1\"\nsuite:\n  name: x\n  teardown:\n    - service: {name: s, command: x}\nscenarios:\n  - name: a\n    steps:\n      - run: {command: echo}\n", "service steps are only allowed in suite.setup"},
+		{"suite duplicate service", "version: \"1\"\nsuite:\n  name: x\n  setup:\n    - service: {name: s, command: x}\n    - service: {name: s, command: y}\nscenarios:\n  - name: a\n    steps:\n      - run: {command: echo}\n", "duplicate suite service name"},
+		{"suite service missing command", "version: \"1\"\nsuite:\n  name: x\n  setup:\n    - service: {name: s}\nscenarios:\n  - name: a\n    steps:\n      - run: {command: echo}\n", "service.command is required"},
+		{"suite service missing name", "version: \"1\"\nsuite:\n  name: x\n  setup:\n    - service: {command: x}\nscenarios:\n  - name: a\n    steps:\n      - run: {command: echo}\n", "service.name is required"},
+		{"suite mock in teardown", "version: \"1\"\nsuite:\n  name: x\n  teardown:\n    - mock_server: {name: m, routes: []}\nscenarios:\n  - name: a\n    steps:\n      - run: {command: echo}\n", "mock_server steps are only allowed in suite.setup"},
+		{"suite duplicate mock", "version: \"1\"\nsuite:\n  name: x\n  setup:\n    - mock_server: {name: m, routes: []}\n    - mock_server: {name: m, routes: []}\nscenarios:\n  - name: a\n    steps:\n      - run: {command: echo}\n", "duplicate suite mock server name"},
+		{"suite mock missing name", "version: \"1\"\nsuite:\n  name: x\n  setup:\n    - mock_server: {routes: []}\nscenarios:\n  - name: a\n    steps:\n      - run: {command: echo}\n", "mock_server.name is required"},
+		{"suite step no action", "version: \"1\"\nsuite:\n  name: x\n  setup:\n    - {}\nscenarios:\n  - name: a\n    steps:\n      - run: {command: echo}\n", "step must set exactly one action"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mustReject(t, tt.name, tt.src, tt.want)
+		})
+	}
+}
+
+// TestBugHunt_Acceptances pins the accept side of each accept/reject boundary so
+// a future over-eager validation rule that starts rejecting a legal spec is
+// caught here.
+func TestBugHunt_Acceptances(t *testing.T) {
+	t.Parallel()
+
+	browserRunner := "runners:\n  b: {type: browser}\n"
+	withRunner := func(runner, body string) string {
+		const anchor = "  name: x\n"
+		i := strings.Index(body, anchor) + len(anchor)
+		return body[:i] + runner + body[i:]
+	}
+	mockScenario := func(step string) string {
+		return "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n" +
+			"    mock_servers:\n      - name: api\n        routes:\n          - {method: GET, path: /, status: 200}\n" +
+			"    steps:\n      - " + step + "\n"
+	}
+	svcScenario := func(step string) string {
+		return "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n" +
+			"    services:\n      - {name: s, command: sleep 10}\n" +
+			"    steps:\n      - " + step + "\n"
+	}
+	scenarioTop := func(extra, step string) string {
+		return "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    " + extra + "\n    steps:\n      - " + step + "\n"
+	}
+
+	tests := []struct{ name, src string }{
+		{"store stdout json", specSteps("store: {name: v, from: {stdout: {json: {path: \"$.a\"}}}}")},
+		{"store header", specSteps("store: {name: v, from: {header: X-Request-Id}}")},
+		{"store stdout matches", specSteps("store: {name: v, from: {stdout: {matches: \"id=(\\\\d+)\"}}}")},
+		{"store file json", specSteps("store: {name: v, from: {file: {path: out.json, json: {path: \"$.id\"}}}}")},
+		{"exit_code in", specSteps("run: {command: echo}", "assert: {exit_code: {in: [0, 1, 2]}}")},
+		{"exit_code not", specSteps("run: {command: echo}", "assert: {exit_code: {not: 1}}")},
+		{"file exists", specSteps("assert: {file: {path: out.txt, exists: true}}")},
+		{"header equals", specSteps("assert: {header: {name: Content-Type, equals: text/html}}")},
+		{"json gt", specSteps("assert: {stdout: {json: {path: \"$.count\", gt: 5}}}")},
+		{"mock count", mockScenario("assert: {mock: {name: api, count: 2}}")},
+		{"signal valid", svcScenario("signal: {service: s, signal: TERM}")},
+		{"signal var target", svcScenario("signal: {service: \"${svc}\", signal: KILL}")},
+		{"cdp navigate", withRunner(browserRunner, specSteps("cdp: {runner: b, actions: [{navigate: \"https://x\"}, {click: \"#go\"}]}"))},
+		{"fixture content", specSteps("fixture: {file: a.txt, content: hello}")},
+		{"pty valid", specSteps("pty: {command: sh, session: [{expect: \"[$] \"}, {send: \"ls\\n\"}]}")},
+		{"assert message", specSteps("assert: {message: {equals: ok}}")},
+		{"assert value", specSteps("assert: {value: {contains: hi}}")},
+		{"assert grpc_status", specSteps("assert: {grpc_status: 0}")},
+		{"assert screen after pty", specSteps("pty: {command: sh}", "assert: {screen: {contains: prompt}}")},
+		{"assert duration after run", specSteps("run: {command: echo}", "assert: {duration: {lt: \"5s\"}}")},
+		{"skip valid os", scenarioTop("skip: {os: darwin}", "run: {command: echo}")},
+		{"only valid os", scenarioTop("only: {os: windows}", "run: {command: echo}")},
+		{"suite setup kinds", "version: \"1\"\nsuite:\n  name: x\n  setup:\n    - fixture: {file: seed.txt, content: hi}\n    - run: {command: echo}\n    - store: {name: v, from: {stdout: {json: {path: \"$.a\"}}}}\n    - assert: {exit_code: 0}\nscenarios:\n  - name: a\n    steps:\n      - run: {command: echo}\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mustAccept(t, tt.name, tt.src)
+		})
+	}
+}
+
+// TestBugHunt_RoundTrip is a metamorphic check: a spec that loads cleanly must,
+// after being re-marshaled to YAML and reloaded, still load cleanly. It catches
+// any decode/marshal asymmetry that would silently change validation outcome.
+func TestBugHunt_RoundTrip(t *testing.T) {
+	t.Parallel()
+	srcs := []string{
+		specSteps("run: {command: echo}", "assert: {exit_code: {in: [0, 1]}}"),
+		specSteps("store: {name: v, from: {stdout: {json: {path: \"$.a\"}}}}"),
+		specSteps("fixture: {file: a.txt, content: hello}"),
+		specSteps("assert: {stdout: {contains: [\"a\", \"b\"]}}"),
+	}
+	for i, src := range srcs {
+		s1, err := LoadBytes("t.atago.yaml", []byte(src))
+		if err != nil {
+			t.Fatalf("case %d: initial load failed: %v", i, err)
+		}
+		out, err := yaml.Marshal(s1)
+		if err != nil {
+			t.Fatalf("case %d: marshal failed: %v", i, err)
+		}
+		if _, err := LoadBytes("t.atago.yaml", out); err != nil {
+			t.Errorf("case %d: reload after round-trip failed: %v\nmarshaled:\n%s", i, err, out)
+		}
+	}
+}
+
+// TestBugHunt_LoadFromDisk covers Load / LoadWithSource error and success paths
+// against the filesystem (the entry points the CLI actually calls).
+func TestBugHunt_LoadFromDisk(t *testing.T) {
+	t.Parallel()
+
+	// Missing file: Load and LoadWithSource both surface a path-annotated error.
+	if _, err := Load(filepath.Join(t.TempDir(), "nope.atago.yaml")); err == nil {
+		t.Error("Load(missing) error = nil, want error")
+	}
+	if _, _, err := LoadWithSource(filepath.Join(t.TempDir(), "nope.atago.yaml")); err == nil {
+		t.Error("LoadWithSource(missing) error = nil, want error")
+	}
+
+	// Invalid spec on disk: LoadWithSource returns the validation error, not a source.
+	bad := filepath.Join(t.TempDir(), "bad.atago.yaml")
+	if err := os.WriteFile(bad, []byte("version: \"2\"\nsuite: {name: x}\nscenarios: []"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, src, err := LoadWithSource(bad); err == nil || src != nil {
+		t.Errorf("LoadWithSource(bad) = src %v err %v, want nil src + error", src, err)
+	}
+
+	// Valid spec on disk loads.
+	good := filepath.Join(t.TempDir(), "good.atago.yaml")
+	if err := os.WriteFile(good, []byte(specSteps("run: {command: echo}")), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(good); err != nil {
+		t.Errorf("Load(good) error = %v", err)
+	}
+}
+
+// TestBugHunt_ErrorString exercises Error.Error's path-less branch.
+func TestBugHunt_ErrorString(t *testing.T) {
+	t.Parallel()
+	if got := (&Error{Msg: "boom"}).Error(); got != "boom" {
+		t.Errorf("path-less Error() = %q, want %q", got, "boom")
+	}
+	if got := (&Error{Path: "f.yaml", Msg: "boom"}).Error(); got != "f.yaml: boom" {
+		t.Errorf("Error() = %q, want %q", got, "f.yaml: boom")
+	}
+}
+
+// TestBugHunt_DirAssert drives validateDir's accept/reject boundary (#25/#74):
+// the tree-snapshot vs matcher-family split, count sanity, and glob validity.
+func TestBugHunt_DirAssert(t *testing.T) {
+	t.Parallel()
+
+	dir := func(body string) string { return specSteps("assert: {dir: " + body + "}") }
+
+	reject := []struct{ name, src, want string }{
+		{"dir path required", dir("{exists: true}"), "dir.path is required"},
+		{"dir no matcher", dir("{path: out}"), "must set at least one of exists/contains/not_contains/count/min_count/max_count/glob/snapshot"},
+		{"dir snapshot with matcher", dir("{path: out, snapshot: tree, exists: true}"), "snapshot cannot be combined with the matcher family"},
+		{"dir snapshot with recursive", dir("{path: out, snapshot: tree, recursive: true}"), "recursive is implied by snapshot; drop it"},
+		{"dir recursive without matcher", dir("{path: out, recursive: true}"), "recursive needs at least one of"},
+		{"dir ignore without recursive", dir("{path: out, count: 1, ignore: [\"*.tmp\"]}"), "ignore only applies to recursive or snapshot"},
+		{"dir negative count", dir("{path: out, count: -1}"), "counts must be >= 0"},
+		{"dir min exceeds max", dir("{path: out, min_count: 5, max_count: 2}"), "min_count 5 exceeds max_count 2"},
+		{"dir bad ignore glob", dir("{path: out, recursive: true, count: 1, ignore: [\"[\"]}"), "is not a valid glob"},
+	}
+	for _, tt := range reject {
+		t.Run("reject/"+tt.name, func(t *testing.T) {
+			t.Parallel()
+			mustReject(t, tt.name, tt.src, tt.want)
+		})
+	}
+
+	accept := []struct{ name, src string }{
+		{"dir exists", dir("{path: out, exists: true}")},
+		{"dir count", dir("{path: out, count: 3}")},
+		{"dir min max", dir("{path: out, min_count: 1, max_count: 4}")},
+		{"dir glob", dir("{path: out, glob: \"*.txt\"}")},
+		{"dir snapshot", dir("{path: out, snapshot: tree}")},
+		{"dir recursive with matcher and ignore", dir("{path: out, recursive: true, count: 2, ignore: [\"*.tmp\", \"logs/**\"]}")},
+		// KNOWN GAP (not a crash, intentionally pinned): `recursive: true` alongside
+		// only `exists` is accepted, because `exists` counts toward n so the
+		// recursive-needs-a-matcher guard (n==0) never fires — even though that
+		// guard's own message excludes exists from the composable matchers. The
+		// recursive flag is effectively a silent no-op here. Pinned so a future
+		// tightening is a deliberate, visible change.
+		{"dir recursive with only exists (gap)", dir("{path: out, exists: true, recursive: true}")},
+	}
+	for _, tt := range accept {
+		t.Run("accept/"+tt.name, func(t *testing.T) {
+			t.Parallel()
+			mustAccept(t, tt.name, tt.src)
+		})
+	}
+}
+
+// TestBugHunt_FileAndJSONExtras closes the remaining file/json matcher branches
+// (executable, snapshot, the numeric json bounds) on the accept side.
+func TestBugHunt_FileAndJSONExtras(t *testing.T) {
+	t.Parallel()
+	accept := []struct{ name, src string }{
+		{"file executable", specSteps("assert: {file: {path: bin/tool, executable: true}}")},
+		{"file snapshot", specSteps("assert: {file: {path: out.txt, snapshot: golden}}")},
+		{"file contains list", specSteps("assert: {file: {path: out.txt, contains: [\"a\", \"b\"]}}")},
+		{"file json", specSteps("assert: {file: {path: out.json, json: {path: \"$.id\", equals: 7}}}")},
+		{"json lt", specSteps("assert: {stdout: {json: {path: \"$.n\", lt: 10}}}")},
+		{"json lte", specSteps("assert: {stdout: {json: {path: \"$.n\", lte: 10}}}")},
+		{"json gte", specSteps("assert: {stdout: {json: {path: \"$.n\", gte: 1}}}")},
+		{"json length", specSteps("assert: {stdout: {json: {path: \"$.items\", length: 3}}}")},
+		{"yaml matcher", specSteps("assert: {stdout: {yaml: {path: \"$.k\", equals: v}}}")},
+		{"store from body matches", specSteps("store: {name: v, from: {body: {matches: \"tok=(\\\\w+)\"}}}")},
+		{"store from rows json", specSteps("store: {name: v, from: {rows: {json: {path: \"$[0].id\"}}}}")},
+		{"store from message json", specSteps("store: {name: v, from: {message: {json: {path: \"$.ok\"}}}}")},
+		{"store from value matches", specSteps("store: {name: v, from: {value: {matches: \"^ok$\"}}}")},
+	}
+	for _, tt := range accept {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mustAccept(t, tt.name, tt.src)
 		})
 	}
 }

--- a/internal/loader/suggest_test.go
+++ b/internal/loader/suggest_test.go
@@ -81,3 +81,141 @@ func TestSuggest_NoWildGuess(t *testing.T) {
 		t.Errorf("error = %q; a distant token must not get a guess", err.Error())
 	}
 }
+
+// TestEditDistance pins the Levenshtein helper that powers "did you mean X?".
+// An off-by-one here would push a real typo just outside the suggestion window
+// (or admit a wild guess), so the boundary values are load-bearing.
+func TestEditDistance(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"", "", 0},
+		{"abc", "abc", 0},
+		{"", "abc", 3},
+		{"abc", "", 3},
+		{"a", "", 1},
+		{"kitten", "sitting", 3},
+		{"stdout", "stdut", 1},
+		{"assert", "asserts", 1},
+		{"flaw", "lawn", 2},
+	}
+	for _, tt := range tests {
+		if got := editDistance(tt.a, tt.b); got != tt.want {
+			t.Errorf("editDistance(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+// TestClosestField checks the suggestion picks the nearest field and declines to
+// guess when nothing is close — and never suggests the same name back.
+func TestClosestField(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		typo     string
+		wantOK   bool
+		wantName string
+	}{
+		{"stdut", true, "stdout"},
+		{"asserts", true, "assert"},
+		{"commnd", true, "command"},
+		{"zzqqxxww", false, ""},
+	}
+	for _, tt := range tests {
+		got, ok := closestField(tt.typo)
+		if ok != tt.wantOK {
+			t.Errorf("closestField(%q) ok = %v, want %v (got %q)", tt.typo, ok, tt.wantOK, got)
+			continue
+		}
+		if ok && got != tt.wantName {
+			t.Errorf("closestField(%q) = %q, want %q", tt.typo, got, tt.wantName)
+		}
+	}
+
+	// A token that exactly matches an existing field must not suggest itself.
+	if got, ok := closestField("command"); ok && got == "command" {
+		t.Errorf("closestField(exact field) suggested itself: %q", got)
+	}
+}
+
+// TestSuggestScalarMatcher_Passthrough proves the hint helpers leave unrelated
+// messages untouched — a spurious hint is worse than none.
+func TestSuggestScalarMatcher_Passthrough(t *testing.T) {
+	t.Parallel()
+	// No "used where mapping is expected" phrase: returned verbatim.
+	if got := suggestScalarMatcher("some unrelated error"); got != "some unrelated error" {
+		t.Errorf("suggestScalarMatcher passthrough = %q", got)
+	}
+	// The phrase is present but no stream target on the marked line: no hint.
+	msg := "string was used where mapping is expected\n>  3 | foo: bar"
+	if got := suggestScalarMatcher(msg); got != msg {
+		t.Errorf("suggestScalarMatcher with no stream target added a hint: %q", got)
+	}
+	// A real stream target on the marked line gets the shape hint.
+	msg2 := "string was used where mapping is expected\n>  9 |     stdout: hi"
+	if got := suggestScalarMatcher(msg2); got == msg2 {
+		t.Errorf("suggestScalarMatcher missed a stream target: %q", got)
+	}
+}
+
+// TestSuggestUnknownField_Passthrough covers the non-field-name branch.
+func TestSuggestUnknownField_Passthrough(t *testing.T) {
+	t.Parallel()
+	if got := suggestUnknownField("no field marker here"); got != "no field marker here" {
+		t.Errorf("suggestUnknownField passthrough = %q", got)
+	}
+	// A distant unknown field yields no "did you mean" guess.
+	if got := suggestUnknownField(`unknown field "zzqqxxww"`); got != `unknown field "zzqqxxww"` {
+		t.Errorf("suggestUnknownField added a wild guess: %q", got)
+	}
+}
+
+// TestSourcePos_UnknownAndNil exercises Source.pos's defensive branches: a nil
+// receiver, a source built from unparseable bytes, a malformed path expression,
+// and a path that resolves to no node — all must report the zero Position.
+func TestSourcePos_UnknownAndNil(t *testing.T) {
+	t.Parallel()
+
+	// nil receiver / nil file.
+	var nilSrc *Source
+	if p := nilSrc.pos("$.suite"); p.Line != 0 {
+		t.Errorf("nil source pos = %+v, want zero", p)
+	}
+
+	// Unparseable YAML: newSource yields a fileless Source that answers unknown.
+	broken := newSource([]byte("a: b: c: ["))
+	if broken == nil {
+		t.Fatal("newSource returned nil")
+	}
+	if p := broken.pos("$.suite"); p.Line != 0 {
+		t.Errorf("broken-source pos = %+v, want zero", p)
+	}
+
+	valid := newSource([]byte("suite:\n  name: x\n"))
+	// A malformed path string resolves to unknown rather than erroring out.
+	if p := valid.pos("$.["); p.Line != 0 {
+		t.Errorf("malformed path pos = %+v, want zero", p)
+	}
+	// A path that names no node resolves to unknown.
+	if p := valid.pos("$.nope.deeper"); p.Line != 0 {
+		t.Errorf("missing-node pos = %+v, want zero", p)
+	}
+}
+
+// TestSuitePos_Fallback proves SuitePos falls back to the `suite:` mapping when
+// the suite has no name key (the primary `$.suite.name` lookup misses).
+func TestSuitePos_Fallback(t *testing.T) {
+	t.Parallel()
+	// suite has no name — $.suite.name misses, fallback to $.suite, which (like
+	// every mapping-node lookup here) resolves to the mapping's first field value
+	// token: the `timeout: 1s` line (line 3).
+	src := newSource([]byte("version: \"1\"\nsuite:\n  timeout: 1s\n"))
+	line, _ := src.SuitePos()
+	if line == 0 {
+		t.Error("SuitePos() fell through to zero; expected the suite mapping line via fallback")
+	}
+	if line != 3 {
+		t.Errorf("SuitePos() fallback line = %d, want 3", line)
+	}
+}

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -2,10 +2,12 @@ package manifest
 
 import (
 	"encoding/json"
+	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/nao1215/atago/internal/loader"
+	"github.com/nao1215/atago/internal/spec"
 )
 
 // mixedSpec exercises run, http, query, grpc, cdp, services, store, and matrix so
@@ -276,4 +278,327 @@ func containsSub(list []string, sub string) bool {
 		}
 	}
 	return false
+}
+
+func bp(b bool) *bool { return &b }
+func ip(i int) *int   { return &i }
+
+// TestBuildStep_EveryKind drives the manifest builder over every step kind,
+// including the ones the loader only allows in specific positions (service,
+// mock_server), by constructing the spec model directly. It asserts the kind,
+// action summary, and the salient declarative fields the manifest promises for
+// each kind, so a silently dropped or mislabeled kind is caught (#49).
+func TestBuildStep_EveryKind(t *testing.T) {
+	t.Parallel()
+	s := &spec.Spec{
+		Version: "1",
+		Suite: spec.Suite{
+			Name: "everykind",
+			// service and mock_server steps are valid only in suite.setup; put
+			// them there so buildStep's StepService / StepMockServer arms run.
+			Setup: []spec.Step{
+				{Service: &spec.Service{Name: "peer", Command: "./peer", Shell: spec.Bool(true), ClearEnv: bp(true), PassEnv: []string{"PATH"}}},
+				{MockServer: &spec.MockServer{Name: "api", Routes: []spec.MockRoute{{Method: "GET", Path: "/a"}, {Method: "GET", Path: "/b"}}}},
+			},
+		},
+		Scenarios: []spec.Scenario{{
+			Name:        "all",
+			SourceIndex: 0,
+			Steps: []spec.Step{
+				{Fixture: &spec.Fixture{File: "in.txt", Content: "hi"}},
+				{Run: &spec.Run{Command: "echo hi", Shell: spec.Bool(true), ClearEnv: bp(true), PassEnv: []string{"HOME"}, Runner: "cmd", Retry: &spec.Retry{Times: 3, Interval: "1s"}}},
+				{HTTP: &spec.HTTP{Runner: "api", Method: "POST", Path: "/x", Retry: &spec.Retry{Times: 2, Interval: "500ms"}}},
+				{Query: &spec.Query{Runner: "db", SQL: "SELECT 1"}},
+				{GRPC: &spec.GRPC{Runner: "g", Method: "pkg.S/M"}},
+				{CDP: &spec.CDP{Runner: "web", Actions: []spec.CDPAction{{Navigate: "http://x"}, {Text: "#h"}}}},
+				{PTY: &spec.PTY{Command: "top", Shell: spec.Bool(true), ClearEnv: bp(true), PassEnv: []string{"TERM"}}},
+				{Signal: &spec.Signal{Service: "peer", Signal: "sigterm", Wait: &spec.SignalWait{Timeout: "3s"}}},
+				{Assert: &spec.Assert{ExitCode: &spec.ExitCode{Equals: ip(0)}, Stdout: &spec.StreamAssert{Contains: spec.StringList{"ok"}}}},
+				{Store: &spec.Store{Name: "uid"}},
+			},
+		}},
+	}
+
+	doc := Build([]Input{{Spec: s, Path: "e.atago.yaml"}})
+	sp := doc.Specs[0]
+
+	// Suite setup carries the service and mock_server steps.
+	if len(sp.SuiteSetup) != 2 {
+		t.Fatalf("suite setup steps = %d, want 2", len(sp.SuiteSetup))
+	}
+	svcStep := sp.SuiteSetup[0]
+	if svcStep.Kind != "service" || svcStep.Target != "peer" || !svcStep.Shell || !svcStep.ClearEnv {
+		t.Errorf("service step = %+v", svcStep)
+	}
+	if svcStep.Action != "start suite service peer" {
+		t.Errorf("service action = %q", svcStep.Action)
+	}
+	msStep := sp.SuiteSetup[1]
+	if msStep.Kind != "mock_server" || msStep.Target != "api" || !strings.Contains(msStep.Action, "2 routes") {
+		t.Errorf("mock_server step = %+v", msStep)
+	}
+
+	steps := sp.Scenarios[0].Steps
+	byKind := map[string]Step{}
+	for _, st := range steps {
+		byKind[st.Kind] = st
+	}
+	for _, want := range []string{"fixture", "run", "http", "query", "grpc", "cdp", "pty", "signal", "assert", "store"} {
+		if _, ok := byKind[want]; !ok {
+			t.Errorf("manifest dropped step kind %q; got kinds %v", want, keysOf(byKind))
+		}
+	}
+
+	if got := byKind["fixture"]; got.File != "in.txt" || got.Action != "write fixture in.txt" {
+		t.Errorf("fixture step = %+v", got)
+	}
+	if got := byKind["run"]; got.Command != "echo hi" || !got.Shell || !got.ClearEnv || got.Runner != "cmd" || got.Retry == nil || got.Retry.Times != 3 || got.Retry.Interval != "1s" {
+		t.Errorf("run step = %+v (retry %+v)", got, got.Retry)
+	}
+	if got := byKind["http"]; got.Method != http.MethodPost || got.Path != "/x" || got.Retry == nil || got.Retry.Times != 2 {
+		t.Errorf("http step = %+v", got)
+	}
+	if got := byKind["query"]; got.SQL != "SELECT 1" || got.Action != "SQL query via db" {
+		t.Errorf("query step = %+v", got)
+	}
+	if got := byKind["grpc"]; got.Runner != "g" || got.Action != "gRPC pkg.S/M via g" {
+		t.Errorf("grpc step = %+v", got)
+	}
+	if got := byKind["cdp"]; got.Runner != "web" || !strings.Contains(got.Action, "navigate http://x") {
+		t.Errorf("cdp step = %+v", got)
+	}
+	if got := byKind["pty"]; got.Command != "top" || !got.Shell || !got.ClearEnv || got.Action != "interactive (pty) top" {
+		t.Errorf("pty step = %+v", got)
+	}
+	// The signal step normalizes SIGTERM and reports the wait timeout.
+	if got := byKind["signal"]; got.Target != "peer" || got.Action != "signal SIGTERM to service peer, wait up to 3s for exit" {
+		t.Errorf("signal step action = %q", byKind["signal"].Action)
+	}
+	// A multi-target assert joins its target names with "+".
+	if got := byKind["assert"]; got.Target != "exit_code+stdout" || got.Action != "assert exit_code+stdout" {
+		t.Errorf("assert step target = %q", byKind["assert"].Target)
+	}
+	if got := byKind["store"]; got.Target != "uid" || got.Action != "store uid" {
+		t.Errorf("store step = %+v", got)
+	}
+}
+
+// TestBuildStep_SignalDefaultWaitTimeout covers the signal step's default-wait
+// branch: `wait:` with no timeout reports the documented 5s default.
+func TestBuildStep_SignalDefaultWaitTimeout(t *testing.T) {
+	t.Parallel()
+	s := &spec.Spec{
+		Suite: spec.Suite{Name: "s"},
+		Scenarios: []spec.Scenario{{
+			Name: "sig",
+			Steps: []spec.Step{
+				{Signal: &spec.Signal{Service: "peer", Signal: "INT", Wait: &spec.SignalWait{}}},
+				// A signal without wait: omits the wait clause entirely.
+				{Signal: &spec.Signal{Service: "peer", Signal: "HUP"}},
+			},
+		}},
+	}
+	steps := Build([]Input{{Spec: s, Path: "s.atago.yaml"}}).Specs[0].Scenarios[0].Steps
+	if steps[0].Action != "signal SIGINT to service peer, wait up to 5s for exit" {
+		t.Errorf("default-wait action = %q", steps[0].Action)
+	}
+	if steps[1].Action != "signal SIGHUP to service peer" {
+		t.Errorf("no-wait action = %q", steps[1].Action)
+	}
+}
+
+// TestBuildService_AllReadinessModes exercises every readiness kind buildService
+// can label, plus the no-readiness case and the store capture.
+func TestBuildService_AllReadinessModes(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		ready *spec.Ready
+		want  string
+		store string
+	}{
+		{"file", &spec.Ready{File: "sock", Store: "addr"}, "file", "addr"},
+		{"port", &spec.Ready{Port: "127.0.0.1:9000"}, "port", ""},
+		{"log", &spec.Ready{Log: "listening"}, "log", ""},
+		{"delay", &spec.Ready{Delay: "200ms"}, "delay", ""},
+		{"none", nil, "", ""},
+		// An empty (all-zero) Ready block is non-nil but names no signal: the
+		// switch falls through and Ready stays empty.
+		{"empty ready block", &spec.Ready{}, "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out := buildService(&spec.Service{Name: "svc", Command: "run", Ready: tc.ready})
+			if out.Ready != tc.want {
+				t.Errorf("Ready = %q, want %q", out.Ready, tc.want)
+			}
+			if out.Store != tc.store {
+				t.Errorf("Store = %q, want %q", out.Store, tc.store)
+			}
+		})
+	}
+}
+
+// TestBuildService_EnvControls proves the hermetic-env controls surface.
+func TestBuildService_EnvControls(t *testing.T) {
+	t.Parallel()
+	out := buildService(&spec.Service{Name: "s", Command: "c", Shell: spec.Bool(true), ClearEnv: bp(true), PassEnv: []string{"PATH", "HOME"}})
+	if !out.Shell || !out.ClearEnv || len(out.PassEnv) != 2 {
+		t.Errorf("service env controls = %+v", out)
+	}
+}
+
+// TestAssertTarget_Invalid covers the empty-assert branch: an assert with no
+// target family reduces to "invalid" rather than an empty or panicking label.
+func TestAssertTarget_Invalid(t *testing.T) {
+	t.Parallel()
+	if got := assertTarget(&spec.Assert{}); got != "invalid" {
+		t.Errorf("assertTarget(empty) = %q, want invalid", got)
+	}
+	// A single-target assert is named directly.
+	if got := assertTarget(&spec.Assert{Status: ip(200)}); got != "status" {
+		t.Errorf("assertTarget(status) = %q", got)
+	}
+}
+
+// TestSourceFrom covers the position-to-Source reduction: an unknown (<=0) line
+// yields nil so the field is omitted; a known line keeps its column.
+func TestSourceFrom(t *testing.T) {
+	t.Parallel()
+	if got := sourceFrom(0, 0); got != nil {
+		t.Errorf("sourceFrom(0,0) = %+v, want nil", got)
+	}
+	if got := sourceFrom(-1, 4); got != nil {
+		t.Errorf("sourceFrom(-1,4) = %+v, want nil", got)
+	}
+	if got := sourceFrom(7, 0); got == nil || got.Line != 7 || got.Column != 0 {
+		t.Errorf("sourceFrom(7,0) = %+v, want line 7 col 0", got)
+	}
+	if got := sourceFrom(7, 3); got == nil || got.Line != 7 || got.Column != 3 {
+		t.Errorf("sourceFrom(7,3) = %+v, want line 7 col 3", got)
+	}
+}
+
+// TestBuildSpec_SuiteLifecycle covers buildSpec's suite-lifecycle handling:
+// suite timeout, sorted env key names (values never leaked), and setup/teardown
+// step summaries.
+func TestBuildSpec_SuiteLifecycle(t *testing.T) {
+	t.Parallel()
+	s := &spec.Spec{
+		Suite: spec.Suite{
+			Name:    "life",
+			Timeout: "30s",
+			Env:     map[string]string{"ZED": "secretz", "ALPHA": "secreta"},
+			Setup:   []spec.Step{{Run: &spec.Run{Command: "build"}}},
+			Teardown: []spec.Step{
+				{Run: &spec.Run{Command: "cleanup"}},
+			},
+		},
+		Scenarios: []spec.Scenario{{Name: "s", Steps: []spec.Step{{Run: &spec.Run{Command: "x"}}}}},
+	}
+	sp := Build([]Input{{Spec: s, Path: "life.atago.yaml"}}).Specs[0]
+	if sp.SuiteTimeout != "30s" {
+		t.Errorf("suite timeout = %q", sp.SuiteTimeout)
+	}
+	// Env is emitted as sorted key names only.
+	if strings.Join(sp.SuiteEnv, ",") != "ALPHA,ZED" {
+		t.Errorf("suite env keys = %v, want [ALPHA ZED]", sp.SuiteEnv)
+	}
+	if len(sp.SuiteSetup) != 1 || sp.SuiteSetup[0].Command != "build" {
+		t.Errorf("suite setup = %+v", sp.SuiteSetup)
+	}
+	if len(sp.SuiteTeardown) != 1 || sp.SuiteTeardown[0].Command != "cleanup" {
+		t.Errorf("suite teardown = %+v", sp.SuiteTeardown)
+	}
+	// Env values must never appear in the serialized manifest.
+	out, err := json.Marshal(sp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(out), "secret") {
+		t.Errorf("suite env value leaked into manifest:\n%s", out)
+	}
+}
+
+// TestBuildScenario_TeardownAndConditions covers scenario teardown steps and the
+// only/skip condition reduction.
+func TestBuildScenario_TeardownAndConditions(t *testing.T) {
+	t.Parallel()
+	s := &spec.Spec{
+		Suite: spec.Suite{Name: "s"},
+		Scenarios: []spec.Scenario{{
+			Name: "sc",
+			Only: &spec.Condition{OS: "linux"},
+			Skip: &spec.Condition{Env: "CI"},
+			Steps: []spec.Step{
+				{Run: &spec.Run{Command: "echo ${who}"}},
+			},
+			Teardown: []spec.Step{
+				{Run: &spec.Run{Command: "rm ${tmp}"}},
+			},
+		}},
+	}
+	sc := Build([]Input{{Spec: s, Path: "s.atago.yaml"}}).Specs[0].Scenarios[0]
+	if sc.Only == nil || sc.Only.OS != "linux" {
+		t.Errorf("only = %+v", sc.Only)
+	}
+	if sc.Skip == nil || sc.Skip.Env != "CI" {
+		t.Errorf("skip = %+v", sc.Skip)
+	}
+	if len(sc.Teardown) != 1 || sc.Teardown[0].Command != "rm ${tmp}" {
+		t.Errorf("teardown = %+v", sc.Teardown)
+	}
+	// Teardown variable references count toward the scenario's variable set,
+	// alongside the main steps'.
+	if strings.Join(sortStrings(sc.Variables), ",") != "tmp,who" {
+		t.Errorf("variables = %v, want [tmp who]", sc.Variables)
+	}
+}
+
+// TestBuildStep_AssertVarsCollected is the manifest-side regression for the
+// assert-variable under-reporting bug: a variable referenced ONLY inside an
+// assert step must appear in the scenario's manifest variable list.
+func TestBuildStep_AssertVarsCollected(t *testing.T) {
+	t.Parallel()
+	s := &spec.Spec{
+		Suite: spec.Suite{Name: "s"},
+		Scenarios: []spec.Scenario{{
+			Name: "sc",
+			Steps: []spec.Step{
+				{Run: &spec.Run{Command: "run-cli"}}, // no vars here
+				{Assert: &spec.Assert{Stdout: &spec.StreamAssert{Equals: strPtr("${expected}")}}},
+			},
+		}},
+	}
+	sc := Build([]Input{{Spec: s, Path: "s.atago.yaml"}}).Specs[0].Scenarios[0]
+	found := false
+	for _, v := range sc.Variables {
+		if v == "expected" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("assert-only variable ${expected} missing from manifest variables: %v", sc.Variables)
+	}
+}
+
+func strPtr(s string) *string { return &s }
+
+func keysOf(m map[string]Step) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return sortStrings(out)
+}
+
+func sortStrings(in []string) []string {
+	out := append([]string(nil), in...)
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j-1] > out[j]; j-- {
+			out[j-1], out[j] = out[j], out[j-1]
+		}
+	}
+	return out
 }

--- a/internal/record/record_test.go
+++ b/internal/record/record_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/goccy/go-yaml"
+
 	"github.com/nao1215/atago/internal/engine"
 	"github.com/nao1215/atago/internal/loader"
 )
@@ -240,5 +242,38 @@ func TestGenerate_Snapshot(t *testing.T) {
 	}
 	if strings.Contains(string(out), "contains:") {
 		t.Errorf("snapshot mode must replace the contains matcher:\n%s", out)
+	}
+}
+
+// TestYAMLScalar_ExoticControlBytesRoundTrip is a metamorphic law for the record
+// escaper: for any string, embedding yamlScalar(s) as a flow scalar and parsing
+// the resulting YAML back must yield s byte-for-byte. It targets the escape
+// branches yaml.Marshal cannot safely inline — an arbitrary C0 control byte
+// (ESC), a backslash, and an embedded double quote — which route through
+// yamlDoubleQuoted's `\xNN` / `\\` / `\"` cases. A regression here would make
+// `atago record` emit a spec whose recorded assertion no longer matches the real
+// output.
+func TestYAMLScalar_ExoticControlBytesRoundTrip(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"esc\x1bhere",                 // ESC → \x1b (the arbitrary-control-byte branch)
+		"bell\aring",                  // BEL (0x07)
+		"vtab\vand\ff",                // VT (0x0b) + FF (0x0c)
+		"back\\slash",                 // literal backslash → \\
+		`has "quotes" inside`,         // embedded double quote → \"
+		"mixed\ttab\nnewline\rcr end", // the common control trio
+		"plain punctuation: # * ? &",  // no control bytes → yaml.Marshal path
+		"日本語と\x1bエスケープ",               // multibyte + control byte together
+	}
+	for _, s := range cases {
+		scalar := yamlScalar(s)
+		var doc map[string]string
+		if err := yaml.Unmarshal([]byte("v: "+scalar+"\n"), &doc); err != nil {
+			t.Errorf("yamlScalar(%q) = %s produced unparseable YAML: %v", s, scalar, err)
+			continue
+		}
+		if doc["v"] != s {
+			t.Errorf("round-trip mismatch: yamlScalar(%q) = %s parsed back as %q", s, scalar, doc["v"])
+		}
 	}
 }

--- a/internal/report/diff_test.go
+++ b/internal/report/diff_test.go
@@ -1,6 +1,7 @@
 package report
 
 import (
+	"fmt"
 	"math/rand"
 	"slices"
 	"strings"
@@ -169,5 +170,49 @@ func TestColorizeDiff(t *testing.T) {
 	}
 	if !strings.Contains(yaml, cGreen+"+++"+cReset) {
 		t.Errorf("added ++ content not green: %q", yaml)
+	}
+}
+
+// TestUnifiedDiff_OutputTruncationAndMultiHunk covers the rendered-output cap
+// (a diff longer than diffMaxOutputLines is truncated with a marker) and
+// multi-hunk grouping (two changes separated by more than 2*context common lines
+// produce two @@ headers), plus the actual-side no-newline marker.
+func TestUnifiedDiff_OutputTruncationAndMultiHunk(t *testing.T) {
+	t.Parallel()
+
+	// Output truncation: 130 wholly-different lines (< diffMaxInputLines, so no
+	// input truncation) diff to 260 hunk lines, exceeding diffMaxOutputLines.
+	var exp, act strings.Builder
+	for i := 0; i < 130; i++ {
+		fmt.Fprintf(&exp, "old-%d\n", i)
+		fmt.Fprintf(&act, "new-%d\n", i)
+	}
+	got := unifiedDiff(exp.String(), act.String(), "expected", "actual")
+	if !strings.Contains(got, "... (diff truncated)") {
+		t.Errorf("expected output-truncation marker, got %d bytes", len(got))
+	}
+	if strings.Contains(got, "inputs truncated") {
+		t.Errorf("130 lines should not trip input truncation:\n%s", got)
+	}
+
+	// Multi-hunk: a long shared body with an isolated change at each end.
+	base := make([]string, 0, 40)
+	for i := 0; i < 40; i++ {
+		base = append(base, fmt.Sprintf("line-%d", i))
+	}
+	a := append([]string{"HEAD-A"}, base...)
+	a = append(a, "TAIL-A")
+	b := append([]string{"HEAD-B"}, base...)
+	b = append(b, "TAIL-B")
+	md := unifiedDiff(strings.Join(a, "\n"), strings.Join(b, "\n"), "expected", "actual")
+	if n := strings.Count(md, "@@ -"); n < 2 {
+		t.Errorf("expected >= 2 hunks for two far-apart changes, got %d:\n%s", n, md)
+	}
+
+	// The actual-side no-newline marker fires when expected ends in \n but actual
+	// does not (the mirror of the existing expected-side test).
+	nl := unifiedDiff("a\n", "a", "expected", "actual")
+	if !strings.Contains(nl, noNewlineMarker+" (actual)") {
+		t.Errorf("actual-side no-newline marker missing:\n%s", nl)
 	}
 }

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -2,13 +2,16 @@ package report
 
 import (
 	"bytes"
+	"encoding/json"
 	"encoding/xml"
+	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/nao1215/atago/internal/assert"
 	"github.com/nao1215/atago/internal/engine"
+	"github.com/nao1215/atago/internal/runner"
 )
 
 func sampleResults() []*engine.SuiteResult {
@@ -415,5 +418,532 @@ func TestProgress_Markers(t *testing.T) {
 	p.Done()
 	if got := b.String(); got != ".sFE\n" {
 		t.Errorf("progress markers = %q, want %q", got, ".sFE\n")
+	}
+}
+
+// suiteWithSetupAndTeardownFailures builds a suite that has real scenario rows
+// (so it is NOT the "errored without scenarios" synthetic path) but whose
+// suite.setup AND suite.teardown each carry a failed assertion check and an
+// errored step. This is the almost-untested writeSuiteSteps / suiteStepFailures
+// path (#7): a suite whose bootstrap or cleanup broke.
+func suiteWithSetupAndTeardownFailures() *engine.SuiteResult {
+	setupCheck := &assert.CheckResult{
+		OK:   false,
+		Desc: "assert file db.sock exists",
+		// Multi-line artifacts trigger the unified-diff rendering branch.
+		ArtifactExpected: []byte("ready\nport 5432\n"),
+		ArtifactActual:   []byte("ready\nport 5433\n"),
+		Hint:             "the service came up on the wrong port",
+	}
+	teardownCheck := &assert.CheckResult{
+		OK:       false,
+		Desc:     "assert dir /tmp/scratch does not exist",
+		Expected: "absent",
+		Actual:   "present",
+		Hint:     "scratch dir was left behind",
+	}
+	return &engine.SuiteResult{
+		Suite:    "svc-suite",
+		SpecPath: "svc.atago.yaml",
+		Status:   engine.StatusFailed,
+		Duration: 4 * time.Millisecond,
+		Setup: []engine.StepResult{
+			{Index: 1, Kind: "assert", Checks: []*assert.CheckResult{setupCheck}},
+			{Index: 2, Kind: "run", ErrMsg: "migrate: connection refused"},
+		},
+		Teardown: []engine.StepResult{
+			{Index: 1, Kind: "assert", Checks: []*assert.CheckResult{teardownCheck}},
+			{Index: 2, Kind: "run", ErrMsg: "docker rm: no such container"},
+		},
+		Scenarios: []engine.ScenarioResult{
+			{Name: "ok", Status: engine.StatusPassed, Duration: time.Millisecond,
+				Steps: []engine.StepResult{{Kind: "assert", Checks: []*assert.CheckResult{{OK: true}}}}},
+		},
+	}
+}
+
+// TestConsole_SuiteSetupAndTeardownBlocks exercises writeSuiteSteps for both the
+// setup and teardown labels, including the unified-diff branch, the
+// Expected/Actual branch, the Hint line, and the per-step ErrMsg line.
+func TestConsole_SuiteSetupAndTeardownBlocks(t *testing.T) {
+	t.Parallel()
+	out := render(t, FormatConsole, suiteWithSetupAndTeardownFailures())
+	for _, want := range []string{
+		"SUITE SETUP FAILED:",
+		"svc-suite",
+		"assert file db.sock exists",
+		"Diff (-expected +actual):",
+		"-port 5432", // the differing line rendered as a removal
+		"+port 5433", // and the actual as an addition
+		"the service came up on the wrong port",
+		"step 2 (run): migrate: connection refused",
+		"SUITE TEARDOWN FAILED:",
+		"assert dir /tmp/scratch does not exist",
+		"Expected:",
+		"Actual:",
+		"scratch dir was left behind",
+		"step 2 (run): docker rm: no such container",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("console suite block missing %q\n--- got ---\n%s", want, out)
+		}
+	}
+}
+
+// TestJSON_SuiteSetupAndTeardownFailures verifies suiteStepFailures maps both
+// suite.setup and suite.teardown failures into the machine-readable document,
+// with the suite name as the scenario label and the diff embedded.
+func TestJSON_SuiteSetupAndTeardownFailures(t *testing.T) {
+	t.Parallel()
+	var doc jsonDocument
+	if err := json.Unmarshal([]byte(render(t, FormatJSON, suiteWithSetupAndTeardownFailures())), &doc); err != nil {
+		t.Fatalf("json invalid: %v", err)
+	}
+	rep := doc.Suites[0]
+	if len(rep.SetupFailures) != 2 {
+		t.Fatalf("setup_failures = %d, want 2: %+v", len(rep.SetupFailures), rep.SetupFailures)
+	}
+	if len(rep.TeardownFailures) != 2 {
+		t.Fatalf("suite teardown_failures = %d, want 2: %+v", len(rep.TeardownFailures), rep.TeardownFailures)
+	}
+	// The suite name labels a suite-level failure (there is no scenario for it).
+	if rep.SetupFailures[0].Scenario != "svc-suite" {
+		t.Errorf("setup failure scenario label = %q, want the suite name", rep.SetupFailures[0].Scenario)
+	}
+	if rep.SetupFailures[0].Diff == "" {
+		t.Errorf("multi-line suite setup failure should carry a diff: %+v", rep.SetupFailures[0])
+	}
+	// The errored step is captured with its phase label and error text.
+	var sawSetupErr, sawTeardownErr bool
+	for _, f := range rep.SetupFailures {
+		if f.Error == "migrate: connection refused" && f.Step == "run" {
+			sawSetupErr = true
+		}
+	}
+	for _, f := range rep.TeardownFailures {
+		if f.Error == "docker rm: no such container" && f.Step == "run" {
+			sawTeardownErr = true
+		}
+	}
+	if !sawSetupErr || !sawTeardownErr {
+		t.Errorf("suite setup/teardown step errors not both mapped: %+v / %+v", rep.SetupFailures, rep.TeardownFailures)
+	}
+}
+
+// scenarioTeardownFailure builds a passing scenario whose TEARDOWN failed — a
+// failed cleanup check (carrying a sidecar artifact) plus an errored teardown
+// step. The verdict stays passed; the failure must still surface.
+func scenarioTeardownFailure() *engine.SuiteResult {
+	return &engine.SuiteResult{
+		Suite:    "td",
+		SpecPath: "td.atago.yaml",
+		Status:   engine.StatusPassed,
+		Duration: 2 * time.Millisecond,
+		Scenarios: []engine.ScenarioResult{
+			{
+				Name:     "leaves-clean",
+				Status:   engine.StatusPassed,
+				Duration: time.Millisecond,
+				Steps:    []engine.StepResult{{Kind: "assert", Checks: []*assert.CheckResult{{OK: true}}}},
+				Teardown: []engine.StepResult{
+					{Index: 1, Kind: "assert", Checks: []*assert.CheckResult{{
+						OK: false, Desc: "assert file lock removed", Hint: "lockfile survived cleanup",
+						ArtifactFiles: []assert.ArtifactFile{{Role: "actual", Path: "artifacts/td/lock.txt"}},
+					}}},
+					{Index: 2, Kind: "run", ErrMsg: "rm: permission denied"},
+				},
+				ServiceLogs: []engine.ServiceLog{{Name: "api", Path: "artifacts/td/api.log"}},
+			},
+		},
+	}
+}
+
+// TestConsole_ScenarioTeardownFailure exercises writeDetail's teardown block and
+// the service-logs footer for a scenario whose verdict stays passed.
+func TestConsole_ScenarioTeardownFailure(t *testing.T) {
+	t.Parallel()
+	out := render(t, FormatConsole, scenarioTeardownFailure())
+	for _, want := range []string{
+		"TEARDOWN FAILED:",
+		"td / leaves-clean",
+		"assert file lock removed",
+		"lockfile survived cleanup",
+		"teardown step 2 (run): rm: permission denied",
+		"Service logs:",
+		"api: artifacts/td/api.log",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("console teardown block missing %q\n--- got ---\n%s", want, out)
+		}
+	}
+	// A passing-with-failed-teardown scenario keeps the verdict green.
+	if strings.Contains(out, "FAILED  ") {
+		t.Errorf("a failed teardown must not flip the summary verdict:\n%s", out)
+	}
+}
+
+// TestJSON_ScenarioTeardownFailures exercises teardownFailuresOf: the failed
+// check (with its artifact) and the errored step must both appear under the
+// scenario's teardown_failures, and never in the top-level failures[] bucket.
+func TestJSON_ScenarioTeardownFailures(t *testing.T) {
+	t.Parallel()
+	var doc jsonDocument
+	if err := json.Unmarshal([]byte(render(t, FormatJSON, scenarioTeardownFailure())), &doc); err != nil {
+		t.Fatalf("json invalid: %v", err)
+	}
+	rep := doc.Suites[0]
+	if len(rep.Failures) != 0 {
+		t.Errorf("a passing scenario with a failed teardown must not populate failures[]: %+v", rep.Failures)
+	}
+	sc := rep.Scenarios[0]
+	if len(sc.TeardownFailures) != 2 {
+		t.Fatalf("scenario teardown_failures = %d, want 2: %+v", len(sc.TeardownFailures), sc.TeardownFailures)
+	}
+	var sawArtifact, sawErr bool
+	for _, f := range sc.TeardownFailures {
+		if len(f.Artifacts) == 1 && f.Artifacts[0].Path == "artifacts/td/lock.txt" {
+			sawArtifact = true
+		}
+		if f.Error == "rm: permission denied" {
+			sawErr = true
+		}
+	}
+	if !sawArtifact {
+		t.Errorf("teardown check artifact not mapped: %+v", sc.TeardownFailures)
+	}
+	if !sawErr {
+		t.Errorf("teardown step error not mapped: %+v", sc.TeardownFailures)
+	}
+	if len(sc.ServiceLogs) != 1 || sc.ServiceLogs[0].Name != "api" {
+		t.Errorf("service logs not mapped: %+v", sc.ServiceLogs)
+	}
+}
+
+// TestConsole_FailedScenarioArtifacts exercises writeDetail's Artifacts footer
+// for a failed check that wrote sidecar files (#48).
+func TestConsole_FailedScenarioArtifacts(t *testing.T) {
+	t.Parallel()
+	res := &engine.SuiteResult{
+		Suite:  "art",
+		Status: engine.StatusFailed,
+		Scenarios: []engine.ScenarioResult{
+			{Name: "diffy", Status: engine.StatusFailed, Steps: []engine.StepResult{
+				{Kind: "run", Run: nil},
+				{Kind: "assert", Checks: []*assert.CheckResult{{
+					OK: false, Desc: "assert stdout equals golden",
+					ArtifactExpected: []byte("a\nb\nc\n"), ArtifactActual: []byte("a\nX\nc\n"),
+					ArtifactFiles: []assert.ArtifactFile{
+						{Role: "expected", Path: "artifacts/art/expected.txt"},
+						{Role: "actual", Path: "artifacts/art/actual.txt"},
+					},
+				}}},
+			}},
+		},
+	}
+	out := render(t, FormatConsole, res)
+	for _, want := range []string{"Artifacts:", "expected: artifacts/art/expected.txt", "actual: artifacts/art/actual.txt", "Diff (-expected +actual):"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("console artifacts footer missing %q\n--- got ---\n%s", want, out)
+		}
+	}
+}
+
+// TestSuiteFailureMessage covers every branch of the one-line message picker.
+func TestSuiteFailureMessage(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   jsonFailure
+		want string
+	}{
+		{"error wins", jsonFailure{Error: "boom", Hint: "h", Step: "s"}, "boom"},
+		{"hint next", jsonFailure{Hint: "check the port", Step: "s"}, "check the port"},
+		{"expected+actual", jsonFailure{Expected: "0", Actual: "3", Step: "s"}, "expected 0, got 3"},
+		{"only expected", jsonFailure{Expected: "x", Step: "s"}, "expected x, got "},
+		{"step fallback", jsonFailure{Step: "service setup"}, "service setup"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := suiteFailureMessage(tc.in); got != tc.want {
+				t.Errorf("suiteFailureMessage(%+v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSuiteFailureBody covers the multi-line detail assembly, including the
+// empty (no detail) case.
+func TestSuiteFailureBody(t *testing.T) {
+	t.Parallel()
+	if got := suiteFailureBody(jsonFailure{Expected: "e", Actual: "a", Hint: "h"}); got != "Expected: e\nActual: a\nHint: h" {
+		t.Errorf("full body = %q", got)
+	}
+	if got := suiteFailureBody(jsonFailure{Hint: "only hint"}); got != "Hint: only hint" {
+		t.Errorf("hint-only body = %q", got)
+	}
+	if got := suiteFailureBody(jsonFailure{Error: "e"}); got != "" {
+		t.Errorf("error-only failure has no detail body, got %q", got)
+	}
+}
+
+// TestJUnit_MessageFallbacks proves the firstFailureMessage/firstErrorMessage
+// fallbacks fire when a failed/errored scenario carries no failing check or no
+// step error (a shape a folded --retry result can produce).
+func TestJUnit_MessageFallbacks(t *testing.T) {
+	t.Parallel()
+	res := &engine.SuiteResult{
+		Suite:  "fb",
+		Status: engine.StatusFailed,
+		Scenarios: []engine.ScenarioResult{
+			// Failed status but every check OK -> "assertion failed" fallback.
+			{Name: "f", Status: engine.StatusFailed, Steps: []engine.StepResult{
+				{Kind: "assert", Checks: []*assert.CheckResult{{OK: true}}},
+			}},
+			// Errored status but no step ErrMsg -> "execution error" fallback.
+			{Name: "e", Status: engine.StatusError, Steps: []engine.StepResult{
+				{Kind: "run"},
+			}},
+		},
+	}
+	var root junitTestsuites
+	if err := xml.Unmarshal([]byte(render(t, FormatJUnit, res)), &root); err != nil {
+		t.Fatalf("junit invalid: %v", err)
+	}
+	out := render(t, FormatJUnit, res)
+	if !strings.Contains(out, "assertion failed") {
+		t.Errorf("missing firstFailureMessage fallback:\n%s", out)
+	}
+	if !strings.Contains(out, "execution error") {
+		t.Errorf("missing firstErrorMessage fallback:\n%s", out)
+	}
+}
+
+// TestDetailText_WithDiff proves the JUnit/TAP plain-text body embeds the
+// uncolored unified diff for a multi-line equals/snapshot failure (#28).
+func TestDetailText_WithDiff(t *testing.T) {
+	t.Parallel()
+	sc := &engine.ScenarioResult{
+		Name:   "d",
+		Status: engine.StatusFailed,
+		Steps: []engine.StepResult{
+			{Kind: "assert", Checks: []*assert.CheckResult{{
+				OK: false, Desc: "assert stdout equals golden",
+				ArtifactExpected: []byte("one\ntwo\n"), ArtifactActual: []byte("one\nTWO\n"),
+			}}},
+			{Index: 1, Kind: "run", ErrMsg: "later boom"},
+		},
+	}
+	got := detailText(sc)
+	for _, want := range []string{"Step: assert stdout equals golden", "Diff (-expected +actual):", "-two", "+TWO", "Error in run step: later boom"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("detailText missing %q\n--- got ---\n%s", want, got)
+		}
+	}
+	// The XML/TAP body must never carry an ANSI escape.
+	if strings.Contains(got, "\x1b[") {
+		t.Errorf("detailText leaked an ANSI escape:\n%q", got)
+	}
+}
+
+// TestProgress_AllMarkers pins every marker glyph including the flaky 'f' and the
+// unknown-status '?' fallback.
+func TestProgress_AllMarkers(t *testing.T) {
+	t.Parallel()
+	var b bytes.Buffer
+	p := NewProgress(&b)
+	p.Scenario(engine.ScenarioResult{Status: engine.StatusPassed})
+	p.Scenario(engine.ScenarioResult{Status: engine.StatusFailed})
+	p.Scenario(engine.ScenarioResult{Status: engine.StatusError})
+	p.Scenario(engine.ScenarioResult{Status: engine.StatusSkipped})
+	p.Scenario(engine.ScenarioResult{Status: engine.StatusFlaky})
+	p.Scenario(engine.ScenarioResult{Status: engine.Status("weird")})
+	p.Done()
+	if got := b.String(); got != ".FEsf?\n" {
+		t.Errorf("markers = %q, want %q", got, ".FEsf?\n")
+	}
+}
+
+// TestProgress_DoneNoMarkers proves Done prints nothing when no scenario ran.
+func TestProgress_DoneNoMarkers(t *testing.T) {
+	t.Parallel()
+	var b bytes.Buffer
+	NewProgress(&b).Done()
+	if b.Len() != 0 {
+		t.Errorf("Done printed %q with no markers", b.String())
+	}
+}
+
+// TestTAP_UnknownStatusIsNotOk proves the default arm of writeTAP emits a
+// failing point for a status TAP has no dedicated arm for.
+func TestTAP_UnknownStatusIsNotOk(t *testing.T) {
+	t.Parallel()
+	res := &engine.SuiteResult{
+		Suite:     "u",
+		Status:    engine.StatusFailed,
+		Scenarios: []engine.ScenarioResult{{Name: "weird", Status: engine.Status("bogus")}},
+	}
+	out := render(t, FormatTAP, res)
+	if !strings.Contains(out, "not ok 1 - u / weird") {
+		t.Errorf("unknown status should emit a not-ok point:\n%s", out)
+	}
+}
+
+// TestVerbose_SetupStepAndErrorAndHeaderColors covers writeStep's setup label and
+// error line, plus headerColor for the flaky and unknown-status arms.
+func TestVerbose_SetupStepAndErrorAndHeaderColors(t *testing.T) {
+	t.Parallel()
+	// A setup step (Setup=true) is labeled with the shared "service setup" phrase,
+	// and its ErrMsg renders on its own line.
+	res := engine.ScenarioResult{
+		Suite:  "v",
+		Name:   "boot",
+		Status: engine.StatusError,
+		Steps: []engine.StepResult{
+			{Index: 0, Setup: true, ErrMsg: "service never came up"},
+		},
+	}
+	var b strings.Builder
+	NewVerbose(&b).Scenario(res)
+	out := b.String()
+	if !strings.Contains(out, setupPhaseLabel) {
+		t.Errorf("verbose setup step should carry the setup label:\n%s", out)
+	}
+	if !strings.Contains(out, "error: service never came up") {
+		t.Errorf("verbose setup error line missing:\n%s", out)
+	}
+
+	// headerColor arms: flaky and unknown both have deterministic returns.
+	if headerColor(engine.StatusFlaky) != cYellow {
+		t.Errorf("flaky header color = %q, want yellow", headerColor(engine.StatusFlaky))
+	}
+	if headerColor(engine.Status("weird")) != "" {
+		t.Errorf("unknown status header color must be empty, got %q", headerColor(engine.Status("weird")))
+	}
+	if headerColor(engine.StatusPassed) != cGreen {
+		t.Errorf("passed header color = %q, want green", headerColor(engine.StatusPassed))
+	}
+}
+
+// TestIsTTY covers the NO_COLOR short-circuit and the non-*os.File path.
+func TestIsTTY(t *testing.T) {
+	// Not parallel: mutates the NO_COLOR environment variable.
+	if isTTY(&bytes.Buffer{}) {
+		t.Error("a bytes.Buffer is not a TTY")
+	}
+	t.Setenv("NO_COLOR", "1")
+	// NO_COLOR forces false even for a real terminal-like file; os.Stdout is not a
+	// char device under `go test`, but the env short-circuit returns first anyway.
+	if isTTY(os.Stdout) {
+		t.Error("NO_COLOR must force isTTY to false")
+	}
+}
+
+// TestConsole_RepeatRates exercises writeRepeatRates for a --repeat run: a
+// per-scenario pass-rate line, red when not every iteration passed.
+func TestConsole_RepeatRates(t *testing.T) {
+	t.Parallel()
+	res := &engine.SuiteResult{
+		Suite:  "rp",
+		Status: engine.StatusFailed,
+		Scenarios: []engine.ScenarioResult{
+			{Name: "race-prone", Status: engine.StatusFailed, Iterations: []engine.Status{
+				engine.StatusPassed, engine.StatusFailed, engine.StatusPassed,
+			}},
+			{Name: "steady", Status: engine.StatusPassed, Iterations: []engine.Status{
+				engine.StatusPassed, engine.StatusPassed,
+			}},
+		},
+	}
+	out := render(t, FormatConsole, res)
+	if !strings.Contains(out, "REPEAT: race-prone: 2/3 passed") {
+		t.Errorf("missing flaky repeat rate:\n%s", out)
+	}
+	if !strings.Contains(out, "REPEAT: steady: 2/2 passed") {
+		t.Errorf("missing steady repeat rate:\n%s", out)
+	}
+}
+
+// TestConsole_FailedScenarioShowsCommand proves writeDetail prints the last run
+// command for a failed scenario so the reader has the invocation context.
+func TestConsole_FailedScenarioShowsCommand(t *testing.T) {
+	t.Parallel()
+	res := &engine.SuiteResult{
+		Suite:  "c",
+		Status: engine.StatusFailed,
+		Scenarios: []engine.ScenarioResult{
+			{Name: "cmd", Status: engine.StatusFailed, Steps: []engine.StepResult{
+				{Kind: "run", Run: &runner.Result{Command: "tool --flag"}},
+				{Kind: "assert", Checks: []*assert.CheckResult{{
+					OK: false, Desc: "assert exit_code is 0", Expected: "0", Actual: "1", Hint: "nonzero",
+				}}},
+			}},
+		},
+	}
+	out := render(t, FormatConsole, res)
+	if !strings.Contains(out, "Command:\n  tool --flag") {
+		t.Errorf("failed-scenario command context missing:\n%s", out)
+	}
+}
+
+// TestSuiteFailurePoints_GenericFallback proves the runtime-creation path (a
+// suite that errored without scenarios AND without any recorded suite.setup
+// detail) still synthesizes one generic failure point so the failure is never
+// rendered green. Regression oracle for the len(pts)==0 branch.
+func TestSuiteFailurePoints_GenericFallback(t *testing.T) {
+	t.Parallel()
+	res := &engine.SuiteResult{Suite: "rt", Status: engine.StatusError} // no scenarios, no Setup
+	pts := suiteFailurePoints(res)
+	if len(pts) != 1 || !strings.Contains(pts[0].message, "errored before any scenario ran") {
+		t.Fatalf("generic fallback point = %+v", pts)
+	}
+	// It must surface in tap and junit as a failing/errored entry.
+	tap := render(t, FormatTAP, res)
+	if !strings.Contains(tap, "not ok 1 - rt / "+setupPhaseLabel) {
+		t.Errorf("generic suite failure not emitted by tap:\n%s", tap)
+	}
+	var root junitTestsuites
+	if err := xml.Unmarshal([]byte(render(t, FormatJUnit, res)), &root); err != nil {
+		t.Fatalf("junit invalid: %v", err)
+	}
+	if root.Errors != 1 {
+		t.Errorf("junit errors = %d, want 1 for the generic suite failure", root.Errors)
+	}
+}
+
+// errWriter fails every write, to exercise the error-return paths of the
+// writers that other tests always feed a bytes.Buffer.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) { return 0, errFakeWrite }
+
+var errFakeWrite = &writeError{}
+
+type writeError struct{}
+
+func (*writeError) Error() string { return "boom" }
+
+// TestWriters_PropagateWriteErrors proves each format's Render surfaces a write
+// error instead of swallowing it.
+func TestWriters_PropagateWriteErrors(t *testing.T) {
+	t.Parallel()
+	for _, f := range []Format{FormatConsole, FormatJSON, FormatJUnit, FormatGHA, FormatTAP} {
+		if err := Render(errWriter{}, f, []*engine.SuiteResult{sampleResults()[0]}); err == nil {
+			t.Errorf("%s: Render swallowed a write error", f)
+		}
+	}
+}
+
+// TestColorize covers both arms of the tiny colorize helper.
+func TestColorize(t *testing.T) {
+	t.Parallel()
+	if got := colorize(false, cRed, "x"); got != "x" {
+		t.Errorf("color off = %q, want plain", got)
+	}
+	if got := colorize(true, "", "x"); got != "x" {
+		t.Errorf("empty code = %q, want plain", got)
+	}
+	if got := colorize(true, cRed, "x"); got != cRed+"x"+cReset {
+		t.Errorf("colorized = %q", got)
 	}
 }

--- a/internal/runner/cmd/cmd_test.go
+++ b/internal/runner/cmd/cmd_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -497,4 +498,171 @@ func TestShellPath(t *testing.T) {
 			t.Errorf("shellPath() = %q, want an absolute path", got)
 		}
 	})
+}
+
+// TestCommandLine_ShellAndArgv covers CommandLine for the shell path, the
+// argv-tokenized path, the empty-command error, and the unparseable-command
+// error (unclosed quote on POSIX).
+func TestCommandLine_ShellAndArgv(t *testing.T) {
+	t.Parallel()
+	// Shell form: POSIX returns the shell with -c; the exact shell binary depends
+	// on the host, so assert on the -c flag and command argument.
+	name, args, err := CommandLine("echo hi | wc -l", true)
+	if err != nil {
+		t.Fatalf("shell CommandLine error: %v", err)
+	}
+	if runtime.GOOS == "windows" {
+		if name != "cmd" || len(args) != 2 || args[0] != "/c" {
+			t.Errorf("windows shell argv = %q %v, want cmd /c ...", name, args)
+		}
+	} else {
+		if len(args) != 2 || args[0] != "-c" || args[1] != "echo hi | wc -l" {
+			t.Errorf("posix shell argv = %q %v, want <sh> -c <command>", name, args)
+		}
+	}
+
+	// Argv form: the first field is the program, the rest are arguments.
+	name, args, err = CommandLine(argvCommand("echo a b c", "cmd /c echo a b c"), false)
+	if err != nil {
+		t.Fatalf("argv CommandLine error: %v", err)
+	}
+	if name == "" || len(args) == 0 {
+		t.Errorf("argv CommandLine returned name=%q args=%v", name, args)
+	}
+
+	// Empty command is an error, not a silent empty argv.
+	if _, _, err := CommandLine("   ", false); err == nil {
+		t.Error("empty command should be rejected")
+	}
+
+	// A syntactically broken command (unclosed quote) is a parse error on both
+	// POSIX (go-shellwords) and Windows (windowsFields).
+	if _, _, err := CommandLine(`echo "unclosed`, false); err == nil {
+		t.Error("unclosed quote should be a parse error")
+	}
+}
+
+// TestShellPath_EnvOverride covers shellPath's ATAGO_SHELL override branch and
+// its default. It cannot be parallel because it mutates process env.
+func TestShellPath_EnvOverride(t *testing.T) {
+	t.Setenv("ATAGO_SHELL", "/custom/shell")
+	if got := shellPath(); got != "/custom/shell" {
+		t.Errorf("shellPath with ATAGO_SHELL = %q, want /custom/shell", got)
+	}
+	t.Setenv("ATAGO_SHELL", "")
+	// With no override, the default is an absolute path (never empty); on POSIX
+	// hosts /bin/sh normally exists.
+	if got := shellPath(); got == "" {
+		t.Error("shellPath default must not be empty")
+	}
+}
+
+// TestParseTimeout covers the empty (zero), valid, and invalid branches.
+func TestParseTimeout(t *testing.T) {
+	t.Parallel()
+	if d, err := parseTimeout(""); err != nil || d != 0 {
+		t.Errorf("parseTimeout(\"\") = %v, %v; want 0, nil", d, err)
+	}
+	if d, err := parseTimeout("250ms"); err != nil || d.Milliseconds() != 250 {
+		t.Errorf("parseTimeout(250ms) = %v, %v", d, err)
+	}
+	if _, err := parseTimeout("soon"); err == nil {
+		t.Error("parseTimeout(soon) should error")
+	}
+}
+
+// TestResolveDir covers every branch of resolveDir: empty and "." collapse to the
+// workdir, an absolute cwd is used verbatim, and a relative cwd joins onto workdir
+// (via filepath.Join, so the separator matches the host — backslash on Windows).
+func TestResolveDir(t *testing.T) {
+	t.Parallel()
+	const wd = "/work/dir"
+	cases := []struct {
+		cwd, want string
+	}{
+		{"", wd},
+		{".", wd},
+		{"sub", filepath.Join(wd, "sub")},
+		{"a/b", filepath.Join(wd, "a", "b")},
+	}
+	for _, c := range cases {
+		if got := resolveDir(wd, c.cwd); got != c.want {
+			t.Errorf("resolveDir(%q, %q) = %q, want %q", wd, c.cwd, got, c.want)
+		}
+	}
+	if runtime.GOOS != "windows" {
+		if got := resolveDir(wd, "/abs/path"); got != "/abs/path" {
+			t.Errorf("resolveDir with absolute cwd = %q, want /abs/path", got)
+		}
+	}
+}
+
+// TestBuildEnv_Precedence pins the documented precedence step env > sandbox >
+// pass_env > host (#16, #71). os/exec keeps the LAST value for a duplicated key,
+// so the contract is expressed as "the winning source appears last in the slice".
+// An inverted append order here would silently leak the host home past an enabled
+// sandbox, so this is a security-relevant invariant, not cosmetics.
+func TestBuildEnv_Precedence(t *testing.T) {
+	// clear_env inherits nothing except the pass_env allowlist, so set a host var
+	// we can pass through. Not parallel: mutates process env.
+	t.Setenv("LEAKY", "host-value")
+
+	env := BuildEnv(
+		map[string]string{"SHARED": "from-override"},
+		true, // clearEnv
+		[]string{"LEAKY"},
+		map[string]string{"SHARED": "from-sandbox", "LEAKY": "from-sandbox"},
+	)
+
+	// SHARED is set by both sandbox and override; override must win (appear last).
+	if last := lastValue(env, "SHARED"); last != "from-override" {
+		t.Errorf("SHARED effective value = %q, want from-override (step env wins)", last)
+	}
+	// LEAKY is passed from host AND overlaid by sandbox; sandbox must win so the
+	// host value cannot leak past the isolated home.
+	if last := lastValue(env, "LEAKY"); last != "from-sandbox" {
+		t.Errorf("LEAKY effective value = %q, want from-sandbox (sandbox beats pass_env host)", last)
+	}
+
+	// Without clear_env and without overrides/sandbox, buildEnv returns nil so
+	// exec inherits os.Environ() directly.
+	if got := BuildEnv(nil, false, nil, nil); got != nil {
+		t.Errorf("BuildEnv(nil,false,nil,nil) = %v, want nil (inherit host)", got)
+	}
+}
+
+// TestLookupHostEnv covers the present and absent branches.
+func TestLookupHostEnv(t *testing.T) {
+	t.Setenv("ATAGO_TEST_PRESENT", "yes")
+	if v, ok := lookupHostEnv("ATAGO_TEST_PRESENT"); !ok || v != "yes" {
+		t.Errorf("lookupHostEnv(present) = %q, %v", v, ok)
+	}
+	if _, ok := lookupHostEnv("ATAGO_TEST_DEFINITELY_ABSENT_XYZ"); ok {
+		t.Error("lookupHostEnv(absent) should report not found")
+	}
+}
+
+// lastValue returns the value of the last "KEY=VALUE" entry for key, mirroring
+// how os/exec resolves a duplicated environment key.
+func lastValue(env []string, key string) string {
+	val := ""
+	for _, kv := range env {
+		if strings.HasPrefix(kv, key+"=") {
+			val = kv[len(key)+1:]
+		}
+	}
+	return val
+}
+
+// TestConfigureShell_NoopOnPOSIX covers the POSIX ConfigureShell, which is a
+// deliberate no-op (the sh -c argv from CommandLine needs no re-quoting). It must
+// not panic or mutate the command.
+func TestConfigureShell_NoopOnPOSIX(t *testing.T) {
+	t.Parallel()
+	c := exec.CommandContext(context.Background(), "sh", "-c", "echo hi")
+	before := append([]string(nil), c.Args...)
+	ConfigureShell(c, "echo hi")
+	if len(c.Args) != len(before) {
+		t.Errorf("ConfigureShell mutated argv: %v -> %v", before, c.Args)
+	}
 }

--- a/internal/runner/db/db_test.go
+++ b/internal/runner/db/db_test.go
@@ -219,3 +219,111 @@ func TestIsRowReturning(t *testing.T) {
 		}
 	}
 }
+
+// TestNormalizeValue covers the []byte→string conversion (so a TEXT/BLOB column
+// serializes as a string, not a base64 byte array in JSON) and the passthrough
+// for every other type.
+func TestNormalizeValue(t *testing.T) {
+	t.Parallel()
+	if got := normalizeValue([]byte("hi")); got != "hi" {
+		t.Errorf("normalizeValue([]byte) = %v, want \"hi\"", got)
+	}
+	if got := normalizeValue(int64(7)); got != int64(7) {
+		t.Errorf("normalizeValue(int64) = %v, want 7", got)
+	}
+	if got := normalizeValue(nil); got != nil {
+		t.Errorf("normalizeValue(nil) = %v, want nil", got)
+	}
+}
+
+// TestSchemeOf covers dsn scheme extraction: a scheme is the lowercased text
+// before the first ':', but only when that ':' is not the first character (a
+// leading ':', like ":memory:", has no scheme).
+func TestSchemeOf(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"sqlite:./a.db":      "sqlite",
+		"POSTGRES://x":       "postgres",
+		"mysql://u@tcp(h)/d": "mysql",
+		"plainpath":          "",
+		":memory:":           "",
+		"":                   "",
+	}
+	for dsn, want := range cases {
+		if got := schemeOf(dsn); got != want {
+			t.Errorf("schemeOf(%q) = %q, want %q", dsn, got, want)
+		}
+	}
+}
+
+// TestValidateDriver covers the loader-facing driver check: empty is valid
+// (inferred later), every alias is accepted, and an unknown/typo'd name is
+// rejected with a helpful message.
+func TestValidateDriver(t *testing.T) {
+	t.Parallel()
+	for _, ok := range []string{"", "sqlite", "sqlite3", "postgres", "postgresql", "pgx", "mysql", "  MySQL  "} {
+		if err := ValidateDriver(ok); err != nil {
+			t.Errorf("ValidateDriver(%q) = %v, want nil", ok, err)
+		}
+	}
+	for _, bad := range []string{"sqllite", "mariadb", "oracle", "x"} {
+		if err := ValidateDriver(bad); err == nil {
+			t.Errorf("ValidateDriver(%q) = nil, want error", bad)
+		}
+	}
+}
+
+// TestDataSource covers the driver-specific DSN rewriting: sqlite strips a
+// sqlite:/sqlite3: prefix (and preserves ":memory:" and bare paths), postgres is
+// passed through verbatim, and a mysql:// URL is converted to the native form.
+func TestDataSource(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		driver, dsn, want string
+	}{
+		{"sqlite", "sqlite:./a.db", "./a.db"},
+		{"sqlite", "sqlite3:./a.db", "./a.db"},
+		{"sqlite", ":memory:", ":memory:"},
+		{"sqlite", "/abs/path.db", "/abs/path.db"},
+		{"postgres", "postgres://u@h/d", "postgres://u@h/d"},
+		{"mysql", "user:pass@tcp(127.0.0.1:3306)/db", "user:pass@tcp(127.0.0.1:3306)/db"},
+	}
+	for _, c := range cases {
+		got, err := dataSource(c.driver, c.dsn)
+		if err != nil {
+			t.Errorf("dataSource(%q, %q) error = %v", c.driver, c.dsn, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("dataSource(%q, %q) = %q, want %q", c.driver, c.dsn, got, c.want)
+		}
+	}
+	// A mysql:// URL is rewritten to the native user:pass@tcp(host)/db form.
+	got, err := dataSource("mysql", "mysql://u:p@h:3306/d")
+	if err != nil {
+		t.Fatalf("dataSource(mysql url) error = %v", err)
+	}
+	if got == "mysql://u:p@h:3306/d" {
+		t.Errorf("dataSource did not rewrite mysql:// URL: %q", got)
+	}
+}
+
+// TestSkipQuotedEdges exercises skipQuoted through isRowReturning for a doubled
+// (escaped) quote and an unterminated quote — the classifier must not panic and
+// must treat the quoted region as opaque data.
+func TestSkipQuotedEdges(t *testing.T) {
+	t.Parallel()
+	// Doubled single quote is an escaped literal; the string spans to the real
+	// close, so the leading verb is still INSERT (row-returning false).
+	if isRowReturning("INSERT INTO t VALUES ('it''s RETURNING x')") {
+		t.Error("doubled-quote literal containing RETURNING should not route as row-returning")
+	}
+	// An unterminated quote must not panic and consumes to end of input.
+	if isRowReturning("INSERT INTO t VALUES ('unterminated") {
+		t.Error("unterminated quote after INSERT should not be row-returning")
+	}
+	// A SELECT with an empty doubled-quote pair still classifies as row-returning.
+	if !isRowReturning("SELECT '''' AS q") {
+		t.Error("SELECT with doubled-quote literal should be row-returning")
+	}
+}

--- a/internal/runner/mock/mock_test.go
+++ b/internal/runner/mock/mock_test.go
@@ -173,3 +173,38 @@ func TestRecords_ThreadSafe(t *testing.T) {
 		t.Errorf("records = %d, want 20", got)
 	}
 }
+
+// TestRequestLog renders the per-request artifact line for a matched and an
+// unmatched request, covering RequestLog and the 404 recording path.
+func TestRequestLog(t *testing.T) {
+	t.Parallel()
+	s := startTest(t, &spec.MockServer{
+		Name: "api",
+		Routes: []spec.MockRoute{
+			{Method: "GET", Path: "/health", Body: "ok"},
+		},
+	}, t.TempDir())
+
+	do(t, http.MethodGet, s.URL()+"/health", nil)
+	do(t, http.MethodPost, s.URL()+"/missing", strings.NewReader("payload"))
+
+	log := s.RequestLog()
+	if !strings.Contains(log, "1: GET /health -> 200") {
+		t.Errorf("RequestLog missing matched line:\n%s", log)
+	}
+	if !strings.Contains(log, "2: POST /missing -> 404") {
+		t.Errorf("RequestLog missing unmatched line:\n%s", log)
+	}
+	if !strings.Contains(log, "7 body bytes") {
+		t.Errorf("RequestLog missing recorded body size:\n%s", log)
+	}
+}
+
+// TestStop_NilSafe covers the nil/zero guards in Stop so a double-stop or a
+// never-started server does not panic.
+func TestStop_NilSafe(t *testing.T) {
+	t.Parallel()
+	var nilServer *Server
+	nilServer.Stop() // must not panic
+	(&Server{}).Stop()
+}

--- a/internal/runner/ptyrun/ptyrun_unix_test.go
+++ b/internal/runner/ptyrun/ptyrun_unix_test.go
@@ -4,6 +4,7 @@ package ptyrun
 
 import (
 	"context"
+	"os"
 	"strings"
 	"testing"
 
@@ -36,6 +37,25 @@ func TestRun_FastExitOutputNotLost(t *testing.T) {
 		}
 		if !strings.Contains(string(res.Stdout), "is-a-tty") {
 			t.Fatalf("iteration %d: transcript lost the child's output: %q", i, res.Stdout)
+		}
+	}
+}
+
+// TestResolveCwd covers cwd resolution for a pty step: empty stays at the
+// workdir, an absolute path is used verbatim, and a relative path nests inside
+// the workdir — matching the cmd runner's rule so a pty and a run step agree on
+// where a relative cwd points.
+func TestResolveCwd(t *testing.T) {
+	t.Parallel()
+	const wd = "/work"
+	cases := []struct{ cwd, want string }{
+		{"", wd},
+		{"sub", "/work" + string(os.PathSeparator) + "sub"},
+		{"/abs", "/abs"},
+	}
+	for _, c := range cases {
+		if got := resolveCwd(wd, c.cwd); got != c.want {
+			t.Errorf("resolveCwd(%q, %q) = %q, want %q", wd, c.cwd, got, c.want)
 		}
 	}
 }

--- a/internal/sitegen/sitegen_test.go
+++ b/internal/sitegen/sitegen_test.go
@@ -1,0 +1,72 @@
+package sitegen
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestGenerate_WritesEverySiteFile drives Generate against a synthetic repo root
+// and asserts it writes exactly the file set Files reports, byte-for-byte. It
+// also seeds a doc/e2e page and a schema so the index's link sections
+// (writeLinkSection / exists) render their populated branches rather than the
+// empty-directory skip.
+func TestGenerate_WritesEverySiteFile(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	// Seed the sources the index links to so both link sections are exercised.
+	mustWrite(t, filepath.Join(root, "doc/e2e/echo.md"), "# echo\n")
+	mustWrite(t, filepath.Join(root, "schema/atago.schema.json"), "{}\n")
+
+	if err := Generate(root); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	files, err := Files(root)
+	if err != nil {
+		t.Fatalf("Files: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatal("Files returned no site files")
+	}
+	for name, want := range files {
+		got, err := os.ReadFile(filepath.Join(root, name))
+		if err != nil {
+			t.Errorf("Generate did not write %s: %v", name, err)
+			continue
+		}
+		if !bytes.Equal(got, want) {
+			t.Errorf("written %s differs from Files() content (%d vs %d bytes)", name, len(got), len(want))
+		}
+	}
+
+	// The index must exist and link the seeded doc page and schema (the populated
+	// link-section branches), and the sample gallery must be materialized.
+	index := string(files["site/README.md"])
+	for _, want := range []string{
+		"# atago documentation",
+		"../doc/e2e/echo.md",
+		"schema/atago.schema.json",
+		"samples/report.json",
+	} {
+		if !strings.Contains(index, want) {
+			t.Errorf("site index missing %q\n%s", want, index)
+		}
+	}
+	// A generated binary sample (PNG) must be non-empty on disk.
+	if fi, err := os.Stat(filepath.Join(root, "site/samples/imagediff/diff.png")); err != nil || fi.Size() == 0 {
+		t.Errorf("diff.png not generated: err=%v", err)
+	}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/spec/walk.go
+++ b/internal/spec/walk.go
@@ -54,6 +54,12 @@ func CollectServiceVars(set map[string]bool, svc *Service) {
 	for _, v := range svc.Env {
 		CollectVars(set, v)
 	}
+	// The readiness file/port/log probes are ${name}-expanded by the engine
+	// (expandService), so a `ready: {port: ${db.port}}` or a log regexp with
+	// ${workdir} references variables the summaries must report.
+	if svc.Ready != nil {
+		CollectVars(set, svc.Ready.File, svc.Ready.Port, svc.Ready.Log)
+	}
 }
 
 // CollectStepVars folds every ${name} reference in a step's fields into set.
@@ -64,7 +70,10 @@ func CollectServiceVars(set map[string]bool, svc *Service) {
 func CollectStepVars(set map[string]bool, step *Step) {
 	switch step.Kind() {
 	case StepFixture:
-		CollectVars(set, step.Fixture.File, step.Fixture.Content, step.Fixture.Symlink)
+		// From is ${name}-expanded by the engine (expandFixture), so a
+		// `from: ${srcdir}/seed.bin` reference is a real variable use and must be
+		// counted like file/content/symlink — omitting it under-reported it.
+		CollectVars(set, step.Fixture.File, step.Fixture.Content, step.Fixture.Symlink, step.Fixture.From)
 	case StepService:
 		CollectVars(set, step.Service.Command, step.Service.Cwd)
 	case StepRun:
@@ -79,13 +88,29 @@ func CollectStepVars(set map[string]bool, step *Step) {
 		for _, v := range h.Form {
 			CollectVars(set, v)
 		}
+		// Header values and the JSON request body are ${name}-expanded by the
+		// engine (expandHTTP: ExpandMap(header), WalkJSONValueStrings(json)), the
+		// exact binding that flows a stored token into `Authorization: Bearer
+		// ${token}` or a request body. Omitting them under-reported those vars.
+		for _, v := range h.Header {
+			CollectVars(set, v)
+		}
+		collectJSONVars(set, h.JSON)
 		for _, f := range h.Files {
 			CollectVars(set, f.Path)
 		}
 	case StepQuery:
 		CollectVars(set, step.Query.SQL)
 	case StepGRPC:
-		CollectVars(set, step.GRPC.Method)
+		g := step.GRPC
+		CollectVars(set, g.Method)
+		// Header values and the JSON request message are ${name}-expanded by the
+		// engine (expandGRPC), mirroring http; count them so a metadata or
+		// message reference is not silently dropped.
+		for _, v := range g.Header {
+			CollectVars(set, v)
+		}
+		collectJSONVars(set, g.JSON)
 	case StepCDP:
 		for _, a := range step.CDP.Actions {
 			collectCDPActionVars(set, a)
@@ -104,7 +129,38 @@ func CollectStepVars(set map[string]bool, step *Step) {
 		}
 	case StepSignal:
 		CollectVars(set, step.Signal.Service)
+	case StepAssert:
+		// An assert step's matcher arguments are ${name}-expanded by the engine
+		// (expandAssert -> WalkAssertStrings), so an `equals: ${expected}` or a
+		// `path: ${dir}/out.txt` is a genuine variable use. Walking through the
+		// SAME helper the engine expands with keeps collection and expansion in
+		// exact lockstep; the whole StepAssert kind was previously uncounted.
+		if step.Assert != nil {
+			WalkAssertStrings(step.Assert, func(s string) string {
+				CollectVars(set, s)
+				return s
+			})
+		}
+	case StepStore:
+		// The engine ${name}-expands a store's file-source path (expandStore),
+		// so `store: {from: {file: {path: ${workdir}/out.json}}}` references a
+		// variable the summaries must report.
+		if step.Store != nil && step.Store.From != nil && step.Store.From.File != nil {
+			CollectVars(set, step.Store.From.File.Path)
+		}
 	}
+}
+
+// collectJSONVars folds every ${name} reference in the string leaves of a
+// decoded JSON request body (http/grpc `json:`) into set. The engine expands
+// those leaves through WalkJSONValueStrings at request time
+// (expandHTTP/expandGRPC), so a body like {token: "${token}"} references a
+// variable the manifest and explain summaries must report.
+func collectJSONVars(set map[string]bool, v any) {
+	WalkJSONValueStrings(v, func(s string) string {
+		CollectVars(set, s)
+		return s
+	})
 }
 
 // collectCDPActionVars folds the ${name} references of one browser action into

--- a/internal/spec/walk_test.go
+++ b/internal/spec/walk_test.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/goccy/go-yaml"
 )
 
 func TestVarRefs(t *testing.T) {
@@ -113,5 +115,573 @@ func TestWalkJSONValueStrings(t *testing.T) {
 	// Input not mutated.
 	if in["s"] != "${x}" {
 		t.Error("WalkJSONValueStrings mutated its input")
+	}
+}
+
+// collectStep is a small helper: it runs CollectStepVars over one step and
+// returns the referenced variable names, sorted, so a test can assert the exact
+// set a step kind contributes.
+func collectStep(step *Step) []string {
+	set := map[string]bool{}
+	CollectStepVars(set, step)
+	return SortedKeys(set)
+}
+
+func hasVar(vars []string, name string) bool {
+	for _, v := range vars {
+		if v == name {
+			return true
+		}
+	}
+	return false
+}
+
+// TestCollectStepVars_UnscannedFields is a regression test for a variable
+// under-reporting bug: CollectStepVars is documented as "the single source of
+// truth for which fields of each step kind carry variables", yet several fields
+// the engine actually ${name}-expands were never scanned. Each ${..._ref} below
+// is referenced ONLY from a field the old code skipped, so a miss regresses the
+// fix. The reference expansion for each lives in internal/engine/expand.go.
+func TestCollectStepVars_UnscannedFields(t *testing.T) {
+	t.Parallel()
+
+	// fixture.from is expanded by expandFixture (from: st.Expand(f.From)).
+	if got := collectStep(&Step{Fixture: &Fixture{File: "out", From: "${fixfrom_ref}"}}); !hasVar(got, "fixfrom_ref") {
+		t.Errorf("fixture.from not collected; got %v", got)
+	}
+
+	// http header values and the JSON request body are expanded by expandHTTP.
+	httpStep := &Step{HTTP: &HTTP{
+		Method: "POST",
+		Path:   "/x",
+		Header: map[string]string{"Authorization": "Bearer ${httphdr_ref}"},
+		JSON:   map[string]any{"id": "${httpjson_ref}", "nested": []any{"${httpjson_arr_ref}"}},
+	}}
+	got := collectStep(httpStep)
+	for _, want := range []string{"httphdr_ref", "httpjson_ref", "httpjson_arr_ref"} {
+		if !hasVar(got, want) {
+			t.Errorf("http field %q not collected; got %v", want, got)
+		}
+	}
+
+	// grpc header values and the JSON request message are expanded by expandGRPC.
+	grpcStep := &Step{GRPC: &GRPC{
+		Runner: "g",
+		Method: "pkg.S/${grpcmethod_ref}",
+		Header: map[string]string{"x-token": "${grpchdr_ref}"},
+		JSON:   map[string]any{"q": "${grpcjson_ref}"},
+	}}
+	got = collectStep(grpcStep)
+	for _, want := range []string{"grpcmethod_ref", "grpchdr_ref", "grpcjson_ref"} {
+		if !hasVar(got, want) {
+			t.Errorf("grpc field %q not collected; got %v", want, got)
+		}
+	}
+
+	// An assert step's matcher arguments are expanded by expandAssert; the whole
+	// StepAssert kind was previously uncounted.
+	assertStep := &Step{Assert: &Assert{
+		Stdout: &StreamAssert{Equals: strp("${assert_stdout_ref}")},
+		File:   &FileAssert{Path: "${assert_path_ref}", Contains: StringList{"${assert_contains_ref}"}},
+	}}
+	got = collectStep(assertStep)
+	for _, want := range []string{"assert_stdout_ref", "assert_path_ref", "assert_contains_ref"} {
+		if !hasVar(got, want) {
+			t.Errorf("assert field %q not collected; got %v", want, got)
+		}
+	}
+
+	// A store step's file-source path is expanded by expandStore.
+	storeStep := &Step{Store: &Store{Name: "v", From: &StoreFrom{File: &FileAssert{Path: "${store_path_ref}"}}}}
+	if got := collectStep(storeStep); !hasVar(got, "store_path_ref") {
+		t.Errorf("store from.file.path not collected; got %v", got)
+	}
+}
+
+// TestCollectServiceVars_ReadyProbes is a regression test: the engine expands a
+// service's readiness file/port/log probes (expandService), so a ${name} in any
+// of them is a real variable reference the summaries must report.
+func TestCollectServiceVars_ReadyProbes(t *testing.T) {
+	t.Parallel()
+	set := map[string]bool{}
+	CollectServiceVars(set, &Service{
+		Name:    "peer",
+		Command: "./peer",
+		Ready: &Ready{
+			File: "${ready_file_ref}",
+			Port: "${ready_port_ref}",
+			Log:  "listening on ${ready_log_ref}",
+		},
+	})
+	got := SortedKeys(set)
+	for _, want := range []string{"ready_file_ref", "ready_port_ref", "ready_log_ref"} {
+		if !hasVar(got, want) {
+			t.Errorf("service ready probe %q not collected; got %v", want, got)
+		}
+	}
+}
+
+// TestCollectStepVars_KnownFields keeps the previously-fixed fields covered so a
+// refactor cannot silently drop them.
+func TestCollectStepVars_KnownFields(t *testing.T) {
+	t.Parallel()
+	run := &Step{Run: &Run{Command: "echo ${cmd}", Cwd: "${cwd}", Env: map[string]string{"T": "${env}"}, Stdin: Stdin{Inline: "${in}"}}}
+	got := collectStep(run)
+	for _, want := range []string{"cmd", "cwd", "env", "in"} {
+		if !hasVar(got, want) {
+			t.Errorf("run field %q not collected; got %v", want, got)
+		}
+	}
+	pty := &Step{PTY: &PTY{Command: "${pcmd}", Cwd: "${pcwd}", Env: map[string]string{"K": "${penv}"}, Session: []PTYAction{{Expect: "${pexp}"}, {Send: SendText("${psend}")}}}}
+	got = collectStep(pty)
+	for _, want := range []string{"pcmd", "pcwd", "penv", "pexp", "psend"} {
+		if !hasVar(got, want) {
+			t.Errorf("pty field %q not collected; got %v", want, got)
+		}
+	}
+}
+
+// TestCollectStepVars_RemainingKinds covers the step kinds not exercised above
+// (service, query, cdp, signal) so CollectStepVars is walked end to end, and
+// drives every field collectCDPActionVars can carry.
+func TestCollectStepVars_RemainingKinds(t *testing.T) {
+	t.Parallel()
+
+	if got := collectStep(&Step{Service: &Service{Name: "s", Command: "echo ${scmd}", Cwd: "${scwd}"}}); !hasVar(got, "scmd") || !hasVar(got, "scwd") {
+		t.Errorf("service step vars = %v", got)
+	}
+	if got := collectStep(&Step{Query: &Query{Runner: "d", SQL: "SELECT ${col}"}}); !hasVar(got, "col") {
+		t.Errorf("query step vars = %v", got)
+	}
+	if got := collectStep(&Step{Signal: &Signal{Service: "${sigsvc}", Signal: "TERM"}}); !hasVar(got, "sigsvc") {
+		t.Errorf("signal step vars = %v", got)
+	}
+
+	// Every CDP action sub-field that carries a variable must be collected.
+	cdp := &Step{CDP: &CDP{Runner: "web", Actions: []CDPAction{
+		{Navigate: "${nav}"},
+		{WaitVisible: "${wv}"},
+		{WaitHidden: "${wh}"},
+		{Click: "${clk}"},
+		{Check: "${chk}"},
+		{Uncheck: "${unchk}"},
+		{Text: "${txt}"},
+		{Eval: "${evl}"},
+		{SendKeys: &CDPSendKeys{Selector: "${sk_sel}", Value: "${sk_val}"}},
+		{Press: &CDPPress{Selector: "${pr_sel}", Key: "${pr_key}"}},
+		{Select: &CDPSelect{Selector: "${se_sel}", Value: "${se_val}"}},
+		{Screenshot: &CDPScreenshot{Path: "${ss_path}", Selector: "${ss_sel}"}},
+		{Attribute: &CDPAttribute{Selector: "${at_sel}", Name: "${at_name}"}},
+		{Upload: &CDPUpload{Selector: "${up_sel}", File: "${up_file}"}},
+		{Download: &CDPDownload{Click: "${dl_click}", Dir: "${dl_dir}"}},
+	}}}
+	got := collectStep(cdp)
+	for _, want := range []string{
+		"nav", "wv", "wh", "clk", "chk", "unchk", "txt", "evl",
+		"sk_sel", "sk_val", "pr_sel", "pr_key", "se_sel", "se_val",
+		"ss_path", "ss_sel", "at_sel", "at_name", "up_sel", "up_file",
+		"dl_click", "dl_dir",
+	} {
+		if !hasVar(got, want) {
+			t.Errorf("cdp action var %q not collected; got %v", want, got)
+		}
+	}
+}
+
+// TestCollectStepVars_NoActionStep is a boundary case: a step with no action key
+// (or more than one) has Kind StepNone and contributes no variables, never
+// panicking.
+func TestCollectStepVars_NoActionStep(t *testing.T) {
+	t.Parallel()
+	if got := collectStep(&Step{}); len(got) != 0 {
+		t.Errorf("empty step collected %v, want none", got)
+	}
+}
+
+// TestCollectJSONVars_NilAndScalar guards the helper's non-map/array inputs: a
+// nil body or a bare scalar contributes nothing and never panics.
+func TestCollectJSONVars_NilAndScalar(t *testing.T) {
+	t.Parallel()
+	set := map[string]bool{}
+	collectJSONVars(set, nil)
+	collectJSONVars(set, 42)
+	collectJSONVars(set, "${top_ref}") // a bare string leaf is still scanned
+	if len(set) != 1 || !set["top_ref"] {
+		t.Errorf("collectJSONVars scalar handling = %v, want {top_ref}", SortedKeys(set))
+	}
+}
+
+func TestDescribeDuration(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		d    DurationAssert
+		want string
+	}{
+		{"empty", DurationAssert{}, ""},
+		{"lt", DurationAssert{LT: "2s"}, "in under 2s"},
+		{"lte", DurationAssert{LTE: "2s"}, "in at most 2s"},
+		{"gt", DurationAssert{GT: "1s"}, "in over 1s"},
+		{"gte", DurationAssert{GTE: "1s"}, "in at least 1s"},
+		{"interval gt+lt", DurationAssert{GT: "1s", LT: "2s"}, "in under 2s and in over 1s"},
+		{"interval gte+lte", DurationAssert{GTE: "1s", LTE: "2s"}, "in at most 2s and in at least 1s"},
+		{"all four", DurationAssert{LT: "4s", LTE: "3s", GT: "1s", GTE: "2s"}, "in under 4s and in at most 3s and in over 1s and in at least 2s"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.d.DescribeDuration(); got != tc.want {
+				t.Errorf("DescribeDuration(%+v) = %q, want %q", tc.d, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPTYSend_BytesAndLabel_Edges(t *testing.T) {
+	t.Parallel()
+	// A zero-value send (neither Text nor Key) resolves to no bytes and the
+	// fallback label, never a panic.
+	zero := &PTYSend{}
+	if got := zero.Bytes(); got != nil {
+		t.Errorf("zero send Bytes = %q, want nil", got)
+	}
+	if got := zero.Label(); got != "send" {
+		t.Errorf("zero send Label = %q, want \"send\"", got)
+	}
+	// A named key resolves to its xterm sequence and a "press <key>" label.
+	if got := (&PTYSend{Key: "ctrl-c"}).Bytes(); string(got) != "\x03" {
+		t.Errorf("ctrl-c bytes = %q", got)
+	}
+	if got := (&PTYSend{Key: "tab"}).Label(); got != "press tab" {
+		t.Errorf("tab label = %q", got)
+	}
+	// Non-empty text is quoted in the label.
+	if got := SendText("hi").Label(); got != `type "hi"` {
+		t.Errorf("text label = %q", got)
+	}
+}
+
+func TestPTYSend_UnmarshalYAML_Errors(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"unknown key":    "{foo: bar}",
+		"non-string key": "{key: 5}",
+		"empty key name": "{key: \"  \"}",
+		"sequence":       "[1, 2]",
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			var p PTYSend
+			if err := yaml.Unmarshal([]byte(in), &p); err == nil {
+				t.Errorf("expected error for %s (%q), got none: %+v", name, in, p)
+			}
+		})
+	}
+	// A valid {key: Enter} normalizes case and whitespace.
+	var p PTYSend
+	if err := yaml.Unmarshal([]byte("{key: \"  ENTER \"}"), &p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Key != "enter" {
+		t.Errorf("key = %q, want normalized \"enter\"", p.Key)
+	}
+}
+
+func TestStdin_UnmarshalYAML_Errors(t *testing.T) {
+	t.Parallel()
+	t.Run("unknown key", func(t *testing.T) {
+		t.Parallel()
+		var s Stdin
+		if err := yaml.Unmarshal([]byte("{bogus: x}"), &s); err == nil {
+			t.Error("expected error for unknown stdin key")
+		}
+	})
+	t.Run("non-string value", func(t *testing.T) {
+		t.Parallel()
+		var s Stdin
+		if err := yaml.Unmarshal([]byte("{file: 5}"), &s); err == nil {
+			t.Error("expected error for non-string stdin.file")
+		}
+	})
+	t.Run("empty mapping records the mapping form", func(t *testing.T) {
+		t.Parallel()
+		// An empty mapping ({}) decodes cleanly as the mapping form with no
+		// source set; the loader is what rejects it. IsMapping lets the loader
+		// tell it apart from "no stdin" (IsZero).
+		var s Stdin
+		if err := yaml.Unmarshal([]byte("{}"), &s); err != nil {
+			t.Fatal(err)
+		}
+		if s.File != "" || s.Base64 != "" || s.Inline != "" {
+			t.Errorf("empty mapping populated a source: %+v", s)
+		}
+		if !s.IsMapping() {
+			t.Error("empty mapping should record the mapping form")
+		}
+		if s.IsZero() {
+			t.Error("a {} mapping is authored stdin, so IsZero should be false")
+		}
+	})
+	t.Run("sequence is neither string nor mapping", func(t *testing.T) {
+		t.Parallel()
+		// A YAML sequence decodes as neither the scalar nor the {file/base64}
+		// mapping form, so it hits the shape error rather than silently accepting.
+		var s Stdin
+		if err := yaml.Unmarshal([]byte("[1, 2]"), &s); err == nil {
+			t.Error("expected error decoding a sequence into stdin")
+		}
+	})
+	t.Run("base64 mapping", func(t *testing.T) {
+		t.Parallel()
+		var s Stdin
+		if err := yaml.Unmarshal([]byte("{base64: aGVsbG8=}"), &s); err != nil {
+			t.Fatal(err)
+		}
+		if s.Base64 != "aGVsbG8=" || !s.IsMapping() {
+			t.Errorf("base64 decode = %+v", s)
+		}
+	})
+}
+
+func TestExitCode_MarshalYAML_AllShapes(t *testing.T) {
+	t.Parallel()
+	// The default (no field set) marshals to nil rather than a bogus map.
+	if v, err := (ExitCode{}).MarshalYAML(); err != nil || v != nil {
+		t.Errorf("empty exit_code marshal = (%v, %v), want (nil, nil)", v, err)
+	}
+	// The `in` set round-trips through YAML.
+	var e ExitCode
+	if err := yaml.Unmarshal([]byte("{in: [0, 2]}"), &e); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(e.In, []int{0, 2}) {
+		t.Errorf("in decode = %v", e.In)
+	}
+	b, err := yaml.Marshal(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var back ExitCode
+	if err := yaml.Unmarshal(b, &back); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(back.In, []int{0, 2}) {
+		t.Errorf("in round-trip = %v, want [0 2]", back.In)
+	}
+}
+
+// TestExitCode_UnmarshalYAML_NotError hits the mapping-decode error path: a
+// non-integer `not` value cannot decode into the {not int, in []int} struct.
+func TestExitCode_UnmarshalYAML_NotError(t *testing.T) {
+	t.Parallel()
+	var e ExitCode
+	if err := yaml.Unmarshal([]byte("{not: abc}"), &e); err == nil {
+		t.Error("expected error for non-integer exit_code.not")
+	}
+}
+
+// TestCDPActionLabel_AllVerbs walks the whole browser action vocabulary through
+// the single label helper, including the unknown-action fallback.
+func TestCDPActionLabel_AllVerbs(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		a    CDPAction
+		want string
+	}{
+		{CDPAction{Navigate: "u"}, "navigate u"},
+		{CDPAction{WaitVisible: "#a"}, "wait_visible #a"},
+		{CDPAction{WaitHidden: "#a"}, "wait_hidden #a"},
+		{CDPAction{Click: "#a"}, "click #a"},
+		{CDPAction{Press: &CDPPress{Selector: "#a", Key: "Enter"}}, "press Enter on #a"},
+		{CDPAction{Select: &CDPSelect{Selector: "#a", Value: "v"}}, "select v in #a"},
+		{CDPAction{Check: "#a"}, "check #a"},
+		{CDPAction{Uncheck: "#a"}, "uncheck #a"},
+		{CDPAction{Screenshot: &CDPScreenshot{Path: "s.png"}}, "screenshot s.png"},
+		{CDPAction{SendKeys: &CDPSendKeys{Selector: "#a", Value: "v"}}, "send_keys #a"},
+		{CDPAction{Text: "#a"}, "text #a"},
+		{CDPAction{Title: true}, "title"},
+		{CDPAction{Attribute: &CDPAttribute{Selector: "#a", Name: "href"}}, "attribute href of #a"},
+		{CDPAction{Eval: "1+1"}, "eval"},
+		{CDPAction{Upload: &CDPUpload{Selector: "#a", File: "f"}}, "upload f to #a"},
+		{CDPAction{Download: &CDPDownload{Click: "#dl"}}, "download via #dl"},
+		{CDPAction{}, "(unknown action)"},
+	}
+	for _, tc := range cases {
+		if got := CDPActionLabel(tc.a); got != tc.want {
+			t.Errorf("CDPActionLabel = %q, want %q", got, tc.want)
+		}
+	}
+}
+
+// TestWalkListPtr_EmptyStaysNonNil pins the nil-vs-empty distinction the
+// changes-assert exhaustive semantics depend on, exercised directly.
+func TestWalkListPtr_EmptyStaysNonNil(t *testing.T) {
+	t.Parallel()
+	identity := func(s string) string { return s }
+	if got := walkListPtr(nil, identity); got != nil {
+		t.Errorf("nil list walked to %v, want nil", got)
+	}
+	empty := StringList{}
+	got := walkListPtr(&empty, identity)
+	if got == nil || len(*got) != 0 {
+		t.Errorf("empty list walked to %v, want non-nil empty", got)
+	}
+	full := StringList{"${a}", "b"}
+	got = walkListPtr(&full, func(s string) string { return s + "!" })
+	if got == nil || !reflect.DeepEqual([]string(*got), []string{"${a}!", "b!"}) {
+		t.Errorf("full list walk = %v", got)
+	}
+}
+
+func TestStringList_UnmarshalYAML(t *testing.T) {
+	t.Parallel()
+	// A scalar decodes to a one-element list (byte-identical to the pre-list
+	// format); a sequence decodes to its elements.
+	var one StringList
+	if err := yaml.Unmarshal([]byte("just one"), &one); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual([]string(one), []string{"just one"}) {
+		t.Errorf("scalar StringList = %v", one)
+	}
+	var many StringList
+	if err := yaml.Unmarshal([]byte("[a, b, c]"), &many); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual([]string(many), []string{"a", "b", "c"}) {
+		t.Errorf("sequence StringList = %v", many)
+	}
+	// A mapping is neither a scalar nor a string sequence and must error.
+	var bad StringList
+	if err := yaml.Unmarshal([]byte("{k: v}"), &bad); err == nil {
+		t.Error("expected error decoding a mapping into StringList")
+	}
+}
+
+func TestCDPActionSummary(t *testing.T) {
+	t.Parallel()
+	c := &CDP{Runner: "web", Actions: []CDPAction{{Navigate: "http://x"}, {Click: "#a"}, {Title: true}}}
+	want := "CDP via web: navigate http://x → click #a → title"
+	if got := CDPActionSummary(c); got != want {
+		t.Errorf("CDPActionSummary = %q, want %q", got, want)
+	}
+	// No actions still renders the prefix.
+	if got := CDPActionSummary(&CDP{Runner: "web"}); got != "CDP via web: " {
+		t.Errorf("empty CDPActionSummary = %q", got)
+	}
+}
+
+func TestPTY_EnvHelpers(t *testing.T) {
+	t.Parallel()
+	if (&PTY{}).ClearEnvEnabled() || (&PTY{}).SandboxHomeEnabled() {
+		t.Error("zero PTY should not enable clear_env or sandbox_home")
+	}
+	if !(&PTY{ClearEnv: boolp(true)}).ClearEnvEnabled() {
+		t.Error("ClearEnv=true not reported")
+	}
+	if !(&PTY{SandboxHome: boolp(true)}).SandboxHomeEnabled() {
+		t.Error("SandboxHome=true not reported")
+	}
+	// An explicit false stays false (distinguishable from unset for defaults).
+	if (&PTY{ClearEnv: boolp(false)}).ClearEnvEnabled() {
+		t.Error("ClearEnv=false reported as enabled")
+	}
+}
+
+func TestPTYKeyForSequence(t *testing.T) {
+	t.Parallel()
+	// Every named key's sequence reverse-maps back to a friendly name, with the
+	// documented preference for the readable name over a ctrl-* alias when a byte
+	// is shared (\r is enter, not ctrl-m).
+	if name, ok := PTYKeyForSequence("\r"); !ok || name != "enter" {
+		t.Errorf("\\r reverse = (%q, %v), want enter", name, ok)
+	}
+	if name, ok := PTYKeyForSequence("\x03"); !ok || name != "ctrl-c" {
+		t.Errorf("\\x03 reverse = (%q, %v), want ctrl-c", name, ok)
+	}
+	if name, ok := PTYKeyForSequence("\x1b[A"); !ok || name != "up" {
+		t.Errorf("up-arrow reverse = (%q, %v), want up", name, ok)
+	}
+	// An arbitrary byte string matches no named key.
+	if _, ok := PTYKeyForSequence("not a key"); ok {
+		t.Error("arbitrary bytes should not reverse-map to a key")
+	}
+	if PTYKeyNames() == "" {
+		t.Error("PTYKeyNames should be non-empty")
+	}
+}
+
+// TestSetTargets_All exhaustively hits every assertion target family so a newly
+// added target that SetTargets forgets is caught.
+func TestSetTargets_All(t *testing.T) {
+	t.Parallel()
+	all := Assert{
+		ExitCode:   &ExitCode{},
+		Stdout:     &StreamAssert{},
+		Stderr:     &StreamAssert{},
+		File:       &FileAssert{},
+		Status:     intp(1),
+		Header:     &HeaderMatch{},
+		Body:       &StreamAssert{},
+		Rows:       &StreamAssert{},
+		GRPCStatus: intp(0),
+		Message:    &StreamAssert{},
+		Value:      &StreamAssert{},
+		Image:      &ImageAssert{},
+		Dir:        &DirAssert{},
+		PDF:        &PDFAssert{},
+		Mock:       &MockAssert{},
+		Screen:     &StreamAssert{},
+		Duration:   &DurationAssert{},
+		Changes:    &ChangesAssert{},
+	}
+	got := all.SetTargets()
+	if len(got) != 18 {
+		t.Errorf("SetTargets found %d families, want 18: %v", len(got), got)
+	}
+}
+
+func TestCollectServiceVars_EnvAndNoReady(t *testing.T) {
+	t.Parallel()
+	set := map[string]bool{}
+	// A service with env values but no readiness probe exercises the env loop
+	// and the nil-Ready skip.
+	CollectServiceVars(set, &Service{Command: "run", Env: map[string]string{"URL": "${svcurl}"}})
+	if !set["svcurl"] {
+		t.Errorf("service env var not collected: %v", SortedKeys(set))
+	}
+}
+
+func TestWalkJSONValueStrings_MapAnyAny(t *testing.T) {
+	t.Parallel()
+	// goccy can decode a YAML mapping into map[any]any; the walker must handle
+	// that shape as well as map[string]any.
+	in := map[any]any{"k": "${x}", 1: "${y}"}
+	out, ok := WalkJSONValueStrings(in, func(s string) string { return s + "!" }).(map[any]any)
+	if !ok {
+		t.Fatalf("result type = %T, want map[any]any", out)
+	}
+	if out["k"] != "${x}!" || out[1] != "${y}!" {
+		t.Errorf("map[any]any walk = %v", out)
+	}
+}
+
+func TestSortedKeys(t *testing.T) {
+	t.Parallel()
+	in := map[string]bool{"c": true, "a": true, "b": true}
+	got := SortedKeys(in)
+	want := []string{"a", "b", "c"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("SortedKeys = %v, want %v", got, want)
+	}
+	if got := SortedKeys(map[string]bool{}); len(got) != 0 {
+		t.Errorf("SortedKeys empty = %v, want []", got)
+	}
+	// Determinism: a second call over an equivalent map yields the same order.
+	again := SortedKeys(map[string]bool{"b": true, "a": true, "c": true})
+	sort.Strings(want)
+	if !reflect.DeepEqual(again, want) {
+		t.Errorf("SortedKeys not deterministic: %v", again)
 	}
 }


### PR DESCRIPTION
## Summary

Raises the combined unit + self-hosted E2E coverage from 86.4% to 94.1% by adding unit and bug-hunting tests across every package, and fixes six correctness defects those tests surfaced. Also drops the `main.go` coverage exclude, since the merged E2E profile already exercises the real binary end to end.

## Changes

Bug fixes (each with a regression test written first):

- `internal/assert/pdf.go`: PDF literal-string decoding now handles octal `\ddd`, `\b`, `\f`, and backslash-newline line continuations (ISO 32000), so a `pdf: {text: {...}}` assertion matches non-ASCII text written by pandoc/LaTeX/wkhtmltopdf instead of the literal escape (`caf\351` now yields the byte for `é`, not `caf351`).
- `internal/assert/screen.go`: the `screen` failure box measures line width and padding in runes, so a rendered pty/TUI screen with box-drawing or CJK characters frames with an aligned right border.
- `internal/engine/store.go`: a store step capturing a JSON `null` returns a clear error instead of storing Go's `"<nil>"` into the variable.
- `internal/engine/expand.go`: browser `cdp` upload and download actions expand `${name}` references in their file path, capture dir, and selectors, matching every other cdp action and what `CollectStepVars` already reports as used.
- `internal/docgen/describe.go` and `internal/explain/explain.go`: `atago doc` and `atago explain` render an HTTP header `matches:` regexp matcher that was previously dropped from the summaries.
- `internal/spec/walk.go`: the shared variable walk now counts `${name}` references in `fixture.from`, HTTP/gRPC header values and JSON bodies, assert matcher arguments, a service `ready` probe, and a store file-source path — every field the engine expands — so the "Variables used" summary no longer under-reports them.

Coverage and config:

- New unit and bug-hunting tests across explain, loader, assert, engine, cli, report, docgen, manifest, spec, sitegen, and the runners, covering boundary values, malformed input, and metamorphic invariants.
- `.octocov.yml`: removes the `main.go` exclude (the merged E2E profile covers it, so it reports 100%) and raises `acceptable` from 80% to 90%.

## Design Decisions

Each fix landed test-first: the regression test was written to fail against the current behavior, then the source was changed to make it pass, so every fix is pinned against re-regression.

The variable-collection fix reuses the engine's own `WalkAssertStrings` / `WalkJSONValueStrings` helpers rather than re-listing fields, keeping variable collection and runtime expansion in exact lockstep so `explain`, `doc`, and `manifest` can never disagree with what the engine actually expands.

The `.octocov.yml` exclude is safe to remove because CI runs `make coverage`, which merges unit coverage with a coverage-instrumented atago binary driven by the self-hosted E2E suites; `main.go` is exercised by that binary and reports 100% in the merged profile.

## Limitations

Coverage lands at 94.1%, short of the 95% target. The remaining uncovered statements are Linux-unreachable `runtime.GOOS == "windows"` branches, runners that need live subprocesses/servers, and canceled-context / I/O-error paths; forcing those through unit tests would trade a marginal number for flakiness, so they were left uncovered rather than tested unreliably.

A few same-class rendering gaps were found but left for a separate change because fixing them regenerates committed doc goldens: `describeFile` drops `not_contains` / `executable`, the `mock` assertion drops its header/body matchers, and suite/scenario teardown failures render in console/JSON but not junit/tap/gha. The loader also silently accepts `dir: {exists: true, recursive: true}` (recursive is a no-op there), pinned as a KNOWN GAP.