### PR TITLE
build(goreleaser): distribute deb, rpm, and apk Linux packages

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,6 +24,16 @@ archives:
     format_overrides:
       - goos: windows
         formats: [zip]
+# Linux system packages for apt/dnf/apk users (the same set gup and sqly ship).
+nfpms:
+  - maintainer: Naohiro CHIKAMATSU <n.chika156@gmail.com>
+    description: "Tests real CLI behavior from plain YAML: commands, files, snapshots, and interactive terminals"
+    homepage: https://github.com/nao1215/atago
+    license: MIT License
+    formats:
+      - deb
+      - rpm
+      - apk
 checksum:
   name_template: "checksums.txt"
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ On macOS, Homebrew works too:
 brew install --cask nao1215/tap/atago
 ```
 
-The [release page](https://github.com/nao1215/atago/releases) contains prebuilt binary archives for Linux, macOS, and Windows (amd64/arm64; `.tar.gz`, or `.zip` on Windows). Requires Go 1.26 or later when building from source.
+The [release page](https://github.com/nao1215/atago/releases) contains prebuilt binary archives for Linux, macOS, and Windows (amd64/arm64; `.tar.gz`, or `.zip` on Windows), plus `.deb`, `.rpm`, and `.apk` packages for Linux. Requires Go 1.26 or later when building from source.
 
 Runs on Linux, macOS, and Windows (CI tests all three).
 


### PR DESCRIPTION
## Summary

Ship `.deb`, `.rpm`, and `.apk` Linux packages from GoReleaser so apt/dnf/apk users can install atago from the release page, matching how gup and sqly already distribute.

## Changes

- [.goreleaser.yml](.goreleaser.yml): add an `nfpms` block (deb/rpm/apk, amd64/arm64) with the same shape gup and sqly use.
- [README.md](README.md): extend the install section's archive sentence to mention the new `.deb`/`.rpm`/`.apk` packages, matching the concise tone used for tar/zip.

## Design Decisions

Reused the minimal `nfpms` config from sqly rather than gup's, since atago ships no shell completions and therefore needs no `contents` entries. Verified locally with `goreleaser check` and a `goreleaser release --snapshot` run that produced deb/rpm/apk for both amd64 and arm64.