### PR TITLE
fix(assert): escape control bytes in dir tree snapshot manifest paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- A `dir:` tree `snapshot:` manifest now escapes control bytes in entry paths and
+  link targets, so a filesystem name embedding a newline (legal on POSIX) can no
+  longer masquerade as several manifest lines. Before, a single entry named
+  `a<newline>dir b` produced the same manifest text as a structurally different
+  two-entry tree and falsely matched its golden. Ordinary names — with no
+  backslash, CR, or LF — render unchanged, so existing goldens are unaffected
+  (#25).
 - `atago run --rerun-failed` narrowed to a subset of the recorded specs no longer
   drops the recorded failures in the specs it did not run. It rewrote the whole
   `.atago/last-failed.json` ledger from only the scenarios that ran, so

--- a/internal/assert/tree.go
+++ b/internal/assert/tree.go
@@ -23,16 +23,35 @@ type treeEntry struct {
 	target string // symlink target, links only
 }
 
-// manifestLine renders the entry's snapshot-manifest line.
+// manifestLine renders the entry's snapshot-manifest line. Paths and link
+// targets are escaped so each entry stays exactly one line — see
+// escapeManifestField.
 func (e treeEntry) manifestLine() string {
 	switch e.kind {
 	case "file":
-		return "file " + e.rel + " sha256:" + e.hash
+		return "file " + escapeManifestField(e.rel) + " sha256:" + e.hash
 	case "link":
-		return "link " + e.rel + " -> " + e.target
+		return "link " + escapeManifestField(e.rel) + " -> " + escapeManifestField(e.target)
 	default:
-		return "dir " + e.rel
+		return "dir " + escapeManifestField(e.rel)
 	}
+}
+
+// escapeManifestField escapes the bytes that would break the one-line-per-entry
+// manifest grammar: a backslash (so the escape stays unambiguous) and the CR/LF
+// a filename may legally carry on POSIX. Without this, a name embedding a
+// newline renders as several manifest lines, so a single such entry produces the
+// same manifest as a structurally different multi-entry tree and falsely matches
+// its golden. Ordinary names (no backslash, CR, or LF) are returned unchanged,
+// so existing goldens are unaffected.
+func escapeManifestField(s string) string {
+	if !strings.ContainsAny(s, "\\\r\n") {
+		return s
+	}
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, "\n", `\n`)
+	s = strings.ReplaceAll(s, "\r", `\r`)
+	return s
 }
 
 // walkTree walks dirPath depth-first and returns every entry (root excluded)

--- a/internal/assert/tree_test.go
+++ b/internal/assert/tree_test.go
@@ -133,6 +133,69 @@ func TestManifestDiff_PathsWithSpaces(t *testing.T) {
 	}
 }
 
+// TestManifestLine_EscapesControlBytes is a regression: a filesystem name
+// carrying a newline (legal on POSIX) must render as ONE manifest line, or a
+// single such entry produces the same manifest text as a structurally different
+// multi-entry tree and falsely matches its golden. The escape must also be
+// unambiguous, so a name containing a literal backslash-n does not collide with
+// a name containing a real newline.
+func TestManifestLine_EscapesControlBytes(t *testing.T) {
+	t.Parallel()
+	newlineDir := treeEntry{rel: "a\ndir b", kind: "dir"}.manifestLine()
+	if strings.ContainsAny(newlineDir, "\n\r") {
+		t.Errorf("manifestLine leaked a raw control byte, breaking one-line-per-entry: %q", newlineDir)
+	}
+	// The single newline-named entry must not equal the two-entry manifest it
+	// previously collided with.
+	twoEntries := treeEntry{rel: "a", kind: "dir"}.manifestLine() + "\n" +
+		treeEntry{rel: "dir b", kind: "dir"}.manifestLine()
+	if newlineDir == twoEntries {
+		t.Errorf("newline-named entry still collides with a two-entry tree: %q", newlineDir)
+	}
+	// A literal backslash-n name and a real-newline name must stay distinct.
+	if literal := (treeEntry{rel: `a\ndir b`, kind: "dir"}).manifestLine(); literal == newlineDir {
+		t.Errorf("literal backslash-n name collides with the real-newline name: %q", literal)
+	}
+	// Ordinary names are untouched, so existing goldens are unaffected.
+	if got := (treeEntry{rel: "content/posts/hello.md", kind: "file", hash: "abc"}).manifestLine(); got != "file content/posts/hello.md sha256:abc" {
+		t.Errorf("ordinary name changed: %q", got)
+	}
+}
+
+// TestCheckDir_SnapshotNewlineNameNoFalseMatch proves the escape end to end: a
+// tree of two dirs and a tree of one dir whose name embeds a newline must not
+// match each other's golden. POSIX-only — Windows forbids newlines in names.
+func TestCheckDir_SnapshotNewlineNameNoFalseMatch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("newlines are not legal in Windows filenames")
+	}
+	t.Parallel()
+	specDir := t.TempDir()
+
+	// Golden recorded from a tree of two sibling dirs.
+	twoDirs := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(twoDirs, "root", "a"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(twoDirs, "root", "dir b"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	d := &spec.DirAssert{Path: "root", Snapshot: "tree_golden"}
+	if cr := checkDir(d, Env{Workdir: twoDirs, SpecDir: specDir, UpdateSnapshots: true}); !cr.OK {
+		t.Fatalf("update failed: %+v", cr)
+	}
+
+	// A different tree: one dir whose name is "a<newline>dir b".
+	oneDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(oneDir, "root", "a\ndir b"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	cr := checkDir(d, Env{Workdir: oneDir, SpecDir: specDir})
+	if cr.OK {
+		t.Error("a one-entry tree with a newline in its name falsely matched a two-dir golden")
+	}
+}
+
 // TestCheckDir_SnapshotRoundTrip proves record → green compare → mutation
 // diff naming exactly the changed path (#25).
 func TestCheckDir_SnapshotRoundTrip(t *testing.T) {


### PR DESCRIPTION
A `dir:` tree `snapshot:` manifest is one line per entry, joined by newlines. Entry paths and link targets were embedded verbatim, so a filesystem name carrying a newline (legal on POSIX) rendered as several manifest lines. A single directory named `a<newline>dir b` then produced byte-identical manifest text to a structurally different tree of two dirs `a` and `dir b`, and each falsely matched the other's golden — a false-green a structural snapshot exists to prevent. The scout that found this confirmed the collision symmetrically in both directions.

The fix escapes backslash, CR, and LF in the path and link-target fields so every entry stays exactly one line and the escape is unambiguous (a literal backslash-n name cannot collide with a real newline). Ordinary names carry none of these bytes and render unchanged, so committed goldens are unaffected.

Regression coverage: `TestManifestLine_EscapesControlBytes` pins the escape and the no-collision property deterministically and cross-platform; `TestCheckDir_SnapshotNewlineNameNoFalseMatch` proves it end to end through record/compare (POSIX-guarded, since Windows forbids newlines in names). The existing tree tests, including the spaced-path diff parser and the round-trip, stay green.