### PR TITLE
fix(run): report spec-load failures in the summary and read FAILED not PASSED

### DIFF
--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-55 suites · 218 scenarios
+55 suites · 219 scenarios
 ## Contents
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 6 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
@@ -61,9 +61,10 @@
   - [an impossible bound fails and shows the measured duration](#scenario-an-impossible-bound-fails-and-shows-the-measured-duration)
   - [a deliberate wait satisfies a lower bound](#scenario-a-deliberate-wait-satisfies-a-lower-bound)
   - [a duration assert with no preceding step is a load-time error](#scenario-a-duration-assert-with-no-preceding-step-is-a-load-time-error)
-- [atago self-hosting / edge cases](#atago-self-hosting--edge-cases) — 2 scenarios
+- [atago self-hosting / edge cases](#atago-self-hosting--edge-cases) — 3 scenarios
   - [JSON assertion on empty stdout reports an empty stream](#scenario-json-assertion-on-empty-stdout-reports-an-empty-stream)
   - [an unsupported matcher is a parse error](#scenario-an-unsupported-matcher-is-a-parse-error)
+  - [a mixed valid+invalid run reads FAILED and counts the dropped spec](#scenario-a-mixed-validinvalid-run-reads-failed-and-counts-the-dropped-spec)
 - [atago self-hosting / workdir + scenario env + not_contains](#atago-self-hosting--workdir--scenario-env--not_contains) — 6 scenarios
   - [run.stdout_to redirects stdout to a workdir file without a shell](#scenario-runstdout_to-redirects-stdout-to-a-workdir-file-without-a-shell)
   - [scenario env is shared by every run step and overridable per step](#scenario-scenario-env-is-shared-by-every-run-step-and-overridable-per-step)
@@ -1347,6 +1348,40 @@ ${atago} run bad.atago.yaml
 ```
 #### Then
 - exit code is `2`
+### Scenario: a mixed valid+invalid run reads FAILED and counts the dropped spec
+#### Given
+- Fixture file `good.atago.yaml` is created.
+- Fixture file `broken.atago.yaml` is created.
+#### Inputs
+_Fixture `good.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: good
+scenarios:
+  - name: echo works
+    steps:
+      - run: {shell: true, command: echo hi}
+      - assert: {exit_code: 0}
+```
+_Fixture `broken.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: broken
+scenarios:
+  - name: uses an unknown field
+    steps:
+      - nonsense_field: {command: echo nope}
+```
+#### When
+```shell
+${atago} run good.atago.yaml broken.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stdout contains `1 spec failed to load`
+- stdout does not contain `PASSED`
 ## atago self-hosting / workdir + scenario env + not_contains
 Source: `test/e2e/atago/env_workdir.atago.yaml`
 ### Scenario: run.stdout_to redirects stdout to a workdir file without a shell

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -353,6 +353,32 @@ func TestRunCmd_ValidationErrorExit2(t *testing.T) {
 	}
 }
 
+// TestRunCmd_MixedLoadFailureSummary proves that when a directory mixes a
+// loadable spec with one that fails schema validation, the console summary
+// reads FAILED (not a misleading PASSED), surfaces the dropped file with a
+// "spec failed to load" count, and exits 2 (#120). Before the fix the headline
+// read "PASSED ... 0 errored" while the process exited 2.
+func TestRunCmd_MixedLoadFailureSummary(t *testing.T) {
+	dir := t.TempDir()
+	writeSpec(t, dir, "good.atago.yaml", passingSpec)
+	writeSpec(t, dir, "bad.atago.yaml",
+		"version: \"1\"\nsuite:\n  name: bad\nscenarios:\n  - name: uses an unknown field\n    steps:\n      - nonsense_field: {command: echo nope}")
+	var out, errb bytes.Buffer
+	if got := Main([]string{"run", dir}, &out, &errb); got != ExitParse {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitParse, errb.String())
+	}
+	summary := out.String()
+	if strings.Contains(summary, "PASSED") {
+		t.Errorf("summary must not read PASSED when a spec failed to load:\n%s", summary)
+	}
+	if !strings.Contains(summary, "FAILED") {
+		t.Errorf("summary should read FAILED to match the exit code:\n%s", summary)
+	}
+	if !strings.Contains(summary, "1 spec failed to load") {
+		t.Errorf("summary should report the dropped spec:\n%s", summary)
+	}
+}
+
 // Issue #21: exit 3 (ExitConfig) is returned for CLI-invocation problems, e.g. a
 // target that matches no spec files.
 func TestRunCmd_NoFilesExit3(t *testing.T) {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -156,10 +156,12 @@ func runCmd(args []string, stdout, stderr io.Writer) int {
 
 	results := make([]*engine.SuiteResult, 0, len(paths))
 	exit := ExitOK
+	loadFailures := 0
 	for i := range paths {
 		if loadErrs[i] != nil {
 			fmt.Fprintf(stderr, "%v\n", loadErrs[i])
 			exit = worseExit(exit, exitForLoadError(loadErrs[i]))
+			loadFailures++
 			continue
 		}
 		results = append(results, suiteResults[i])
@@ -231,7 +233,7 @@ func runCmd(args []string, stdout, stderr io.Writer) int {
 		}
 	}
 
-	if err := report.Render(stdout, format, results); err != nil {
+	if err := report.Render(stdout, format, results, report.WithLoadFailures(loadFailures)); err != nil {
 		fmt.Fprintf(stderr, "atago run: failed to write report: %v\n", err)
 		return worseExit(exit, ExitInternal)
 	}

--- a/internal/report/console.go
+++ b/internal/report/console.go
@@ -10,12 +10,15 @@ import (
 
 // writeSummary prints the final tally line. The uppercase status word
 // (PASSED/FAILED) anchors the line and is part of the stable output contract.
-func writeSummary(b *strings.Builder, color bool, c engine.Counts, total int, d time.Duration, hardFail bool) {
+func writeSummary(b *strings.Builder, color bool, c engine.Counts, total int, d time.Duration, hardFail bool, loadFailures int) {
 	status, code := "PASSED", cGreen
 	// hardFail covers a suite that errored before producing any scenario row (#7):
 	// the counts are all zero, but the verdict must still read FAILED to match the
 	// non-zero exit code and the SUITE SETUP FAILED block printed above.
-	if c.Failed > 0 || c.Errored > 0 || hardFail {
+	// loadFailures covers spec files that could not be parsed/validated (#120):
+	// they run no scenario, so without this the headline would read PASSED while
+	// the process exits non-zero and the dropped file is silently uncounted.
+	if c.Failed > 0 || c.Errored > 0 || hardFail || loadFailures > 0 {
 		status, code = "FAILED", cRed
 	}
 	plural := "scenarios"
@@ -28,9 +31,19 @@ func writeSummary(b *strings.Builder, color bool, c engine.Counts, total int, d 
 	if c.Flaky > 0 {
 		flaky = fmt.Sprintf(", %d flaky", c.Flaky)
 	}
-	fmt.Fprintf(b, "\n%s  %d %s: %d passed, %d failed, %d errored, %d skipped%s (%s)\n",
+	// Spec-load failures are not scenarios, so they get their own count in the
+	// tally line — otherwise the totals silently omit the dropped files (#120).
+	loadFail := ""
+	if loadFailures > 0 {
+		specPlural := "specs"
+		if loadFailures == 1 {
+			specPlural = "spec"
+		}
+		loadFail = fmt.Sprintf(", %d %s failed to load", loadFailures, specPlural)
+	}
+	fmt.Fprintf(b, "\n%s  %d %s: %d passed, %d failed, %d errored, %d skipped%s%s (%s)\n",
 		colorize(color, code+cBold, status), total, plural,
-		c.Passed, c.Failed, c.Errored, c.Skipped, flaky, d.Round(time.Millisecond))
+		c.Passed, c.Failed, c.Errored, c.Skipped, flaky, loadFail, d.Round(time.Millisecond))
 }
 
 // writeDetail prints the failure/error block for a scenario, or nothing if it

--- a/internal/report/render.go
+++ b/internal/report/render.go
@@ -10,10 +10,33 @@ import (
 	"github.com/nao1215/atago/internal/engine"
 )
 
+// Option configures an optional aspect of a Render call. It keeps the common
+// three-argument form unchanged while letting callers pass extra run-level
+// context (e.g. spec-load failures) without a signature churn.
+type Option func(*renderOptions)
+
+type renderOptions struct {
+	// loadFailures is the number of spec files that failed to load (parse/schema
+	// errors) before any scenario could run. Such files contribute to no suite in
+	// results, so the console summary reports them separately and reads FAILED
+	// rather than a misleading PASSED that contradicts the non-zero exit code (#120).
+	loadFailures int
+}
+
+// WithLoadFailures records how many spec files failed to load for this run, so
+// the summary can reflect them instead of silently omitting them (#120).
+func WithLoadFailures(n int) Option {
+	return func(o *renderOptions) { o.loadFailures = n }
+}
+
 // Render writes one or more suite results in the requested format. Console
 // renders each suite in turn; JSON emits one stable top-level document
 // ({"schema_version","suites":[...]}) regardless of suite count (#43).
-func Render(w io.Writer, f Format, results []*engine.SuiteResult) error {
+func Render(w io.Writer, f Format, results []*engine.SuiteResult, opts ...Option) error {
+	var o renderOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
 	switch f {
 	case FormatConsole:
 		var b strings.Builder
@@ -43,7 +66,7 @@ func Render(w io.Writer, f Format, results []*engine.SuiteResult) error {
 				hardFail = true
 			}
 		}
-		writeSummary(&b, color, agg, total, dur, hardFail)
+		writeSummary(&b, color, agg, total, dur, hardFail, o.loadFailures)
 		_, err := io.WriteString(w, b.String())
 		return err
 	case FormatJSON:

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -47,6 +47,73 @@ func TestRender_Console(t *testing.T) {
 	}
 }
 
+// allPassingResults is a single all-green suite, used to prove the load-failure
+// path (#120) flips an otherwise-PASSED summary to FAILED.
+func allPassingResults() []*engine.SuiteResult {
+	return []*engine.SuiteResult{{
+		Suite:    "good",
+		Status:   engine.StatusPassed,
+		Duration: time.Millisecond,
+		Scenarios: []engine.ScenarioResult{
+			{Name: "ok", Status: engine.StatusPassed, Duration: time.Millisecond,
+				Steps: []engine.StepResult{{Kind: "assert", Checks: []*assert.CheckResult{{OK: true}}}}},
+		},
+	}}
+}
+
+// TestRender_Console_LoadFailures proves that when spec files failed to load
+// (#120) the console summary reads FAILED — not a misleading PASSED that
+// contradicts the non-zero exit code — and surfaces the dropped-file count so
+// the totals are not silently short. With zero load failures a green run is
+// unchanged.
+func TestRender_Console_LoadFailures(t *testing.T) {
+	t.Parallel()
+
+	t.Run("mixed valid+invalid reads FAILED and counts the drop", func(t *testing.T) {
+		t.Parallel()
+		var b bytes.Buffer
+		if err := Render(&b, FormatConsole, allPassingResults(), WithLoadFailures(1)); err != nil {
+			t.Fatal(err)
+		}
+		out := b.String()
+		if !strings.Contains(out, "FAILED") {
+			t.Errorf("summary should read FAILED when a spec failed to load:\n%s", out)
+		}
+		if strings.Contains(out, "PASSED") {
+			t.Errorf("summary must not read PASSED when a spec failed to load:\n%s", out)
+		}
+		if !strings.Contains(out, "1 spec failed to load") {
+			t.Errorf("summary should report the load failure count:\n%s", out)
+		}
+	})
+
+	t.Run("plural spec count", func(t *testing.T) {
+		t.Parallel()
+		var b bytes.Buffer
+		if err := Render(&b, FormatConsole, allPassingResults(), WithLoadFailures(3)); err != nil {
+			t.Fatal(err)
+		}
+		if out := b.String(); !strings.Contains(out, "3 specs failed to load") {
+			t.Errorf("summary should pluralize the load failure count:\n%s", out)
+		}
+	})
+
+	t.Run("no load failures is unchanged (green stays PASSED)", func(t *testing.T) {
+		t.Parallel()
+		var b bytes.Buffer
+		if err := Render(&b, FormatConsole, allPassingResults()); err != nil {
+			t.Fatal(err)
+		}
+		out := b.String()
+		if !strings.Contains(out, "PASSED") {
+			t.Errorf("all-green run should read PASSED:\n%s", out)
+		}
+		if strings.Contains(out, "failed to load") {
+			t.Errorf("clean run must not mention load failures:\n%s", out)
+		}
+	})
+}
+
 // Regression for issue #19: a service/setup-phase error (StepResult with an
 // empty Kind) must render as "service setup", not the misleading "step 0 ()".
 func TestRender_Console_ServiceSetupError(t *testing.T) {

--- a/test/e2e/atago/edge.atago.yaml
+++ b/test/e2e/atago/edge.atago.yaml
@@ -56,3 +56,38 @@ scenarios:
           command: ${atago} run bad.atago.yaml
       - assert:
           exit_code: 2
+
+  - name: a mixed valid+invalid run reads FAILED and counts the dropped spec
+    steps:
+      - fixture:
+          file: good.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: good
+            scenarios:
+              - name: echo works
+                steps:
+                  - run: {shell: true, command: echo hi}
+                  - assert: {exit_code: 0}
+      - fixture:
+          file: broken.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: broken
+            scenarios:
+              - name: uses an unknown field
+                steps:
+                  - nonsense_field: {command: echo nope}
+      # The valid spec runs, the invalid one is dropped: the headline must read
+      # FAILED (not a misleading PASSED), surface the dropped spec, and exit 2.
+      - run:
+          command: ${atago} run good.atago.yaml broken.atago.yaml
+      - assert:
+          exit_code: 2
+          stdout:
+            contains: "1 spec failed to load"
+      - assert:
+          stdout:
+            not_contains: "PASSED"


### PR DESCRIPTION
## Summary

Closes #120.

When `atago run <dir>` mixes loadable specs with one that fails schema/YAML validation, atago printed the parse error, ran the valid specs, and then printed a summary that began with `PASSED` and reported `0 errored` — while the process exited `2`. The dropped file appeared in no bucket, so the headline and counts silently contradicted the failing exit code. In CI logs that reads as success.

Now, when one or more spec files failed to load:

- The summary headline reads **FAILED** (matching the non-zero exit code) instead of `PASSED`.
- The tally line surfaces the drop: `... 0 skipped, 1 spec failed to load (1ms)` (pluralized).

The exit code (`2`) is unchanged and already documented; only the summary wording/counts now agree with it. A fully-valid run is unchanged (`PASSED`, no load-failure line). An all-invalid run is unchanged (parse error, exit 2, no summary). A mix where a valid spec also has a failing scenario still exits 2 (parse error outranks scenario failure) and the summary shows both `1 failed` and the load-failure count.

## Changes

- `report`: `Render` gains a variadic `Option` (`WithLoadFailures(n)`) so existing 3-arg callers are unchanged; the console summary flips to FAILED and prints the load-failure count when `n > 0`.
- `cli/run`: count spec-load failures and pass them to `Render`.

## Tests

- Unit (`report`): FAILED verdict + count on load failure, plural form, and unchanged green output with zero failures.
- CLI (`cli`): mixed valid+invalid directory exits 2, summary is not PASSED, and reports `1 spec failed to load`.
- E2E (`test/e2e/atago/edge.atago.yaml`): self-hosted mixed run asserts exit 2, `1 spec failed to load`, and no `PASSED` (doc regenerated).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved run summaries to accurately reflect spec files that fail to load.
  * Mixed valid/invalid runs now show a failed status and include the number of specs that could not be loaded.
  * Updated end-to-end coverage for mixed-load scenarios, including the expected exit code and summary output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->