### PR TITLE
fix(record): rewrite the scratch workdir to ${workdir} in the stdout anchor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `atago record` no longer pins its own scratch directory into the generated
+  stdout anchor. A command that prints an absolute path under its workdir (the
+  canonical case is `atago record -- pwd`) recorded a `contains:` matcher on the
+  dead `/tmp/atago-record-NNN` scratch path, which the replay's own isolated
+  workdir could never match — so the very spec `record` produced failed on its
+  first `run`. The record-time workdir is now rewritten to the built-in
+  `${workdir}` reference, which expands to the replay workdir, matching the
+  masking `record --snapshot` already applied. The record→run round-trip is
+  green again (#30).
+
 ## [0.4.0] - 2026-07-05
 
 Runner-selection and reporting polish surfaced while migrating real E2E suites

--- a/internal/cli/record.go
+++ b/internal/cli/record.go
@@ -110,7 +110,7 @@ recording is a non-goal for now — write those steps by hand.
 		Stderr:       res.Stderr,
 		CreatedFiles: created,
 	}
-	opts := record.Options{SuiteName: suiteNameFor(cmdArgs[0])}
+	opts := record.Options{SuiteName: suiteNameFor(cmdArgs[0]), Workdir: workdir}
 	if *snap {
 		opts.Snapshot = true
 		opts.SnapshotPath = "snapshots/" + strings.TrimSuffix(filepath.Base(*out), ".atago.yaml") + ".stdout.txt"

--- a/internal/record/record.go
+++ b/internal/record/record.go
@@ -43,6 +43,13 @@ type Options struct {
 	// SnapshotPath (spec-relative).
 	Snapshot     bool
 	SnapshotPath string
+	// Workdir is the record-time scratch directory the command ran in. Any
+	// occurrence of it in the generated stdout anchor is rewritten to the
+	// built-in ${workdir} reference, so a command that prints an absolute path
+	// under its workdir (e.g. `pwd`) still replays green: the anchor expands to
+	// the replay's own isolated workdir instead of pinning the dead scratch path
+	// the record run happened to use.
+	Workdir string
 }
 
 // Generate renders the spec skeleton and proves it loads cleanly — a
@@ -74,7 +81,8 @@ func Generate(obs Observation, opts Options) ([]byte, error) {
 	case firstLine(obs.Stdout) != "":
 		b.WriteString("      - assert:\n")
 		b.WriteString("          stdout:\n")
-		fmt.Fprintf(&b, "            contains: %s # first non-empty line, trimmed\n", yamlScalar(escapeVarRefs(firstLine(obs.Stdout))))
+		anchor := maskWorkdir(escapeVarRefs(firstLine(obs.Stdout)), opts.Workdir)
+		fmt.Fprintf(&b, "            contains: %s # first non-empty line, trimmed\n", yamlScalar(anchor))
 	}
 	if len(obs.Stderr) == 0 {
 		b.WriteString("      - assert:\n")
@@ -117,6 +125,23 @@ func Generate(obs Observation, opts Options) ([]byte, error) {
 // into a $${1} that the expander never restores and that could never match.
 func escapeVarRefs(s string) string {
 	return store.Escape(s)
+}
+
+// maskWorkdir rewrites the record-time scratch directory to the built-in
+// ${workdir} reference so the stdout anchor replays green. A command that
+// prints an absolute path under its workdir (`pwd`, a tool echoing an output
+// path) would otherwise pin the dead scratch dir the record run used, which the
+// replay's own isolated workdir can never match — the round-trip law (#30)
+// broken by construction. It runs after escapeVarRefs so the injected reference
+// is a live one the expander restores, not a $${...} literal. The scratch path
+// is a plain filesystem path with no ${...} of its own, so escaping never
+// touches it. Snapshot mode masks the same path via snapshot.Normalize already;
+// this brings the default contains anchor to parity.
+func maskWorkdir(s, workdir string) string {
+	if workdir == "" {
+		return s
+	}
+	return strings.ReplaceAll(s, workdir, "${workdir}")
 }
 
 // firstLine returns the first non-empty line, trimmed.

--- a/internal/record/record_test.go
+++ b/internal/record/record_test.go
@@ -3,6 +3,7 @@ package record
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -246,6 +247,69 @@ func TestGenerate_RecordRunRoundTrip(t *testing.T) {
 				t.Errorf("recorded spec did not replay green: status=%s\n--- spec ---\n%s", res.Status, out)
 			}
 		})
+	}
+}
+
+// TestGenerate_MasksScratchWorkdirInAnchor is a regression for the record→run
+// round-trip (#30): a command that prints an absolute path under the
+// record-time scratch dir must not pin that path as a literal contains anchor.
+// The replay runs in a *different* isolated workdir, so a literal scratch path
+// can never match and the generated spec fails on its first replay. The
+// record-time workdir is rewritten to the built-in ${workdir} reference, which
+// expands to the replay workdir. This is deterministic and OS-independent
+// (`atago record -- pwd` is the canonical trigger).
+func TestGenerate_MasksScratchWorkdirInAnchor(t *testing.T) {
+	t.Parallel()
+	const wd = "/tmp/atago-record-4242"
+	out, err := Generate(Observation{
+		Command:  "pwd",
+		ExitCode: 0,
+		Stdout:   []byte("cwd is " + wd + "/logs\n"),
+	}, Options{SuiteName: "pwd", Workdir: wd})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	got := string(out)
+	if strings.Contains(got, wd) {
+		t.Errorf("generated anchor pins the literal scratch workdir %q:\n%s", wd, got)
+	}
+	if !strings.Contains(got, "contains: cwd is ${workdir}/logs") {
+		t.Errorf("anchor did not rewrite the scratch workdir to ${workdir}:\n%s", got)
+	}
+	// The rewrite must be a live reference: re-escaping must not neutralize it
+	// into the $${workdir} literal the expander would leave untouched.
+	if strings.Contains(got, "$${workdir}") {
+		t.Errorf("workdir reference was escaped to a literal:\n%s", got)
+	}
+}
+
+// TestGenerate_WorkdirAnchorReplaysGreen proves the metamorphic law end to end
+// for the workdir case: a recorded `pwd` replays green because its anchor
+// expands to the replay's workdir. POSIX-only (`pwd` is not a cmd.exe builtin);
+// the rewrite itself is proven OS-independently by
+// TestGenerate_MasksScratchWorkdirInAnchor.
+func TestGenerate_WorkdirAnchorReplaysGreen(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("pwd is POSIX-only; the rewrite is proven cross-platform elsewhere")
+	}
+	t.Parallel()
+	const wd = "/tmp/atago-record-9999"
+	out, err := Generate(Observation{
+		Command:  "pwd",
+		Shell:    true,
+		ExitCode: 0,
+		Stdout:   []byte(wd + "\n"),
+	}, Options{SuiteName: "pwd", Workdir: wd})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	s, err := loader.LoadBytes("rt.atago.yaml", out)
+	if err != nil {
+		t.Fatalf("load generated: %v\n%s", err, out)
+	}
+	res := engine.New().Run(context.Background(), s, "rt.atago.yaml")
+	if res.Status != engine.StatusPassed {
+		t.Errorf("recorded pwd spec did not replay green: status=%s\n%s", res.Status, out)
 	}
 }
 


