### PR TITLE
feat(run): let --filter select multiple scenarios with OR semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Every feature has a commented, runnable spec under [examples/](examples/). The e
 | [grpc](examples/grpc.atago.yaml) | unary gRPC calls via server reflection |
 | [browser](examples/browser.atago.yaml) | headless-Chrome flows and screenshots |
 
-Selection flags compose with any spec: `--filter NAME`, `--tag T`, `--skip-tag T`, `--parallel N`, `--fail-fast`, and `--rerun-failed`. While authoring, `--verbose` traces every command, capture, and assertion verdict — for passing scenarios too.
+Selection flags compose with any spec: `--filter NAME` (repeatable, and comma-separated for OR — `--filter a,b` or `--filter a --filter b` runs scenarios whose name contains `a` or `b`), `--tag T`, `--skip-tag T`, `--parallel N`, `--fail-fast`, and `--rerun-failed`. While authoring, `--verbose` traces every command, capture, and assertion verdict — for passing scenarios too.
 
 ## Use it in CI
 

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-55 suites · 217 scenarios
+55 suites · 218 scenarios
 ## Contents
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 6 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
@@ -208,8 +208,9 @@
   - [declared secrets are masked in failure output](#scenario-declared-secrets-are-masked-in-failure-output)
   - [a file assertion path may not escape the scenario workdir](#scenario-a-file-assertion-path-may-not-escape-the-scenario-workdir)
   - [a snapshot path may not escape the spec directory](#scenario-a-snapshot-path-may-not-escape-the-spec-directory)
-- [atago self-hosting / selection](#atago-self-hosting--selection) — 2 scenarios
+- [atago self-hosting / selection](#atago-self-hosting--selection) — 3 scenarios
   - [--filter runs only matching scenarios](#scenario---filter-runs-only-matching-scenarios)
+  - [--filter selects multiple scenarios with OR (comma and repeated)](#scenario---filter-selects-multiple-scenarios-with-or-comma-and-repeated)
   - [--skip-tag drops tagged scenarios](#scenario---skip-tag-drops-tagged-scenarios)
 - [atago self-hosting / background services](#atago-self-hosting--background-services) — 7 scenarios
   - [file readiness captures a dynamic value into a variable](#scenario-file-readiness-captures-a-dynamic-value-into-a-variable)
@@ -3761,6 +3762,35 @@ ${atago} run --filter keep many.atago.yaml
 #### Then
 - exit code is `0`
 - stdout contains `1 passed`
+### Scenario: --filter selects multiple scenarios with OR (comma and repeated)
+#### Given
+- Fixture file `three.atago.yaml` is created.
+#### Inputs
+_Fixture `three.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: three
+scenarios:
+  - name: alpha one
+    steps: [{run: {shell: true, command: echo a}}, {assert: {exit_code: 0}}]
+  - name: beta two
+    steps: [{run: {shell: true, command: echo b}}, {assert: {exit_code: 0}}]
+  - name: gamma three
+    steps: [{run: {shell: true, command: echo c}}, {assert: {exit_code: 0}}]
+```
+#### When
+```shell
+${atago} run --filter alpha,beta three.atago.yaml
+${atago} run --filter alpha --filter gamma three.atago.yaml
+```
+#### Then
+- after `${atago} run --filter alpha,beta three.atago.yaml`:
+  - exit code is `0`
+  - stdout contains `2 passed`
+- after `${atago} run --filter alpha --filter gamma three.atago.yaml`:
+  - exit code is `0`
+  - stdout contains `2 passed`
 ### Scenario: --skip-tag drops tagged scenarios
 #### Given
 - Fixture file `tagged.atago.yaml` is created.

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -194,6 +194,89 @@ func TestRunCmd_SelectionMatchesNothingWarns(t *testing.T) {
 	}
 }
 
+// filterSpec has three distinctly-named scenarios so --filter selection can be
+// asserted precisely (#119).
+const filterSpec = `version: "1"
+suite:
+  name: filterchk
+scenarios:
+  - name: alpha one
+    steps:
+      - run: {shell: true, command: "true"}
+      - assert: {exit_code: 0}
+  - name: beta two
+    steps:
+      - run: {shell: true, command: "true"}
+      - assert: {exit_code: 0}
+  - name: gamma three
+    steps:
+      - run: {shell: true, command: "true"}
+      - assert: {exit_code: 0}
+`
+
+// TestRunCmd_FilterMultiple proves --filter selects by name with OR semantics
+// across both a comma list and repeated flags, and that a single substring is
+// unchanged (#119). Before this, a comma list was one literal substring and
+// repeated flags silently kept only the last.
+func TestRunCmd_FilterMultiple(t *testing.T) {
+	dir := t.TempDir()
+	p := writeSpec(t, dir, "f.atago.yaml", filterSpec)
+
+	run := func(args ...string) (int, string, string) {
+		var out, errb bytes.Buffer
+		code := Main(append([]string{"run", "--report", "json"}, append(args, p)...), &out, &errb)
+		return code, out.String(), errb.String()
+	}
+	ran := func(stdout string, names ...string) {
+		t.Helper()
+		for _, n := range names {
+			if !strings.Contains(stdout, n) {
+				t.Errorf("scenario %q did not run; stdout=%s", n, stdout)
+			}
+		}
+	}
+	notRan := func(stdout string, names ...string) {
+		t.Helper()
+		for _, n := range names {
+			if strings.Contains(stdout, n) {
+				t.Errorf("scenario %q ran but should have been filtered out; stdout=%s", n, stdout)
+			}
+		}
+	}
+
+	// Comma OR: alpha,beta selects alpha one and beta two, not gamma three.
+	if code, out, errb := run("--filter", "alpha,beta"); code != ExitOK {
+		t.Fatalf("comma-OR exit = %d, want %d (stderr=%s)", code, ExitOK, errb)
+	} else {
+		ran(out, "alpha one", "beta two")
+		notRan(out, "gamma three")
+	}
+
+	// Repeatable OR: --filter alpha --filter gamma selects both (old bug silently
+	// dropped the first).
+	if code, out, errb := run("--filter", "alpha", "--filter", "gamma"); code != ExitOK {
+		t.Fatalf("repeat-OR exit = %d, want %d (stderr=%s)", code, ExitOK, errb)
+	} else {
+		ran(out, "alpha one", "gamma three")
+		notRan(out, "beta two")
+	}
+
+	// Single substring is unchanged.
+	if code, out, errb := run("--filter", "alpha"); code != ExitOK {
+		t.Fatalf("single exit = %d, want %d (stderr=%s)", code, ExitOK, errb)
+	} else {
+		ran(out, "alpha one")
+		notRan(out, "beta two", "gamma three")
+	}
+
+	// No match still warns and exits 0.
+	if code, _, errb := run("--filter", "zzz,qqq"); code != ExitOK {
+		t.Fatalf("no-match exit = %d, want %d (stderr=%s)", code, ExitOK, errb)
+	} else if !strings.Contains(errb, "no scenarios matched") {
+		t.Errorf("no-match stderr = %q, want a no-match warning", errb)
+	}
+}
+
 func TestRunCmd_Failing(t *testing.T) {
 	dir := t.TempDir()
 	p := writeSpec(t, dir, "fail.atago.yaml", failingSpec)

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -30,7 +30,8 @@ func runCmd(args []string, stdout, stderr io.Writer) int {
 	ci := fs.Bool("ci", false, "CI-safe defaults: deterministic, no color (sets NO_COLOR), secret masking")
 	parallel := fs.Int("parallel", runtime.NumCPU(), "number of scenarios to run concurrently; scenarios are isolated, each in its own temp dir")
 	failFast := fs.Bool("fail-fast", false, "stop scheduling new scenarios after the first failure")
-	filter := fs.String("filter", "", "run only scenarios whose name contains this substring")
+	var filter csvFlag
+	fs.Var(&filter, "filter", "run only scenarios whose name contains any of these comma-separated substrings (repeatable; OR semantics like --tag)")
 	tag := fs.String("tag", "", "run only scenarios with any of these comma-separated tags")
 	skipTag := fs.String("skip-tag", "", "skip scenarios with any of these comma-separated tags")
 	artifactsDir := fs.String("artifacts-dir", "", "write deterministic failure artifacts (actual/expected payloads) under DIR for review tooling")
@@ -91,7 +92,7 @@ func runCmd(args []string, stdout, stderr io.Writer) int {
 	eng.FailFast = *failFast
 	eng.Repeat = *repeat
 	eng.RetryFailed = *retryFailed
-	eng.FilterName = *filter
+	eng.FilterNames = filter
 	eng.Tags = splitCSV(*tag)
 	eng.SkipTags = splitCSV(*skipTag)
 	if strings.TrimSpace(*artifactsDir) != "" {
@@ -210,15 +211,15 @@ func runCmd(args []string, stdout, stderr io.Writer) int {
 	// A selection that matches nothing still exits 0 (nothing ran, nothing
 	// failed), but stay loud about it: a typo'd --filter/--tag in CI would
 	// otherwise greenlight silently.
-	if *filter != "" || *tag != "" || *skipTag != "" {
+	if len(filter) > 0 || *tag != "" || *skipTag != "" {
 		total := 0
 		for _, r := range results {
 			total += len(r.Scenarios)
 		}
 		if total == 0 && ctx.Err() == nil {
 			var sel []string
-			if *filter != "" {
-				sel = append(sel, fmt.Sprintf("--filter %q", *filter))
+			if len(filter) > 0 {
+				sel = append(sel, fmt.Sprintf("--filter %q", strings.Join(filter, ",")))
 			}
 			if *tag != "" {
 				sel = append(sel, fmt.Sprintf("--tag %q", *tag))
@@ -363,6 +364,20 @@ func walkSpecDir(dir string, add func(string)) error {
 
 func isSpecFile(p string) bool {
 	return strings.HasSuffix(p, ".atago.yaml") || strings.HasSuffix(p, ".atago.yml")
+}
+
+// csvFlag is a repeatable flag whose every occurrence is split on commas and
+// accumulated, giving OR semantics across both forms: `--filter a,b` and
+// `--filter a --filter b` both select names containing "a" or "b". This fixes
+// the old single-string --filter, which treated a comma list as one literal
+// substring and silently kept only the last of repeated flags (#119).
+type csvFlag []string
+
+func (c *csvFlag) String() string { return strings.Join(*c, ",") }
+
+func (c *csvFlag) Set(v string) error {
+	*c = append(*c, splitCSV(v)...)
+	return nil
 }
 
 // splitCSV splits a comma-separated flag value into trimmed, non-empty tokens.

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -65,13 +65,14 @@ type Engine struct {
 	// worker pool). When nil, only this suite's own Parallel workers bound it.
 	Sem chan struct{}
 
-	// FilterName, Tags, and SkipTags select which scenarios run.
-	// FilterName is a substring match on the scenario name; Tags keeps only
-	// scenarios carrying at least one listed tag; SkipTags drops scenarios
-	// carrying any listed tag. Unselected scenarios are excluded entirely.
-	FilterName string
-	Tags       []string
-	SkipTags   []string
+	// FilterNames, Tags, and SkipTags select which scenarios run.
+	// FilterNames keeps a scenario whose name contains ANY listed substring
+	// (OR semantics, mirroring Tags); Tags keeps only scenarios carrying at
+	// least one listed tag; SkipTags drops scenarios carrying any listed tag.
+	// Unselected scenarios are excluded entirely.
+	FilterNames []string
+	Tags        []string
+	SkipTags    []string
 
 	// Select, when non-nil, restricts execution to the exact scenario identities
 	// it contains, keyed by ScenarioID(specPath, scenarioName). It composes with
@@ -293,7 +294,7 @@ func (e *Engine) selectScenarios(s *spec.Spec, specPath string) []int {
 }
 
 func (e *Engine) matches(sc *spec.Scenario, specPath string) bool {
-	if e.FilterName != "" && !strings.Contains(sc.Name, e.FilterName) {
+	if len(e.FilterNames) > 0 && !nameMatchesAny(sc.Name, e.FilterNames) {
 		return false
 	}
 	if len(e.Tags) > 0 && !hasAnyTag(sc, e.Tags) {
@@ -313,6 +314,17 @@ func (e *Engine) matches(sc *spec.Scenario, specPath string) bool {
 // by the --rerun-failed state file and Engine.Select (#64).
 func ScenarioID(specPath, scenarioName string) string {
 	return specPath + "\x00" + scenarioName
+}
+
+// nameMatchesAny reports whether name contains any of the substrings (OR),
+// giving --filter the same multi-value semantics as --tag.
+func nameMatchesAny(name string, subs []string) bool {
+	for _, sub := range subs {
+		if strings.Contains(name, sub) {
+			return true
+		}
+	}
+	return false
 }
 
 func hasAnyTag(sc *spec.Scenario, tags []string) bool {

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -644,7 +644,8 @@ scenarios:
 		configure         func(*Engine)
 		wantScenarioNames []string
 	}{
-		{"filter substring", func(e *Engine) { e.FilterName = "bet" }, []string{"beta"}},
+		{"filter substring", func(e *Engine) { e.FilterNames = []string{"bet"} }, []string{"beta"}},
+		{"filter OR selects multiple", func(e *Engine) { e.FilterNames = []string{"alph", "gam"} }, []string{"alpha", "gamma"}},
 		{"tag include", func(e *Engine) { e.Tags = []string{"fast"} }, []string{"alpha", "gamma"}},
 		{"skip tag", func(e *Engine) { e.SkipTags = []string{"slow"} }, []string{"alpha", "gamma"}},
 		{"no selection runs all", func(e *Engine) {}, []string{"alpha", "beta", "gamma"}},
@@ -715,7 +716,7 @@ scenarios:
 			[]string{"login", "logout", "signup", "search", "billing"}},
 		{"skip-tag wins over an included tag", func(e *Engine) { e.Tags = []string{"fast"}; e.SkipTags = []string{"slow"} },
 			[]string{"login", "logout", "search"}},
-		{"filter intersects tag", func(e *Engine) { e.FilterName = "log"; e.Tags = []string{"fast"} },
+		{"filter intersects tag", func(e *Engine) { e.FilterNames = []string{"log"}; e.Tags = []string{"fast"} },
 			[]string{"login", "logout"}},
 		{"skip-tag alone", func(e *Engine) { e.SkipTags = []string{"core"} },
 			[]string{"login", "logout", "signup"}},
@@ -1213,13 +1214,17 @@ func TestEngineMatches(t *testing.T) {
 	}
 
 	byName := New()
-	byName.FilterName = "login"
+	byName.FilterNames = []string{"login"}
 	if !byName.matches(sc, "s.yaml") {
 		t.Error("name substring should match")
 	}
-	byName.FilterName = "logout"
+	byName.FilterNames = []string{"logout"}
 	if byName.matches(sc, "s.yaml") {
 		t.Error("non-matching name substring should reject")
+	}
+	byName.FilterNames = []string{"logout", "login"}
+	if !byName.matches(sc, "s.yaml") {
+		t.Error("OR of substrings should match when any matches")
 	}
 
 	byTag := New()

--- a/test/e2e/atago/select.atago.yaml
+++ b/test/e2e/atago/select.atago.yaml
@@ -24,6 +24,36 @@ scenarios:
           stdout:
             contains: "1 passed"
 
+  - name: --filter selects multiple scenarios with OR (comma and repeated)
+    steps:
+      - fixture:
+          file: three.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: three
+            scenarios:
+              - name: alpha one
+                steps: [{run: {shell: true, command: echo a}}, {assert: {exit_code: 0}}]
+              - name: beta two
+                steps: [{run: {shell: true, command: echo b}}, {assert: {exit_code: 0}}]
+              - name: gamma three
+                steps: [{run: {shell: true, command: echo c}}, {assert: {exit_code: 0}}]
+      # Comma list ORs the substrings: alpha + beta run, gamma does not.
+      - run:
+          command: ${atago} run --filter alpha,beta three.atago.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "2 passed"
+      # Repeating the flag ORs too (the old behavior silently kept only the last).
+      - run:
+          command: ${atago} run --filter alpha --filter gamma three.atago.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "2 passed"
+
   - name: --skip-tag drops tagged scenarios
     steps:
       - fixture:


### PR DESCRIPTION
## Summary

Closes #119.

`atago run --filter S` previously matched a single substring, treated a comma list as one literal substring, and **silently kept only the last** of repeated `--filter` flags. That last behavior is the sharpest edge: a green run could hide that half your selection never executed.

`--filter` now has the same OR semantics as `--tag`, via both forms:

- **Comma-separated**: `--filter alpha,beta` runs every scenario whose name contains `alpha` OR `beta`.
- **Repeatable**: `--filter alpha --filter beta` ORs across occurrences instead of dropping all but the last.

A single substring keeps working unchanged, and the existing "no scenarios matched" warning still fires when none of the OR terms match.

## Changes

- `engine`: `FilterName string` → `FilterNames []string`; a scenario is kept if its name contains any listed substring (`nameMatchesAny`), mirroring `hasAnyTag`.
- `cli/run`: `--filter` is now a repeatable `csvFlag` that splits each occurrence on commas and accumulates.
- README: document the OR/repeatable behavior.

## Tests

- Unit (`engine`): OR selects multiple; single substring unchanged; OR in `matches`.
- CLI (`cli`): comma-OR, repeatable-OR, single-unchanged, and no-match-warns via the JSON report.
- E2E (`test/e2e/atago/select.atago.yaml`): comma and repeated `--filter` each select 2 of 3 scenarios (self-hosted, doc regenerated).