### PR TITLE
release: v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-07-05
+
+A correctness pass over five independent surfaces — record, the equals matcher,
+the rerun ledger, tree snapshots, and the loader — each surfaced by a systematic
+bug hunt and fixed with a reproduction test first. No new features.
+
+Highlights: `atago record -- pwd` (and any command printing a path under its
+workdir) round-trips green again; `stdout equals` no longer ignores trailing
+blank lines; a narrowed `--rerun-failed` no longer forgets still-failing specs
+it did not run; a `dir:` tree snapshot can no longer be fooled by a newline in a
+filename; and a spec saved with a UTF-8 BOM loads instead of failing with a
+misleading unknown-field error.
+
 ### Fixed
 
 - A spec file saved with a leading UTF-8 byte-order mark now loads. Windows and


### PR DESCRIPTION
Stamp v0.4.1 — a correctness release. Five independent bugs, each surfaced by a systematic bug hunt and fixed with a reproduction test first. No new features.

Fixed:
- record: rewrite the scratch workdir to `${workdir}` in the stdout anchor, so `atago record -- pwd` round-trips green (#126, refs #30).
- assert: `equals`/`not_equals` tolerate only a single trailing newline, not an arbitrary run of trailing blank lines (#127).
- run: a narrowed `--rerun-failed` preserves the recorded failures in specs it did not run, instead of wiping them from the ledger (#128, refs #64).
- assert: a `dir:` tree `snapshot:` manifest escapes control bytes in paths, so a newline in a filename can no longer forge a false match (#129, refs #25).
- loader: strip a leading UTF-8 BOM before parsing, so a spec saved by a BOM-emitting editor loads instead of failing with a misleading `unknown field` error (#130).

All five landed on main green (unit tests on Linux/macOS/Windows across Go 1/1.26, e2e, lint, CodeRabbit). The tag `v0.4.1` will be pushed on the merge commit to trigger the release workflow.