### PR TITLE
feat(init,record): emit a resolvable schema header for editor completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,10 +298,10 @@ atago snapshot update spec.atago.yaml
 
 ## Editor support (JSON Schema)
 
-A JSON Schema lives at [schema/atago.schema.json](schema/atago.schema.json). With the YAML language server you get completion and validation as you type:
+A JSON Schema lives at [schema/atago.schema.json](schema/atago.schema.json). With the YAML language server you get completion and validation as you type — step types, every matcher, and the `${workdir}` / `${env:NAME}` / `${name}` / `$${...}` expansion rules. `atago init` and `atago record` already emit this header as the first line of every generated spec, so scaffolded specs get completion out of the box. To add it to an existing spec, use the absolute URL (it resolves in any project, unlike a repo-relative path):
 
 ```yaml
-# yaml-language-server: $schema=./schema/atago.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nao1215/atago/main/schema/atago.schema.json
 version: "1"
 ```
 

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-55 suites · 219 scenarios
+55 suites · 220 scenarios
 ## Contents
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 6 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
@@ -109,8 +109,9 @@
   - [a pixel comparison against an identical baseline passes](#scenario-a-pixel-comparison-against-an-identical-baseline-passes)
   - [a wrong dimension assertion fails with a clear diff](#scenario-a-wrong-dimension-assertion-fails-with-a-clear-diff)
   - [a failing similar_to writes visual diff artifacts](#scenario-a-failing-similar_to-writes-visual-diff-artifacts)
-- [atago self-hosting / init](#atago-self-hosting--init) — 2 scenarios
+- [atago self-hosting / init](#atago-self-hosting--init) — 3 scenarios
   - [init scaffolds a runnable spec](#scenario-init-scaffolds-a-runnable-spec)
+  - [init emits a resolvable schema header for editor completion](#scenario-init-emits-a-resolvable-schema-header-for-editor-completion)
   - [init refuses to overwrite without --force](#scenario-init-refuses-to-overwrite-without---force)
 - [atago self-hosting / init templates](#atago-self-hosting--init-templates) — 12 scenarios
   - [every template scaffolds a schema-valid spec \[template=cli\]](#scenario-every-template-scaffolds-a-schema-valid-spec-templatecli)
@@ -2124,6 +2125,19 @@ ${atago} run starter.atago.yaml
   - stdout contains `PASSED`
 #### Generated artifacts
 - `starter.atago.yaml`
+### Scenario: init emits a resolvable schema header for editor completion
+#### When
+```shell
+${atago} init headed.atago.yaml
+head -1 headed.atago.yaml
+```
+#### Then
+- after `${atago} init headed.atago.yaml`:
+  - exit code is `0`
+- after `head -1 headed.atago.yaml`:
+  - exit code is `0`
+  - stdout contains `# yaml-language-server: $schema=https://`
+  - stdout does not contain `./schema/`
 ### Scenario: init refuses to overwrite without --force
 #### Given
 - Fixture file `taken.atago.yaml` is created.

--- a/internal/buildinfo/schema.go
+++ b/internal/buildinfo/schema.go
@@ -1,0 +1,34 @@
+package buildinfo
+
+import "regexp"
+
+// releaseTag matches a clean release tag (v1.2.3). A pseudo-version
+// (v0.3.5-0.2026...-abcdef) or "dev" deliberately does not match: those refer to
+// commits GitHub raw cannot resolve by name, so they fall back to "main".
+var releaseTag = regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
+
+// SchemaRef is the git ref the emitted schema URL pins to: this build's release
+// tag when it is one, otherwise "main". Pinning a released binary to its own tag
+// keeps a generated spec's completion matched to the atago that scaffolded it,
+// while dev builds still resolve against the latest schema on main (#121).
+func SchemaRef() string {
+	if v := Get(); releaseTag.MatchString(v) {
+		return v
+	}
+	return "main"
+}
+
+// SchemaURL is the absolute, resolvable URL of the spec-file JSON schema for
+// this build.
+func SchemaURL() string {
+	return "https://raw.githubusercontent.com/nao1215/atago/" + SchemaRef() + "/schema/atago.schema.json"
+}
+
+// SchemaHeader is the `# yaml-language-server: $schema=<url>` comment line that
+// steers editor completion to the spec DSL, terminated with a newline. Emitted
+// as the first line of every scaffolded/recorded spec so completion — the only
+// delivery path for the DSL reference — is the default, not a thing users must
+// discover and wire up by hand (#121).
+func SchemaHeader() string {
+	return "# yaml-language-server: $schema=" + SchemaURL() + "\n"
+}

--- a/internal/buildinfo/schema_test.go
+++ b/internal/buildinfo/schema_test.go
@@ -1,0 +1,54 @@
+package buildinfo
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSchemaRef proves the emitted schema URL pins to a clean release tag when
+// this build is one, and otherwise falls back to "main" — a ref GitHub raw can
+// always resolve — for "dev" and pseudo-version builds (#121).
+func TestSchemaRef(t *testing.T) {
+	orig := Version
+	t.Cleanup(func() { Version = orig })
+
+	tests := []struct {
+		version string
+		want    string
+	}{
+		{"v0.4.0", "v0.4.0"},
+		{"v1.2.3", "v1.2.3"},
+		{"dev", "main"}, // source checkout
+		{"v0.3.5-0.20260101120000-abcdef123456", "main"}, // pseudo-version
+		{"v0.4.0-rc1", "main"},                           // pre-release tag
+		{"garbage", "main"},
+	}
+	for _, tt := range tests {
+		Version = tt.version
+		if got := SchemaRef(); got != tt.want {
+			t.Errorf("SchemaRef() with Version=%q = %q, want %q", tt.version, got, tt.want)
+		}
+	}
+}
+
+// TestSchemaHeader proves the header is a single yaml-language-server comment
+// line carrying an absolute schema URL, terminated with a newline.
+func TestSchemaHeader(t *testing.T) {
+	orig := Version
+	t.Cleanup(func() { Version = orig })
+	Version = "v0.4.0"
+
+	h := SchemaHeader()
+	if !strings.HasPrefix(h, "# yaml-language-server: $schema=https://") {
+		t.Errorf("header %q must start with an absolute yaml-language-server schema comment", h)
+	}
+	if !strings.HasSuffix(h, "/schema/atago.schema.json\n") {
+		t.Errorf("header %q must point at the schema file and end with a newline", h)
+	}
+	if !strings.Contains(h, "/v0.4.0/") {
+		t.Errorf("header %q must pin to the release tag", h)
+	}
+	if strings.Count(h, "\n") != 1 {
+		t.Errorf("header must be exactly one line, got %q", h)
+	}
+}

--- a/internal/cli/features_test.go
+++ b/internal/cli/features_test.go
@@ -230,6 +230,38 @@ func TestInit_EveryTemplateIsSchemaValid(t *testing.T) {
 	}
 }
 
+// TestInit_EmitsResolvableSchemaHeader proves that init writes a resolvable
+// `# yaml-language-server: $schema=<url>` header as the first line of the
+// generated spec, so a scaffolded spec gets editor completion for the DSL out
+// of the box, and that the URL is absolute (not the old repo-relative
+// `./schema/...` path that only resolves inside the atago repo) (#121).
+func TestInit_EmitsResolvableSchemaHeader(t *testing.T) {
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "out.atago.yaml")
+	var out, errb bytes.Buffer
+	if got := Main([]string{"init", "--template", "cli", outPath}, &out, &errb); got != ExitOK {
+		t.Fatalf("init exit = %d (stderr=%s)", got, errb.String())
+	}
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstLine, _, _ := strings.Cut(string(data), "\n")
+	if !strings.HasPrefix(firstLine, "# yaml-language-server: $schema=") {
+		t.Errorf("first line = %q, want a yaml-language-server schema header", firstLine)
+	}
+	if !strings.Contains(firstLine, "https://") {
+		t.Errorf("schema URL must be absolute, got %q", firstLine)
+	}
+	if strings.Contains(firstLine, "./schema/") {
+		t.Errorf("schema URL must not be the repo-relative ./schema path: %q", firstLine)
+	}
+	// The header is an ignored YAML comment, so the spec still loads and runs.
+	if _, err := loader.Load(outPath); err != nil {
+		t.Fatalf("header-carrying spec does not load: %v", err)
+	}
+}
+
 func TestInit_UnknownTemplate(t *testing.T) {
 	dir := t.TempDir()
 	var out, errb bytes.Buffer

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"sort"
 	"strings"
+
+	"github.com/nao1215/atago/internal/buildinfo"
 )
 
 // starterSpec is the default scaffold written by `atago init` (the `cli`
@@ -423,7 +425,11 @@ func initCmd(args []string, stdout, stderr io.Writer) int {
 		return ExitConfig
 	}
 
-	if err := os.WriteFile(path, []byte(tmpl.body), 0o600); err != nil {
+	// Prepend a resolvable schema header so a freshly scaffolded spec gets
+	// editor completion for step types, matchers, and ${...} forms out of the
+	// box — the only delivery path for the DSL reference (#121).
+	body := buildinfo.SchemaHeader() + tmpl.body
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
 		fmt.Fprintf(stderr, "atago init: %v\n", err)
 		return ExitConfig
 	}

--- a/internal/record/pty.go
+++ b/internal/record/pty.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/nao1215/atago/internal/buildinfo"
 	"github.com/nao1215/atago/internal/loader"
 	"github.com/nao1215/atago/internal/spec"
 )
@@ -61,6 +62,7 @@ var ansiPattern = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b\][^\x07\x1b
 // returning it (the same round-trip guarantee plain record gives) (#69).
 func GeneratePTY(rec PTYRecording, opts Options) ([]byte, error) {
 	var b strings.Builder
+	b.WriteString(buildinfo.SchemaHeader())
 	b.WriteString("version: \"1\"\n\n")
 	b.WriteString("# Recorded by `atago record --pty` — a starting point, not a verdict:\n")
 	b.WriteString("# each send replays a burst you typed, and each expect anchors on the\n")

--- a/internal/record/record.go
+++ b/internal/record/record.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/goccy/go-yaml"
+	"github.com/nao1215/atago/internal/buildinfo"
 	"github.com/nao1215/atago/internal/loader"
 	"github.com/nao1215/atago/internal/store"
 )
@@ -49,6 +50,7 @@ type Options struct {
 // problem.
 func Generate(obs Observation, opts Options) ([]byte, error) {
 	var b strings.Builder
+	b.WriteString(buildinfo.SchemaHeader())
 	b.WriteString("version: \"1\"\n\n")
 	b.WriteString("# Recorded by `atago record` — a starting point, not a verdict:\n")
 	b.WriteString("# tighten the matchers to pin the behavior you actually care about.\n")

--- a/internal/record/record_test.go
+++ b/internal/record/record_test.go
@@ -44,6 +44,29 @@ func TestGenerate_Skeleton(t *testing.T) {
 	}
 }
 
+// TestGenerate_EmitsSchemaHeader proves a recorded spec starts with the
+// resolvable yaml-language-server schema header, so `atago record` output gets
+// editor completion for the DSL out of the box, and the spec still loads with
+// the header present (it is an ignored YAML comment) (#121).
+func TestGenerate_EmitsSchemaHeader(t *testing.T) {
+	t.Parallel()
+	out, err := Generate(Observation{
+		Command:  "echo hi",
+		ExitCode: 0,
+		Stdout:   []byte("hi\n"),
+	}, Options{SuiteName: "echo"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	first, _, _ := strings.Cut(string(out), "\n")
+	if !strings.HasPrefix(first, "# yaml-language-server: $schema=https://") {
+		t.Errorf("first line = %q, want an absolute schema header", first)
+	}
+	if strings.Contains(first, "./schema/") {
+		t.Errorf("schema URL must be absolute, not repo-relative: %q", first)
+	}
+}
+
 // TestGenerate_EscapesVariableReferences proves the round-trip law for
 // observed text containing ${...}: the engine expands ${name} in run.command
 // and assert values at replay (and errors on an unresolved reference in a

--- a/test/e2e/atago/init.atago.yaml
+++ b/test/e2e/atago/init.atago.yaml
@@ -21,6 +21,25 @@ scenarios:
           stdout:
             contains: PASSED
 
+  - name: init emits a resolvable schema header for editor completion
+    steps:
+      - run:
+          command: ${atago} init headed.atago.yaml
+      - assert:
+          exit_code: 0
+      # The first line must be an absolute yaml-language-server schema URL, so
+      # completion works in any project (not the repo-relative ./schema path).
+      - run:
+          shell: true
+          command: head -1 headed.atago.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "# yaml-language-server: $schema=https://"
+      - assert:
+          stdout:
+            not_contains: "./schema/"
+
   - name: init refuses to overwrite without --force
     steps:
       - fixture:


### PR DESCRIPTION
## Summary

Closes #121.

atago's richest reference for the *spec DSL* (step types, every matcher, and the `${workdir}` / `${env:NAME}` / `${name}` / `$${...}` expansion rules) is `schema/atago.schema.json`, but it only reaches a user through editor completion — and nothing steered them to it. `atago init` / `atago record` scaffolded specs with no `# yaml-language-server: $schema=...` header, and the README's snippet used a repo-relative path that resolves only inside the atago repo.

Now:

1. **`atago init` and `atago record` emit a resolvable schema header** as the first line of every generated spec:

   ```yaml
   # yaml-language-server: $schema=https://raw.githubusercontent.com/nao1215/atago/<ref>/schema/atago.schema.json
   version: "1"
   ```

   `<ref>` is the build's release tag for a tagged binary (e.g. `v0.4.0`), so a scaffolded spec's completion matches the atago that made it; dev / `go install` pseudo-version builds fall back to `main`, a ref GitHub raw can always resolve. The header is an ignored YAML comment, so specs still parse and run unchanged.

2. **README editor-support snippet** now uses the same absolute URL instead of the repo-relative `./schema/...` path, so copy-pasting it works outside the repo.

(The optional part 3 — a generated human-readable DSL reference page — is intentionally deferred; parts 1 and 2 close the discoverability gap the issue centers on.)

## Changes

- New `buildinfo.SchemaRef/SchemaURL/SchemaHeader`: version-pinned, resolvable schema URL (release tag → tag, else `main`).
- `cli/init`, `record.Generate`, `record.GeneratePTY`: prepend the header.
- README: absolute URL + note that init/record already emit it.

## Tests

- Unit (`buildinfo`): ref resolution for release tags, pseudo-versions, pre-releases, and `dev`; header shape.
- Unit (`cli`): init's first line is an absolute schema header (not `./schema/...`) and the spec still loads.
- Unit (`record`): recorded spec starts with the absolute header.
- E2E (`test/e2e/atago/init.atago.yaml`): `head -1` of a scaffolded spec is the absolute `# yaml-language-server: $schema=https://` header and not repo-relative (doc regenerated).