### PR TITLE
fix(run): preserve out-of-scope failures on a narrowed --rerun-failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- `atago run --rerun-failed` narrowed to a subset of the recorded specs no longer
+  drops the recorded failures in the specs it did not run. It rewrote the whole
+  `.atago/last-failed.json` ledger from only the scenarios that ran, so
+  `--rerun-failed a.atago.yaml` forgot a still-broken `b.atago.yaml` — and if the
+  narrowed target now passed, the ledger was wiped and the run exited green while
+  other work stayed broken. Recorded failures for specs outside the run's target
+  are now carried back into the saved ledger, since they were never re-verified;
+  a full-scope rerun and a normal run are unchanged (#64).
 - `stdout`/`stderr` `equals` and `not_equals` now tolerate only a single
   trailing newline, not an arbitrary run of trailing blank lines. The matcher
   trimmed every trailing newline, so `equals: "hello"` passed against output

--- a/internal/cli/features_test.go
+++ b/internal/cli/features_test.go
@@ -487,6 +487,103 @@ func TestRerunFailed_GreenRunClearsState(t *testing.T) {
 	})
 }
 
+// singleFailSpec renders a one-scenario spec named <name> whose only scenario
+// <name>_fail asserts exit_code 0. When passes is false the command exits 1 (the
+// assertion fails); when true it exits 0 (passes). Used to build multi-spec
+// rerun-ledger fixtures.
+func singleFailSpec(name string, passes bool) string {
+	code := "1"
+	if passes {
+		code = "0"
+	}
+	return `version: "1"
+suite:
+  name: ` + name + `
+scenarios:
+  - name: ` + name + `_fail
+    steps:
+      - run: {shell: true, command: "exit ` + code + `"}
+      - assert: {exit_code: 0}
+`
+}
+
+// TestRerunFailed_NarrowedTargetPreservesOtherFailures is a regression: a
+// `--rerun-failed` narrowed to a subset of the recorded specs must not drop the
+// recorded failures in the specs it did not run. Rewriting the whole ledger from
+// only the narrowed subset forgot still-failing work elsewhere — a red-green
+// loop that silently loses a broken scenario the moment you rerun a single spec.
+func TestRerunFailed_NarrowedTargetPreservesOtherFailures(t *testing.T) {
+	dir := t.TempDir()
+	writeSpec(t, dir, "a.atago.yaml", singleFailSpec("a", false))
+	writeSpec(t, dir, "b.atago.yaml", singleFailSpec("b", false))
+
+	withWorkdir(t, dir, func() {
+		var out, errb bytes.Buffer
+		// A full run records both a_fail and b_fail.
+		if got := Main([]string{"run", "."}, &out, &errb); got != ExitFailures {
+			t.Fatalf("first run exit = %d, want %d (stderr=%s)", got, ExitFailures, errb.String())
+		}
+		st, err := loadRerunState()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(st.Failed) != 2 {
+			t.Fatalf("recorded failures = %+v, want both a_fail and b_fail", st.Failed)
+		}
+
+		// Rerun only a (still failing). b was not re-verified and is still broken,
+		// so it must survive in the ledger alongside the freshly-recorded a_fail.
+		out.Reset()
+		errb.Reset()
+		if got := Main([]string{"run", "--rerun-failed", "a.atago.yaml"}, &out, &errb); got != ExitFailures {
+			t.Fatalf("narrowed rerun exit = %d, want %d (stderr=%s)", got, ExitFailures, errb.String())
+		}
+		st, err = loadRerunState()
+		if err != nil {
+			t.Fatal(err)
+		}
+		names := map[string]bool{}
+		for _, e := range st.Failed {
+			names[e.Scenario] = true
+		}
+		if !names["a_fail"] || !names["b_fail"] {
+			t.Errorf("ledger after narrowed rerun = %+v, want both a_fail (re-verified) and b_fail (preserved)", st.Failed)
+		}
+	})
+}
+
+// TestRerunFailed_NarrowedGreenKeepsOtherFailures is the greenlight variant: a
+// narrowed `--rerun-failed` whose target now passes must not wipe the ledger
+// and exit green while another recorded spec is still broken. Only the specs it
+// actually re-ran may be cleared.
+func TestRerunFailed_NarrowedGreenKeepsOtherFailures(t *testing.T) {
+	dir := t.TempDir()
+	writeSpec(t, dir, "a.atago.yaml", singleFailSpec("a", false))
+	writeSpec(t, dir, "b.atago.yaml", singleFailSpec("b", false))
+
+	withWorkdir(t, dir, func() {
+		var out, errb bytes.Buffer
+		if got := Main([]string{"run", "."}, &out, &errb); got != ExitFailures {
+			t.Fatalf("first run exit = %d (stderr=%s)", got, errb.String())
+		}
+		// Fix a so its narrowed rerun passes; leave b broken and un-run.
+		writeSpec(t, dir, "a.atago.yaml", singleFailSpec("a", true))
+
+		out.Reset()
+		errb.Reset()
+		if got := Main([]string{"run", "--rerun-failed", "a.atago.yaml"}, &out, &errb); got != ExitOK {
+			t.Fatalf("narrowed green rerun exit = %d, want %d (stderr=%s)", got, ExitOK, errb.String())
+		}
+		st, err := loadRerunState()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(st.Failed) != 1 || st.Failed[0].Scenario != "b_fail" {
+			t.Errorf("ledger = %+v, want only b_fail preserved (a cleared, b kept)", st.Failed)
+		}
+	})
+}
+
 // TestCompletion_HelpFlag proves --help behaves like every other subcommand's
 // --help (usage on stdout, exit 0) instead of being mistaken for a shell name.
 func TestCompletion_HelpFlag(t *testing.T) {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -104,6 +104,13 @@ func runCmd(args []string, stdout, stderr io.Writer) int {
 	// collected targets so the usual path semantics still apply, and installs an
 	// identity selector so only the recorded scenarios execute. With nothing
 	// recorded there is nothing to rerun, which is reported and treated as success.
+	//
+	// rerunPreserved holds recorded failures in specs OUTSIDE this run's target
+	// (a narrowed `--rerun-failed a.atago.yaml` when b.atago.yaml also had
+	// recorded failures). Those scenarios were not re-verified, so they must be
+	// carried back into the saved ledger below; overwriting it with only what ran
+	// would forget still-failing work and could greenlight the loop.
+	var rerunPreserved []failedEntry
 	if *rerunFailed {
 		state, lerr := loadRerunState()
 		if lerr != nil {
@@ -119,6 +126,15 @@ func runCmd(args []string, stdout, stderr io.Writer) int {
 		if len(paths) == 0 {
 			fmt.Fprintln(stderr, "atago run: no previously failed scenarios under the given targets")
 			return ExitOK
+		}
+		inScope := make(map[string]bool, len(paths))
+		for _, p := range paths {
+			inScope[p] = true
+		}
+		for _, e := range state.Failed {
+			if !inScope[e.SpecPath] {
+				rerunPreserved = append(rerunPreserved, e)
+			}
 		}
 		eng.Select = sel
 	}
@@ -195,11 +211,14 @@ func runCmd(args []string, stdout, stderr io.Writer) int {
 	// fully-green run clears the file. It is only rewritten when at least one suite
 	// loaded, so a run where every spec failed to parse leaves prior state intact;
 	// and a --rerun-failed that matched no scenario must NOT clear the file, or the
-	// still-failing work it could not map would be forgotten. Writing is
+	// still-failing work it could not map would be forgotten. A narrowed
+	// --rerun-failed carries back the recorded failures for specs outside its
+	// target (rerunPreserved), which it did not re-verify, so a partial rerun
+	// cannot silently drop still-failing work elsewhere in the ledger. Writing is
 	// best-effort — a read-only checkout must not fail the run — so a write error
 	// is a warning, not a fatal exit.
 	if len(results) > 0 && !rerunMatchedNothing {
-		if err := saveRerunState(collectFailures(results)); err != nil {
+		if err := saveRerunState(append(collectFailures(results), rerunPreserved...)); err != nil {
 			fmt.Fprintf(stderr, "atago run: could not update %s: %v\n", rerunStatePath(), err)
 		}
 	}


### PR DESCRIPTION
A `--rerun-failed` narrowed to a subset of the recorded specs rewrote the whole `.atago/last-failed.json` ledger from only the scenarios that ran. So `--rerun-failed a.atago.yaml`, when `b.atago.yaml` also had recorded failures, dropped `b_fail` even though it was never re-verified and is still broken. And if the narrowed target now passed, `collectFailures` returned empty, the ledger was removed, and the run exited green while other work stayed broken — the red-green loop silently lost a failing scenario the moment you reran a single spec.

The rerun block now captures the recorded failures for specs outside the run's target and carries them back into the saved ledger, unioned with the freshly recorded failures for the specs that ran. A full-scope `--rerun-failed` (target covers every recorded spec) and a normal run are unchanged: the preserved set is empty, so the ledger is rewritten exactly as before. This extends the existing guard whose stated intent — a rerun that matched nothing must not forget still-failing work — did not cover partial coverage.

Regression coverage: `TestRerunFailed_NarrowedTargetPreservesOtherFailures` (narrowed rerun still failing keeps both entries) and `TestRerunFailed_NarrowedGreenKeepsOtherFailures` (narrowed rerun now green keeps the other spec's failure and does not wipe the ledger). Both fail on the pre-fix code; the existing rerun tests, including the normal-run `GreenRunClearsState`, stay green.

Refs #64