### PR TITLE
feat(snapshot,repeat): add scrub normalization and classify partial-repeat runs as flaky

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,31 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 A correctness pass across `record`, `snapshot`, the report formats, the loader,
 the assertion matchers, secret masking, and the run engine. Each defect was
-surfaced by an edge-case bug hunt and fixed with a reproduction test first. No
-new features.
+surfaced by an edge-case bug hunt and fixed with a reproduction test first, plus
+two flaky-test tooling improvements described below.
+
+### Added
+
+- `scrub:` (#137) — spec-wide declarative output normalization for snapshots. Each rule
+  rewrites every regex match in captured output to a literal placeholder
+  (`{pattern: 'id=\d+', placeholder: 'id=<ID>'}`) before a snapshot is compared
+  or written. Where the built-in normalizers fold a fixed set of volatile forms
+  (ANSI, UUID, timestamp, port, path) and `secrets:` masks known values, `scrub:`
+  handles the open set of volatile patterns only the author knows about —
+  auto-increment IDs, request identifiers, custom timestamps — so a snapshot that
+  flaked every run becomes deterministic. Rules apply after secret masking and
+  before the built-in normalization. See [examples/scrub.atago.yaml](examples/scrub.atago.yaml).
+
+### Changed
+
+- `--repeat` (#138) now distinguishes an unstable scenario from a broken one. A run
+  where some iterations passed and some failed folds to `flaky` (green for the
+  exit code, surfaced with its flake rate, e.g. `2/10 iterations failed`) instead
+  of a hard `failed`; a scenario that failed *every* iteration stays a
+  deterministic `failed`. Previously any failing iteration collapsed the whole
+  fold to `failed`, so "3/10 flaked" was indistinguishable from "10/10 is a real
+  bug" — the exact signal `--repeat` exists to surface. This matches how
+  `--retry-failed` already reports a recovery as `flaky`.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Every feature has a commented, runnable spec under [examples/](examples/). The e
 | [pty_screen](examples/pty_screen.atago.yaml) | TUI testing on the RENDERED terminal screen: vt100 emulation, row-addressed asserts, and screen snapshots (POSIX-only) |
 | [retry](examples/retry.atago.yaml) | polling a command until an assertion passes |
 | [snapshot](examples/snapshot.atago.yaml) | golden-file testing with normalized output |
+| [scrub](examples/scrub.atago.yaml) | `scrub:` rewrites volatile output patterns (auto-increment IDs, request identifiers, epoch times) to a placeholder before a snapshot compares — the flake-killer the built-in normalizers do not cover |
 | [duration](examples/duration.atago.yaml) | bound a step's wall-clock time with `duration: {lt: 2s, gte: 100ms}` (use generous bounds — CI runners are slow) |
 | [dir_tree](examples/dir_tree.atago.yaml) | recursive dir assertions and directory-tree snapshots: pin a generator's whole output tree with one golden manifest |
 | [changes](examples/changes.atago.yaml) | `changes:` pins the exact workdir delta of a step — which files it created, modified, and deleted, and nothing else |
@@ -295,6 +296,15 @@ atago list ./specs
 ```shell
 atago snapshot update spec.atago.yaml
 ```
+
+For volatile patterns the built-ins do not cover — auto-increment IDs, request identifiers, epoch times — declare spec-wide `scrub:` rules that rewrite each regex match to a placeholder before the compare (applied after `secrets:` masking):
+
+```yaml
+scrub:
+  - {pattern: 'id=\d+', placeholder: 'id=<ID>'}
+```
+
+See [scrub](examples/scrub.atago.yaml).
 
 ## Editor support (JSON Schema)
 

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1730,6 +1730,7 @@ _skipped on windows_
 #### Given
 - Fixture file `green.atago.yaml` is created.
 - Fixture file `flaky.atago.yaml` is created.
+- Fixture file `broken.atago.yaml` is created.
 #### Inputs
 _Fixture `green.atago.yaml`:_
 ```text
@@ -1757,18 +1758,34 @@ scenarios:
       - assert:
           exit_code: 0
 ```
+_Fixture `broken.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: inner
+scenarios:
+  - name: always fails
+    steps:
+      - run: {shell: true, command: exit 1}
+      - assert:
+          exit_code: 0
+```
 #### When
 ```shell
 ${atago} run --repeat 3 green.atago.yaml
 ${atago} run --repeat 3 flaky.atago.yaml
+${atago} run --repeat 3 broken.atago.yaml
 ```
 #### Then
 - after `${atago} run --repeat 3 green.atago.yaml`:
   - exit code is `0`
   - stdout contains `steady: 3/3 passed`
 - after `${atago} run --repeat 3 flaky.atago.yaml`:
+  - exit code is `0`
+  - stdout contains `flaky once: 2/3 passed`, `1 flaky`
+- after `${atago} run --repeat 3 broken.atago.yaml`:
   - exit code is `1`
-  - stdout contains `flaky once: 2/3 passed`
+  - stdout contains `always fails: 0/3 passed`, `1 failed`
 ### Scenario: repeat and retry-failed are mutually exclusive
 #### Given
 - Fixture file `any.atago.yaml` is created.

--- a/drift_test.go
+++ b/drift_test.go
@@ -246,6 +246,7 @@ var exampleSpecs = map[string]bool{ // path -> hermetic (run, not just validate)
 	"examples/pty_screen.atago.yaml":          true,
 	"examples/retry.atago.yaml":               true,
 	"examples/run_and_assert.atago.yaml":      true,
+	"examples/scrub.atago.yaml":               true,
 	"examples/select_skip_only.atago.yaml":    true,
 	"examples/services.atago.yaml":            true,
 	"examples/shell_and_redirect.atago.yaml":  true,

--- a/examples/scrub.atago.yaml
+++ b/examples/scrub.atago.yaml
@@ -1,0 +1,37 @@
+version: "1"
+
+# scrub normalizes volatile OUTPUT PATTERNS the built-in snapshot normalizers do
+# not know about — auto-increment IDs, request identifiers, epoch times — so a
+# raw-stdout snapshot stops flaking. Each rule replaces every regex match with a
+# literal placeholder, in order, before the snapshot is compared.
+#
+# (The built-ins already fold ANSI, temp paths, UUIDs, ISO timestamps, and
+# ports; `secrets:` masks known values. `scrub:` is the open-ended layer for
+# everything else.)
+#
+#   atago run examples/scrub.atago.yaml               # compare
+#   atago snapshot update examples/scrub.atago.yaml   # (re)record
+#
+# Runs green as-is: the id and epoch below change every run, but both scrub to a
+# stable placeholder, so the committed golden always matches.
+
+suite:
+  name: scrub
+
+scrub:
+  - {pattern: 'id=\d+', placeholder: 'id=<ID>'}
+  - {pattern: 'at \d+', placeholder: 'at <TIME>'}
+
+scenarios:
+  - name: a volatile id and epoch normalize to a stable golden
+    # Uses POSIX shell expansion ($$, $(date +%s)) to synthesize volatile
+    # output; skipped on Windows (cmd.exe would not expand them).
+    skip:
+      os: windows
+    steps:
+      - run:
+          shell: true
+          command: echo "request id=$$ finished at $(date +%s)"
+      - assert:
+          stdout:
+            snapshot: snapshots/scrub.txt

--- a/examples/snapshots/scrub.txt
+++ b/examples/snapshots/scrub.txt
@@ -1,0 +1,1 @@
+request id=<ID> finished at <TIME>

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -89,6 +89,11 @@ type Env struct {
 	// snapshot is written or compared, so a real credential is never committed to
 	// a golden file (issue #11).
 	Secrets func([]byte) []byte
+	// Scrub, when set, applies the spec's declarative regex→placeholder rewrites
+	// (#137) during snapshot normalization, so volatile output patterns the
+	// built-in normalizers do not cover (auto-increment IDs, request identifiers)
+	// are determinized before a snapshot is written or compared.
+	Scrub func([]byte) []byte
 	// MockRecords, when set, resolves a mock server's recorded requests by
 	// name for the `mock:` assertion target (#24). Nil in contexts with no
 	// mock servers (retry `until` asserts, direct API use).

--- a/internal/assert/snapshot.go
+++ b/internal/assert/snapshot.go
@@ -17,7 +17,7 @@ func checkSnapshot(desc, label, snapPath string, data []byte, env Env) *CheckRes
 	if err != nil {
 		return &CheckResult{Desc: desc, Hint: err.Error()}
 	}
-	opt := snapshot.Options{Workdir: env.Workdir, Secrets: env.Secrets}
+	opt := snapshot.Options{Workdir: env.Workdir, Secrets: env.Secrets, Scrub: env.Scrub}
 
 	if env.UpdateSnapshots {
 		if err := snapshot.Update(path, data, opt); err != nil {

--- a/internal/engine/attempts.go
+++ b/internal/engine/attempts.go
@@ -27,6 +27,15 @@ func (e *Engine) runScenarioWithPolicy(ctx context.Context, idx int, sc *spec.Sc
 // one scenario must never race themselves) and folds the outcomes: the
 // reported Steps belong to the FIRST failing iteration — the interesting one
 // — or the last iteration when all passed. Duration sums the iterations.
+//
+// The folded Status distinguishes the two failure shapes --repeat exists to
+// tell apart (#138): a scenario that failed EVERY iteration is a deterministic
+// bug (StatusFailed, or StatusError when the failures were execution errors),
+// while one that passed some iterations and failed others is unstable, not
+// broken, and folds to StatusFlaky — surfaced with its flake rate but green for
+// the exit code, exactly like a --retry-failed recovery. Collapsing a partial
+// failure into StatusFailed (the old behavior) erased that distinction, so
+// "3/10 flaked" was indistinguishable from "10/10 is a real bug".
 func (e *Engine) runRepeated(ctx context.Context, idx int, sc *spec.Scenario, rc runConfig) ScenarioResult {
 	var folded ScenarioResult
 	var iterations []Status
@@ -50,16 +59,34 @@ func (e *Engine) runRepeated(ctx context.Context, idx int, sc *spec.Scenario, rc
 	}
 	folded.Iterations = iterations
 	folded.Duration = total
-	if haveFailure && folded.Status != StatusError {
-		folded.Status = StatusFailed
-	}
-	// When the kept result failed with StatusError, keep it — error outranks
-	// failed everywhere else too.
+
+	// Classify the fold by how many iterations came out clean. A skip gate is
+	// deterministic (every iteration skips), so a skipped iteration counts as
+	// "not a failure" alongside a pass.
+	passed, errored := 0, 0
 	for _, st := range iterations {
-		if st == StatusError {
-			folded.Status = StatusError
-			break
+		switch st {
+		case StatusPassed, StatusSkipped:
+			passed++
+		case StatusError:
+			errored++
 		}
+	}
+	switch bad := len(iterations) - passed; {
+	case bad == 0:
+		// Every iteration was clean; folded already holds a passing/skipped run.
+	case passed == 0:
+		// Never passed: a deterministic failure, not instability. Error outranks
+		// failed (a step that could not execute is worse than an assertion miss).
+		if errored > 0 {
+			folded.Status = StatusError
+		} else {
+			folded.Status = StatusFailed
+		}
+	default:
+		// Passed some, failed some: unstable. This is the flake --repeat is built
+		// to catch; folded keeps the first failing iteration's steps.
+		folded.Status = StatusFlaky
 	}
 	return folded
 }

--- a/internal/engine/attempts_test.go
+++ b/internal/engine/attempts_test.go
@@ -90,8 +90,8 @@ scenarios:
 }
 
 // TestEngine_RepeatFoldsIterations proves --repeat (#29): every iteration
-// runs, per-iteration statuses are recorded, and any failing iteration fails
-// the fold while an all-green repeat passes.
+// runs, per-iteration statuses are recorded, an all-green repeat passes, and a
+// partial-failure repeat folds to flaky rather than a hard failure (#138).
 func TestEngine_RepeatFoldsIterations(t *testing.T) {
 	skipOnWindows(t)
 	t.Parallel()
@@ -119,8 +119,10 @@ scenarios:
 		t.Fatalf("iterations = %v, want 3 entries", got)
 	}
 
-	// The flaky-once scenario passes on its second execution — under repeat
-	// that is still a FAILURE (any iteration failing fails the run).
+	// The flaky-once scenario fails once and passes twice — a PARTIAL failure.
+	// That is instability, not a deterministic bug, so the fold is StatusFlaky
+	// (green for the verdict) and the flake rate is preserved (#138), not
+	// collapsed into a hard StatusFailed the way it used to be.
 	flaky, err := loader.LoadBytes("t.atago.yaml", []byte(flakyOnceSpec(t)))
 	if err != nil {
 		t.Fatalf("load: %v", err)
@@ -128,21 +130,70 @@ scenarios:
 	eng2 := New()
 	eng2.Repeat = 3
 	res2 := eng2.Run(context.Background(), flaky, "t.atago.yaml")
-	if res2.Status != StatusFailed {
-		t.Fatalf("suite status = %s, want failed (one bad iteration taints the fold)", res2.Status)
+	if res2.Status != StatusPassed {
+		t.Fatalf("suite status = %s, want passed (a partial-failure repeat is flaky, which is green)", res2.Status)
 	}
-	iters := res2.Scenarios[0].Iterations
+	sc2 := res2.Scenarios[0]
+	if sc2.Status != StatusFlaky {
+		t.Fatalf("scenario status = %s, want flaky (1/3 failed is unstable, not broken)", sc2.Status)
+	}
+	if sc2.PassedIterations() != 2 {
+		t.Errorf("PassedIterations = %d, want 2 (of 3)", sc2.PassedIterations())
+	}
+	if c := res2.Counts(); c.Flaky != 1 || c.Failed != 0 {
+		t.Errorf("counts = %+v, want 1 flaky, 0 failed", c)
+	}
+	iters := sc2.Iterations
 	if len(iters) != 3 || iters[0] != StatusFailed || iters[1] != StatusPassed {
 		t.Errorf("iterations = %v, want [failed passed passed]", iters)
 	}
 	// The kept steps come from the first failing iteration.
 	var joined strings.Builder
-	for _, st := range res2.Scenarios[0].Steps {
+	for _, st := range sc2.Steps {
 		if st.Run != nil {
 			joined.Write(st.Run.Stdout)
 		}
 	}
 	if strings.Contains(joined.String(), "recovered") {
 		t.Errorf("kept steps should belong to the failing iteration, got %q", joined.String())
+	}
+}
+
+// TestEngine_RepeatAllFailIsDeterministic proves the other side of the #138
+// distinction: a scenario that fails EVERY iteration is a deterministic bug, so
+// the fold is a hard StatusFailed (red, non-zero exit), NOT flaky. This is what
+// keeps "10/10 failed" from being mistaken for instability.
+func TestEngine_RepeatAllFailIsDeterministic(t *testing.T) {
+	skipOnWindows(t)
+	t.Parallel()
+	s, err := loader.LoadBytes("t.atago.yaml", []byte(`
+version: "1"
+suite:
+  name: s
+scenarios:
+  - name: always fails
+    steps:
+      - run: {shell: true, command: exit 1}
+      - assert:
+          exit_code: 0
+`))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	eng := New()
+	eng.Repeat = 4
+	res := eng.Run(context.Background(), s, "t.atago.yaml")
+	if res.Status != StatusFailed {
+		t.Fatalf("suite status = %s, want failed (every iteration failed → deterministic)", res.Status)
+	}
+	sc := res.Scenarios[0]
+	if sc.Status != StatusFailed {
+		t.Errorf("scenario status = %s, want failed", sc.Status)
+	}
+	if sc.PassedIterations() != 0 || len(sc.Iterations) != 4 {
+		t.Errorf("PassedIterations=%d of %d, want 0 of 4", sc.PassedIterations(), len(sc.Iterations))
+	}
+	if c := res.Counts(); c.Failed != 1 || c.Flaky != 0 {
+		t.Errorf("counts = %+v, want 1 failed, 0 flaky", c)
 	}
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -16,6 +16,7 @@ import (
 	runnercmd "github.com/nao1215/atago/internal/runner/cmd"
 	mockrunner "github.com/nao1215/atago/internal/runner/mock"
 	servicerunner "github.com/nao1215/atago/internal/runner/service"
+	"github.com/nao1215/atago/internal/scrub"
 	"github.com/nao1215/atago/internal/security"
 	"github.com/nao1215/atago/internal/spec"
 )
@@ -49,8 +50,10 @@ type Engine struct {
 	FailFast bool
 
 	// Repeat runs each selected scenario this many times (#29) to surface
-	// flakiness: any failing iteration fails the scenario, and the per-
-	// iteration statuses are recorded. Values < 2 disable it.
+	// flakiness. The per-iteration statuses are recorded and the fold is
+	// classified (#138): all-clean passes, a partial failure is flaky (green,
+	// with a flake rate), and an all-failed repeat is a deterministic failure.
+	// Values < 2 disable it.
 	Repeat int
 
 	// RetryFailed re-runs a failed/errored scenario up to this many times in
@@ -122,6 +125,7 @@ func (e *Engine) Run(ctx context.Context, s *spec.Spec, specPath string) *SuiteR
 		specDir:      filepath.Dir(specPath),
 		specPath:     specPath,
 		masker:       security.NewMaskerForSpec(s),
+		scrubber:     newScrubber(s),
 		runners:      s.Runners,
 		allow:        allowedHosts(s),
 		suiteTimeout: s.Suite.Timeout,
@@ -345,6 +349,10 @@ type runConfig struct {
 	specDir  string
 	specPath string
 	masker   *security.Masker
+	// scrubber applies the spec's declarative snapshot scrub rules (#137). Nil
+	// when the spec declares no `scrub:`; its Apply method is nil-safe, so it is
+	// always safe to pass scrubber.Apply as the assert Env's Scrub hook.
+	scrubber *scrub.Scrubber
 	runners  map[string]spec.Runner
 	allow    []string
 	// suiteVars is the suite store snapshot (#7): ${suitedir} plus values

--- a/internal/engine/http.go
+++ b/internal/engine/http.go
@@ -28,7 +28,7 @@ func (e *Engine) runHTTPStep(ctx context.Context, h *spec.HTTP, st *store.Store,
 
 	interval, _ := time.ParseDuration(h.Retry.Interval) // validated at load time
 	until := expandAssert(st, h.Retry.Until)
-	env := assert.Env{Workdir: workdir, SpecDir: specDir, UpdateSnapshots: e.UpdateSnapshots, Secrets: rc.masker.MaskBytes}
+	env := assert.Env{Workdir: workdir, SpecDir: specDir, UpdateSnapshots: e.UpdateSnapshots, Secrets: rc.masker.MaskBytes, Scrub: rc.scrubber.Apply}
 
 	var last *runner.Result
 	var checks []*assert.CheckResult

--- a/internal/engine/mask.go
+++ b/internal/engine/mask.go
@@ -8,8 +8,22 @@ import (
 	"github.com/nao1215/atago/internal/assert"
 	"github.com/nao1215/atago/internal/runner"
 	servicerunner "github.com/nao1215/atago/internal/runner/service"
+	"github.com/nao1215/atago/internal/scrub"
 	"github.com/nao1215/atago/internal/security"
+	"github.com/nao1215/atago/internal/spec"
 )
+
+// newScrubber compiles the spec's declarative snapshot scrub rules (#137). The
+// loader already validated every pattern, so New cannot fail here; on the
+// impossible error path it returns a nil scrubber (a no-op) rather than aborting
+// the run — a broken scrub rule must never silently swallow a real assertion.
+func newScrubber(s *spec.Spec) *scrub.Scrubber {
+	sc, err := scrub.New(s.Scrub)
+	if err != nil {
+		return nil
+	}
+	return sc
+}
 
 // isPolicyViolation reports whether err is a network-allowlist denial, so the
 // engine can flag a security-policy violation for grpc/ssh steps (issue #17),

--- a/internal/engine/result.go
+++ b/internal/engine/result.go
@@ -20,9 +20,12 @@ const (
 	StatusSkipped Status = "skipped"
 	// StatusError means a step could not execute (e.g. command not found).
 	StatusError Status = "error"
-	// StatusFlaky means the scenario failed at least once and then passed on
-	// a --retry-failed re-run (#29): green for the exit code, but surfaced
-	// everywhere so instability is never silently hidden.
+	// StatusFlaky means the scenario was unstable, not broken: it failed at
+	// least once and passed at least once. Two paths produce it — a
+	// --retry-failed re-run that recovered (#29), or a --repeat run where some
+	// iterations passed and some failed (#138). Either way it is green for the
+	// exit code, but surfaced everywhere (with its attempt count or flake rate)
+	// so instability is never silently hidden.
 	StatusFlaky Status = "flaky"
 )
 
@@ -76,6 +79,20 @@ type ScenarioResult struct {
 	// visible Steps belong to the first failing iteration (or the last one
 	// when all passed).
 	Iterations []Status
+}
+
+// PassedIterations counts how many --repeat iterations came out clean (passed,
+// or skipped by a deterministic OS/env gate). Paired with len(Iterations) it is
+// the flake rate a repeat-flaky scenario reports ("7/10 passed"). Zero-valued
+// when --repeat was not used (Iterations is empty).
+func (s *ScenarioResult) PassedIterations() int {
+	n := 0
+	for _, st := range s.Iterations {
+		if st == StatusPassed || st == StatusSkipped {
+			n++
+		}
+	}
+	return n
 }
 
 // TeardownFailed reports whether any teardown step failed or errored. Reports

--- a/internal/engine/scrub_test.go
+++ b/internal/engine/scrub_test.go
@@ -1,0 +1,90 @@
+package engine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/atago/internal/loader"
+)
+
+// scrubSpec emits a line carrying a volatile auto-increment id and snapshots
+// stdout, with a spec-level scrub rule that normalizes the id to a placeholder.
+func scrubSpec(id string, withScrub bool) string {
+	scrubBlock := ""
+	if withScrub {
+		scrubBlock = "scrub:\n  - {pattern: 'id=\\d+', placeholder: 'id=<ID>'}\n"
+	}
+	return `
+version: "1"
+suite:
+  name: scrub
+` + scrubBlock + `scenarios:
+  - name: snapshot with a volatile id
+    steps:
+      - run:
+          shell: true
+          command: echo "user id=` + id + `"
+      - assert:
+          stdout:
+            snapshot: out.snap
+`
+}
+
+// TestEngine_ScrubDeterminizesSnapshot proves the #137 scrub layer end-to-end:
+// a golden recorded from one run matches a later run whose only difference is a
+// different auto-increment id, because the scrub rule normalizes both ids to the
+// same placeholder BEFORE the snapshot compare. This is the metamorphic property
+// that kills the flake — two observably different outputs, one stable golden.
+func TestEngine_ScrubDeterminizesSnapshot(t *testing.T) {
+	skipOnWindows(t)
+	t.Parallel()
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "s.atago.yaml")
+
+	// Record the golden from a run that printed id=4711.
+	record := scrubSpec("4711", true)
+	if err := os.WriteFile(specPath, []byte(record), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s, err := loader.LoadBytes(specPath, []byte(record))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	eng := New()
+	eng.UpdateSnapshots = true
+	if res := eng.Run(context.Background(), s, specPath); res.Status != StatusPassed {
+		t.Fatalf("record status = %s, want passed: %+v", res.Status, res.Scenarios)
+	}
+	golden, err := os.ReadFile(filepath.Join(dir, "out.snap"))
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if !strings.Contains(string(golden), "id=<ID>") || strings.Contains(string(golden), "4711") {
+		t.Fatalf("golden should carry the scrubbed placeholder, not the raw id:\n%s", golden)
+	}
+
+	// A later run printing a DIFFERENT id still matches the same golden.
+	compare := scrubSpec("99999", true)
+	s2, err := loader.LoadBytes(specPath, []byte(compare))
+	if err != nil {
+		t.Fatalf("load compare: %v", err)
+	}
+	eng2 := New() // UpdateSnapshots off → real comparison
+	if res := eng2.Run(context.Background(), s2, specPath); res.Status != StatusPassed {
+		t.Fatalf("compare status = %s, want passed (scrub should normalize the new id): %+v", res.Status, res.Scenarios)
+	}
+
+	// Control: without the scrub rule, the same differing id fails the compare —
+	// proving the scrub rule, not some accident, is what makes it pass.
+	noScrub := scrubSpec("99999", false)
+	s3, err := loader.LoadBytes(specPath, []byte(noScrub))
+	if err != nil {
+		t.Fatalf("load no-scrub: %v", err)
+	}
+	if res := New().Run(context.Background(), s3, specPath); res.Status != StatusFailed {
+		t.Fatalf("no-scrub status = %s, want failed (raw id must not match the placeholder golden)", res.Status)
+	}
+}

--- a/internal/engine/stepexec.go
+++ b/internal/engine/stepexec.go
@@ -77,6 +77,7 @@ func (x *scenarioRun) execStep(ctx context.Context, i int, step *spec.Step) (Ste
 			SpecDir:         x.specDir,
 			UpdateSnapshots: x.e.UpdateSnapshots,
 			Secrets:         x.masker.MaskBytes,
+			Scrub:           x.rc.scrubber.Apply,
 			MockRecords:     x.mockRecords,
 		})
 		x.e.recordChecks(x.masker, crs, x.rc.specPath, x.sc.Name, x.idx, i)
@@ -308,7 +309,7 @@ func (e *Engine) runStep(ctx context.Context, run *spec.Run, st *store.Store, wo
 
 	interval, _ := time.ParseDuration(run.Retry.Interval) // validated at load time
 	until := expandAssert(st, run.Retry.Until)
-	env := assert.Env{Workdir: workdir, SpecDir: specDir, UpdateSnapshots: e.UpdateSnapshots, Secrets: rc.masker.MaskBytes}
+	env := assert.Env{Workdir: workdir, SpecDir: specDir, UpdateSnapshots: e.UpdateSnapshots, Secrets: rc.masker.MaskBytes, Scrub: rc.scrubber.Apply}
 
 	var last *runner.Result
 	var checks []*assert.CheckResult

--- a/internal/engine/suite.go
+++ b/internal/engine/suite.go
@@ -145,6 +145,7 @@ func (e *Engine) runSuiteSteps(ctx context.Context, steps []spec.Step, rt *suite
 				SpecDir:         rc.specDir,
 				UpdateSnapshots: e.UpdateSnapshots,
 				Secrets:         rc.masker.MaskBytes,
+				Scrub:           rc.scrubber.Apply,
 				MockRecords: func(name string) ([]mockrunner.Record, bool) {
 					for _, m := range rt.mocks {
 						if m.Name() == name {

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -445,6 +445,18 @@ func TestLoadBytes_Errors(t *testing.T) {
 			wantMsg:  "is not a valid regexp",
 		},
 		{
+			name:     "invalid scrub pattern fails at load",
+			src:      "version: \"1\"\nsuite:\n  name: x\nscrub:\n  - {pattern: \"a(\", placeholder: X}\nscenarios:\n  - name: a\n    steps:\n      - run: {command: echo}",
+			wantKind: KindValidation,
+			wantMsg:  "scrub[0]",
+		},
+		{
+			name:     "empty scrub pattern fails at load",
+			src:      "version: \"1\"\nsuite:\n  name: x\nscrub:\n  - {pattern: \"\", placeholder: X}\nscenarios:\n  - name: a\n    steps:\n      - run: {command: echo}",
+			wantKind: KindValidation,
+			wantMsg:  "scrub[0].pattern is required",
+		},
+		{
 			name:     "invalid not_matches regexp fails at load",
 			src:      "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps:\n      - run: {command: echo}\n      - assert:\n          stdout:\n            not_matches: \"hi[\"",
 			wantKind: KindValidation,

--- a/internal/loader/validate.go
+++ b/internal/loader/validate.go
@@ -142,7 +142,7 @@ func validateSuiteTimeout(add func(string, ...any), s *spec.Suite) {
 func validateScrub(add func(string, ...any), rules []spec.ScrubRule) {
 	for i, r := range rules {
 		if r.Pattern == "" {
-			add("scrub[%d].pattern is required (a regex to normalize; e.g. \"req-\\\\d+\")", i)
+			add("scrub[%d].pattern is required (a regex to normalize; e.g. \"req-\\d+\")", i)
 		}
 	}
 	if _, err := scrub.New(rules); err != nil {

--- a/internal/loader/validate.go
+++ b/internal/loader/validate.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nao1215/atago/internal/scrub"
 	"github.com/nao1215/atago/internal/spec"
 )
 
@@ -27,6 +28,7 @@ func validate(s *spec.Spec) []string {
 		add("suite.name is required")
 	}
 	validateSuiteTimeout(add, &s.Suite)
+	validateScrub(add, s.Scrub)
 	if len(s.Scenarios) == 0 {
 		add("scenarios must contain at least one scenario")
 	}
@@ -129,6 +131,22 @@ func validateSuiteTimeout(add func(string, ...any), s *spec.Suite) {
 		add("suite.timeout %q is not a valid duration (e.g. \"2m\"); use \"0\" to disable the built-in default", s.Timeout)
 	} else if d < 0 {
 		add("suite.timeout must not be negative (got %q); a wall-clock bound is never below zero", s.Timeout)
+	}
+}
+
+// validateScrub checks the top-level `scrub:` rules (#137): every pattern must
+// be non-empty and compile as a Go regexp, so a broken rule fails at load rather
+// than silently normalizing nothing (or, for an empty pattern, matching between
+// every byte). The compile check reuses scrub.New so validation and runtime
+// agree on what a valid rule is.
+func validateScrub(add func(string, ...any), rules []spec.ScrubRule) {
+	for i, r := range rules {
+		if r.Pattern == "" {
+			add("scrub[%d].pattern is required (a regex to normalize; e.g. \"req-\\\\d+\")", i)
+		}
+	}
+	if _, err := scrub.New(rules); err != nil {
+		add("%v", err)
 	}
 }
 

--- a/internal/report/console.go
+++ b/internal/report/console.go
@@ -150,8 +150,14 @@ func writeRepeatRates(b *strings.Builder, color bool, res *engine.SuiteResult) {
 				passed++
 			}
 		}
+		// Color by the fold's verdict: all clean is green, a partial failure is
+		// flaky (yellow, green for the exit code), and an all-failed repeat is a
+		// deterministic red failure (#138).
 		code := cGreen
-		if passed < len(sc.Iterations) {
+		switch sc.Status {
+		case engine.StatusFlaky:
+			code = cYellow
+		case engine.StatusFailed, engine.StatusError:
 			code = cRed
 		}
 		fmt.Fprintf(b, "\n%s %s: %d/%d passed\n",
@@ -159,12 +165,14 @@ func writeRepeatRates(b *strings.Builder, color bool, res *engine.SuiteResult) {
 	}
 }
 
-// writeFlaky prints one line per recovered scenario (#29): green for the
-// verdict, but never hidden.
+// writeFlaky prints one line per --retry-failed recovery (#29): green for the
+// verdict, but never hidden. A --repeat flake (Iterations set) is reported by
+// writeRepeatRates instead, with its rate; skip it here so it is not
+// double-reported with a meaningless "0 attempts".
 func writeFlaky(b *strings.Builder, color bool, res *engine.SuiteResult) {
 	for i := range res.Scenarios {
 		sc := &res.Scenarios[i]
-		if sc.Status != engine.StatusFlaky {
+		if sc.Status != engine.StatusFlaky || len(sc.Iterations) > 0 {
 			continue
 		}
 		fmt.Fprintf(b, "\n%s %s / %s: passed after %d attempts\n",

--- a/internal/report/gha.go
+++ b/internal/report/gha.go
@@ -27,9 +27,9 @@ func writeGHA(w io.Writer, results []*engine.SuiteResult) error {
 				fmt.Fprintf(&b, "::error title=%s::%s\n",
 					ghaEscapeProp(res.Suite+" / "+sc.Name), ghaEscapeData(firstErrorMessage(sc)))
 			case engine.StatusFlaky:
-				// Green for the job, loud in the annotations (#29).
+				// Green for the job, loud in the annotations (#29, #138).
 				fmt.Fprintf(&b, "::warning title=%s::%s\n",
-					ghaEscapeProp(res.Suite+" / "+sc.Name), ghaEscapeData(fmt.Sprintf("flaky: passed after %d attempts", sc.Attempts)))
+					ghaEscapeProp(res.Suite+" / "+sc.Name), ghaEscapeData(flakyMessage(sc)))
 			}
 		}
 		// A suite that errored before any scenario ran (#7) surfaces its cause as

--- a/internal/report/junit.go
+++ b/internal/report/junit.go
@@ -82,7 +82,7 @@ func buildJUnit(results []*engine.SuiteResult) junitTestsuites {
 				ts.Skipped++
 			case engine.StatusFlaky:
 				tc.FlakyFailure = &junitMessage{
-					Message: fmt.Sprintf("flaky: passed after %d attempts", sc.Attempts),
+					Message: flakyMessage(sc),
 					Body:    detailText(sc),
 				}
 			}

--- a/internal/report/render.go
+++ b/internal/report/render.go
@@ -10,6 +10,19 @@ import (
 	"github.com/nao1215/atago/internal/engine"
 )
 
+// flakyMessage renders the one-line reason a scenario is flaky, in a form that
+// fits whichever knob produced the instability (#138): a --repeat run reports
+// its flake rate ("2/10 iterations failed"), while a --retry-failed recovery
+// reports its attempt count ("passed after 2 attempts"). Every format (tap, gha,
+// junit) shares this so the wording never drifts between them.
+func flakyMessage(sc *engine.ScenarioResult) string {
+	if len(sc.Iterations) > 0 {
+		total := len(sc.Iterations)
+		return fmt.Sprintf("flaky: %d/%d iterations failed", total-sc.PassedIterations(), total)
+	}
+	return fmt.Sprintf("flaky: passed after %d attempts", sc.Attempts)
+}
+
 // Option configures an optional aspect of a Render call. It keeps the common
 // three-argument form unchanged while letting callers pass extra run-level
 // context (e.g. spec-load failures) without a signature churn.

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -907,14 +907,16 @@ func TestIsTTY(t *testing.T) {
 }
 
 // TestConsole_RepeatRates exercises writeRepeatRates for a --repeat run: a
-// per-scenario pass-rate line, red when not every iteration passed.
+// per-scenario pass-rate line. A partial-failure repeat is flaky (#138), and it
+// must be reported ONCE via its rate line — not also via writeFlaky with a
+// meaningless "0 attempts".
 func TestConsole_RepeatRates(t *testing.T) {
 	t.Parallel()
 	res := &engine.SuiteResult{
 		Suite:  "rp",
-		Status: engine.StatusFailed,
+		Status: engine.StatusPassed,
 		Scenarios: []engine.ScenarioResult{
-			{Name: "race-prone", Status: engine.StatusFailed, Iterations: []engine.Status{
+			{Name: "race-prone", Status: engine.StatusFlaky, Iterations: []engine.Status{
 				engine.StatusPassed, engine.StatusFailed, engine.StatusPassed,
 			}},
 			{Name: "steady", Status: engine.StatusPassed, Iterations: []engine.Status{
@@ -928,6 +930,48 @@ func TestConsole_RepeatRates(t *testing.T) {
 	}
 	if !strings.Contains(out, "REPEAT: steady: 2/2 passed") {
 		t.Errorf("missing steady repeat rate:\n%s", out)
+	}
+	if strings.Contains(out, "passed after 0 attempts") || strings.Contains(out, "FLAKY: rp / race-prone") {
+		t.Errorf("repeat-flaky scenario double-reported via writeFlaky:\n%s", out)
+	}
+}
+
+// TestRepeatFlaky_MessageAcrossFormats proves a --repeat flake (Iterations set,
+// zero retry Attempts) reports its flake RATE — not a "0 attempts" retry phrase
+// — in every machine format, so a partial-failure repeat reads correctly in
+// tap/gha/junit (#138).
+func TestRepeatFlaky_MessageAcrossFormats(t *testing.T) {
+	t.Parallel()
+	res := []*engine.SuiteResult{{
+		Suite:  "rp",
+		Status: engine.StatusPassed,
+		Scenarios: []engine.ScenarioResult{
+			{Name: "race-prone", Status: engine.StatusFlaky, Duration: time.Millisecond, Iterations: []engine.Status{
+				engine.StatusPassed, engine.StatusFailed, engine.StatusPassed,
+			}},
+		},
+	}}
+	for _, tc := range []struct {
+		name   string
+		format Format
+	}{
+		{"tap", FormatTAP},
+		{"gha", FormatGHA},
+		{"junit", FormatJUnit},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var b strings.Builder
+			if err := Render(&b, tc.format, res); err != nil {
+				t.Fatalf("render: %v", err)
+			}
+			out := b.String()
+			if !strings.Contains(out, "flaky: 1/3 iterations failed") {
+				t.Errorf("%s missing repeat flake rate:\n%s", tc.name, out)
+			}
+			if strings.Contains(out, "passed after 0 attempts") {
+				t.Errorf("%s used the retry phrasing for a --repeat flake:\n%s", tc.name, out)
+			}
+		})
 	}
 }
 

--- a/internal/report/tap.go
+++ b/internal/report/tap.go
@@ -39,12 +39,13 @@ func writeTAP(w io.Writer, results []*engine.SuiteResult) error {
 			case engine.StatusSkipped:
 				fmt.Fprintf(&b, "ok %d - %s # SKIP %s\n", n, name, tapInline(sc.SkipReason))
 			case engine.StatusFlaky:
-				// A scenario that failed and then passed on retry (#29) is green
-				// for the verdict, matching the exit code, console, gha, and
-				// junit. Emit a passing point so a TAP consumer agrees, and keep
-				// the recovery visible in the diagnostic rather than hiding it.
+				// A scenario that was unstable but green (a retry recovery or a
+				// partial --repeat) is green for the verdict, matching the exit
+				// code, console, gha, and junit. Emit a passing point so a TAP
+				// consumer agrees, and keep the instability visible in the
+				// diagnostic rather than hiding it.
 				fmt.Fprintf(&b, "ok %d - %s\n", n, name)
-				writeTAPDiagnostic(&b, fmt.Sprintf("flaky: passed after %d attempts", sc.Attempts), detailText(sc))
+				writeTAPDiagnostic(&b, flakyMessage(sc), detailText(sc))
 			case engine.StatusFailed:
 				fmt.Fprintf(&b, "not ok %d - %s\n", n, name)
 				writeTAPDiagnostic(&b, firstFailureMessage(sc), detailText(sc))

--- a/internal/scrub/scrub.go
+++ b/internal/scrub/scrub.go
@@ -1,0 +1,60 @@
+// Package scrub applies user-declared regex→placeholder rewrites to captured
+// CLI output before snapshot comparison (#137). Where internal/security's Masker
+// redacts known secret *values* and internal/snapshot's built-in normalizers
+// fold a fixed set of volatile forms (ANSI, UUID, timestamp, port, path), a
+// Scrubber handles the open set of volatile *patterns* only the spec author
+// knows about: auto-increment IDs, request identifiers, custom timestamps. This
+// is atago's declarative "output determinization layer" — the piece that turns a
+// snapshot that flakes on every run into a stable golden.
+package scrub
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/nao1215/atago/internal/spec"
+)
+
+// Scrubber applies an ordered list of compiled rewrite rules. A nil Scrubber is
+// a valid no-op, so callers may hold a possibly-nil value and always call Apply.
+type Scrubber struct {
+	rules []compiledRule
+}
+
+type compiledRule struct {
+	re          *regexp.Regexp
+	placeholder []byte
+}
+
+// New compiles the rules in order. It returns (nil, nil) for an empty rule set —
+// a nil Scrubber is a safe no-op — and an error naming the offending index and
+// pattern when a rule's regexp does not compile.
+func New(rules []spec.ScrubRule) (*Scrubber, error) {
+	if len(rules) == 0 {
+		return nil, nil
+	}
+	compiled := make([]compiledRule, 0, len(rules))
+	for i, r := range rules {
+		re, err := regexp.Compile(r.Pattern)
+		if err != nil {
+			return nil, fmt.Errorf("scrub[%d]: invalid pattern %q: %w", i, r.Pattern, err)
+		}
+		compiled = append(compiled, compiledRule{re: re, placeholder: []byte(r.Placeholder)})
+	}
+	return &Scrubber{rules: compiled}, nil
+}
+
+// Apply rewrites b through every rule in order and returns the result. Rules
+// apply top-to-bottom: a later rule sees the output of the earlier ones. The
+// placeholder is inserted literally — a `$1` in it is NOT a regexp expansion
+// reference — so a placeholder can safely contain any bytes. A nil/empty
+// Scrubber returns b unchanged.
+func (s *Scrubber) Apply(b []byte) []byte {
+	if s == nil || len(s.rules) == 0 {
+		return b
+	}
+	for _, r := range s.rules {
+		b = r.re.ReplaceAllLiteral(b, r.placeholder)
+	}
+	return b
+}

--- a/internal/scrub/scrub_test.go
+++ b/internal/scrub/scrub_test.go
@@ -1,0 +1,93 @@
+package scrub
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/nao1215/atago/internal/spec"
+)
+
+// TestNew_CompilesAndApplies proves an ordered rule set rewrites every match to
+// its literal placeholder, applying rules top-to-bottom.
+func TestNew_CompilesAndApplies(t *testing.T) {
+	t.Parallel()
+	s, err := New([]spec.ScrubRule{
+		{Pattern: `req-\d+`, Placeholder: "<REQ>"},
+		{Pattern: `id=\d+`, Placeholder: "id=<ID>"},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	in := []byte("start req-42 mid id=1007 end req-9")
+	got := string(s.Apply(in))
+	want := "start <REQ> mid id=<ID> end <REQ>"
+	if got != want {
+		t.Errorf("Apply = %q, want %q", got, want)
+	}
+}
+
+// TestNew_InvalidPatternErrors proves a malformed regexp is reported with its
+// index and the offending pattern, so a spec author can fix it.
+func TestNew_InvalidPatternErrors(t *testing.T) {
+	t.Parallel()
+	_, err := New([]spec.ScrubRule{
+		{Pattern: `ok`, Placeholder: "x"},
+		{Pattern: `(`, Placeholder: "y"},
+	})
+	if err == nil {
+		t.Fatal("New accepted an invalid regexp, want error")
+	}
+	for _, want := range []string{"scrub[1]", "("} {
+		if !bytes.Contains([]byte(err.Error()), []byte(want)) {
+			t.Errorf("error %q missing %q", err, want)
+		}
+	}
+}
+
+// TestApply_LiteralPlaceholder proves a `$`-bearing placeholder is inserted
+// literally, not treated as a regexp expansion template ($1 must survive).
+func TestApply_LiteralPlaceholder(t *testing.T) {
+	t.Parallel()
+	s, err := New([]spec.ScrubRule{{Pattern: `(foo)`, Placeholder: "$1<X>"}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	got := string(s.Apply([]byte("foo")))
+	if got != "$1<X>" {
+		t.Errorf("Apply = %q, want literal %q (no $1 expansion)", got, "$1<X>")
+	}
+}
+
+// TestApply_EmptyPlaceholderDeletes proves an empty placeholder deletes matches.
+func TestApply_EmptyPlaceholderDeletes(t *testing.T) {
+	t.Parallel()
+	s, err := New([]spec.ScrubRule{{Pattern: `\s+trailing`, Placeholder: ""}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if got := string(s.Apply([]byte("keep   trailing"))); got != "keep" {
+		t.Errorf("Apply = %q, want %q", got, "keep")
+	}
+}
+
+// TestNilAndEmpty_Passthrough proves a nil Scrubber and an empty rule set are
+// safe no-ops that return the input unchanged, so callers can hold a possibly-nil
+// scrubber and always call Apply.
+func TestNilAndEmpty_Passthrough(t *testing.T) {
+	t.Parallel()
+	var nilS *Scrubber
+	in := []byte("unchanged 123")
+	if got := nilS.Apply(in); !bytes.Equal(got, in) {
+		t.Errorf("nil Apply = %q, want %q", got, in)
+	}
+	empty, err := New(nil)
+	if err != nil {
+		t.Fatalf("New(nil): %v", err)
+	}
+	if empty != nil {
+		t.Errorf("New(nil) = %v, want nil scrubber for an empty rule set", empty)
+	}
+	if got := empty.Apply(in); !bytes.Equal(got, in) {
+		t.Errorf("empty Apply = %q, want %q", got, in)
+	}
+}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -1,7 +1,9 @@
 // Package snapshot stores and compares golden output. Captured
 // output is normalized — volatile details such as ANSI codes, temp paths, the
 // home directory, UUIDs, timestamps, and local ports are masked — so snapshots
-// stay stable across machines and runs.
+// stay stable across machines and runs. A spec may also declare its own
+// regex→placeholder rewrites via Options.Scrub (#137) for volatile patterns the
+// built-ins do not cover.
 package snapshot
 
 import (
@@ -26,6 +28,13 @@ type Options struct {
 	// never lands in a committed snapshot (issue #11). It is applied before the
 	// volatile-detail normalization below.
 	Secrets func([]byte) []byte
+	// Scrub, when set, applies the spec's user-declared regex→placeholder rewrites
+	// (#137) to captured output: the open set of volatile patterns the built-in
+	// normalizers below do not know about (auto-increment IDs, request
+	// identifiers, custom timestamps). It runs AFTER secret masking and BEFORE
+	// the built-in ANSI/UUID/timestamp/port/path normalization, so a rule sees the
+	// already-secret-masked text and the built-ins see the already-scrubbed text.
+	Scrub func([]byte) []byte
 }
 
 var (
@@ -53,6 +62,9 @@ var (
 func Normalize(data []byte, opt Options) []byte {
 	if opt.Secrets != nil {
 		data = opt.Secrets(data)
+	}
+	if opt.Scrub != nil {
+		data = opt.Scrub(data)
 	}
 	s := string(data)
 	// Line endings are an OS artifact, not observable behavior: fold CRLF so a

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"testing"
@@ -72,6 +73,34 @@ func TestNormalize(t *testing.T) {
 				t.Errorf("Normalize(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestNormalize_Scrub proves the user Scrub hook rewrites volatile patterns the
+// built-in normalizers do not know about (an auto-increment id), and that it runs
+// BEFORE the built-ins: a scrub whose placeholder overlaps a built-in target is
+// itself left alone by the built-in pass (the placeholder is literal text).
+func TestNormalize_Scrub(t *testing.T) {
+	t.Parallel()
+	reID := regexp.MustCompile(`id=\d+`)
+	scrub := func(b []byte) []byte { return reID.ReplaceAllLiteral(b, []byte("id=<ID>")) }
+	opt := Options{Scrub: scrub}
+
+	// The auto-increment id is scrubbed; the built-in timestamp masker still runs
+	// afterwards on the rest of the line.
+	in := "row id=4093 created 2026-06-30T09:00:00Z"
+	want := "row id=<ID> created <timestamp>"
+	if got := string(Normalize([]byte(in), opt)); got != want {
+		t.Errorf("Normalize(%q) = %q, want %q", in, got, want)
+	}
+
+	// Secrets run before scrub: a scrub rule sees the already-masked text.
+	opt2 := Options{
+		Secrets: func(b []byte) []byte { return []byte(strings.ReplaceAll(string(b), "topsecret", "***")) },
+		Scrub:   func(b []byte) []byte { return regexp.MustCompile(`\*\*\*`).ReplaceAllLiteral(b, []byte("<REDACTED>")) },
+	}
+	if got := string(Normalize([]byte("token=topsecret"), opt2)); got != "token=<REDACTED>" {
+		t.Errorf("secrets-then-scrub = %q, want %q", got, "token=<REDACTED>")
 	}
 }
 

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -13,12 +13,32 @@ type Spec struct {
 	Runners     map[string]Runner `yaml:"runners,omitempty"`
 	Permissions *Permissions      `yaml:"permissions,omitempty"`
 	Secrets     []string          `yaml:"secrets,omitempty"`
+	// Scrub declares spec-wide regex→placeholder rewrites applied to captured
+	// output before it is compared against (or written to) a snapshot golden.
+	// Where `secrets:` masks known values, `scrub:` normalizes volatile
+	// patterns the built-in normalizers do not know about — auto-increment
+	// IDs, request identifiers, custom timestamps — so a flaky snapshot becomes
+	// deterministic (#137). Rules apply in order, after secret masking and
+	// before the built-in ANSI/UUID/timestamp/port/path normalization.
+	Scrub []ScrubRule `yaml:"scrub,omitempty"`
 	// Defaults declares spec-wide default fragments merged into every matching
 	// element at load time. It is authoring sugar only: the loader
 	// expands it into the concrete scenario/step/service model before validation,
 	// so nothing downstream (engine, manifest, explain) ever observes `defaults`.
 	Defaults  *Defaults  `yaml:"defaults,omitempty"`
 	Scenarios []Scenario `yaml:"scenarios"`
+}
+
+// ScrubRule is one declarative output-normalization rule (#137): every substring
+// matching Pattern (a Go RE2 regexp) is replaced with Placeholder, literally
+// (no `$1` expansion), before snapshot comparison. Ordering is significant —
+// earlier rules see the raw text, later rules see the output of earlier ones.
+type ScrubRule struct {
+	// Pattern is a Go regular expression (regexp/syntax). Required and must compile.
+	Pattern string `yaml:"pattern"`
+	// Placeholder is the literal replacement text, e.g. "<ID>". May be empty to
+	// delete matches outright.
+	Placeholder string `yaml:"placeholder"`
 }
 
 // Defaults holds the top-level `defaults:` block. Each fragment is

--- a/schema/atago.schema.json
+++ b/schema/atago.schema.json
@@ -58,6 +58,19 @@
       }
     },
     "secrets": { "type": "array", "items": { "type": "string" } },
+    "scrub": {
+      "type": "array",
+      "description": "Declarative output-normalization rules (#137): each replaces every regex match in captured output with a literal placeholder before a snapshot is compared or written. Where `secrets` masks known values, `scrub` normalizes volatile patterns the built-in normalizers do not cover (auto-increment IDs, request identifiers, custom timestamps). Rules apply in order, after secret masking and before the built-in ANSI/UUID/timestamp/port/path normalization.",
+      "items": {
+        "type": "object",
+        "required": ["pattern"],
+        "additionalProperties": false,
+        "properties": {
+          "pattern": { "type": "string", "minLength": 1, "description": "A Go (RE2) regular expression; every match is replaced. Required." },
+          "placeholder": { "type": "string", "description": "Literal replacement text (no $1 expansion), e.g. \"<ID>\". Defaults to empty, which deletes matches." }
+        }
+      }
+    },
     "defaults": { "$ref": "#/$defs/defaults" },
     "scenarios": {
       "type": "array",

--- a/test/e2e/atago/flaky.atago.yaml
+++ b/test/e2e/atago/flaky.atago.yaml
@@ -97,13 +97,39 @@ scenarios:
                       command: "if [ -f '${workdir}/seen.txt' ]; then echo recovered; else touch '${workdir}/seen.txt'; exit 1; fi"
                   - assert:
                       exit_code: 0
-      # Any failing iteration fails the run — repeat DETECTS, never tolerates.
+      # A PARTIAL failure (some iterations pass, some fail) is instability, not a
+      # bug: repeat folds it to flaky — green for the exit code but surfaced with
+      # its rate and counted in the summary (#138).
       - run:
           command: ${atago} run --repeat 3 flaky.atago.yaml
       - assert:
+          exit_code: 0
+          stdout:
+            contains:
+              - "flaky once: 2/3 passed"
+              - "1 flaky"
+      # An EVERY-iteration failure is a deterministic bug, not a flake: it stays
+      # a hard failure with a non-zero exit (#138).
+      - fixture:
+          file: broken.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: inner
+            scenarios:
+              - name: always fails
+                steps:
+                  - run: {shell: true, command: exit 1}
+                  - assert:
+                      exit_code: 0
+      - run:
+          command: ${atago} run --repeat 3 broken.atago.yaml
+      - assert:
           exit_code: 1
           stdout:
-            contains: "flaky once: 2/3 passed"
+            contains:
+              - "always fails: 0/3 passed"
+              - "1 failed"
 
   - name: repeat and retry-failed are mutually exclusive
     steps:


### PR DESCRIPTION
## Summary

Address two valid points from a review of atago's flaky-test tooling: raw-output snapshots have no user-defined pattern normalization (so timestamps/UUIDs/IDs the built-ins miss flake every run), and `--repeat` collapses a partial failure into the same hard `failed` as a deterministic bug — erasing the exact flake signal `--repeat` exists to surface. Both are fixed here with reproduction tests first. Closes #137, closes #138.

## Changes

- `scrub:` (#137) — a new spec-wide list of `{pattern, placeholder}` rules ([internal/spec/spec.go](internal/spec/spec.go)) compiled by a new [internal/scrub](internal/scrub/scrub.go) package, validated at load ([internal/loader/validate.go](internal/loader/validate.go)), and applied during snapshot normalization ([internal/snapshot/snapshot.go](internal/snapshot/snapshot.go)) after secret masking and before the built-in ANSI/UUID/timestamp/port/path passes. Threaded from the engine through `assert.Env` at every snapshot site ([internal/engine](internal/engine/mask.go), [internal/assert](internal/assert/snapshot.go)).
- `--repeat` classification (#138) — [internal/engine/attempts.go](internal/engine/attempts.go) now folds an all-clean run to `passed`, a partial-failure run to `flaky` (green for the exit code, with a flake rate), and an all-failed run to a deterministic `failed`/`error`. A `PassedIterations` helper ([internal/engine/result.go](internal/engine/result.go)) backs the rate, and every report format ([internal/report](internal/report/render.go): console/tap/gha/junit) surfaces it via a shared `flakyMessage`.
- Schema ([schema/atago.schema.json](schema/atago.schema.json)), a runnable example ([examples/scrub.atago.yaml](examples/scrub.atago.yaml)) registered in [drift_test.go](drift_test.go), README, and CHANGELOG.
- Tests: unit tests for the scrub package, loader validation, snapshot normalization, a metamorphic engine E2E (two different volatile ids match one golden), the repeat classification (partial→flaky, all-fail→failed), and cross-format flaky-message rendering.

## Design Decisions

`scrub` lives at snapshot-normalization time (not a general output filter) because that is where determinization matters and where the built-in normalizers already live; it reuses the existing `func([]byte) []byte` hook shape that `secrets:` uses, so it needed no new plumbing shape. Placeholders are inserted literally (`ReplaceAllLiteral`) so a `$1` in a placeholder is never a regexp expansion.

For `--repeat`, a partial failure maps to the existing `StatusFlaky` (green exit, surfaced everywhere) to stay coherent with how `--retry-failed` already reports a recovery — one meaning of "flaky" across the tool. This is a behavior change: a `--repeat` run with a partial failure now exits 0 (reported as flaky) rather than non-zero. An all-failed repeat still fails the build.

## Limitations

Two other review points are deliberately not code-changed here. The request to filter `--retry-failed` by failure class (`on: [timeout, connection]`) is valid but needs a real failure taxonomy — atago has no clean timeout/connection class today (a timeout surfaces as an `exit_code` assertion `failed`, not a distinct status) — so it is filed as #136 for design rather than bolted on half-formed. The "repeat and retry-failed are silently mutually exclusive" point does not reproduce: the CLI already rejects both flags together with an error ([internal/cli/run.go](internal/cli/run.go)), so no change was needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added snapshot scrubbing rules to normalize volatile output before comparisons, improving stability for IDs and time-based values.
  * Documented and added support for declarative scrub rules in configuration and schema.
  * Repeat runs now distinguish flaky results from deterministic failures, with clearer reporting across output formats.

* **Bug Fixes**
  * Prevented flaky repeat scenarios from being reported as failed when only some iterations fail.
  * Improved console, TAP, JUnit, and GitHub Actions reporting to show consistent flaky messages and counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->