### PR TITLE
fix: correctness sweep across record, snapshot, report, loader, assert, and run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,76 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+A correctness pass across `record`, `snapshot`, the report formats, the loader,
+the assertion matchers, secret masking, and the run engine. Each defect was
+surfaced by an edge-case bug hunt and fixed with a reproduction test first. No
+new features.
+
+### Fixed
+
+- `record --pty` now anchors its generated `expect`/`stdout: contains` on text
+  that is a verbatim substring of the raw transcript. It stripped ANSI from the
+  visible line and joined the result, so a colored prompt produced an anchor with
+  mid-line color codes removed that never matched the raw pty stdout — the
+  generated spec failed on replay. It now anchors on the longest color-free run
+  of the last visible line.
+- `record --pty` no longer explodes a typed password into one
+  `${env:ATAGO_SECRET_n}` placeholder per character. Raw-mode capture delivers
+  one keystroke per read, and consecutive input bursts were not coalesced, so a
+  six-character password generated seven single-character secret sends.
+  Consecutive input bursts with the same echo state are now merged.
+- A directory-tree snapshot no longer reports a false match when a symlink name
+  or target contains the ` -> ` that joins the two in the manifest. `>` is now
+  escaped inside a manifest field, so a symlink named `a -> b` pointing at `c` no
+  longer collides with one named `a` pointing at `b -> c`.
+- Snapshot normalization no longer corrupts a path that merely shares a prefix
+  with the home or scratch directory. The home dir `/home/nao` turned
+  `/home/naoki` into `~ki`, a container `HOME=/` turned every absolute path into
+  tildes, and the workdir `/tmp/run1` turned `/tmp/run10` into `<workdir>0`.
+  Masking is now path-component aware and skips a root home.
+- A unified diff now numbers a zero-line hunk side `0`, per the GNU convention
+  patch(1) relies on: a pure insertion emitted `@@ -1,0 +1,2 @@` instead of
+  `@@ -0,0 +1,2 @@`, and an empty side no longer carries a spurious
+  "No newline at end of file" marker.
+- A `--report tap` diagnostic message no longer injects a stray backslash before
+  a `#`. The message was escaped for the bare `ok`/`not ok` line and then quoted,
+  so `issue #42` reached the consumer as `issue \#42`; `#` is an ordinary
+  character inside the quoted YAML scalar and is left alone.
+- A `--report junit` `time` attribute is now a plain decimal. A sub-millisecond
+  duration serialized as `1.5e-06`, which the JUnit/Surefire schema and strict
+  parsers reject.
+- The console summary headline duration now reports the run's real wall-clock
+  time. It summed each suite's own duration, so `--parallel` running four
+  one-second suites concurrently printed `(4s)` for a run that took about one.
+- `--fail-fast` now stops scheduling across spec files, not only within a single
+  suite. A failing first spec still let every later spec run to completion.
+- `--tag` and `--skip-tag` are now repeatable and OR their values, like
+  `--filter`. `--tag a --tag b` silently kept only `b`.
+- `json:`/`yaml:` `gt`/`gte`/`lt`/`lte` now compare integers beyond 2^53 exactly,
+  like `equals` already does. The comparison rounded the selected value through
+  float64, so `9007199254740993` was reported not greater than
+  `9007199254740992`.
+- `json:`/`yaml:` `equals` no longer reports a JSON boolean as equal to the
+  string spelling of its value. A fallback compared the two by their printed
+  form, so `true` matched `equals: "true"`.
+- Secret masking no longer leaks part of an overlapping secret. Masking one
+  secret consumed bytes a second, overlapping secret needed, so its tail survived
+  in cleartext even though it appeared verbatim; every occurrence is now masked
+  in one pass over the original text.
+- The loader now rejects a `mock_server` step placed in a scenario's `steps` or
+  `teardown`. It is a `suite.setup`-only action, like `service`, but was silently
+  accepted and never started.
+- The loader now rejects an unknown key in the `exit_code` mapping form
+  (`exit_code: {not: 0, bogus: 5}`). The `{not}`/`{in}` decode bypassed the
+  document-wide strict decoding, silently dropping the typo.
+- The loader now validates a `dir.glob` pattern at load time, like the sibling
+  `dir.ignore` and `changes` globs, instead of only failing when the assertion
+  runs.
+- The loader now rejects a negative `timeout`/`delay` duration on the suite, run,
+  defaults, runner, service readiness, and mock-route fields. A negative
+  wall-clock bound yields an already-expired context that kills the step
+  immediately — the same rule the pty and signal timeouts already enforce.
+
 ## [0.4.2] - 2026-07-05
 
 A correctness pass over three surfaces — the JSON/YAML numeric matchers, the

--- a/internal/assert/assert_test.go
+++ b/internal/assert/assert_test.go
@@ -1984,3 +1984,48 @@ func TestParsersNeverPanicOnGarbage(t *testing.T) {
 		}()
 	}
 }
+
+// TestCheck_JSON_CompareLargeIntExact is a regression: the numeric bound
+// matchers (gt/gte/lt/lte) must compare integers beyond 2^53 exactly, like
+// equals already does, instead of collapsing distinct values to the same float64.
+func TestCheck_JSON_CompareLargeIntExact(t *testing.T) {
+	t.Parallel()
+	// 9007199254740993 = 2^53 + 1; float64 rounds it down to 2^53.
+	res := &runner.Result{Stdout: []byte(`{"big":9007199254740993}`)}
+	tests := []struct {
+		name   string
+		j      *spec.JSONAssert
+		wantOK bool
+	}{
+		{"gt its lower neighbor", &spec.JSONAssert{Path: "$.big", Gt: f64p(9007199254740992)}, true},
+		{"not lte its lower neighbor", &spec.JSONAssert{Path: "$.big", Lte: f64p(9007199254740992)}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := Check(&spec.Assert{Stdout: &spec.StreamAssert{JSON: tt.j}}, res, Env{})
+			if got.OK != tt.wantOK {
+				t.Errorf("OK = %v, want %v (%s)", got.OK, tt.wantOK, got.Hint)
+			}
+		})
+	}
+}
+
+// TestCheck_JSON_BoolNotEqualStringSpelling is a regression: a JSON boolean must
+// not equal the string spelling of its value — `true` (bool) and "true" (string)
+// are different JSON types. The old fmt.Sprintf fallback compared their printed
+// forms and reported a false pass.
+func TestCheck_JSON_BoolNotEqualStringSpelling(t *testing.T) {
+	t.Parallel()
+	res := &runner.Result{Stdout: []byte(`{"b":true}`)}
+	// bool true must NOT equal the string "true".
+	got := Check(&spec.Assert{Stdout: &spec.StreamAssert{JSON: &spec.JSONAssert{Path: "$.b", Equals: "true"}}}, res, Env{})
+	if got.OK {
+		t.Errorf("JSON boolean true wrongly equals the string \"true\"")
+	}
+	// bool true must still equal the boolean true.
+	got = Check(&spec.Assert{Stdout: &spec.StreamAssert{JSON: &spec.JSONAssert{Path: "$.b", Equals: true}}}, res, Env{})
+	if !got.OK {
+		t.Errorf("JSON boolean true did not equal true (%s)", got.Hint)
+	}
+}

--- a/internal/assert/jsonmatch.go
+++ b/internal/assert/jsonmatch.go
@@ -104,7 +104,7 @@ func jsonCompare(desc, path string, nodes []any, op string, want float64) *Check
 	if cr != nil {
 		return cr
 	}
-	got, ok := toFloat(node)
+	cmp, ok := numericCmp(node, want)
 	if !ok {
 		return &CheckResult{
 			Desc:     desc,
@@ -116,13 +116,13 @@ func jsonCompare(desc, path string, nodes []any, op string, want float64) *Check
 	var okCmp bool
 	switch op {
 	case "gt":
-		okCmp = got > want
+		okCmp = cmp > 0
 	case "gte":
-		okCmp = got >= want
+		okCmp = cmp >= 0
 	case "lt":
-		okCmp = got < want
+		okCmp = cmp < 0
 	case "lte":
-		okCmp = got <= want
+		okCmp = cmp <= 0
 	}
 	d := fmt.Sprintf("%s %s %v", desc, opSymbol(op), want)
 	if okCmp {
@@ -131,8 +131,34 @@ func jsonCompare(desc, path string, nodes []any, op string, want float64) *Check
 	return &CheckResult{
 		Desc:     d,
 		Expected: fmt.Sprintf("%s %s %v", path, opSymbol(op), want),
-		Actual:   fmt.Sprintf("%s = %v", path, formatNum(got)),
-		Hint:     fmt.Sprintf("value at %s (%v) is not %s %v", path, formatNum(got), op, want),
+		Actual:   fmt.Sprintf("%s = %s", path, renderNode(node)),
+		Hint:     fmt.Sprintf("value at %s (%s) is not %s %v", path, renderNode(node), op, want),
+	}
+}
+
+// numericCmp returns the sign of node−want (−1, 0, +1) for a numeric ordering.
+// It prefers exact big.Int arithmetic so a JSON integer beyond 2^53 compares
+// exactly — the same precision equals uses — instead of collapsing distinct
+// values to the same float64; it falls back to float64 for fractional operands.
+// ok is false when node is not numeric (nor a numeric string).
+func numericCmp(node any, want float64) (int, bool) {
+	if ni, ok := toBigInt(node); ok {
+		if wf := big.NewFloat(want); wf.IsInt() {
+			wi, _ := wf.Int(nil)
+			return ni.Cmp(wi), true
+		}
+	}
+	nf, ok := toFloat(node)
+	if !ok {
+		return 0, false
+	}
+	switch {
+	case nf < want:
+		return -1, true
+	case nf > want:
+		return 1, true
+	default:
+		return 0, true
 	}
 }
 
@@ -327,6 +353,19 @@ func valuesEqual(node, want any) bool {
 			}
 		}
 		return true
+	case string:
+		// A non-numeric node vs a string is a string match (the string-vs-number
+		// case was already handled by the numeric branch above). Comparing by
+		// fmt.Sprintf would let a JSON string equal a like-printed non-string.
+		w, ok := want.(string)
+		return ok && n == w
+	case bool:
+		// A JSON boolean equals only a boolean: `true` must not equal the string
+		// "true", which the old fmt.Sprintf fallback reported as a false pass.
+		w, ok := want.(bool)
+		return ok && n == w
+	case nil:
+		return want == nil
 	}
 	return fmt.Sprintf("%v", node) == fmt.Sprintf("%v", want)
 }

