### PR TITLE
fix(assert): tolerate only a single trailing newline in equals/not_equals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- `stdout`/`stderr` `equals` and `not_equals` now tolerate only a single
+  trailing newline, not an arbitrary run of trailing blank lines. The matcher
+  trimmed every trailing newline, so `equals: "hello"` passed against output
+  that was `hello` followed by extra blank lines, and `not_equals` reported a
+  false "equal" for the same output — an exact-text assertion silently ignoring
+  real trailing content. It now drops at most one trailing newline per side,
+  consistent with the `line:` selector, which already keeps a deliberate
+  trailing blank line addressable.
 - `atago record` no longer pins its own scratch directory into the generated
   stdout anchor. A command that prints an absolute path under its workdir (the
   canonical case is `atago record -- pwd`) recorded a `contains:` matcher on the

--- a/internal/assert/assert_test.go
+++ b/internal/assert/assert_test.go
@@ -183,6 +183,41 @@ func TestCheck_Stream_CRLF(t *testing.T) {
 	}
 }
 
+// TestCheck_Stream_EqualsTrailingNewline is a regression: `equals`/`not_equals`
+// tolerate a single phantom trailing newline (the one most commands emit, which
+// a YAML block scalar also carries), not an arbitrary run of trailing blank
+// lines. Trimming every trailing newline made `equals "hello"` pass against
+// output with extra blank lines, and `not_equals` report a false "equal", and
+// it disagreed with the line: matcher, which drops exactly one trailing newline
+// so a deliberate trailing blank line stays addressable (see splitLines).
+func TestCheck_Stream_EqualsTrailingNewline(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		stdout string
+		a      *spec.Assert
+		wantOK bool
+	}{
+		{"single trailing newline tolerated", "hello\n", &spec.Assert{Stdout: &spec.StreamAssert{Equals: strp("hello")}}, true},
+		{"no newline either side", "hello", &spec.Assert{Stdout: &spec.StreamAssert{Equals: strp("hello")}}, true},
+		{"want carries the newline", "hello", &spec.Assert{Stdout: &spec.StreamAssert{Equals: strp("hello\n")}}, true},
+		{"extra trailing blank lines are not equal", "hello\n\n\n", &spec.Assert{Stdout: &spec.StreamAssert{Equals: strp("hello")}}, false},
+		{"a deliberate trailing blank line is distinguishable", "hello\n\n", &spec.Assert{Stdout: &spec.StreamAssert{Equals: strp("hello\n")}}, false},
+		{"empty output is not equal to blank lines", "\n\n", &spec.Assert{Stdout: &spec.StreamAssert{Equals: strp("")}}, false},
+		{"not_equals sees the extra blank lines", "hello\n\n\n", &spec.Assert{Stdout: &spec.StreamAssert{NotEquals: strp("hello")}}, true},
+		{"not_equals stays tolerant of one newline", "hello\n", &spec.Assert{Stdout: &spec.StreamAssert{NotEquals: strp("hello")}}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			res := &runner.Result{Stdout: []byte(tc.stdout)}
+			if got := Check(tc.a, res, Env{}); got.OK != tc.wantOK {
+				t.Errorf("OK = %v, want %v (%s)", got.OK, tc.wantOK, got.Hint)
+			}
+		})
+	}
+}
+
 // TestCheck_ContainsList_FailureNamesElement verifies an array contains /
 // not_contains failure identifies which element failed, and that a single-element
 // list keeps the original (no "element N of M") failure phrasing.

--- a/internal/assert/stream.go
+++ b/internal/assert/stream.go
@@ -189,15 +189,20 @@ func containsDesc(name string, subs spec.StringList, want bool) string {
 	return fmt.Sprintf("assert %s contains none of %s", name, quoteList(subs))
 }
 
-// equalsNormalized compares ignoring a single trailing newline difference, since
-// most commands emit a trailing newline that YAML block scalars also carry.
-// CRLF line endings are folded to LF first so a spec written with `equals:`
-// passes against cmd.exe output on Windows exactly as it does against POSIX
-// output — line endings are an OS artifact, not observable CLI behavior.
+// equalsNormalized compares ignoring at most one trailing newline per side — the
+// single phantom final newline most commands emit, which a YAML block scalar
+// also carries — not an arbitrary run of trailing blank lines. Trimming EVERY
+// trailing newline (strings.TrimRight) made `equals "x"` pass against "x\n\n\n"
+// and `not_equals` report a false "equal"; it also disagreed with the line:
+// matcher, whose splitLines drops exactly one trailing newline so a deliberate
+// trailing blank line stays addressable. CRLF is folded to LF first so a spec
+// written with `equals:` passes against cmd.exe output on Windows exactly as it
+// does against POSIX output — line endings are an OS artifact, not observable
+// CLI behavior.
 func equalsNormalized(got, want string) bool {
 	got = strings.ReplaceAll(got, "\r\n", "\n")
 	want = strings.ReplaceAll(want, "\r\n", "\n")
-	return got == want || strings.TrimRight(got, "\n") == strings.TrimRight(want, "\n")
+	return strings.TrimSuffix(got, "\n") == strings.TrimSuffix(want, "\n")
 }
 
 // selectLine returns the n-th (1-based) line of s, ignoring a single trailing


### PR DESCRIPTION
`equalsNormalized` claimed (in its own doc comment) to ignore "a single trailing newline difference" but used `strings.TrimRight(s, "\n")`, which strips every trailing newline. So `equals: "hello"` passed against output that was `hello` followed by extra blank lines, and `not_equals: "hello"` reported a false "equal" for the same output — an exact-text assertion silently discarding real trailing content.

It also disagreed with the sibling `line:` matcher, whose `splitLines` deliberately drops exactly one trailing newline so a deliberate trailing blank line stays addressable (regression-pinned since #64-era work).

The fix trims at most one trailing newline per side with `strings.TrimSuffix`, matching the `line:` matcher's documented semantics. Existing single-trailing-newline tolerance and CRLF folding are preserved; only an arbitrary run of trailing blank lines now correctly counts as a difference.

Regression coverage: `TestCheck_Stream_EqualsTrailingNewline` pins the single-newline tolerance, the extra-blank-lines difference, the empty-vs-blank-lines case, and the `not_equals` mirror. The full self-hosted + thirdparty e2e suite (226 scenarios) stays green.