### PR DESCRIPTION
A recorded command that prints an absolute path under its scratch directory pinned that path as a literal `contains:` matcher. The canonical trigger is `atago record -- pwd`: the generated spec asserted `stdout contains /tmp/atago-record-NNN`, the record-time scratch dir. Replay runs each scenario in a different isolated workdir, so the dead scratch path can never match and the spec `record` just produced failed on its first `run` — the record→run round-trip broken by construction.

The fix rewrites any occurrence of the record-time workdir in the generated stdout anchor to the built-in `${workdir}` reference, which expands to the replay's own workdir. This brings the default contains anchor to parity with `record --snapshot`, which already masked the same path via snapshot.Normalize. The substitution runs after escapeVarRefs so the injected reference stays live rather than being neutralized into a `$${...}` literal.

Regression coverage: `TestGenerate_MasksScratchWorkdirInAnchor` pins the rewrite deterministically and cross-platform (mid-line and whole-line), and `TestGenerate_WorkdirAnchorReplaysGreen` proves the metamorphic round-trip end to end by replaying a recorded `pwd` through the real engine (POSIX-guarded).

Refs #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recorded specs now preserve relative workdir behavior, so replayed runs match the original execution environment.
  * Generated output no longer hard-codes temporary absolute paths, making record-and-run flows more reliable.
  * Added coverage to ensure workdir-related recordings replay successfully across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->