### PR TITLE
fix: ten edge-case correctness defects across assert, loader, and report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `json:`/`yaml:` `equals` no longer reports two distinct large integers as
+  equal. The comparison rounded both operands through float64, so a 64-bit id
+  like `9007199254740993` matched `9007199254740992`. Integer operands are now
+  compared at full precision.
+- `json:`/`yaml:` `gt`/`gte`/`lt`/`lte` now compare integers larger than int64.
+  Such a number decodes as a JSON number the numeric path did not recognize, so
+  a valid large value failed with "not numeric, so it cannot be compared".
+- `json:`/`yaml:` `matches:` now sees a whole-number float as its digits. A
+  value like `1000000.0` rendered as `1e+06`, so a pattern written against the
+  digits (`^1000000$`) never matched; it now renders as `1000000`, and the
+  `equals` failure message reads the same way.
+- The loader now rejects an empty `matches:`/`not_matches:` pattern on the
+  `stdout`/`stderr`/`body`, `json:`/`yaml:`, and `header:` matchers. An empty
+  regexp matches everything, so `matches: ""` is an always-true no-op and
+  `not_matches: ""` can never pass — mirroring the existing empty-string
+  `contains`/`not_contains` rejection.
+- The loader now rejects a negative `json:`/`yaml:` `length:` and a negative
+  `duration:` bound. No array, object, or string has a negative length, and a
+  measured wall-clock duration is never below zero, so either bound could only
+  ever be an authoring mistake.
+- The TAP (`--report tap`) failure diagnostic stays valid YAML. A captured
+  control byte from a command's output — most often an ANSI color escape —
+  landed verbatim in the diagnostic's `data:` block, so a TAP consumer parsing
+  it failed with "control characters are not allowed". Such bytes are now folded
+  to the Unicode replacement character, keeping tab and newline, as junit
+  already does through its XML encoder; the GitHub Actions (`--report gha`)
+  annotations are cleaned the same way.
+
 ## [0.4.1] - 2026-07-05
 
 A correctness pass over five independent surfaces — record, the equals matcher,

--- a/internal/assert/assert_test.go
+++ b/internal/assert/assert_test.go
@@ -501,6 +501,70 @@ func TestCheck_YAML_UnsignedInteger(t *testing.T) {
 	}
 }
 
+// TestCheck_JSON_LargeInteger is a regression for numeric matchers on integers
+// that exceed float64's 53-bit exact range. oj decodes an integer beyond int64
+// as json.Number; both cases previously misbehaved: equals compared through
+// float64 and reported two distinct ids equal, and gt/gte/lt/lte rejected a
+// json.Number as "not numeric".
+func TestCheck_JSON_LargeInteger(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		data   string
+		j      *spec.JSONAssert
+		wantOK bool
+	}{
+		// int64 values one apart, both beyond 2^53: must NOT be equal.
+		{"distinct int64 not equal", `{"id":9007199254740993}`, &spec.JSONAssert{Path: "$.id", Equals: int64(9007199254740992)}, false},
+		{"same int64 equal", `{"id":9007199254740993}`, &spec.JSONAssert{Path: "$.id", Equals: int64(9007199254740993)}, true},
+		// A value beyond int64 decodes as json.Number; comparisons must work.
+		{"json.Number gt", `{"n":10000000000000000000}`, &spec.JSONAssert{Path: "$.n", Gt: f64p(1)}, true},
+		{"json.Number lt", `{"n":10000000000000000000}`, &spec.JSONAssert{Path: "$.n", Lt: f64p(2e19)}, true},
+		// Distinct integers beyond uint64, one apart: equals stays exact.
+		{"distinct huge not equal", `{"n":100000000000000000001}`, &spec.JSONAssert{Path: "$.n", Equals: "100000000000000000000"}, false},
+		{"same huge equal", `{"n":100000000000000000000}`, &spec.JSONAssert{Path: "$.n", Equals: "100000000000000000000"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			res := &runner.Result{Stdout: []byte(tt.data)}
+			got := Check(&spec.Assert{Stdout: &spec.StreamAssert{JSON: tt.j}}, res, Env{})
+			if got.OK != tt.wantOK {
+				t.Errorf("OK = %v, want %v (%s)", got.OK, tt.wantOK, got.Hint)
+			}
+		})
+	}
+}
+
+// TestCheck_JSON_MatchesWholeNumberFloat is a regression: a JSON whole-number
+// float (1000000.0) was rendered with %v as "1e+06", so a matches pattern
+// written against the digits ("^1000000$") failed. Numeric nodes must render
+// without scientific notation.
+func TestCheck_JSON_MatchesWholeNumberFloat(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		data   string
+		j      *spec.JSONAssert
+		wantOK bool
+	}{
+		{"whole float matches digits", `{"n":1000000.0}`, &spec.JSONAssert{Path: "$.n", Matches: strp("^1000000$")}, true},
+		{"whole float not scientific", `{"n":1000000.0}`, &spec.JSONAssert{Path: "$.n", Matches: strp("e\\+")}, false},
+		{"integer matches digits", `{"n":9007199254740993}`, &spec.JSONAssert{Path: "$.n", Matches: strp("^9007199254740993$")}, true},
+		{"fractional float still matches", `{"n":0.0001}`, &spec.JSONAssert{Path: "$.n", Matches: strp("^0.0001$")}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			res := &runner.Result{Stdout: []byte(tt.data)}
+			got := Check(&spec.Assert{Stdout: &spec.StreamAssert{JSON: tt.j}}, res, Env{})
+			if got.OK != tt.wantOK {
+				t.Errorf("OK = %v, want %v (%s)", got.OK, tt.wantOK, got.Hint)
+			}
+		})
+	}
+}
+
 // TestCheck_JSON_EqualsStructural verifies json.equals compares nested
 // objects/arrays structurally and is insensitive to map key ordering (#40),
 // rather than relying on fmt.Sprintf("%v") of the decoded Go values.

