### PR TITLE
fix(loader): strip a leading UTF-8 BOM before parsing a spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- A spec file saved with a leading UTF-8 byte-order mark now loads. Windows and
+  Notepad-family editors emit a BOM routinely, and the YAML decoder glued it onto
+  the first key, so a correctly-authored spec failed with a confusing
+  `unknown field "version"` that blamed a field the author wrote right. A single
+  leading BOM is now stripped before parsing, as most YAML tooling does.
 - A `dir:` tree `snapshot:` manifest now escapes control bytes in entry paths and
   link targets, so a filesystem name embedding a newline (legal on POSIX) can no
   longer masquerade as several manifest lines. Before, a single entry named

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -52,6 +52,12 @@ func Load(path string) (*spec.Spec, error) {
 
 // LoadBytes parses and validates spec bytes, labeling errors with path.
 func LoadBytes(path string, data []byte) (*spec.Spec, error) {
+	// Strip a leading UTF-8 byte-order mark. Windows/Notepad-family editors emit
+	// one routinely, and goccy/go-yaml does not skip it: it glues the BOM onto the
+	// first key, so a correctly-authored spec failed with a confusing "unknown
+	// field" error naming a field the author wrote right. Most YAML tooling strips
+	// a single leading BOM transparently.
+	data = bytes.TrimPrefix(data, []byte("\ufeff"))
 	var s spec.Spec
 	dec := yaml.NewDecoder(bytes.NewReader(data), yaml.Strict())
 	if err := dec.Decode(&s); err != nil {

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -57,6 +57,37 @@ scenarios:
 	}
 }
 
+// TestLoadBytes_StripsLeadingBOM is a regression: a spec saved with a leading
+// UTF-8 byte-order mark (routinely emitted by Windows/Notepad-family editors)
+// must load. The raw bytes went straight to the YAML decoder, which glued the
+// BOM onto the first key and failed with a confusing `unknown field "version"`
+// that blamed a field the author wrote correctly. A single leading BOM is now
+// stripped transparently, as most YAML tooling does.
+func TestLoadBytes_StripsLeadingBOM(t *testing.T) {
+	t.Parallel()
+	src := "\ufeff" + `version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: ok
+    steps:
+      - run:
+          command: echo hi
+      - assert:
+          exit_code: 0
+`
+	s, err := LoadBytes("bom.atago.yaml", []byte(src))
+	if err != nil {
+		t.Fatalf("LoadBytes() with a leading BOM error = %v", err)
+	}
+	if s.Suite.Name != "sample" {
+		t.Errorf("suite name = %q, want sample", s.Suite.Name)
+	}
+	if len(s.Scenarios) != 1 || s.Scenarios[0].Name != "ok" {
+		t.Errorf("scenario not decoded through the BOM: %+v", s.Scenarios)
+	}
+}
+
 // TestLoadBytes_BrowserRunnerConfig proves the minimal browser-runner
 // configuration surface loads and round-trips: headless, exec_path, browser_args.
 func TestLoadBytes_BrowserRunnerConfig(t *testing.T) {


### PR DESCRIPTION
A spec file saved with a leading UTF-8 byte-order mark failed to load. Windows and Notepad-family editors emit a BOM routinely, and goccy/go-yaml does not skip it: the decoder glued the BOM onto the first key and reported `unknown field "version"`, blaming a field the author wrote correctly and giving no hint that the byte-order mark was the cause.

The fix strips a single leading BOM in `LoadBytes` before decoding, so both `Load` (file path) and `LoadBytes` benefit. Ordinary specs carry no BOM and are unaffected, and a second BOM (or one mid-document) is left in place to surface as a real error rather than being silently swallowed.

Regression coverage: `TestLoadBytes_StripsLeadingBOM` loads a BOM-prefixed spec and checks it decodes through to the suite and scenario; it fails on the pre-fix code with the exact misleading `unknown field` message. Surfaced by a loader fuzzing/boundary sweep that otherwise found the loader clean across 600k+ fuzz executions.