--- a/internal/assert/tree.go
+++ b/internal/assert/tree.go
@@ -38,19 +38,22 @@ func (e treeEntry) manifestLine() string {
 }
 
 // escapeManifestField escapes the bytes that would break the one-line-per-entry
-// manifest grammar: a backslash (so the escape stays unambiguous) and the CR/LF
-// a filename may legally carry on POSIX. Without this, a name embedding a
-// newline renders as several manifest lines, so a single such entry produces the
-// same manifest as a structurally different multi-entry tree and falsely matches
-// its golden. Ordinary names (no backslash, CR, or LF) are returned unchanged,
-// so existing goldens are unaffected.
+// manifest grammar: a backslash (so the escape stays unambiguous), the CR/LF a
+// filename may legally carry on POSIX, and `>` so the ` -> ` that joins a
+// symlink's name and target can never appear inside either field. Without the
+// newline escaping a name renders as several manifest lines; without the `>`
+// escaping a name or target embedding ` -> ` collides with a structurally
+// different symlink (name "a -> b" → "c" vs name "a" → "b -> c") and falsely
+// matches its golden. Ordinary names (no backslash, CR, LF, or `>`) are returned
+// unchanged, so existing goldens are unaffected.
 func escapeManifestField(s string) string {
-	if !strings.ContainsAny(s, "\\\r\n") {
+	if !strings.ContainsAny(s, "\\\r\n>") {
 		return s
 	}
 	s = strings.ReplaceAll(s, `\`, `\\`)
 	s = strings.ReplaceAll(s, "\n", `\n`)
 	s = strings.ReplaceAll(s, "\r", `\r`)
+	s = strings.ReplaceAll(s, ">", `\>`)
 	return s
 }
 

--- a/internal/assert/tree_test.go
+++ b/internal/assert/tree_test.go
@@ -162,6 +162,23 @@ func TestManifestLine_EscapesControlBytes(t *testing.T) {
 	}
 }
 
+// TestManifestLine_SymlinkSeparatorUnambiguous is a regression: the " -> " that
+// joins a symlink's name and target must be escaped inside either field, or two
+// structurally different symlinks render the same manifest line and one falsely
+// matches the other's golden. Name "a -> b" → target "c" collided with name "a"
+// → target "b -> c".
+func TestManifestLine_SymlinkSeparatorUnambiguous(t *testing.T) {
+	t.Parallel()
+	e1 := treeEntry{rel: "a -> b", kind: "link", target: "c"}.manifestLine()
+	e2 := treeEntry{rel: "a", kind: "link", target: "b -> c"}.manifestLine()
+	if e1 == e2 {
+		t.Errorf("distinct symlinks share a manifest line: %q", e1)
+	}
+	if strings.ContainsAny(e1, "\n\r") || strings.ContainsAny(e2, "\n\r") {
+		t.Errorf("manifest line is not single-line: %q / %q", e1, e2)
+	}
+}
+
 // TestCheckDir_SnapshotNewlineNameNoFalseMatch proves the escape end to end: a
 // tree of two dirs and a tree of one dir whose name embeds a newline must not
 // match each other's golden. POSIX-only — Windows forbids newlines in names.

--- a/internal/cli/features_test.go
+++ b/internal/cli/features_test.go
@@ -611,3 +611,65 @@ func TestSnapshot_HelpFlag(t *testing.T) {
 		}
 	}
 }
+
+// tagSelectSpec has one smoke-tagged scenario that FAILS and one slow-tagged
+// scenario that passes, so tag selection is observable through the exit code.
+const tagSelectSpec = `version: "1"
+suite:
+  name: tagged
+scenarios:
+  - name: alpha
+    tags: [smoke]
+    steps:
+      - run: {shell: true, command: "exit 1"}
+      - assert: {exit_code: 0}
+  - name: beta
+    tags: [slow]
+    steps:
+      - run: {command: "true"}
+      - assert: {exit_code: 0}
+`
+
+// TestRunTags_RepeatableFlagOrSemantics is a regression: --tag and --skip-tag
+// must be repeatable and OR their values, like --filter (#119). The old
+// single-string flags kept only the last occurrence, silently dropping earlier
+// selections.
+func TestRunTags_RepeatableFlagOrSemantics(t *testing.T) {
+	dir := t.TempDir()
+	writeSpec(t, dir, "s.atago.yaml", tagSelectSpec)
+	withWorkdir(t, dir, func() {
+		// --tag smoke --tag slow selects BOTH; alpha (smoke) fails, so the run
+		// fails. Last-flag-wins would have kept only slow (beta) and gone green.
+		var out, errb bytes.Buffer
+		if got := Main([]string{"run", "--tag", "smoke", "--tag", "slow", "."}, &out, &errb); got != ExitFailures {
+			t.Fatalf("--tag OR exit = %d, want %d; a repeated --tag dropped the smoke selection\n%s", got, ExitFailures, out.String())
+		}
+		// --skip-tag smoke --skip-tag slow skips BOTH, so the failing alpha never
+		// runs and the run is green. Last-flag-wins would skip only slow, run alpha,
+		// and fail.
+		out.Reset()
+		errb.Reset()
+		if got := Main([]string{"run", "--skip-tag", "smoke", "--skip-tag", "slow", "."}, &out, &errb); got != ExitOK {
+			t.Fatalf("--skip-tag OR exit = %d, want %d; a repeated --skip-tag dropped the smoke skip\n%s", got, ExitOK, out.String())
+		}
+	})
+}
+
+// TestFailFast_StopsSubsequentSpecFiles is a regression: --fail-fast must stop
+// scheduling across spec files, not only within one suite. The first spec fails;
+// the second (which would pass) must never run.
+func TestFailFast_StopsSubsequentSpecFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeSpec(t, dir, "1first.atago.yaml", singleFailSpec("firstsuite", false))
+	writeSpec(t, dir, "2second.atago.yaml", singleFailSpec("secondsuite", true))
+	withWorkdir(t, dir, func() {
+		var out, errb bytes.Buffer
+		got := Main([]string{"run", "--fail-fast", "--parallel", "1", "--report", "json", "."}, &out, &errb)
+		if got != ExitFailures {
+			t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitFailures, errb.String())
+		}
+		if strings.Contains(out.String(), "secondsuite") {
+			t.Errorf("--fail-fast scheduled a spec after the first failure:\n%s", out.String())
+		}
+	})
+}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -234,9 +234,14 @@ func runCmd(args []string, stdout, stderr io.Writer) int {
 		}
 	}
 
-	// Every spec failed to load; the errors are already on stderr. Don't print a
-	// misleading "0 scenarios" report.
+	// Every spec failed to load, or an interrupt skipped every suite before it
+	// produced a result. Don't print a misleading "0 scenarios" report — but a run
+	// that was interrupted before completing must never exit 0.
 	if len(results) == 0 {
+		if ctx.Err() != nil {
+			fmt.Fprintln(stderr, "atago run: interrupted")
+			return worseExit(exit, ExitExec)
+		}
 		return exit
 	}
 
@@ -339,7 +344,7 @@ func runSpecs(ctx context.Context, eng *engine.Engine, paths []string) ([]*engin
 	} else {
 		for i, p := range paths {
 			// Stop launching new suites once interrupted or --fail-fast has tripped;
-			// the already-cancelled ctx still flows into eng.Run so a partially-run
+			// the already-canceled ctx still flows into eng.Run so a partially-run
 			// suite reports cleanly.
 			if ctx.Err() != nil || failStop.Load() {
 				break

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -13,7 +13,9 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
+	"time"
 
 	"github.com/nao1215/atago/internal/artifact"
 	"github.com/nao1215/atago/internal/engine"
@@ -32,8 +34,10 @@ func runCmd(args []string, stdout, stderr io.Writer) int {
 	failFast := fs.Bool("fail-fast", false, "stop scheduling new scenarios after the first failure")
 	var filter csvFlag
 	fs.Var(&filter, "filter", "run only scenarios whose name contains any of these comma-separated substrings (repeatable; OR semantics like --tag)")
-	tag := fs.String("tag", "", "run only scenarios with any of these comma-separated tags")
-	skipTag := fs.String("skip-tag", "", "skip scenarios with any of these comma-separated tags")
+	var tag csvFlag
+	fs.Var(&tag, "tag", "run only scenarios with any of these tags (comma-separated and repeatable; OR semantics)")
+	var skipTag csvFlag
+	fs.Var(&skipTag, "skip-tag", "skip scenarios with any of these tags (comma-separated and repeatable)")
 	artifactsDir := fs.String("artifacts-dir", "", "write deterministic failure artifacts (actual/expected payloads) under DIR for review tooling")
 	rerunFailed := fs.Bool("rerun-failed", false, "run only the scenarios that failed on the previous run (recorded in .atago/last-failed.json)")
 	repeat := fs.Int("repeat", 0, "run each selected scenario N times to surface flakiness; any failing iteration fails the run")
@@ -93,8 +97,8 @@ func runCmd(args []string, stdout, stderr io.Writer) int {
 	eng.Repeat = *repeat
 	eng.RetryFailed = *retryFailed
 	eng.FilterNames = filter
-	eng.Tags = splitCSV(*tag)
-	eng.SkipTags = splitCSV(*skipTag)
+	eng.Tags = tag
+	eng.SkipTags = skipTag
 	if strings.TrimSpace(*artifactsDir) != "" {
 		eng.Artifacts = artifact.NewDir(*artifactsDir)
 	}
@@ -168,7 +172,9 @@ func runCmd(args []string, stdout, stderr io.Writer) int {
 	if *parallel > 1 {
 		eng.Sem = make(chan struct{}, *parallel)
 	}
+	start := time.Now()
 	suiteResults, loadErrs := runSpecs(ctx, eng, paths)
+	elapsed := time.Since(start)
 
 	results := make([]*engine.SuiteResult, 0, len(paths))
 	exit := ExitOK
@@ -178,6 +184,11 @@ func runCmd(args []string, stdout, stderr io.Writer) int {
 			fmt.Fprintf(stderr, "%v\n", loadErrs[i])
 			exit = worseExit(exit, exitForLoadError(loadErrs[i]))
 			loadFailures++
+			continue
+		}
+		// A nil result with no load error is a spec fail-fast (or an interrupt)
+		// skipped before running: it contributes no scenarios, so omit it.
+		if suiteResults[i] == nil {
 			continue
 		}
 		results = append(results, suiteResults[i])
@@ -232,7 +243,7 @@ func runCmd(args []string, stdout, stderr io.Writer) int {
 	// A selection that matches nothing still exits 0 (nothing ran, nothing
 	// failed), but stay loud about it: a typo'd --filter/--tag in CI would
 	// otherwise greenlight silently.
-	if len(filter) > 0 || *tag != "" || *skipTag != "" {
+	if len(filter) > 0 || len(tag) > 0 || len(skipTag) > 0 {
 		total := 0
 		for _, r := range results {
 			total += len(r.Scenarios)
@@ -242,17 +253,17 @@ func runCmd(args []string, stdout, stderr io.Writer) int {
 			if len(filter) > 0 {
 				sel = append(sel, fmt.Sprintf("--filter %q", strings.Join(filter, ",")))
 			}
-			if *tag != "" {
-				sel = append(sel, fmt.Sprintf("--tag %q", *tag))
+			if len(tag) > 0 {
+				sel = append(sel, fmt.Sprintf("--tag %q", strings.Join(tag, ",")))
 			}
-			if *skipTag != "" {
-				sel = append(sel, fmt.Sprintf("--skip-tag %q", *skipTag))
+			if len(skipTag) > 0 {
+				sel = append(sel, fmt.Sprintf("--skip-tag %q", strings.Join(skipTag, ",")))
 			}
 			fmt.Fprintf(stderr, "atago run: warning: no scenarios matched %s (name matching is a case-sensitive substring)\n", strings.Join(sel, " "))
 		}
 	}
 
-	if err := report.Render(stdout, format, results, report.WithLoadFailures(loadFailures)); err != nil {
+	if err := report.Render(stdout, format, results, report.WithLoadFailures(loadFailures), report.WithElapsed(elapsed)); err != nil {
 		fmt.Fprintf(stderr, "atago run: failed to write report: %v\n", err)
 		return worseExit(exit, ExitInternal)
 	}
@@ -275,6 +286,11 @@ func runCmd(args []string, stdout, stderr io.Writer) int {
 func runSpecs(ctx context.Context, eng *engine.Engine, paths []string) ([]*engine.SuiteResult, []error) {
 	suiteResults := make([]*engine.SuiteResult, len(paths))
 	loadErrs := make([]error, len(paths))
+	// failStop threads --fail-fast ACROSS spec files. The engine's own fail-fast
+	// stops scenarios only within one suite; without this a failing first spec
+	// would still let every later spec run. Once a suite fails, no new spec is
+	// scheduled (specs already in flight under --parallel still finish).
+	var failStop atomic.Bool
 	runOne := func(i int, p string) {
 		s, lerr := loader.Load(p)
 		if lerr != nil {
@@ -282,6 +298,9 @@ func runSpecs(ctx context.Context, eng *engine.Engine, paths []string) ([]*engin
 			return
 		}
 		suiteResults[i] = eng.Run(ctx, s, p)
+		if eng.FailFast && suiteFailed(suiteResults[i]) {
+			failStop.Store(true)
+		}
 	}
 	if eng.Sem != nil {
 		// A fixed worker pool rather than one goroutine per spec: with a goroutine
@@ -307,7 +326,7 @@ func runSpecs(ctx context.Context, eng *engine.Engine, paths []string) ([]*engin
 			}()
 		}
 		for i := range paths {
-			if ctx.Err() != nil {
+			if ctx.Err() != nil || failStop.Load() {
 				break
 			}
 			select {
@@ -319,15 +338,22 @@ func runSpecs(ctx context.Context, eng *engine.Engine, paths []string) ([]*engin
 		wg.Wait()
 	} else {
 		for i, p := range paths {
-			// Stop launching new suites once interrupted; the already-cancelled ctx
-			// still flows into eng.Run so a partially-run suite reports cleanly.
-			if ctx.Err() != nil {
+			// Stop launching new suites once interrupted or --fail-fast has tripped;
+			// the already-cancelled ctx still flows into eng.Run so a partially-run
+			// suite reports cleanly.
+			if ctx.Err() != nil || failStop.Load() {
 				break
 			}
 			runOne(i, p)
 		}
 	}
 	return suiteResults, loadErrs
+}
+
+// suiteFailed reports whether a completed suite counts as a failure for
+// --fail-fast: a failed or errored verdict, or a security-policy violation.
+func suiteFailed(res *engine.SuiteResult) bool {
+	return res != nil && (res.Status == engine.StatusFailed || res.Status == engine.StatusError || res.SecurityViolation)
 }
 
 // collectSpecFiles resolves run targets into a deduplicated list of spec files.

--- a/internal/loader/authoring_test.go
+++ b/internal/loader/authoring_test.go
@@ -283,3 +283,144 @@ scenarios:
 		t.Errorf("stdout_to/stderr_to decoded as %q/%q, want out.txt/err.txt", run.StdoutTo, run.StderrTo)
 	}
 }
+
+// TestLoadBytes_MockServerRejectedInScenario proves a mock_server step is
+// rejected outside suite.setup, like a service step. It is a suite-setup-only
+// action, but validateStep (the scenario steps/teardown path) had no case for
+// it, so it was silently accepted and never started.
+func TestLoadBytes_MockServerRejectedInScenario(t *testing.T) {
+	t.Parallel()
+	specs := map[string]string{
+		"steps": `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: ok
+    steps:
+      - mock_server:
+          name: api
+          routes:
+            - {method: GET, path: /}
+`,
+		"teardown": `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: ok
+    steps:
+      - run: {command: echo hi}
+    teardown:
+      - mock_server:
+          name: api
+          routes:
+            - {method: GET, path: /}
+`,
+	}
+	for block, src := range specs {
+		_, err := LoadBytes("sample.atago.yaml", []byte(src))
+		if err == nil {
+			t.Fatalf("%s: LoadBytes() error = nil, want a 'mock_server steps are only allowed in suite.setup' error", block)
+		}
+		if !strings.Contains(err.Error(), "mock_server") || !strings.Contains(err.Error(), "suite.setup") {
+			t.Fatalf("%s: LoadBytes() error = %v, want it to mention mock_server and suite.setup", block, err)
+		}
+	}
+}
+
+// TestLoadBytes_ExitCodeUnknownKeyRejected proves the exit_code mapping form is
+// decoded strictly: an unknown key is an authoring typo and must be rejected,
+// matching the loader's yaml.Strict() decode for the rest of the document.
+func TestLoadBytes_ExitCodeUnknownKeyRejected(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: ok
+    steps:
+      - run: {command: echo hi}
+      - assert:
+          exit_code: {not: 0, bogus: 5}
+`
+	_, err := LoadBytes("sample.atago.yaml", []byte(src))
+	if err == nil {
+		t.Fatalf("LoadBytes() error = nil, want an unknown-field error for exit_code.bogus")
+	}
+}
+
+// TestLoadBytes_DirGlobValidated proves a malformed dir.glob pattern is rejected
+// at load time, like the changes globs and dir.ignore patterns already are,
+// instead of only misbehaving at check time.
+func TestLoadBytes_DirGlobValidated(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: ok
+    steps:
+      - run: {command: echo hi}
+      - assert:
+          dir:
+            path: out
+            glob: "a["
+`
+	_, err := LoadBytes("sample.atago.yaml", []byte(src))
+	if err == nil {
+		t.Fatalf("LoadBytes() error = nil, want a 'not a valid glob' error for dir.glob")
+	}
+	if !strings.Contains(err.Error(), "glob") {
+		t.Fatalf("LoadBytes() error = %v, want it to mention the invalid glob", err)
+	}
+}
+
+// TestLoadBytes_NegativeDurationRejected proves a negative timeout is rejected at
+// load time. A negative wall-clock bound is never meaningful — the same rule
+// validatePTY and validateSignal already enforce — and a negative step timeout
+// produces an already-expired context that kills the step immediately.
+func TestLoadBytes_NegativeDurationRejected(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"suite.timeout": `
+version: "1"
+suite:
+  name: sample
+  timeout: "-5s"
+scenarios:
+  - name: ok
+    steps:
+      - run: {command: echo hi}
+`,
+		"run.timeout": `
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: ok
+    steps:
+      - run: {command: echo hi, timeout: "-5s"}
+`,
+		"defaults.run.timeout": `
+version: "1"
+suite:
+  name: sample
+defaults:
+  run:
+    timeout: "-5s"
+scenarios:
+  - name: ok
+    steps:
+      - run: {command: echo hi}
+`,
+	}
+	for name, src := range cases {
+		_, err := LoadBytes("sample.atago.yaml", []byte(src))
+		if err == nil {
+			t.Fatalf("%s: LoadBytes() error = nil, want a negative-duration validation error", name)
+		}
+	}
+}

--- a/internal/loader/validate.go
+++ b/internal/loader/validate.go
@@ -125,8 +125,10 @@ func validateSuiteTimeout(add func(string, ...any), s *spec.Suite) {
 	if s.Timeout == "" {
 		return
 	}
-	if _, err := time.ParseDuration(s.Timeout); err != nil {
+	if d, err := time.ParseDuration(s.Timeout); err != nil {
 		add("suite.timeout %q is not a valid duration (e.g. \"2m\"); use \"0\" to disable the built-in default", s.Timeout)
+	} else if d < 0 {
+		add("suite.timeout must not be negative (got %q); a wall-clock bound is never below zero", s.Timeout)
 	}
 }
 
@@ -150,8 +152,10 @@ func validateDefaults(add func(string, ...any), d *spec.Defaults) {
 			add("defaults.run.stdin is not supported (stdin is per-step input data, like command)")
 		}
 		if r.Timeout != "" {
-			if _, err := time.ParseDuration(r.Timeout); err != nil {
+			if d, err := time.ParseDuration(r.Timeout); err != nil {
 				add("defaults.run.timeout %q is not a valid duration (e.g. \"30s\")", r.Timeout)
+			} else if d < 0 {
+				add("defaults.run.timeout must not be negative (got %q); a wall-clock bound is never below zero", r.Timeout)
 			}
 		}
 		validateHermeticEnv(add, "defaults.run", r.ClearEnv, r.PassEnv)
@@ -340,6 +344,8 @@ func validateStep(add func(string, ...any), where string, st *spec.Step, runners
 		validateStore(add, where, st.Store)
 	case spec.StepService:
 		add("%s: service steps are only allowed in suite.setup (scenario-scoped peers go under the scenario's services: list)", where)
+	case spec.StepMockServer:
+		add("%s: mock_server steps are only allowed in suite.setup (a scenario-scoped stub goes under the scenario's mock_servers: list)", where)
 	case spec.StepPTY:
 		validatePTY(add, where, st.PTY)
 	case spec.StepSignal:

--- a/internal/loader/validate_artifact.go
+++ b/internal/loader/validate_artifact.go
@@ -137,6 +137,13 @@ func validateDir(add func(string, ...any), where string, d *spec.DirAssert) {
 	}
 	if d.Glob != "" {
 		n++
+		// Validate the pattern at load time like the sibling dir.ignore and changes
+		// globs, so a malformed glob (e.g. "a[") fails with a positioned message
+		// instead of only misbehaving when the assertion runs. dir.glob is matched
+		// with path.Match at check time, so validate with the same grammar.
+		if _, err := path.Match(d.Glob, "probe"); err != nil {
+			add("%s.glob %q is not a valid glob: %v", where, d.Glob, err)
+		}
 	}
 	if d.MinCount != nil && d.MaxCount != nil && *d.MinCount > *d.MaxCount {
 		add("%s: min_count %d exceeds max_count %d", where, *d.MinCount, *d.MaxCount)

--- a/internal/loader/validate_run.go
+++ b/internal/loader/validate_run.go
@@ -16,8 +16,10 @@ import (
 func validateRunStep(add func(string, ...any), where string, r *spec.Run, runners map[string]spec.Runner, full bool) {
 	validateRunnerRef(add, where, "run", r.Runner, runners)
 	if r.Timeout != "" {
-		if _, err := time.ParseDuration(r.Timeout); err != nil {
+		if d, err := time.ParseDuration(r.Timeout); err != nil {
 			add("%s.run.timeout %q is not a valid duration (e.g. \"30s\")", where, r.Timeout)
+		} else if d < 0 {
+			add("%s.run.timeout must not be negative (got %q); a wall-clock bound is never below zero", where, r.Timeout)
 		}
 	}
 	if r.Command == "" {

--- a/internal/loader/validate_runner.go
+++ b/internal/loader/validate_runner.go
@@ -48,8 +48,10 @@ func validateRunners(add func(string, ...any), runners map[string]spec.Runner) {
 		// timeout is common to every runner type; catch a malformed value here
 		// instead of when the first step opens the connection.
 		if r.Timeout != "" {
-			if _, err := time.ParseDuration(r.Timeout); err != nil {
+			if d, err := time.ParseDuration(r.Timeout); err != nil {
 				add("%s.timeout %q is not a valid duration (e.g. \"30s\")", where, r.Timeout)
+			} else if d < 0 {
+				add("%s.timeout must not be negative (got %q); a wall-clock bound is never below zero", where, r.Timeout)
 			}
 		}
 		validateRunnerFields(add, where, &r)

--- a/internal/loader/validate_service.go
+++ b/internal/loader/validate_service.go
@@ -51,8 +51,10 @@ func validateReady(add func(string, ...any), where string, r *spec.Ready) {
 		key, val string
 	}{{"timeout", r.Timeout}, {"delay", r.Delay}} {
 		if d.val != "" {
-			if _, err := time.ParseDuration(d.val); err != nil {
+			if dur, err := time.ParseDuration(d.val); err != nil {
 				add("%s.ready.%s %q is not a valid duration", where, d.key, d.val)
+			} else if dur < 0 {
+				add("%s.ready.%s must not be negative (got %q); a wall-clock bound is never below zero", where, d.key, d.val)
 			}
 		}
 	}
@@ -114,8 +116,10 @@ func validateMockRoutes(add func(string, ...any), where string, routes []spec.Mo
 			add("%s.status %d is not a valid HTTP status", rw, rt.Status)
 		}
 		if rt.Delay != "" {
-			if _, err := time.ParseDuration(rt.Delay); err != nil {
+			if d, err := time.ParseDuration(rt.Delay); err != nil {
 				add("%s.delay %q is not a valid duration (e.g. \"500ms\")", rw, rt.Delay)
+			} else if d < 0 {
+				add("%s.delay must not be negative (got %q); a wall-clock bound is never below zero", rw, rt.Delay)
 			}
 		}
 	}

--- a/internal/record/pty.go
+++ b/internal/record/pty.go
@@ -63,7 +63,7 @@ func (r *PTYRecording) AppendInput(b []byte, echoOff bool) {
 // ansiPattern matches the terminal control sequences that carry no visible
 // text: CSI (ESC [ ... final), OSC (ESC ] ... BEL/ST), and two-byte ESC forms.
 // Stripping them yields the plain prompt text an expect should anchor on.
-var ansiPattern = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)|\x1b[@-Z\\-_]`)
+var ansiPattern = regexp.MustCompile(`\x1b\[[0-9:;?]*[ -/]*[@-~]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)|\x1b[@-Z\\-_]`)
 
 // GeneratePTY renders a spec skeleton whose single pty: step replays the
 // recorded session as expect/send pairs, and proves it loads cleanly before

--- a/internal/record/pty.go
+++ b/internal/record/pty.go
@@ -47,8 +47,16 @@ func (r *PTYRecording) AppendOutput(b []byte) {
 }
 
 // AppendInput records one burst of user input, tagged with whether terminal
-// echo was off (a secret prompt) at the time it was typed.
+// echo was off (a secret prompt) at the time it was typed. Consecutive input
+// bursts with the same echo state are coalesced (mirroring AppendOutput): raw
+// mode delivers one keystroke per read, so a typed line arrives as many one-byte
+// bursts, and without coalescing an N-character password would render as N
+// separate ${env:ATAGO_SECRET_n} placeholders instead of one.
 func (r *PTYRecording) AppendInput(b []byte, echoOff bool) {
+	if n := len(r.Segments); n > 0 && r.Segments[n-1].Input != nil && r.Segments[n-1].EchoOff == echoOff {
+		r.Segments[n-1].Input = append(r.Segments[n-1].Input, b...)
+		return
+	}
 	r.Segments = append(r.Segments, PTYSegment{Input: append([]byte(nil), b...), EchoOff: echoOff})
 }
 
@@ -200,17 +208,48 @@ func endsWithNewline(b []byte) bool {
 	return len(b) > 0 && (b[len(b)-1] == '\r' || b[len(b)-1] == '\n')
 }
 
-// stableLine returns the last non-empty visible line of output with ANSI
-// control sequences stripped and surrounding whitespace trimmed — the
-// conservative literal an expect/contains anchors on (#69).
+// stableLine returns the conservative literal an expect/contains anchors on: the
+// longest run of plain text on the last visible line of the transcript that
+// carries no ANSI sequence or control byte (#69). The returned run is a VERBATIM
+// substring of the raw transcript — ANSI sequences are turned into a delimiter,
+// not stripped and concatenated — so an anchor built from it actually matches the
+// raw pty stdout the replay compares against. Stripping ANSI and joining the
+// visible text (the old behavior) produced an anchor with mid-line color codes
+// removed that was never a substring of the raw output, so a colored prompt made
+// the generated spec fail on replay.
 func stableLine(output []byte) string {
-	clean := ansiPattern.ReplaceAllString(string(output), "")
-	clean = strings.ReplaceAll(clean, "\r", "\n")
+	// Replace ANSI/OSC sequences with a NUL so the plain text on either side stays
+	// contiguous and verbatim; fold CR so a redraw does not merge lines.
+	s := ansiPattern.ReplaceAllString(string(output), "\x00")
+	s = strings.ReplaceAll(s, "\r", "\n")
 	best := ""
-	for _, line := range strings.Split(clean, "\n") {
-		if t := strings.TrimSpace(line); t != "" {
-			best = t
+	for _, line := range strings.Split(s, "\n") {
+		if run := longestPlainRun(line); run != "" {
+			best = run
 		}
 	}
+	return best
+}
+
+// longestPlainRun returns the longest run of line that contains no C0 control
+// byte (the NUL standing in for an ANSI sequence, a tab, or any other), trimmed
+// of surrounding whitespace. Each such run existed verbatim in the raw output.
+func longestPlainRun(line string) string {
+	best := ""
+	var cur strings.Builder
+	flush := func() {
+		if t := strings.TrimSpace(cur.String()); len(t) > len(best) {
+			best = t
+		}
+		cur.Reset()
+	}
+	for _, r := range line {
+		if r < 0x20 {
+			flush()
+			continue
+		}
+		cur.WriteRune(r)
+	}
+	flush()
 	return best
 }

--- a/internal/record/pty_test.go
+++ b/internal/record/pty_test.go
@@ -212,3 +212,60 @@ func TestStableLine(t *testing.T) {
 		}
 	}
 }
+
+// TestStableLine_AnchorIsRawSubstring is a regression for the pty round-trip law
+// (#30/#69): the anchor an expect/contains is built from must be a verbatim
+// substring of the RAW transcript the replay matches against. Stripping ANSI and
+// concatenating the visible text produced an anchor with mid-line color codes
+// removed, so it was never a substring of the raw pty stdout and the generated
+// spec failed on replay.
+func TestStableLine_AnchorIsRawSubstring(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"Welcome\r\n\x1b[32mLogged in as \x1b[1mroot\x1b[0m\r\n",
+		"\x1b[1mUsername\x1b[0m: ",
+		"progress: \x1b[33m75%\x1b[0m done\r\n",
+	}
+	for _, raw := range cases {
+		anchor := stableLine([]byte(raw))
+		if anchor == "" {
+			t.Errorf("stableLine(%q) = empty, want a non-empty anchor", raw)
+			continue
+		}
+		if !strings.Contains(raw, anchor) {
+			t.Errorf("stableLine(%q) = %q, which is NOT a substring of the raw transcript", raw, anchor)
+		}
+	}
+}
+
+// TestAppendInput_CoalescesConsecutiveBursts is a regression: raw-mode capture
+// delivers one keystroke per read, so a typed password arrives as many one-byte
+// echo-off bursts. Without coalescing each becomes its own ${env:ATAGO_SECRET_n}
+// placeholder, yielding an unusable spec that asks the author to set one env var
+// per character. Consecutive input bursts with the same echo state must merge.
+func TestAppendInput_CoalescesConsecutiveBursts(t *testing.T) {
+	t.Parallel()
+	var rec PTYRecording
+	rec.AppendOutput([]byte("Password: "))
+	for _, c := range []string{"s", "3", "c", "r", "3", "t"} {
+		rec.AppendInput([]byte(c), true)
+	}
+	rec.AppendInput([]byte("\r"), true)
+	inputs := 0
+	for _, seg := range rec.Segments {
+		if seg.Input != nil {
+			inputs++
+		}
+	}
+	if inputs != 1 {
+		t.Fatalf("consecutive echo-off keystrokes not coalesced: %d input segments, want 1", inputs)
+	}
+	rec.Command = "login"
+	got, err := GeneratePTY(rec, Options{SuiteName: "pw"})
+	if err != nil {
+		t.Fatalf("GeneratePTY: %v", err)
+	}
+	if strings.Contains(string(got), "ATAGO_SECRET_2") {
+		t.Errorf("password fragmented into multiple secret placeholders:\n%s", got)
+	}
+}

--- a/internal/report/diff.go
+++ b/internal/report/diff.go
@@ -61,7 +61,7 @@ func unifiedDiff(expected, actual, expectedLabel, actualLabel string) string {
 	out = append(out, "--- "+expectedLabel, "+++ "+actualLabel)
 	hunks := groupHunks(ops, 3)
 	for _, h := range hunks {
-		out = append(out, fmt.Sprintf("@@ -%d,%d +%d,%d @@", h.aStart+1, h.aCount, h.bStart+1, h.bCount))
+		out = append(out, fmt.Sprintf("@@ -%s +%s @@", hunkRange(h.aStart, h.aCount), hunkRange(h.bStart, h.bCount)))
 		for _, op := range h.ops {
 			switch op.kind {
 			case ' ':
@@ -80,13 +80,26 @@ func unifiedDiff(expected, actual, expectedLabel, actualLabel string) string {
 	if aTrunc || bTrunc {
 		out = append(out, fmt.Sprintf("... (inputs truncated at %d lines; full payloads in artifacts)", diffMaxInputLines))
 	}
-	if !strings.HasSuffix(expected, "\n") && strings.HasSuffix(actual, "\n") {
+	// The marker describes a side whose last line lacks a trailing newline; an
+	// empty side has no last line, so it never carries the marker.
+	if expected != "" && !strings.HasSuffix(expected, "\n") && strings.HasSuffix(actual, "\n") {
 		out = append(out, noNewlineMarker+" (expected)")
 	}
-	if strings.HasSuffix(expected, "\n") && !strings.HasSuffix(actual, "\n") {
+	if actual != "" && strings.HasSuffix(expected, "\n") && !strings.HasSuffix(actual, "\n") {
 		out = append(out, noNewlineMarker+" (actual)")
 	}
 	return strings.Join(out, "\n")
+}
+
+// hunkRange formats one side of a unified-diff `@@` header. A side that
+// contributes zero lines (a pure insertion or deletion) is numbered 0, the GNU
+// convention patch(1) and strict diff parsers rely on; otherwise the 1-based
+// start line and its count.
+func hunkRange(start, count int) string {
+	if count == 0 {
+		return fmt.Sprintf("%d,0", start)
+	}
+	return fmt.Sprintf("%d,%d", start+1, count)
 }
 
 // splitDiffLines splits text into lines for diffing (CRLF folded so an OS

--- a/internal/report/diff.go
+++ b/internal/report/diff.go
@@ -80,12 +80,13 @@ func unifiedDiff(expected, actual, expectedLabel, actualLabel string) string {
 	if aTrunc || bTrunc {
 		out = append(out, fmt.Sprintf("... (inputs truncated at %d lines; full payloads in artifacts)", diffMaxInputLines))
 	}
-	// The marker describes a side whose last line lacks a trailing newline; an
+	// The marker describes a side whose last line lacks a trailing newline, judged
+	// per side and independently: when both sides lack it, both are annotated. An
 	// empty side has no last line, so it never carries the marker.
-	if expected != "" && !strings.HasSuffix(expected, "\n") && strings.HasSuffix(actual, "\n") {
+	if expected != "" && !strings.HasSuffix(expected, "\n") {
 		out = append(out, noNewlineMarker+" (expected)")
 	}
-	if actual != "" && strings.HasSuffix(expected, "\n") && !strings.HasSuffix(actual, "\n") {
+	if actual != "" && !strings.HasSuffix(actual, "\n") {
 		out = append(out, noNewlineMarker+" (actual)")
 	}
 	return strings.Join(out, "\n")

--- a/internal/report/diff_test.go
+++ b/internal/report/diff_test.go
@@ -216,3 +216,27 @@ func TestUnifiedDiff_OutputTruncationAndMultiHunk(t *testing.T) {
 		t.Errorf("actual-side no-newline marker missing:\n%s", nl)
 	}
 }
+
+// TestUnifiedDiff_ZeroCountHunkHeader is a regression: a hunk whose one side
+// contributes zero lines (a pure insertion or deletion) must number that side
+// 0, per the GNU unified-diff convention that patch(1) and strict parsers rely
+// on — not 1. The empty side also has no trailing-newline state to report.
+func TestUnifiedDiff_ZeroCountHunkHeader(t *testing.T) {
+	t.Parallel()
+	// Pure insertion: the expected side is empty (0 lines).
+	got := unifiedDiff("", "line1\nline2\n", "expected", "actual")
+	if !strings.Contains(got, "@@ -0,0 +1,2 @@") {
+		t.Errorf("insertion hunk header wrong:\n%s\nwant a \"@@ -0,0 +1,2 @@\" header", got)
+	}
+	if strings.Contains(got, "No newline at end of file (expected)") {
+		t.Errorf("spurious no-newline marker for an empty expected side:\n%s", got)
+	}
+	// Pure deletion: the actual side is empty (0 lines).
+	got = unifiedDiff("line1\nline2\n", "", "expected", "actual")
+	if !strings.Contains(got, "@@ -1,2 +0,0 @@") {
+		t.Errorf("deletion hunk header wrong:\n%s\nwant a \"@@ -1,2 +0,0 @@\" header", got)
+	}
+	if strings.Contains(got, "No newline at end of file (actual)") {
+		t.Errorf("spurious no-newline marker for an empty actual side:\n%s", got)
+	}
+}

--- a/internal/report/diff_test.go
+++ b/internal/report/diff_test.go
@@ -239,4 +239,10 @@ func TestUnifiedDiff_ZeroCountHunkHeader(t *testing.T) {
 	if strings.Contains(got, "No newline at end of file (actual)") {
 		t.Errorf("spurious no-newline marker for an empty actual side:\n%s", got)
 	}
+	// When BOTH non-empty sides lack a trailing newline, both are annotated —
+	// the marker is judged per side, not by comparing the two sides.
+	got = unifiedDiff("a", "b", "expected", "actual")
+	if !strings.Contains(got, noNewlineMarker+" (expected)") || !strings.Contains(got, noNewlineMarker+" (actual)") {
+		t.Errorf("both-no-newline sides not both annotated:\n%s", got)
+	}
 }

--- a/internal/report/format_parity_test.go
+++ b/internal/report/format_parity_test.go
@@ -256,3 +256,79 @@ func rejectedControlRune(r rune) bool {
 	}
 	return r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f)
 }
+
+// TestTAP_DiagnosticMessageNotDoubleEscaped is a regression: a `#` inside a TAP
+// diagnostic message is not special (it is a plain char in a double-quoted YAML
+// scalar), so it must round-trip verbatim. The old code ran the message through
+// tapInline — which escapes `#`→`\#` for the bare ok/not-ok line — then %q,
+// injecting a spurious backslash a TAP consumer would decode.
+func TestTAP_DiagnosticMessageNotDoubleEscaped(t *testing.T) {
+	t.Parallel()
+	res := &engine.SuiteResult{
+		Suite: "s", SpecPath: "s.atago.yaml", Status: engine.StatusFailed, Duration: time.Millisecond,
+		Scenarios: []engine.ScenarioResult{
+			{Name: "sc", Status: engine.StatusFailed, Duration: time.Millisecond, Steps: []engine.StepResult{
+				{Kind: "assert", Checks: []*assert.CheckResult{{OK: false, Desc: "issue #42 body contains foo"}}},
+			}},
+		},
+	}
+	tap := render(t, FormatTAP, res)
+	if !strings.Contains(tap, `message: "issue #42 body contains foo"`) {
+		t.Errorf("tap diagnostic message double-escaped or altered:\n%s\nwant a plain `message: \"issue #42 body contains foo\"`", tap)
+	}
+	if strings.Contains(tap, `\#`) {
+		t.Errorf("tap diagnostic message injected a spurious backslash before #:\n%s", tap)
+	}
+}
+
+// TestJUnit_TimeAttrIsPlainDecimal is a regression: a sub-millisecond scenario
+// duration must render as a plain decimal seconds value, not Go's default float
+// %g scientific notation (e.g. "1.5e-06"), which the JUnit/Surefire schema and
+// strict parsers reject.
+func TestJUnit_TimeAttrIsPlainDecimal(t *testing.T) {
+	t.Parallel()
+	res := &engine.SuiteResult{
+		Suite: "s", SpecPath: "s.atago.yaml", Status: engine.StatusPassed, Duration: 1500,
+		Scenarios: []engine.ScenarioResult{
+			{Name: "quick", Status: engine.StatusPassed, Duration: 1500, // 1500ns
+				Steps: []engine.StepResult{{Kind: "assert", Checks: []*assert.CheckResult{{OK: true}}}}},
+		},
+	}
+	out := render(t, FormatJUnit, res)
+	if strings.Contains(out, "e-") || strings.Contains(out, "e+") {
+		t.Errorf("junit time attribute uses scientific notation:\n%s", out)
+	}
+	// It must still parse as XML with the documented shape.
+	var root junitTestsuites
+	if err := xml.Unmarshal([]byte(out), &root); err != nil {
+		t.Fatalf("junit XML not well-formed: %v", err)
+	}
+}
+
+// TestRender_SummaryUsesElapsedNotSuiteSum is a regression: the console summary
+// headline duration must be the run's real wall-clock time, not the sum of
+// per-suite durations, which overcounts when --parallel runs suites concurrently
+// (two one-second suites in parallel finish in ~1s, not 2s).
+func TestRender_SummaryUsesElapsedNotSuiteSum(t *testing.T) {
+	t.Parallel()
+	suite := func(name string) *engine.SuiteResult {
+		return &engine.SuiteResult{
+			Suite: name, SpecPath: name + ".atago.yaml", Status: engine.StatusPassed, Duration: time.Second,
+			Scenarios: []engine.ScenarioResult{
+				{Name: "sc", Status: engine.StatusPassed, Duration: time.Second,
+					Steps: []engine.StepResult{{Kind: "assert", Checks: []*assert.CheckResult{{OK: true}}}}},
+			},
+		}
+	}
+	var b strings.Builder
+	if err := Render(&b, FormatConsole, []*engine.SuiteResult{suite("a"), suite("b")}, WithElapsed(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	out := b.String()
+	if !strings.Contains(out, "(1s)") {
+		t.Errorf("summary did not report the elapsed wall-clock (1s):\n%s", out)
+	}
+	if strings.Contains(out, "(2s)") {
+		t.Errorf("summary summed per-suite durations (2s) instead of using elapsed:\n%s", out)
+	}
+}

--- a/internal/report/junit.go
+++ b/internal/report/junit.go
@@ -4,10 +4,21 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 
 	"github.com/nao1215/atago/internal/engine"
 )
+
+// junitSeconds is a duration in seconds rendered as a plain fixed-point decimal.
+// encoding/xml marshals a float64 with %g, so a sub-millisecond time would come
+// out in scientific notation (e.g. "1.5e-06"), which the JUnit/Surefire schema
+// and strict parsers reject. Six decimals keep microsecond resolution.
+type junitSeconds float64
+
+func (s junitSeconds) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
+	return xml.Attr{Name: name, Value: strconv.FormatFloat(float64(s), 'f', 6, 64)}, nil
+}
 
 // A JUnit XML report, consumable by CI systems and test-result
 // viewers. Rendered by Render (FormatJUnit) via buildJUnit/writeJUnit.
@@ -17,7 +28,7 @@ type junitTestsuites struct {
 	Failures int              `xml:"failures,attr"`
 	Errors   int              `xml:"errors,attr"`
 	Skipped  int              `xml:"skipped,attr"`
-	Time     float64          `xml:"time,attr"`
+	Time     junitSeconds     `xml:"time,attr"`
 	Suites   []junitTestsuite `xml:"testsuite"`
 }
 
@@ -27,13 +38,13 @@ type junitTestsuite struct {
 	Failures  int             `xml:"failures,attr"`
 	Errors    int             `xml:"errors,attr"`
 	Skipped   int             `xml:"skipped,attr"`
-	Time      float64         `xml:"time,attr"`
+	Time      junitSeconds    `xml:"time,attr"`
 	Testcases []junitTestcase `xml:"testcase"`
 }
 
 type junitTestcase struct {
 	Name    string        `xml:"name,attr"`
-	Time    float64       `xml:"time,attr"`
+	Time    junitSeconds  `xml:"time,attr"`
 	Failure *junitMessage `xml:"failure,omitempty"`
 	Error   *junitMessage `xml:"error,omitempty"`
 	Skipped *junitSkipped `xml:"skipped,omitempty"`
@@ -55,10 +66,10 @@ type junitSkipped struct {
 func buildJUnit(results []*engine.SuiteResult) junitTestsuites {
 	root := junitTestsuites{}
 	for _, res := range results {
-		ts := junitTestsuite{Name: res.Suite, Time: res.Duration.Seconds()}
+		ts := junitTestsuite{Name: res.Suite, Time: junitSeconds(res.Duration.Seconds())}
 		for i := range res.Scenarios {
 			sc := &res.Scenarios[i]
-			tc := junitTestcase{Name: sc.Name, Time: sc.Duration.Seconds()}
+			tc := junitTestcase{Name: sc.Name, Time: junitSeconds(sc.Duration.Seconds())}
 			switch sc.Status {
 			case engine.StatusFailed:
 				tc.Failure = &junitMessage{Message: firstFailureMessage(sc), Body: detailText(sc)}

--- a/internal/report/render.go
+++ b/internal/report/render.go
@@ -21,12 +21,25 @@ type renderOptions struct {
 	// results, so the console summary reports them separately and reads FAILED
 	// rather than a misleading PASSED that contradicts the non-zero exit code (#120).
 	loadFailures int
+	// elapsed, when set, is the run's real wall-clock time. The console summary
+	// prefers it over the sum of per-suite durations, which overcounts when
+	// --parallel runs suites concurrently (4 one-second suites in parallel finish
+	// in ~1s, not 4s).
+	elapsed    time.Duration
+	hasElapsed bool
 }
 
 // WithLoadFailures records how many spec files failed to load for this run, so
 // the summary can reflect them instead of silently omitting them (#120).
 func WithLoadFailures(n int) Option {
 	return func(o *renderOptions) { o.loadFailures = n }
+}
+
+// WithElapsed supplies the run's real wall-clock duration so the console summary
+// reports it instead of summing per-suite durations, which overcounts under
+// concurrent (--parallel) suites.
+func WithElapsed(d time.Duration) Option {
+	return func(o *renderOptions) { o.elapsed = d; o.hasElapsed = true }
 }
 
 // Render writes one or more suite results in the requested format. Console
@@ -65,6 +78,9 @@ func Render(w io.Writer, f Format, results []*engine.SuiteResult, opts ...Option
 			if suiteErroredWithoutScenarios(res) {
 				hardFail = true
 			}
+		}
+		if o.hasElapsed {
+			dur = o.elapsed
 		}
 		writeSummary(&b, color, agg, total, dur, hardFail, o.loadFailures)
 		_, err := io.WriteString(w, b.String())

--- a/internal/report/tap.go
+++ b/internal/report/tap.go
@@ -72,7 +72,12 @@ func writeTAP(w io.Writer, results []*engine.SuiteResult) error {
 // body is defanged so it cannot close the block early.
 func writeTAPDiagnostic(b *strings.Builder, message, body string) {
 	b.WriteString("  ---\n")
-	fmt.Fprintf(b, "  message: %q\n", tapInline(message))
+	// The message is a double-quoted YAML scalar, where `#` is an ordinary
+	// character — so flatten and fold control bytes, but do NOT apply tapInline's
+	// `#`→`\#` directive escaping (that is only for the bare ok/not-ok line).
+	// Running it here and then %q would inject a spurious backslash the consumer
+	// decodes back into the message.
+	fmt.Fprintf(b, "  message: %q\n", tapFlatten(message))
 	if body != "" {
 		b.WriteString("  data: |\n")
 		for _, line := range strings.Split(body, "\n") {
@@ -95,12 +100,17 @@ func tapDescription(suite, name string) string {
 // tapInline flattens a string to a single line and escapes `#` so it cannot be
 // misread as the start of a TAP directive.
 func tapInline(s string) string {
+	return strings.TrimSpace(strings.ReplaceAll(tapFlatten(s), "#", "\\#"))
+}
+
+// tapFlatten collapses a string onto one clean line — newlines and CRs become
+// spaces and any captured control byte (ANSI escape, bell, DEL) is folded — but
+// applies no TAP-directive escaping. It backs a quoted YAML diagnostic message,
+// where `#` is an ordinary character; tapInline adds the `#` escaping the bare
+// ok/not-ok line needs.
+func tapFlatten(s string) string {
 	s = strings.ReplaceAll(s, "\n", " ")
 	s = strings.ReplaceAll(s, "\r", " ")
-	s = strings.ReplaceAll(s, "#", "\\#")
-	// A captured control byte (ANSI escape, bell, DEL) has no place on a TAP
-	// line; fold it so the ok/not-ok description and any SKIP directive stay
-	// clean. Newlines are already flattened above, so none survive here.
 	s = sanitizeControlBytes(s)
 	return strings.TrimSpace(s)
 }

--- a/internal/security/masker.go
+++ b/internal/security/masker.go
@@ -137,7 +137,9 @@ func (m *Masker) Mask(s string) string {
 				covered[k] = true
 			}
 			any = true
-			i = start + len(v)
+			// Advance by one, not len(v), so overlapping occurrences of the same
+			// secret are all covered — "aaaa" occurs three times in "aaaaaa".
+			i = start + 1
 		}
 	}
 	if !any {

--- a/internal/security/masker.go
+++ b/internal/security/masker.go
@@ -63,9 +63,10 @@ func NewMasker(values []string) *Masker {
 			v = append(v, x)
 		}
 	}
-	// Mask longest-first: sequential ReplaceAll would otherwise let a short
-	// secret that is a substring of a longer one mask only its prefix and leak
-	// the rest (e.g. masking "abcd" before "abcdefgh" leaves "efgh" visible).
+	// Order the values longest-first for deterministic, stable output. Mask now
+	// unions the byte ranges of every occurrence over the original string, so
+	// correctness no longer depends on order (a substring or an overlapping
+	// secret is masked regardless), but a stable order keeps output reproducible.
 	sort.SliceStable(v, func(i, j int) bool { return len(v[i]) > len(v[j]) })
 	return &Masker{values: v}
 }
@@ -112,15 +113,49 @@ func NewMaskerForSpec(s *spec.Spec) *Masker {
 // Empty reports whether the masker has nothing to mask.
 func (m *Masker) Empty() bool { return m == nil || len(m.values) == 0 }
 
-// Mask replaces every known secret value in s with "***".
+// Mask replaces every known secret value in s with "***". It marks the byte
+// ranges of every secret occurrence over the ORIGINAL string in one pass, then
+// collapses each maximal covered run to a single placeholder. Scanning the
+// original (rather than a sequence of ReplaceAll that mutates s) is what keeps
+// two overlapping secrets — one ending with the bytes the next begins with, e.g.
+// "abcXYZ" and "XYZdef" in "abcXYZdef" — both masked; a sequential replace would
+// consume the shared bytes and leak the second secret's tail.
 func (m *Masker) Mask(s string) string {
 	if m.Empty() {
 		return s
 	}
+	covered := make([]bool, len(s))
+	any := false
 	for _, v := range m.values {
-		s = strings.ReplaceAll(s, v, "***")
+		for i := 0; ; {
+			j := strings.Index(s[i:], v)
+			if j < 0 {
+				break
+			}
+			start := i + j
+			for k := start; k < start+len(v); k++ {
+				covered[k] = true
+			}
+			any = true
+			i = start + len(v)
+		}
 	}
-	return s
+	if !any {
+		return s
+	}
+	var b strings.Builder
+	for i := 0; i < len(s); {
+		if covered[i] {
+			b.WriteString("***")
+			for i < len(s) && covered[i] {
+				i++
+			}
+			continue
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String()
 }
 
 // MaskBytes is Mask for byte slices, returning the input unchanged when there is

--- a/internal/security/masker_test.go
+++ b/internal/security/masker_test.go
@@ -40,6 +40,22 @@ func TestMasker_OverlappingSecretsNoLeak(t *testing.T) {
 	}
 }
 
+// TestMasker_AdjacentOverlapNoLeak is a regression: two secrets that overlap
+// end-to-start (one ends with the bytes the other begins with) must both be
+// masked. Sequential ReplaceAll masked the first and consumed the shared bytes,
+// so the second secret's tail leaked though it appeared verbatim in the output.
+func TestMasker_AdjacentOverlapNoLeak(t *testing.T) {
+	t.Parallel()
+	m := NewMasker([]string{"abcXYZ", "XYZdef"})
+	got := m.Mask("token=abcXYZdef end")
+	if strings.Contains(got, "def") {
+		t.Errorf("overlapping secret tail leaked: %q", got)
+	}
+	if strings.Contains(got, "abc") {
+		t.Errorf("overlapping secret head leaked: %q", got)
+	}
+}
+
 func TestMasker_MaskBytes(t *testing.T) {
 	t.Parallel()
 	m := NewMasker([]string{"supersecret"})

--- a/internal/security/masker_test.go
+++ b/internal/security/masker_test.go
@@ -56,6 +56,18 @@ func TestMasker_AdjacentOverlapNoLeak(t *testing.T) {
 	}
 }
 
+// TestMasker_SelfOverlappingSecret is a regression: a secret that overlaps its
+// own repeats must be masked at every occurrence. Advancing past a hit by the
+// secret's full length skipped the overlapping repeats, so "aaaa" in "aaaaaa"
+// masked only the first four bytes and leaked "aa".
+func TestMasker_SelfOverlappingSecret(t *testing.T) {
+	t.Parallel()
+	m := NewMasker([]string{"aaaa"})
+	if got := m.Mask("token=aaaaaa"); got != "token=***" {
+		t.Errorf("Mask self-overlap = %q, want %q", got, "token=***")
+	}
+}
+
 func TestMasker_MaskBytes(t *testing.T) {
 	t.Parallel()
 	m := NewMasker([]string{"supersecret"})

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -95,7 +95,7 @@ func maskPathPrefix(s, prefix, replacement string) string {
 	for i := 0; i < len(s); {
 		if strings.HasPrefix(s[i:], prefix) {
 			end := i + len(prefix)
-			if end >= len(s) || !isPathContinuation(s[end]) {
+			if end >= len(s) || isComponentBoundary(s[end]) {
 				b.WriteString(replacement)
 				i = end
 				continue
@@ -107,19 +107,14 @@ func maskPathPrefix(s, prefix, replacement string) string {
 	return b.String()
 }
 
-// isPathContinuation reports whether c can continue a filename component. A
-// masked prefix must not be applied when the next byte is one of these, or it
-// would swallow part of a longer name (/home/naoki for home /home/nao). A
-// separator or punctuation ends the component and is a safe masking boundary.
-func isPathContinuation(c byte) bool {
-	switch {
-	case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
-		return true
-	case c == '.' || c == '-' || c == '_':
-		return true
-	default:
-		return false
-	}
+// isComponentBoundary reports whether byte c ends a path component so the prefix
+// before it can be masked: a path separator or a whitespace/control byte, where a
+// path token in captured output ends. Filename-legal bytes — letters, digits, and
+// punctuation like '.', '-', '_', '+', '@' — are NOT boundaries, so a longer
+// sibling path (/home/naoki for home /home/nao, /tmp/run1+cache for workdir
+// /tmp/run1) is left intact rather than corrupted.
+func isComponentBoundary(c byte) bool {
+	return c == '/' || c == '\\' || c <= ' '
 }
 
 // Compare normalizes actual and checks it against the stored snapshot at path.

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -61,16 +61,65 @@ func Normalize(data []byte, opt Options) []byte {
 	s = strings.ReplaceAll(s, "\r\n", "\n")
 	s = reCSI.ReplaceAllString(s, "")
 	s = reOSC.ReplaceAllString(s, "")
-	if opt.Workdir != "" {
-		s = strings.ReplaceAll(s, opt.Workdir, "<workdir>")
-	}
-	if home, err := os.UserHomeDir(); err == nil && home != "" {
-		s = strings.ReplaceAll(s, home, "~")
-	}
 	s = reUUID.ReplaceAllString(s, "<uuid>")
 	s = reTimestamp.ReplaceAllString(s, "<timestamp>")
 	s = rePort.ReplaceAllString(s, "$1:<port>")
+	// Path masking is component-boundary aware (it must not turn /home/naoki into
+	// ~ki), so it depends on the byte that follows the prefix. Run it AFTER the
+	// uuid/timestamp/port maskers so that neighbor byte is already in its final
+	// form — otherwise a workdir abutting a timestamp (".../tmp/x2026-..." → mask
+	// timestamp → ".../tmp/x<timestamp>") would flip the boundary between passes
+	// and break idempotence.
+	if opt.Workdir != "" {
+		s = maskPathPrefix(s, opt.Workdir, "<workdir>")
+	}
+	// Skip a root home ("/"): masking it would rewrite every absolute path. It is
+	// the home of some container/CI users, where os.UserHomeDir returns "/".
+	if home, err := os.UserHomeDir(); err == nil && home != "" && home != "/" {
+		s = maskPathPrefix(s, home, "~")
+	}
 	return []byte(s)
+}
+
+// maskPathPrefix replaces every occurrence of prefix in s with replacement, but
+// only where prefix ends a path component — the following byte is a separator or
+// other boundary character, or the match is at end of string. Masking a bare
+// substring instead would corrupt a longer sibling path: the home dir /home/nao
+// must not turn /home/naoki into ~ki, and the workdir /tmp/run1 must not turn
+// /tmp/run10 into <workdir>0.
+func maskPathPrefix(s, prefix, replacement string) string {
+	if prefix == "" {
+		return s
+	}
+	var b strings.Builder
+	for i := 0; i < len(s); {
+		if strings.HasPrefix(s[i:], prefix) {
+			end := i + len(prefix)
+			if end >= len(s) || !isPathContinuation(s[end]) {
+				b.WriteString(replacement)
+				i = end
+				continue
+			}
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String()
+}
+
+// isPathContinuation reports whether c can continue a filename component. A
+// masked prefix must not be applied when the next byte is one of these, or it
+// would swallow part of a longer name (/home/naoki for home /home/nao). A
+// separator or punctuation ends the component and is a safe masking boundary.
+func isPathContinuation(c byte) bool {
+	switch {
+	case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
+		return true
+	case c == '.' || c == '-' || c == '_':
+		return true
+	default:
+		return false
+	}
 }
 
 // Compare normalizes actual and checks it against the stored snapshot at path.

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -138,3 +138,36 @@ func TestCompare_CRLFGolden(t *testing.T) {
 		t.Error("a CRLF golden did not match LF-folded actual; CRLF must be folded on both sides")
 	}
 }
+
+// TestNormalize_PathMaskingBoundaries is a regression for the naive substring
+// masking of the home and workdir prefixes: a masked prefix must only replace a
+// whole path component, or it corrupts an unrelated sibling path.
+func TestNormalize_PathMaskingBoundaries(t *testing.T) {
+	t.Run("home does not swallow a longer sibling", func(t *testing.T) {
+		t.Setenv("HOME", "/home/nao")
+		// /home/naoki is a different user; only the exact home dir is masked.
+		got := string(Normalize([]byte("/home/naoki/project and /home/nao/x"), Options{}))
+		if strings.Contains(got, "~ki") {
+			t.Errorf("home masking corrupted a sibling path: %q", got)
+		}
+		if !strings.Contains(got, "~/x") {
+			t.Errorf("home dir was not masked: %q", got)
+		}
+	})
+	t.Run("root home does not turn every slash into tilde", func(t *testing.T) {
+		t.Setenv("HOME", "/")
+		got := string(Normalize([]byte("path /usr/local/bin"), Options{}))
+		if got != "path /usr/local/bin" {
+			t.Errorf("HOME=/ mangled unrelated paths: %q", got)
+		}
+	})
+	t.Run("workdir does not swallow a prefix-sibling temp dir", func(t *testing.T) {
+		got := string(Normalize([]byte("a /tmp/run1/x b /tmp/run10/y"), Options{Workdir: "/tmp/run1"}))
+		if !strings.Contains(got, "<workdir>/x") {
+			t.Errorf("workdir was not masked: %q", got)
+		}
+		if !strings.Contains(got, "/tmp/run10/y") {
+			t.Errorf("workdir masking corrupted a prefix-sibling: %q", got)
+		}
+	})
+}

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -168,6 +168,18 @@ func TestNormalize_PathMaskingBoundaries(t *testing.T) {
 			t.Errorf("HOME=/ mangled unrelated paths: %q", got)
 		}
 	})
+	t.Run("workdir does not swallow a punctuation-suffixed sibling", func(t *testing.T) {
+		// '+' is a legal filename byte, so /tmp/run1+cache is a different directory
+		// and must be left intact; only a separator, whitespace, or end of token is
+		// a masking boundary.
+		got := string(Normalize([]byte("/tmp/run1/x and /tmp/run1+cache/y"), Options{Workdir: "/tmp/run1"}))
+		if !strings.Contains(got, "<workdir>/x") {
+			t.Errorf("workdir was not masked: %q", got)
+		}
+		if !strings.Contains(got, "/tmp/run1+cache/y") {
+			t.Errorf("workdir masking corrupted a punctuation-suffixed sibling: %q", got)
+		}
+	})
 	t.Run("workdir does not swallow a prefix-sibling temp dir", func(t *testing.T) {
 		got := string(Normalize([]byte("a /tmp/run1/x b /tmp/run10/y"), Options{Workdir: "/tmp/run1"}))
 		if !strings.Contains(got, "<workdir>/x") {

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -144,6 +145,9 @@ func TestCompare_CRLFGolden(t *testing.T) {
 // whole path component, or it corrupts an unrelated sibling path.
 func TestNormalize_PathMaskingBoundaries(t *testing.T) {
 	t.Run("home does not swallow a longer sibling", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("os.UserHomeDir ignores $HOME on Windows, so the POSIX home path cannot be forced")
+		}
 		t.Setenv("HOME", "/home/nao")
 		// /home/naoki is a different user; only the exact home dir is masked.
 		got := string(Normalize([]byte("/home/naoki/project and /home/nao/x"), Options{}))
@@ -155,6 +159,9 @@ func TestNormalize_PathMaskingBoundaries(t *testing.T) {
 		}
 	})
 	t.Run("root home does not turn every slash into tilde", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("os.UserHomeDir ignores $HOME on Windows, so a root home cannot be forced")
+		}
 		t.Setenv("HOME", "/")
 		got := string(Normalize([]byte("path /usr/local/bin"), Options{}))
 		if got != "path /usr/local/bin" {

--- a/internal/spec/assert.go
+++ b/internal/spec/assert.go
@@ -255,7 +255,11 @@ func (e *ExitCode) UnmarshalYAML(b []byte) error {
 		Not *int  `yaml:"not"`
 		In  []int `yaml:"in"`
 	}
-	if err := yaml.Unmarshal(b, &m); err != nil {
+	// Decode strictly so an unknown key (a typo like {not: 0, bogus: 5}) is
+	// rejected here too. A custom unmarshaler bypasses the loader's document-wide
+	// yaml.Strict(), so without this the mapping form silently drops misspelled
+	// fields — the same reason PTYSend and Stdin reject unknown keys.
+	if err := yaml.UnmarshalWithOptions(b, &m, yaml.Strict()); err != nil {
 		return fmt.Errorf("exit_code must be an integer (exit_code: 0), a negation (exit_code: {not: 0}), or a set (exit_code: {in: [0, 2]}), got %q", strings.TrimSpace(string(b)))
 	}
 	e.Not = m.Not

--- a/site/samples/report.junit.xml
+++ b/site/samples/report.junit.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites tests="2" failures="1" errors="0" skipped="0" time="0">
-  <testsuite name="demo" tests="2" failures="1" errors="0" skipped="0" time="0">
-    <testcase name="echo greets the world" time="0"></testcase>
-    <testcase name="detects a wrong greeting" time="0">
+<testsuites tests="2" failures="1" errors="0" skipped="0" time="0.000000">
+  <testsuite name="demo" tests="2" failures="1" errors="0" skipped="0" time="0.000000">
+    <testcase name="echo greets the world" time="0.000000"></testcase>
+    <testcase name="detects a wrong greeting" time="0.000000">
       <failure message="assert stdout contains &#34;Alice&#34;">Step: assert stdout contains &#34;Alice&#34;&#xA;Expected: stdout contains &#34;Alice&#34;&#xA;Actual: Bob&#xA;Hint: the substring &#34;Alice&#34; was not present in stdout</failure>
     </testcase>
   </testsuite>


### PR DESCRIPTION
A correctness pass across `record`, `snapshot`, the report formats, the loader, the assertion matchers, secret masking, and the run engine. Each defect was surfaced by an edge-case bug hunt and fixed with a reproduction test first. No new features; twenty-one distinct defects across seven packages, grouped into the changelog's Fixed entries.

record

The `record --pty` anchor stripped ANSI from the visible line and joined the result, so a colored prompt produced an `expect`/`stdout: contains` value with mid-line color codes removed that was never a substring of the raw pty stdout the replay matches — the generated spec failed on replay. `stableLine` now returns the longest color-free run of the last visible line, which is verbatim in the raw output. Separately, raw-mode capture delivers one keystroke per read and consecutive input bursts were not coalesced, so a six-character password generated seven single-character `${env:ATAGO_SECRET_n}` sends; `AppendInput` now merges consecutive bursts with the same echo state.

snapshot

A dir-tree manifest joins a symlink's name and target with ` -> ` but did not escape it inside either field, so a symlink named `a -> b` pointing at `c` rendered the same line as one named `a` pointing at `b -> c` and falsely matched its golden. Snapshot normalization also masked the home and workdir prefixes with a bare substring replace, so `/home/nao` corrupted `/home/naoki` into `~ki`, a container `HOME=/` turned every absolute path into tildes, and workdir `/tmp/run1` turned `/tmp/run10` into `<workdir>0`. Masking is now path-component aware, skips a root home, and runs after the uuid/timestamp/port maskers so it stays idempotent.

report

A unified-diff hunk with a zero-line side emitted `@@ -1,0 ...` instead of the GNU `@@ -0,0 ...` that patch(1) relies on, and an empty side carried a spurious no-newline marker. A `--report tap` diagnostic message was escaped for the bare ok/not-ok line and then quoted, so `issue #42` reached the consumer as `issue \#42`. A `--report junit` `time` attribute serialized a sub-millisecond duration as `1.5e-06`, which the JUnit/Surefire schema rejects. The console summary headline summed each suite's own duration, overcounting when `--parallel` runs suites concurrently.

run engine

`--fail-fast` only stopped scenarios within one suite, so a failing first spec still let every later spec run; scheduling now halts across files. `--tag` and `--skip-tag` were single-string flags that kept only the last occurrence, so `--tag a --tag b` silently dropped `a`; both are now repeatable and OR their values like `--filter`.

assert and security

The `gt`/`gte`/`lt`/`lte` matchers rounded the selected value through float64, so a JSON integer beyond 2^53 compared equal to its neighbor; they now use exact big.Int arithmetic like `equals`. A scalar `equals` fallback compared operands by their printed form, so a JSON boolean `true` matched `equals: "true"`. Secret masking let one secret consume bytes an overlapping secret needed, leaking its tail in cleartext; every occurrence is now masked in one pass over the original text.

loader

A `mock_server` step in a scenario's `steps` or `teardown` was silently accepted though it is `suite.setup`-only. An unknown key in the `exit_code` mapping form bypassed strict decoding. A `dir.glob` pattern was never compile-checked at load time. A negative `timeout`/`delay` on the suite, run, defaults, runner, service readiness, and mock-route fields was accepted and produced an already-expired context.

Verification

`make test`, `make lint`, and `make e2e` (228 scenarios) all pass. Every fix carries a reproduction test that fails before the change; the `--report junit` time-format change regenerated `site/samples/report.junit.xml` via `make site`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved report formatting for diffs, TAP, JUnit, and console summaries.
  * Fixed snapshot/path masking so similar paths and home directories are handled correctly.
  * Made secret masking more reliable, including overlapping secrets and bursty hidden input.
  * Improved replay anchors for terminal recordings so prompts and colored output replay more consistently.
  * Tightened validation for durations, glob patterns, exit-code rules, and mock server placement.
  * Updated tag filtering and fail-fast behavior so runs stop and select scenarios more predictably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->