--- a/internal/assert/assert_test.go
+++ b/internal/assert/assert_test.go
@@ -523,6 +523,10 @@ func TestCheck_JSON_LargeInteger(t *testing.T) {
 		// Distinct integers beyond uint64, one apart: equals stays exact.
 		{"distinct huge not equal", `{"n":100000000000000000001}`, &spec.JSONAssert{Path: "$.n", Equals: "100000000000000000000"}, false},
 		{"same huge equal", `{"n":100000000000000000000}`, &spec.JSONAssert{Path: "$.n", Equals: "100000000000000000000"}, true},
+		// A json.Number is a real number, so equals against a numeric spec value
+		// compares numerically, not lexically: whitespace around the expected
+		// digits does not defeat the match.
+		{"huge equals ignores surrounding space", `{"n":100000000000000000000}`, &spec.JSONAssert{Path: "$.n", Equals: " 100000000000000000000 "}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/assert/jsonmatch.go
+++ b/internal/assert/jsonmatch.go
@@ -331,15 +331,18 @@ func valuesEqual(node, want any) bool {
 	return fmt.Sprintf("%v", node) == fmt.Sprintf("%v", want)
 }
 
-// isNumericKind reports whether v is a genuine numeric type (not a numeric
+// isNumericKind reports whether v is a genuine number (not an arbitrary numeric
 // string). It gates valuesEqual's numeric coercion so string-vs-string equality
 // stays byte-exact. Unsigned kinds are included because goccy/go-yaml decodes a
-// large integer that overflows int64 as uint64.
+// large integer that overflows int64 as uint64, and json.Number because oj
+// decodes an integer beyond int64/uint64 as one — both are real numbers from a
+// parsed document, so an `equals` against a numeric spec value must compare them
+// numerically (via toBigInt/toFloat), not lexically.
 func isNumericKind(v any) bool {
 	switch v.(type) {
 	case int, int8, int16, int32, int64,
 		uint, uint8, uint16, uint32, uint64,
-		float32, float64:
+		float32, float64, json.Number:
 		return true
 	default:
 		return false

--- a/internal/assert/jsonmatch.go
+++ b/internal/assert/jsonmatch.go
@@ -1,7 +1,10 @@
 package assert
 
 import (
+	"encoding/json"
 	"fmt"
+	"math"
+	"math/big"
 	"regexp"
 	"strconv"
 	"strings"
@@ -168,8 +171,25 @@ func jsonEquals(desc, path string, nodes []any, want any) *CheckResult {
 	return &CheckResult{
 		Desc:     d,
 		Expected: fmt.Sprintf("%s == %v", path, want),
-		Actual:   fmt.Sprintf("%s = %v", path, node),
+		Actual:   fmt.Sprintf("%s = %s", path, renderNode(node)),
 		Hint:     fmt.Sprintf("value at %s did not equal %v", path, want),
+	}
+}
+
+// renderNode renders a selected JSON value for a matcher subject or a failure
+// message. Floating-point numbers print without scientific notation — a whole
+// number like 1000000.0 reads as "1000000", not "1e+06" — so `matches` sees the
+// digits a spec author wrote and a failure message stays readable. Everything
+// else falls back to the default Go rendering (json.Number already carries its
+// exact digits as a string).
+func renderNode(v any) string {
+	switch t := v.(type) {
+	case float64:
+		return formatNum(t)
+	case float32:
+		return formatNum(float64(t))
+	default:
+		return fmt.Sprintf("%v", v)
 	}
 }
 
@@ -182,7 +202,7 @@ func jsonMatches(desc, path string, nodes []any, pattern string) *CheckResult {
 	if err != nil {
 		return &CheckResult{Desc: desc, Hint: fmt.Sprintf("invalid regexp %q: %v", pattern, err)}
 	}
-	got := fmt.Sprintf("%v", node)
+	got := renderNode(node)
 	if re.MatchString(got) {
 		return pass(desc)
 	}
@@ -268,6 +288,15 @@ func valuesEqual(node, want any) bool {
 	// operand keeps number/numeric-string equality while making string-vs-string
 	// byte-exact.
 	if isNumericKind(node) || isNumericKind(want) {
+		// Prefer exact integer comparison. Two distinct integers beyond 2^53 (a
+		// JSON id, or a value beyond int64 that decodes as json.Number) round to
+		// the same float64, so a float compare would report them equal. big.Int
+		// keeps every digit.
+		if ni, ok := toBigInt(node); ok {
+			if wi, ok := toBigInt(want); ok {
+				return ni.Cmp(wi) == 0
+			}
+		}
 		if nf, ok := toFloat(node); ok {
 			if wf, ok := toFloat(want); ok {
 				return nf == wf
@@ -343,6 +372,14 @@ func toFloat(v any) (float64, bool) {
 		return float64(t), true
 	case float64:
 		return t, true
+	case json.Number:
+		// oj decodes a JSON integer beyond int64/uint64 range as json.Number
+		// (a string carrying the exact digits). Without this case the numeric
+		// matchers (gt/gte/lt/lte) reject a perfectly valid large number as
+		// "not numeric".
+		if f, err := strconv.ParseFloat(strings.TrimSpace(string(t)), 64); err == nil {
+			return f, true
+		}
 	case string:
 		// strconv.ParseFloat requires the WHOLE (trimmed) string to be a valid
 		// float. fmt.Sscanf("%g") used to be used here, but it stops at the first
@@ -355,4 +392,60 @@ func toFloat(v any) (float64, bool) {
 		}
 	}
 	return 0, false
+}
+
+// toBigInt returns v as an exact arbitrary-precision integer when it is an
+// integer value: a signed/unsigned integer kind, an integer-valued float, a
+// json.Number, or a numeric string with no fractional part. It is the exact
+// half of the numeric comparison — non-integers (2.5) return false so the
+// caller falls back to float comparison. Using big.Int keeps large integers
+// (JSON ids beyond 2^53, values beyond uint64) byte-exact where float64 would
+// silently collapse distinct values.
+func toBigInt(v any) (*big.Int, bool) {
+	switch t := v.(type) {
+	case int:
+		return big.NewInt(int64(t)), true
+	case int8:
+		return big.NewInt(int64(t)), true
+	case int16:
+		return big.NewInt(int64(t)), true
+	case int32:
+		return big.NewInt(int64(t)), true
+	case int64:
+		return big.NewInt(t), true
+	case uint:
+		return new(big.Int).SetUint64(uint64(t)), true
+	case uint8:
+		return new(big.Int).SetUint64(uint64(t)), true
+	case uint16:
+		return new(big.Int).SetUint64(uint64(t)), true
+	case uint32:
+		return new(big.Int).SetUint64(uint64(t)), true
+	case uint64:
+		return new(big.Int).SetUint64(t), true
+	case float32:
+		return floatToBigInt(float64(t))
+	case float64:
+		return floatToBigInt(t)
+	case json.Number:
+		if i, ok := new(big.Int).SetString(strings.TrimSpace(string(t)), 10); ok {
+			return i, true
+		}
+	case string:
+		if i, ok := new(big.Int).SetString(strings.TrimSpace(t), 10); ok {
+			return i, true
+		}
+	}
+	return nil, false
+}
+
+// floatToBigInt returns a finite, integer-valued float as an exact integer.
+// A fractional or non-finite value returns false so numeric equality falls back
+// to float comparison.
+func floatToBigInt(f float64) (*big.Int, bool) {
+	if math.IsInf(f, 0) || math.IsNaN(f) || f != math.Trunc(f) {
+		return nil, false
+	}
+	bi, _ := big.NewFloat(f).Int(nil)
+	return bi, true
 }

--- a/internal/loader/authoring_test.go
+++ b/internal/loader/authoring_test.go
@@ -142,6 +142,68 @@ scenarios:
 	}
 }
 
+// TestLoadBytes_EmptyRegexpRejected proves an empty matches/not_matches pattern
+// is a validation error, mirroring the empty-string contains/not_contains case:
+// an empty regexp matches everything, so `matches: ""` is an always-true no-op
+// and `not_matches: ""` can never pass. Covered for the stream, json, and
+// header matchers that expose a regexp field.
+func TestLoadBytes_EmptyRegexpRejected(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		matcher string
+	}{
+		{"stream matches", `            matches: ""`},
+		{"stream not_matches", `            not_matches: ""`},
+		{"json matches", "            json:\n              path: $.x\n              matches: \"\""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			src := `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: ok
+    steps:
+      - run: {command: echo hi}
+      - assert:
+          stdout:
+` + tc.matcher + "\n"
+			_, err := LoadBytes("sample.atago.yaml", []byte(src))
+			if err == nil || !strings.Contains(err.Error(), "empty regexp") {
+				t.Fatalf("LoadBytes() error = %v, want an 'empty regexp' validation error", err)
+			}
+		})
+	}
+}
+
+// TestLoadBytes_NegativeJSONLengthRejected proves a negative json/yaml length is
+// a validation error: no array, object, or string has a negative length, so the
+// matcher could never pass and the mistake is caught at load time.
+func TestLoadBytes_NegativeJSONLengthRejected(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: ok
+    steps:
+      - run: {command: echo hi}
+      - assert:
+          stdout:
+            json:
+              path: $.items
+              length: -1
+`
+	_, err := LoadBytes("sample.atago.yaml", []byte(src))
+	if err == nil || !strings.Contains(err.Error(), "length must be >= 0") {
+		t.Fatalf("LoadBytes() error = %v, want a 'length must be >= 0' validation error", err)
+	}
+}
+
 // TestLoadBytes_ShellMetacharWithoutShell proves a command carrying shell syntax
 // is rejected when shell is not enabled, with a fix-forward hint. Each metachar
 // in the guarded set is exercised.

--- a/internal/loader/defaults_test.go
+++ b/internal/loader/defaults_test.go
@@ -606,6 +606,8 @@ scenarios:
 		{"empty interval", step("{gt: 2s, lt: 1s}"), "empty interval"},
 		{"touching strict", step("{gt: 1s, lt: 1s}"), "empty interval"},
 		{"bad duration", step("{lt: soon}"), "not a valid duration"},
+		{"negative lower bound", step("{gt: -1s}"), "must not be negative"},
+		{"negative upper bound", step("{lt: -5ms}"), "must not be negative"},
 		{"valid interval loads", step("{gte: 100ms, lt: 60s}"), ""},
 		{"inclusive point loads", step("{gte: 1s, lte: 1s}"), ""},
 		{

--- a/internal/loader/validate_assert.go
+++ b/internal/loader/validate_assert.go
@@ -114,14 +114,10 @@ func validateStream(add func(string, ...any), where string, s *spec.StreamAssert
 			validateJSON(add, where+".yaml", s.YAML)
 		}
 		if s.Matches != nil {
-			if _, err := regexp.Compile(*s.Matches); err != nil {
-				add("%s.matches %q is not a valid regexp: %v", where, *s.Matches, err)
-			}
+			validateRegexp(add, where, "matches", *s.Matches)
 		}
 		if s.NotMatches != nil {
-			if _, err := regexp.Compile(*s.NotMatches); err != nil {
-				add("%s.not_matches %q is not a valid regexp: %v", where, *s.NotMatches, err)
-			}
+			validateRegexp(add, where, "not_matches", *s.NotMatches)
 		}
 	default:
 		add("%s: must set exactly one matcher, but set %v", where, matchers)
@@ -187,9 +183,7 @@ func validateHeaderMatch(add func(string, ...any), where string, h *spec.HeaderM
 	}
 	if h.Matches != nil {
 		n++
-		if _, err := regexp.Compile(*h.Matches); err != nil {
-			add("%s.matches %q is not a valid regexp: %v", where, *h.Matches, err)
-		}
+		validateRegexp(add, where, "matches", *h.Matches)
 	}
 	switch n {
 	case 0:
@@ -210,12 +204,13 @@ func validateJSON(add func(string, ...any), where string, j *spec.JSONAssert) {
 	}
 	if j.Matches != nil {
 		n++
-		if _, err := regexp.Compile(*j.Matches); err != nil {
-			add("%s.matches %q is not a valid regexp: %v", where, *j.Matches, err)
-		}
+		validateRegexp(add, where, "matches", *j.Matches)
 	}
 	if j.Length != nil {
 		n++
+		if *j.Length < 0 {
+			add("%s.length must be >= 0 (got %d); no array, object, or string has a negative length", where, *j.Length)
+		}
 	}
 	if j.Gt != nil {
 		n++
@@ -253,6 +248,21 @@ func validateStringList(add func(string, ...any), where, key string, l spec.Stri
 	}
 }
 
+// validateRegexp rejects an empty pattern and an uncompilable one for a
+// matches/not_matches matcher. An empty regexp matches everything, so `matches:
+// ""` is an always-true no-op and `not_matches: ""` can never pass — either is
+// an authoring mistake, caught at load time like the empty-string contains/
+// not_contains case in validateStringList.
+func validateRegexp(add func(string, ...any), where, key, pattern string) {
+	if pattern == "" {
+		add("%s.%s must not be an empty regexp, which matches everything (matches) or nothing (not_matches); remove it or give a real pattern", where, key)
+		return
+	}
+	if _, err := regexp.Compile(pattern); err != nil {
+		add("%s.%s %q is not a valid regexp: %v", where, key, pattern, err)
+	}
+}
+
 // validateDuration checks a duration assert (#31): at least one bound, lt/lte
 // and gt/gte mutually exclusive, every bound a valid Go duration, and any
 // interval non-empty (lower < upper).
@@ -264,6 +274,13 @@ func validateDuration(add func(string, ...any), where string, d *spec.DurationAs
 		dur, err := time.ParseDuration(val)
 		if err != nil {
 			add("%s.%s %q is not a valid duration (e.g. \"2s\", \"100ms\")", where, field, val)
+			return 0, false
+		}
+		// A measured wall-clock duration is never negative, so a negative bound
+		// is always an authoring mistake: gt/gte trivially hold and lt/lte can
+		// never pass. Caught at load time like the empty-interval case below.
+		if dur < 0 {
+			add("%s.%s must not be negative (got %q); a measured duration is never below zero", where, field, val)
 			return 0, false
 		}
 		return dur, true

--- a/internal/report/format_parity_test.go
+++ b/internal/report/format_parity_test.go
@@ -233,4 +233,26 @@ func TestRender_HostileCharsStayWellFormed(t *testing.T) {
 		}
 		_ = render(t, FormatGHA, res)
 	})
+
+	// A raw control byte (here \x01, but a captured ANSI escape is the common
+	// case) must not survive into a TAP YAML diagnostic or a GHA annotation, or
+	// the surrounding document is malformed. Tab and newline are structural.
+	t.Run("tap and gha carry no raw control bytes", func(t *testing.T) {
+		t.Parallel()
+		for _, f := range []Format{FormatTAP, FormatGHA} {
+			out := render(t, f, res)
+			if i := strings.IndexFunc(out, rejectedControlRune); i >= 0 {
+				t.Errorf("%v output carries a raw control byte at offset %d:\n%q", f, i, out)
+			}
+		}
+	})
+}
+
+// rejectedControlRune reports a control character no machine-readable report may
+// carry verbatim: any C0 byte other than tab/newline, DEL, or a C1 control.
+func rejectedControlRune(r rune) bool {
+	if r == '\t' || r == '\n' {
+		return false
+	}
+	return r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f)
 }

--- a/internal/report/gha.go
+++ b/internal/report/gha.go
@@ -65,11 +65,14 @@ func oneLine(s string) string {
 }
 
 // ghaEscapeData escapes a workflow-command message body per the GitHub spec.
+// Beyond the required %/CR/LF encoding it folds any other raw control byte from
+// captured output (an ANSI escape, a bell) to U+FFFD, so an annotation never
+// carries a byte the Actions UI would mangle.
 func ghaEscapeData(s string) string {
 	s = strings.ReplaceAll(s, "%", "%25")
 	s = strings.ReplaceAll(s, "\r", "%0D")
 	s = strings.ReplaceAll(s, "\n", "%0A")
-	return s
+	return sanitizeControlBytes(s)
 }
 
 // ghaEscapeProp escapes a workflow-command property value (stricter than data).

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -8,6 +8,27 @@ import (
 	"github.com/nao1215/atago/internal/engine"
 )
 
+// sanitizeControlBytes replaces control characters a machine-readable report
+// cannot carry verbatim with the Unicode replacement rune, matching what the
+// XML encoder already does for junit. A TAP 13 diagnostic is a YAML block and a
+// GitHub Actions annotation is a single line; both reject raw C0/C1 control
+// bytes, so a captured ANSI escape, bell, or DEL byte in a command's output
+// would otherwise make the surrounding document malformed. Tab and newline are
+// structural and kept; invalid UTF-8 is folded to the replacement rune too,
+// since a YAML stream must be valid UTF-8.
+func sanitizeControlBytes(s string) string {
+	s = strings.ToValidUTF8(s, "�")
+	return strings.Map(func(r rune) rune {
+		if r == '\t' || r == '\n' {
+			return r
+		}
+		if r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f) {
+			return '�'
+		}
+		return r
+	}, s)
+}
+
 // suiteErroredWithoutScenarios reports a suite that failed or errored before it
 // produced any scenario row: a suite.setup failure (#7) with nothing selected to
 // run (all scenarios filtered out, or an empty scenario list), or a

--- a/internal/report/tap.go
+++ b/internal/report/tap.go
@@ -76,7 +76,11 @@ func writeTAPDiagnostic(b *strings.Builder, message, body string) {
 	if body != "" {
 		b.WriteString("  data: |\n")
 		for _, line := range strings.Split(body, "\n") {
-			fmt.Fprintf(b, "    %s\n", line)
+			// The literal block is copied verbatim into the reader's YAML, so a
+			// raw control byte from captured output (an ANSI escape, a bell)
+			// would make the diagnostic unparseable. Tab survives; the rest
+			// becomes U+FFFD.
+			fmt.Fprintf(b, "    %s\n", sanitizeControlBytes(line))
 		}
 	}
 	b.WriteString("  ...\n")
@@ -94,5 +98,9 @@ func tapInline(s string) string {
 	s = strings.ReplaceAll(s, "\n", " ")
 	s = strings.ReplaceAll(s, "\r", " ")
 	s = strings.ReplaceAll(s, "#", "\\#")
+	// A captured control byte (ANSI escape, bell, DEL) has no place on a TAP
+	// line; fold it so the ok/not-ok description and any SKIP directive stay
+	// clean. Newlines are already flattened above, so none survive here.
+	s = sanitizeControlBytes(s)
 	return strings.TrimSpace(s)
 }


### PR DESCRIPTION
A single-session edge-case bug hunt over the assert, loader, and report surfaces. Ten distinct correctness defects, each reproduced with a test first and fixed in place; no new features and no behavior change on the common path. Full test suite, golangci-lint, and the 228-scenario self-hosted e2e all pass.

Numeric matchers (internal/assert). json/yaml equals rounded both operands through float64, so two distinct 64-bit ids (9007199254740993 vs 9007199254740992) compared equal; integers are now compared at full precision with math/big. gt/gte/lt/lte rejected any integer beyond int64 as "not numeric" because oj decodes it as a json.Number the numeric path ignored; json.Number is now accepted. matches rendered a whole-number float with %v, so 1000000.0 became "1e+06" and a digit pattern like ^1000000$ never matched; numeric nodes now render without scientific notation, and the equals failure message reads the same way.

Loader validation (internal/loader). An empty matches/not_matches pattern matches everything, so matches: "" is an always-true no-op and not_matches: "" can never pass; both are now rejected at load on the stream, json/yaml, and header matchers, mirroring the existing empty-string contains/not_contains rejection. A negative json/yaml length and a negative duration bound are likewise rejected, since no length is negative and no measured duration is below zero.

Report formats (internal/report). A control byte in captured output — most often an ANSI color escape — flowed verbatim into the machine-readable reports: in a TAP diagnostic it broke the YAML data: block ("control characters are not allowed"), and in a GitHub Actions annotation it reached the message unescaped. Both now fold such bytes to the Unicode replacement character, keeping tab and newline, as junit already does through its XML encoder; invalid UTF-8 is folded the same way so a TAP stream stays valid UTF-8.

https://claude.ai/code/session_01BtcgityD3NW5Q89fbbWH91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric comparisons so large integers and whole-number floats are handled correctly in assertions.
  * Tightened validation for test configurations by rejecting empty patterns and negative numeric bounds at load time.
  * Cleaned up failure output to avoid raw control characters, helping TAP, YAML, and GitHub Actions logs render safely and parse reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->