### PR TITLE
feat(assert): let stream text matchers compose in one block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ two flaky-test tooling improvements described below.
 
 ### Added
 
+- Stream matchers now compose. `contains`, `not_contains`, `matches`, and
+  `not_matches` can be set together on one `stdout`/`stderr`/`body` block and all
+  have to hold — the common "output has X but not Y" shape, previously two
+  separate `assert:` steps. The whole-stream matchers (`equals`, `empty`,
+  `snapshot`, `json`, `yaml`) are still used alone; mixing one in with a text
+  matcher is a load error. See [examples/run_and_assert.atago.yaml](examples/run_and_assert.atago.yaml).
 - `scrub:` (#137) — spec-wide declarative output normalization for snapshots. Each rule
   rewrites every regex match in captured output to a literal placeholder
   (`{pattern: 'id=\d+', placeholder: 'id=<ID>'}`) before a snapshot is compared

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ $ atago run ./specs
 PASSED  47 scenarios: 47 passed, 0 failed, 0 errored, 0 skipped (1.2s)
 ```
 
+Scenarios run concurrently by default (`--parallel N`, defaulting to your CPU count; set `--parallel 1` to serialize). Workdirs are isolated, but the host network is shared — so if two scenarios each start a background `service:`, give them distinct ports, or one scenario's requests can reach the other's server.
+
 When a check fails, atago prints exactly what was expected and what happened; multi-line mismatches render a colorized unified diff:
 
 ```text
@@ -212,7 +214,7 @@ Every feature has a commented, runnable spec under [examples/](examples/). The e
 
 | Example | Shows |
 |---------|-------|
-| [run_and_assert](examples/run_and_assert.atago.yaml) | exit code (exact, `not`, `in: [0, 2]` sets), stdout/stderr matchers (`contains`, `equals`, `matches`/`not_matches`, lists, `line`), multi-target asserts |
+| [run_and_assert](examples/run_and_assert.atago.yaml) | exit code (exact, `not`, `in: [0, 2]` sets), stdout/stderr matchers (`contains`, `equals`, `matches`/`not_matches`, `empty: true`/`false`, lists, `line`), combining `contains`/`not_contains`/`matches`/`not_matches` in one block, multi-target asserts |
 | [shell_and_redirect](examples/shell_and_redirect.atago.yaml) | `shell: true` vs direct argv execution, `stdout_to`/`stderr_to` redirects |
 | [json_and_yaml](examples/json_and_yaml.atago.yaml) | JSONPath assertions, numeric bounds (`gt`/`lte`), the `yaml` matcher |
 | [files_and_fixtures](examples/files_and_fixtures.atago.yaml) | input fixtures (text and base64), `file` and `dir` assertions |

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-55 suites · 220 scenarios
+56 suites · 226 scenarios
 ## Contents
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 6 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
@@ -150,6 +150,13 @@
   - [count, header, and body-json asserts pass against a real client](#scenario-count-header-and-body-json-asserts-pass-against-a-real-client)
   - [a failing count summarizes the recorded requests](#scenario-a-failing-count-summarizes-the-recorded-requests)
   - [an unknown mock name in an assert is a load-time error](#scenario-an-unknown-mock-name-in-an-assert-is-a-load-time-error)
+- [atago self-hosting / combined stream matchers](#atago-self-hosting--combined-stream-matchers) — 6 scenarios
+  - [contains and not_contains hold together](#scenario-contains-and-not_contains-hold-together)
+  - [matches and not_matches hold together](#scenario-matches-and-not_matches-hold-together)
+  - [all four text matchers compose](#scenario-all-four-text-matchers-compose)
+  - [a combined matcher composes with a line selector](#scenario-a-combined-matcher-composes-with-a-line-selector)
+  - [a failing member fails the inner spec and names the offender](#scenario-a-failing-member-fails-the-inner-spec-and-names-the-offender)
+  - [mixing a whole-stream matcher with a text matcher is a load error](#scenario-mixing-a-whole-stream-matcher-with-a-text-matcher-is-a-load-error)
 - [atago self-hosting / not_equals matcher](#atago-self-hosting--not_equals-matcher) — 4 scenarios
   - [not_equals passes when stdout differs from the given text](#scenario-not_equals-passes-when-stdout-differs-from-the-given-text)
   - [not_equals is trailing-newline tolerant like equals](#scenario-not_equals-is-trailing-newline-tolerant-like-equals)
@@ -2745,6 +2752,88 @@ ${atago} run bad.atago.yaml
 #### Then
 - exit code is `2`
 - stderr contains `not a declared mock server (declared: api)`
+## atago self-hosting / combined stream matchers
+Source: `test/e2e/atago/multi_matcher.atago.yaml`
+### Scenario: contains and not_contains hold together
+#### When
+```shell
+echo "hello world"
+```
+#### Then
+- stdout contains `hello`
+### Scenario: matches and not_matches hold together
+#### When
+```shell
+echo "release 1.2.3"
+```
+#### Then
+- stdout matches `/[0-9]+\.[0-9]+\.[0-9]+/`
+### Scenario: all four text matchers compose
+#### When
+```shell
+echo "Alice and Bob"
+```
+#### Then
+- stdout contains `Alice`, `Bob`
+### Scenario: a combined matcher composes with a line selector
+#### When
+```shell
+printf 'first line\nsecond line\n'
+```
+#### Then
+- stdout contains `second`
+### Scenario: a failing member fails the inner spec and names the offender
+#### Given
+- Fixture file `inner.atago.yaml` is created.
+#### Inputs
+_Fixture `inner.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: inner
+scenarios:
+  - name: contains holds but not_contains does not
+    steps:
+      - run:
+          command: echo "hello goodbye"
+      - assert:
+          stdout:
+            contains: hello
+            not_contains: goodbye
+```
+#### When
+```shell
+${atago} run inner.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `goodbye`
+### Scenario: mixing a whole-stream matcher with a text matcher is a load error
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: bad
+scenarios:
+  - name: equals cannot combine
+    steps:
+      - run:
+          command: echo hi
+      - assert:
+          stdout:
+            equals: hi
+            contains: h
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `cannot be combined with another matcher`
 ## atago self-hosting / not_equals matcher
 Source: `test/e2e/atago/not_equals.atago.yaml`
 ### Scenario: not_equals passes when stdout differs from the given text

--- a/examples/run_and_assert.atago.yaml
+++ b/examples/run_and_assert.atago.yaml
@@ -52,6 +52,24 @@ scenarios:
           stdout:
             not_contains: [panic, fatal]
 
+  - name: text matchers combine in one block
+    steps:
+      - run:
+          shell: true
+          command: echo "release 1.2.3 ready"
+      # contains/not_contains/matches/not_matches can be set together on one
+      # stream; every one has to hold (the common "has X but not Y" shape). The
+      # whole-stream matchers (equals/empty/snapshot/json/yaml) are used alone.
+      - assert:
+          stdout:
+            contains: ready
+            not_contains: error
+            matches: "[0-9]+\\.[0-9]+\\.[0-9]+"
+      # empty is a boolean: `empty: false` asserts the stream is NOT empty.
+      - assert:
+          stdout:
+            empty: false
+
   - name: negative exit code and line selection
     steps:
       - run:

--- a/internal/assert/assert_test.go
+++ b/internal/assert/assert_test.go
@@ -146,6 +146,12 @@ func TestCheck_Stream(t *testing.T) {
 		{"not_equals on a line", &spec.Assert{Stdout: &spec.StreamAssert{Line: intp(1), NotEquals: strp("nope")}}, true},
 		{"stderr empty", &spec.Assert{Stderr: &spec.StreamAssert{Empty: boolp(true)}}, true},
 		{"stdout not empty", &spec.Assert{Stdout: &spec.StreamAssert{Empty: boolp(false)}}, true},
+		// Text matchers compose (AND): every one that is set must hold.
+		{"contains and not_contains both hold", &spec.Assert{Stdout: &spec.StreamAssert{Contains: spec.StringList{"Alice"}, NotContains: spec.StringList{"Carol"}}}, true},
+		{"contains holds but not_contains fails", &spec.Assert{Stdout: &spec.StreamAssert{Contains: spec.StringList{"Alice"}, NotContains: spec.StringList{"Bob"}}}, false},
+		{"contains fails while not_contains holds", &spec.Assert{Stdout: &spec.StreamAssert{Contains: spec.StringList{"Carol"}, NotContains: spec.StringList{"Dave"}}}, false},
+		{"matches and not_matches both hold", &spec.Assert{Stdout: &spec.StreamAssert{Matches: strp("A.+e"), NotMatches: strp("(?i)error")}}, true},
+		{"contains not_contains and matches all hold", &spec.Assert{Stdout: &spec.StreamAssert{Contains: spec.StringList{"Alice"}, NotContains: spec.StringList{"Carol"}, Matches: strp("Bob")}}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/assert/stream.go
+++ b/internal/assert/stream.go
@@ -12,9 +12,8 @@ import (
 // hasData reports whether a command actually ran (to distinguish "no output"
 // from "no command").
 func checkStream(name string, s *spec.StreamAssert, data []byte, hasData bool, env Env) (out *CheckResult) {
-	matchers := s.SetMatchers()
-	if len(matchers) != 1 {
-		return &CheckResult{Desc: "assert " + name, Hint: "stream assertion must set exactly one matcher"}
+	if len(s.SetMatchers()) == 0 {
+		return &CheckResult{Desc: "assert " + name, Hint: "stream assertion must set at least one matcher"}
 	}
 	if !hasData {
 		return &CheckResult{Desc: "assert " + name, Hint: "no command has run in this scenario yet"}
@@ -50,6 +49,8 @@ func checkStream(name string, s *spec.StreamAssert, data []byte, hasData bool, e
 		name = fmt.Sprintf("%s line %d", name, *s.Line)
 	}
 
+	// Whole-stream matchers pin the entire output, so each is used on its own
+	// (the loader rejects combining them). Handle them first and return.
 	switch {
 	case s.Empty != nil:
 		want := *s.Empty
@@ -64,44 +65,6 @@ func checkStream(name string, s *spec.StreamAssert, data []byte, hasData bool, e
 			Actual:   excerpt(got),
 			Hint:     fmt.Sprintf("expected %s to be %s", name, emptiness(want)),
 		}
-
-	case s.Contains != nil:
-		return checkContainsAll(name, got, s.Contains)
-
-	case s.NotContains != nil:
-		return checkNotContainsAll(name, got, s.NotContains)
-
-	case s.Matches != nil:
-		re, err := regexp.Compile(*s.Matches)
-		if err != nil {
-			return &CheckResult{Desc: "assert " + name, Hint: fmt.Sprintf("invalid regexp %q: %v", *s.Matches, err)}
-		}
-		desc := fmt.Sprintf("assert %s matches %q", name, *s.Matches)
-		if re.MatchString(got) {
-			return pass(desc)
-		}
-		return &CheckResult{
-			Desc:     desc,
-			Expected: fmt.Sprintf("%s matches /%s/", name, *s.Matches),
-			Actual:   excerpt(got),
-			Hint:     fmt.Sprintf("regexp /%s/ did not match %s", *s.Matches, name),
-		}
-
-	case s.NotMatches != nil:
-		re, err := regexp.Compile(*s.NotMatches)
-		if err != nil {
-			return &CheckResult{Desc: "assert " + name, Hint: fmt.Sprintf("invalid regexp %q: %v", *s.NotMatches, err)}
-		}
-		desc := fmt.Sprintf("assert %s does not match %q", name, *s.NotMatches)
-		if loc := re.FindString(got); re.MatchString(got) {
-			return &CheckResult{
-				Desc:     desc,
-				Expected: fmt.Sprintf("%s without a match for /%s/", name, *s.NotMatches),
-				Actual:   excerpt(got),
-				Hint:     fmt.Sprintf("regexp /%s/ unexpectedly matched %q in %s", *s.NotMatches, loc, name),
-			}
-		}
-		return pass(desc)
 
 	case s.Equals != nil:
 		desc := fmt.Sprintf("assert %s equals exact text", name)
@@ -136,10 +99,87 @@ func checkStream(name string, s *spec.StreamAssert, data []byte, hasData bool, e
 
 	case s.Snapshot != "":
 		return checkSnapshot("assert "+name+" snapshot", name, s.Snapshot, data, env)
-
-	default:
-		return &CheckResult{Desc: "assert " + name, Hint: "matcher not supported yet"}
 	}
+
+	// The text matchers compose: every one that is set must hold (AND). Return
+	// the first failure; if all pass, return the last passing result.
+	var last *CheckResult
+	for _, r := range []*CheckResult{
+		streamContains(name, got, s.Contains),
+		streamNotContains(name, got, s.NotContains),
+		streamMatches(name, got, s.Matches),
+		streamNotMatches(name, got, s.NotMatches),
+	} {
+		if r == nil {
+			continue
+		}
+		if !r.OK {
+			return r
+		}
+		last = r
+	}
+	if last != nil {
+		return last
+	}
+	return &CheckResult{Desc: "assert " + name, Hint: "matcher not supported yet"}
+}
+
+// streamContains runs the contains matcher, or returns nil when it is unset.
+func streamContains(name, got string, subs spec.StringList) *CheckResult {
+	if subs == nil {
+		return nil
+	}
+	return checkContainsAll(name, got, subs)
+}
+
+// streamNotContains runs the not_contains matcher, or returns nil when unset.
+func streamNotContains(name, got string, subs spec.StringList) *CheckResult {
+	if subs == nil {
+		return nil
+	}
+	return checkNotContainsAll(name, got, subs)
+}
+
+// streamMatches runs the matches matcher, or returns nil when it is unset.
+func streamMatches(name, got string, pat *string) *CheckResult {
+	if pat == nil {
+		return nil
+	}
+	re, err := regexp.Compile(*pat)
+	if err != nil {
+		return &CheckResult{Desc: "assert " + name, Hint: fmt.Sprintf("invalid regexp %q: %v", *pat, err)}
+	}
+	desc := fmt.Sprintf("assert %s matches %q", name, *pat)
+	if re.MatchString(got) {
+		return pass(desc)
+	}
+	return &CheckResult{
+		Desc:     desc,
+		Expected: fmt.Sprintf("%s matches /%s/", name, *pat),
+		Actual:   excerpt(got),
+		Hint:     fmt.Sprintf("regexp /%s/ did not match %s", *pat, name),
+	}
+}
+
+// streamNotMatches runs the not_matches matcher, or returns nil when unset.
+func streamNotMatches(name, got string, pat *string) *CheckResult {
+	if pat == nil {
+		return nil
+	}
+	re, err := regexp.Compile(*pat)
+	if err != nil {
+		return &CheckResult{Desc: "assert " + name, Hint: fmt.Sprintf("invalid regexp %q: %v", *pat, err)}
+	}
+	desc := fmt.Sprintf("assert %s does not match %q", name, *pat)
+	if loc := re.FindString(got); re.MatchString(got) {
+		return &CheckResult{
+			Desc:     desc,
+			Expected: fmt.Sprintf("%s without a match for /%s/", name, *pat),
+			Actual:   excerpt(got),
+			Hint:     fmt.Sprintf("regexp /%s/ unexpectedly matched %q in %s", *pat, loc, name),
+		}
+	}
+	return pass(desc)
 }
 
 // checkContainsAll verifies every substring in subs is present in got. The whole

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -403,10 +403,10 @@ func TestLoadBytes_Errors(t *testing.T) {
 			wantMsg:  "exactly one action",
 		},
 		{
-			name:     "assert with two matchers",
+			name:     "whole-stream matcher cannot combine with a text matcher",
 			src:      "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps:\n      - assert:\n          stdout:\n            contains: a\n            equals: b",
 			wantKind: KindValidation,
-			wantMsg:  "exactly one matcher",
+			wantMsg:  "cannot be combined with another matcher",
 		},
 		{
 			name:     "line below 1",
@@ -461,12 +461,6 @@ func TestLoadBytes_Errors(t *testing.T) {
 			src:      "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps:\n      - run: {command: echo}\n      - assert:\n          stdout:\n            not_matches: \"hi[\"",
 			wantKind: KindValidation,
 			wantMsg:  "not_matches \"hi[\" is not a valid regexp",
-		},
-		{
-			name:     "matches and not_matches together are rejected",
-			src:      "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps:\n      - run: {command: echo}\n      - assert:\n          stdout:\n            matches: a\n            not_matches: b",
-			wantKind: KindValidation,
-			wantMsg:  "exactly one matcher",
 		},
 		{
 			name:     "invalid json matches regexp fails at load",
@@ -839,8 +833,8 @@ func TestBugHunt_Rejections(t *testing.T) {
 		{"exit_code in dup", specSteps("assert: {exit_code: {in: [0, 0]}}"), "in lists 0 more than once"},
 
 		// ---- validateStream ----
-		{"stream no matcher", specSteps("assert: {stdout: {}}"), "must set exactly one matcher"},
-		{"stream two matchers", specSteps("assert: {stdout: {contains: a, equals: b}}"), "must set exactly one matcher, but set"},
+		{"stream no matcher", specSteps("assert: {stdout: {}}"), "must set at least one matcher"},
+		{"stream text plus whole-stream matcher", specSteps("assert: {stdout: {contains: a, equals: b}}"), "cannot be combined with another matcher"},
 		{"stream line with snapshot", specSteps("assert: {stdout: {line: 1, snapshot: snap}}"), "line cannot be combined with json/yaml/snapshot"},
 		{"stream contains empty list", specSteps("assert: {stdout: {contains: []}}"), "contains must not be empty"},
 		{"stream contains empty element", specSteps("assert: {stdout: {contains: [\"\"]}}"), "is an empty string"},
@@ -869,7 +863,7 @@ func TestBugHunt_Rejections(t *testing.T) {
 		{"mock count negative", mockScenario("assert: {mock: {name: api, count: -1}}"), "count must be >= 0"},
 		{"mock count zero with matcher", mockScenario("assert: {mock: {name: api, count: 0, header: {name: X, equals: y}}}"), "count: 0 cannot be combined"},
 		{"mock header invalid", mockScenario("assert: {mock: {name: api, header: {name: X}}}"), "must set one of contains/equals/matches"},
-		{"mock body invalid", mockScenario("assert: {mock: {name: api, body: {}}}"), "must set exactly one matcher"},
+		{"mock body invalid", mockScenario("assert: {mock: {name: api, body: {}}}"), "must set at least one matcher"},
 
 		// ---- validateCondition ----
 		{"skip bad os", scenarioTop("skip: {os: solaris}", "run: {command: echo}"), "skip.os \"solaris\" is invalid"},

--- a/internal/loader/validate_assert.go
+++ b/internal/loader/validate_assert.go
@@ -101,26 +101,41 @@ func validateExitCode(add func(string, ...any), where string, e *spec.ExitCode) 
 	}
 }
 
+// streamExclusiveMatchers pin the whole stream, so each is used on its own. The
+// text matchers (contains/not_contains/matches/not_matches) may be combined —
+// they all have to hold — which is the common "output has X but not Y" shape.
+var streamExclusiveMatchers = map[string]bool{
+	"empty": true, "equals": true, "not_equals": true,
+	"json": true, "yaml": true, "snapshot": true,
+}
+
 func validateStream(add func(string, ...any), where string, s *spec.StreamAssert) {
 	matchers := s.SetMatchers()
-	switch len(matchers) {
-	case 0:
-		add("%s: must set exactly one matcher (empty/contains/not_contains/matches/not_matches/equals/not_equals/json/yaml/snapshot)", where)
-	case 1:
-		if s.JSON != nil {
-			validateJSON(add, where+".json", s.JSON)
+	if len(matchers) == 0 {
+		add("%s: must set at least one matcher (empty/contains/not_contains/matches/not_matches/equals/not_equals/json/yaml/snapshot)", where)
+	}
+	// A whole-stream matcher cannot be combined with anything else; only the
+	// text matchers compose.
+	var exclusive []string
+	for _, m := range matchers {
+		if streamExclusiveMatchers[m] {
+			exclusive = append(exclusive, m)
 		}
-		if s.YAML != nil {
-			validateJSON(add, where+".yaml", s.YAML)
-		}
-		if s.Matches != nil {
-			validateRegexp(add, where, "matches", *s.Matches)
-		}
-		if s.NotMatches != nil {
-			validateRegexp(add, where, "not_matches", *s.NotMatches)
-		}
-	default:
-		add("%s: must set exactly one matcher, but set %v", where, matchers)
+	}
+	if len(exclusive) > 0 && len(matchers) > 1 {
+		add("%s: %v cannot be combined with another matcher (only contains/not_contains/matches/not_matches may be combined)", where, exclusive)
+	}
+	if s.JSON != nil {
+		validateJSON(add, where+".json", s.JSON)
+	}
+	if s.YAML != nil {
+		validateJSON(add, where+".yaml", s.YAML)
+	}
+	if s.Matches != nil {
+		validateRegexp(add, where, "matches", *s.Matches)
+	}
+	if s.NotMatches != nil {
+		validateRegexp(add, where, "not_matches", *s.NotMatches)
 	}
 	validateStringList(add, where, "contains", s.Contains)
 	validateStringList(add, where, "not_contains", s.NotContains)

--- a/schema/atago.schema.json
+++ b/schema/atago.schema.json
@@ -786,15 +786,20 @@
       "additionalProperties": false,
       "oneOf": [
         { "required": ["empty"] },
-        { "required": ["contains"] },
-        { "required": ["not_contains"] },
-        { "required": ["matches"] },
-        { "required": ["not_matches"] },
         { "required": ["equals"] },
         { "required": ["not_equals"] },
         { "required": ["json"] },
         { "required": ["yaml"] },
-        { "required": ["snapshot"] }
+        { "required": ["snapshot"] },
+        {
+          "comment": "The text matchers contains/not_contains/matches/not_matches may be combined (all must hold); the whole-stream matchers above are each used alone.",
+          "anyOf": [
+            { "required": ["contains"] },
+            { "required": ["not_contains"] },
+            { "required": ["matches"] },
+            { "required": ["not_matches"] }
+          ]
+        }
       ],
       "properties": {
         "line": { "type": "integer", "minimum": 1 },

--- a/test/e2e/atago/multi_matcher.atago.yaml
+++ b/test/e2e/atago/multi_matcher.atago.yaml
@@ -1,0 +1,100 @@
+version: "1"
+
+suite:
+  name: atago self-hosting / combined stream matchers
+
+# Exercises combining the text matchers on a single stdout/stderr/body block:
+# contains/not_contains/matches/not_matches may be set together and all have to
+# hold (AND). The whole-stream matchers (equals/empty/snapshot/json/yaml) are
+# still used alone, and mixing one in is a load error.
+scenarios:
+  - name: contains and not_contains hold together
+    steps:
+      - run:
+          command: echo "hello world"
+      - assert:
+          stdout:
+            contains: hello
+            not_contains: goodbye
+
+  - name: matches and not_matches hold together
+    steps:
+      - run:
+          command: echo "release 1.2.3"
+      - assert:
+          stdout:
+            matches: "[0-9]+\\.[0-9]+\\.[0-9]+"
+            not_matches: "(?i)error"
+
+  - name: all four text matchers compose
+    steps:
+      - run:
+          command: echo "Alice and Bob"
+      - assert:
+          stdout:
+            contains:
+              - Alice
+              - Bob
+            not_contains: Carol
+            matches: "A.+e"
+            not_matches: Dave
+
+  - name: a combined matcher composes with a line selector
+    steps:
+      - run:
+          shell: true
+          command: "printf 'first line\\nsecond line\\n'"
+      - assert:
+          stdout:
+            line: 2
+            contains: second
+            not_contains: first
+
+  - name: a failing member fails the inner spec and names the offender
+    steps:
+      - fixture:
+          file: inner.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: inner
+            scenarios:
+              - name: contains holds but not_contains does not
+                steps:
+                  - run:
+                      command: echo "hello goodbye"
+                  - assert:
+                      stdout:
+                        contains: hello
+                        not_contains: goodbye
+      - run:
+          command: ${atago} run inner.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains: "goodbye"
+            not_contains: "internal error"
+
+  - name: mixing a whole-stream matcher with a text matcher is a load error
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: bad
+            scenarios:
+              - name: equals cannot combine
+                steps:
+                  - run:
+                      command: echo hi
+                  - assert:
+                      stdout:
+                        equals: hi
+                        contains: h
+      - run:
+          command: ${atago} run bad.atago.yaml
+      - assert:
+          exit_code: 2
+          stderr:
+            contains: "cannot be combined with another matcher"


### PR DESCRIPTION
## What

`contains`, `not_contains`, `matches`, and `not_matches` can now be set together on a single `stdout`/`stderr`/`body` block; every one that is set must hold (AND). This is the common "output has X but not Y" shape, which previously needed two separate `assert:` steps because a stream block accepted exactly one matcher.

## Why

Writing E2E for real CLIs, the "contains X and not_contains Y" assertion comes up constantly and having to split it into two `assert:` steps is a papercut. Combining the text matchers is a clean AND with no ambiguity.

## Design

- The whole-stream matchers (`equals`, `not_equals`, `empty`, `snapshot`, `json`, `yaml`) each pin the entire output, so they stay exclusive: combining one with any other matcher is a load error naming the offender.
- The loader (`validateStream`) enforces the family-vs-exclusive rule; the schema's stream `oneOf` is relaxed so the four text matchers may co-occur while the whole-stream matchers each remain alone; `checkStream` evaluates the set text matchers as an AND and returns the first failure.

## Regression coverage

- loader unit tests for the accepted (text-matcher) and rejected (text + whole-stream) combinations, and the new empty/two-matcher error messages;
- assert unit tests for the AND evaluation — pass when all hold, fail naming the unsatisfied member;
- a self-hosted E2E, `test/e2e/atago/multi_matcher.atago.yaml`, covering the passing combinations, composition with a `line:` selector, the failure path (inner spec exits 1), and the load error (exits 2).

The `run_and_assert` example and README document the combined form and that `empty: false` asserts a non-empty stream; the README also notes that scenarios run in parallel over a shared network, so background `service:` scenarios need distinct ports (a pitfall hit while writing the third-party server suites).

`make lint`, the full `go test ./...` (unit + self-hosted E2E + docs/site drift + schema conformance), and the golden guards are green locally.