### PR TITLE
ci: harden E2E drift guards and de-duplicate workflow config

### DIFF
--- a/.github/workflows/e2e-cross.yml
+++ b/.github/workflows/e2e-cross.yml
@@ -42,38 +42,12 @@ jobs:
           - os: macos-latest
             targets: "./test/e2e/atago ./test/e2e/thirdparty/git"
           # Portable subset: specs whose commands are shell builtins of both
-          # /bin/sh and cmd.exe, or that only drive atago itself. Keep this
-          # list in sync with the e2e-windows job in e2e.yml.
+          # /bin/sh and cmd.exe, or that only drive atago itself. The list is
+          # the single source of truth in scripts/windows_portable_specs.sh
+          # (shared with the e2e-windows job in e2e.yml); the @portable sentinel
+          # is expanded from it in the run step below.
           - os: windows-latest
-            targets: >-
-              ./test/e2e/atago/version.atago.yaml
-              ./test/e2e/atago/completion.atago.yaml
-              ./test/e2e/atago/list.atago.yaml
-              ./test/e2e/atago/manifest.atago.yaml
-              ./test/e2e/atago/doc.atago.yaml
-              ./test/e2e/atago/explain.atago.yaml
-              ./test/e2e/atago/init.atago.yaml
-              ./test/e2e/atago/init_templates.atago.yaml
-              ./test/e2e/atago/edge.atago.yaml
-              ./test/e2e/atago/matrix.atago.yaml
-              ./test/e2e/atago/parallel.atago.yaml
-              ./test/e2e/atago/run.atago.yaml
-              ./test/e2e/atago/select.atago.yaml
-              ./test/e2e/atago/skip_command.atago.yaml
-              ./test/e2e/atago/rerun.atago.yaml
-              ./test/e2e/atago/db.atago.yaml
-              ./test/e2e/atago/http.atago.yaml
-              ./test/e2e/atago/mock_server.atago.yaml
-              ./test/e2e/atago/dir_tree.atago.yaml
-              ./test/e2e/atago/changes.atago.yaml
-              ./test/e2e/atago/record.atago.yaml
-              ./test/e2e/atago/duration.atago.yaml
-              ./test/e2e/atago/sandbox_home.atago.yaml
-              ./test/e2e/atago/grpc.atago.yaml
-              ./test/e2e/atago/ssh.atago.yaml
-              ./test/e2e/atago/cdp.atago.yaml
-              ./test/e2e/atago/pdf.atago.yaml
-              ./test/e2e/thirdparty/git
+            targets: "@portable"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -86,6 +60,12 @@ jobs:
 
       # `go run .` compiles atago and runs it; os.Executable() (which seeds the
       # ${atago} spec variable) points at that binary, so specs self-invoke atago
-      # correctly on every OS without per-platform binary-name handling.
+      # correctly on every OS without per-platform binary-name handling. The
+      # Windows leg passes @portable, expanded from the shared spec list.
       - name: Run the self-hosted E2E specs
-        run: go run . run ${{ matrix.targets }}
+        run: |
+          targets="${{ matrix.targets }}"
+          if [ "$targets" = "@portable" ]; then
+            targets="$(bash scripts/windows_portable_specs.sh)"
+          fi
+          go run . run $targets

--- a/.github/workflows/e2e-cross.yml
+++ b/.github/workflows/e2e-cross.yml
@@ -64,8 +64,9 @@ jobs:
       # Windows leg passes @portable, expanded from the shared spec list.
       - name: Run the self-hosted E2E specs
         run: |
-          targets="${{ matrix.targets }}"
-          if [ "$targets" = "@portable" ]; then
-            targets="$(bash scripts/windows_portable_specs.sh)"
+          if [ "${{ matrix.targets }}" = "@portable" ]; then
+            mapfile -t targets < <(bash scripts/windows_portable_specs.sh)
+          else
+            read -ra targets <<< "${{ matrix.targets }}"
           fi
-          go run . run $targets
+          go run . run "${targets[@]}"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -79,8 +79,8 @@ jobs:
   # Windows regressions must fail a PR, not surface days later in the daily
   # cross-platform run (#78 follow-up). This job runs the portable subset —
   # specs whose commands are shell builtins of both /bin/sh and cmd.exe, or
-  # that only drive atago itself. Keep this list in sync with the Windows
-  # matrix entry in e2e-cross.yml.
+  # that only drive atago itself. The list is the single source of truth in
+  # scripts/windows_portable_specs.sh, shared with e2e-cross.yml.
   e2e-windows:
     runs-on: windows-latest
     timeout-minutes: 15
@@ -99,33 +99,4 @@ jobs:
       # atago correctly without per-platform binary-name handling.
       - name: Run the portable self-hosted E2E subset
         shell: bash
-        run: >-
-          go run . run
-          ./test/e2e/atago/version.atago.yaml
-          ./test/e2e/atago/completion.atago.yaml
-          ./test/e2e/atago/list.atago.yaml
-          ./test/e2e/atago/manifest.atago.yaml
-          ./test/e2e/atago/doc.atago.yaml
-          ./test/e2e/atago/explain.atago.yaml
-          ./test/e2e/atago/init.atago.yaml
-          ./test/e2e/atago/init_templates.atago.yaml
-          ./test/e2e/atago/edge.atago.yaml
-          ./test/e2e/atago/matrix.atago.yaml
-          ./test/e2e/atago/parallel.atago.yaml
-          ./test/e2e/atago/run.atago.yaml
-          ./test/e2e/atago/select.atago.yaml
-          ./test/e2e/atago/skip_command.atago.yaml
-          ./test/e2e/atago/rerun.atago.yaml
-          ./test/e2e/atago/db.atago.yaml
-          ./test/e2e/atago/http.atago.yaml
-          ./test/e2e/atago/mock_server.atago.yaml
-          ./test/e2e/atago/dir_tree.atago.yaml
-          ./test/e2e/atago/changes.atago.yaml
-          ./test/e2e/atago/record.atago.yaml
-          ./test/e2e/atago/duration.atago.yaml
-          ./test/e2e/atago/sandbox_home.atago.yaml
-          ./test/e2e/atago/grpc.atago.yaml
-          ./test/e2e/atago/ssh.atago.yaml
-          ./test/e2e/atago/cdp.atago.yaml
-          ./test/e2e/atago/pdf.atago.yaml
-          ./test/e2e/thirdparty/git
+        run: go run . run $(bash scripts/windows_portable_specs.sh)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -99,4 +99,6 @@ jobs:
       # atago correctly without per-platform binary-name handling.
       - name: Run the portable self-hosted E2E subset
         shell: bash
-        run: go run . run $(bash scripts/windows_portable_specs.sh)
+        run: |
+          mapfile -t targets < <(bash scripts/windows_portable_specs.sh)
+          go run . run "${targets[@]}"

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,48 @@
+name: Fuzz
+
+# The repository ships fuzz targets (internal/loader, internal/store,
+# internal/assert), but the push/PR test workflows only exercise their seed
+# corpus. This job runs real mutation fuzzing on a schedule so the loader, the
+# ${...} expander, and the JSON matcher keep getting adversarial input over
+# time — atago parses untrusted specs and arbitrary program output, so its input
+# surface is exactly where fuzzing pays off. A newly discovered crasher fails the
+# scheduled run (its reproducer is printed in the log and written under
+# testdata/fuzz/); it never blocks a PR.
+on:
+  workflow_dispatch:
+  schedule:
+    # 04:00 UTC daily, before the cross-platform E2E run (05:00).
+    - cron: "0 4 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    name: fuzz (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - pkg: ./internal/loader
+            target: FuzzLoadBytes
+          - pkg: ./internal/store
+            target: FuzzExpand
+          - pkg: ./internal/assert
+            target: FuzzCheckJSON
+          - pkg: ./internal/assert
+            target: FuzzValuesEqual
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: "go.mod"
+
+      - name: Fuzz ${{ matrix.target }}
+        run: go test -run='^$' -fuzz='^${{ matrix.target }}$' -fuzztime=3m ${{ matrix.pkg }}

--- a/doc/e2e/age.md
+++ b/doc/e2e/age.md
@@ -119,6 +119,8 @@ passphrase protected
 ## age + changes (single-artifact generator)
 Source: `test/e2e/thirdparty/age/changes.atago.yaml`
 ### Scenario: age-keygen writes exactly the key file (HOME untouched)
+#### Given
+- The command runs with an isolated home under `${workdir}/.atago-home` (HOME/XDG or APPDATA redirected).
 #### When
 ```shell
 age-keygen -o key.txt

--- a/doc/e2e/fzf.md
+++ b/doc/e2e/fzf.md
@@ -1,8 +1,8 @@
 # atago Behavior Specs
 ## Summary
-1 suite · 7 scenarios
+1 suite · 8 scenarios
 ## Contents
-- [fzf (third-party CLI, pty testbed)](#fzf-third-party-cli-pty-testbed) — 7 scenarios
+- [fzf (third-party CLI, pty testbed)](#fzf-third-party-cli-pty-testbed) — 8 scenarios
   - [version prints a semantic version](#scenario-version-prints-a-semantic-version)
   - [filter mode matches fuzzily on stdin without a terminal](#scenario-filter-mode-matches-fuzzily-on-stdin-without-a-terminal)
   - [filter mode exits 1 when nothing matches](#scenario-filter-mode-exits-1-when-nothing-matches)
@@ -10,6 +10,7 @@
   - [interactive selection picks the queried line](#scenario-interactive-selection-picks-the-queried-line)
   - [multi-select accepts several lines at once](#scenario-multi-select-accepts-several-lines-at-once)
   - [aborting the finder exits 130](#scenario-aborting-the-finder-exits-130)
+  - [the finder screen narrows to the typed query](#scenario-the-finder-screen-narrows-to-the-typed-query)
 ## fzf (third-party CLI, pty testbed)
 Source: `test/e2e/thirdparty/fzf/fzf.atago.yaml`
 ### Scenario: version prints a semantic version
@@ -85,3 +86,12 @@ _skipped on windows_
 ```
 #### Then
 - exit code is `130`
+### Scenario: the finder screen narrows to the typed query
+_skipped on windows_
+#### When
+```shell
+# interactive (pty): printf 'apple\nbanana\ncherry\n' | fzf
+```
+#### Then
+- rendered screen contains `banana`
+- rendered screen does not contain `cherry`

--- a/doc/e2e/jq.md
+++ b/doc/e2e/jq.md
@@ -51,7 +51,7 @@ jq empty
   - stdout is empty
   - stderr is empty
 - after `jq empty`:
-  - exit code is `5`
+  - exit code is one of `4`, `5`
   - stdout is empty
   - stderr contains `parse error`
 ## jq (third-party CLI, no build required)

--- a/drift_test.go
+++ b/drift_test.go
@@ -115,6 +115,9 @@ var (
 	// thirdpartyDirRe extracts each suite directory the thirdparty.yml CI matrix
 	// runs (`dir: ./test/e2e/thirdparty/<name>`).
 	thirdpartyDirRe = regexp.MustCompile(`dir:\s*\./test/e2e/thirdparty/([a-zA-Z0-9_-]+)`)
+	// windowsSpecRe extracts each ./test/e2e spec path listed in the single-source
+	// scripts/windows_portable_specs.sh.
+	windowsSpecRe = regexp.MustCompile(`(\./test/e2e/\S+)`)
 )
 
 // collectSpecs mirrors cli.collectSpecFiles for a single directory target: every
@@ -287,6 +290,29 @@ func TestThirdParty_MatrixCoversEverySuite(t *testing.T) {
 		}
 		if !inMatrix[e.Name()] {
 			t.Errorf("test/e2e/thirdparty/%s has specs but no matrix leg in .github/workflows/thirdparty.yml", e.Name())
+		}
+	}
+}
+
+// TestWindowsPortableSubset_Exists asserts every spec path in the single-source
+// scripts/windows_portable_specs.sh resolves to a real file or directory, so a
+// spec rename fails here — a fast unit test — instead of only in the Windows CI
+// legs that read the script (e2e.yml and e2e-cross.yml).
+func TestWindowsPortableSubset_Exists(t *testing.T) {
+	data, err := os.ReadFile("scripts/windows_portable_specs.sh")
+	if err != nil {
+		t.Fatalf("read scripts/windows_portable_specs.sh: %v", err)
+	}
+	var paths []string
+	for _, m := range windowsSpecRe.FindAllSubmatch(data, -1) {
+		paths = append(paths, string(m[1]))
+	}
+	if len(paths) == 0 {
+		t.Fatal("no ./test/e2e spec paths found in scripts/windows_portable_specs.sh")
+	}
+	for _, p := range paths {
+		if _, err := os.Stat(filepath.FromSlash(p)); err != nil {
+			t.Errorf("scripts/windows_portable_specs.sh lists %q which does not resolve: %v", p, err)
 		}
 	}
 }

--- a/drift_test.go
+++ b/drift_test.go
@@ -44,36 +44,78 @@ func TestDocs_NoStaleLintReferences(t *testing.T) {
 	}
 }
 
-// e2eDocSuites maps a committed generated doc under doc/e2e/ to the spec
-// directory it is rendered from. Keep this in sync with the `atago doc`
-// invocations recorded in doc/e2e/README.md.
-var e2eDocSuites = map[string]string{
-	"doc/e2e/atago.md":       "test/e2e/atago",
-	"doc/e2e/git.md":         "test/e2e/thirdparty/git",
-	"doc/e2e/caddy.md":       "test/e2e/thirdparty/caddy",
-	"doc/e2e/pushgateway.md": "test/e2e/thirdparty/pushgateway",
-	"doc/e2e/webhook.md":     "test/e2e/thirdparty/webhook",
-	"doc/e2e/gitea.md":       "test/e2e/thirdparty/gitea",
-	"doc/e2e/minio.md":       "test/e2e/thirdparty/minio",
-	"doc/e2e/prometheus.md":  "test/e2e/thirdparty/prometheus",
-	"doc/e2e/rclone.md":      "test/e2e/thirdparty/rclone",
-	"doc/e2e/restic.md":      "test/e2e/thirdparty/restic",
-	"doc/e2e/coredns.md":     "test/e2e/thirdparty/coredns",
-	"doc/e2e/nats.md":        "test/e2e/thirdparty/nats",
-	"doc/e2e/mailpit.md":     "test/e2e/thirdparty/mailpit",
-	"doc/e2e/ntfy.md":        "test/e2e/thirdparty/ntfy",
-	"doc/e2e/transfersh.md":  "test/e2e/thirdparty/transfersh",
-	"doc/e2e/gotify.md":      "test/e2e/thirdparty/gotify",
-	"doc/e2e/grafana.md":     "test/e2e/thirdparty/grafana",
-	"doc/e2e/gup.md":         "test/e2e/tools/gup",
-	"doc/e2e/sqly.md":        "test/e2e/tools/sqly",
-	"doc/e2e/truss.md":       "test/e2e/tools/truss",
-	"doc/e2e/iso8583tool.md": "test/e2e/tools/iso8583tool",
-	"doc/e2e/jose.md":        "test/e2e/tools/jose",
-	"doc/e2e/career.md":      "test/e2e/tools/career",
-	"doc/e2e/mimixbox.md":    "test/e2e/tools/mimixbox",
-	"doc/e2e/mobilepkg.md":   "test/e2e/tools/mobilepkg",
+// docSkipDirs are spec directories that deliberately ship no committed doc under
+// doc/e2e/. gup-offline is the fully offline variant of the gup suite, exercised
+// only by `make dogfood-gup`; it intentionally has no generated behavior doc.
+var docSkipDirs = map[string]bool{
+	"gup-offline": true,
 }
+
+// dirHasSpecs reports whether dir contains at least one *.atago.yaml/.yml spec
+// anywhere beneath it.
+func dirHasSpecs(t *testing.T, dir string) bool {
+	t.Helper()
+	found := false
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && (strings.HasSuffix(path, ".atago.yaml") || strings.HasSuffix(path, ".atago.yml")) {
+			found = true
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", dir, err)
+	}
+	return found
+}
+
+// e2eDocSuites derives the committed doc/e2e/*.md → spec-directory mapping from
+// the filesystem, mirroring the `make docs` recipe: the self-hosted atago suite,
+// every third-party suite under test/e2e/thirdparty/*, and every dogfood suite
+// under test/e2e/tools/* (minus docSkipDirs). Deriving it — rather than hand-
+// maintaining a map — means a new suite is drift-guarded the moment its specs
+// land. A hand-maintained map is what let doc/e2e/{age,fzf,jq}.md silently rot:
+// they were generated and committed by `make docs` but never registered here, so
+// nothing caught that the committed docs had fallen behind their specs.
+func e2eDocSuites(t *testing.T) map[string]string {
+	t.Helper()
+	suites := map[string]string{
+		"doc/e2e/atago.md": "test/e2e/atago",
+	}
+	for _, parent := range []string{"test/e2e/thirdparty", "test/e2e/tools"} {
+		entries, err := os.ReadDir(parent)
+		if err != nil {
+			t.Fatalf("read %s: %v", parent, err)
+		}
+		for _, e := range entries {
+			if !e.IsDir() || docSkipDirs[e.Name()] {
+				continue
+			}
+			dir := filepath.Join(parent, e.Name())
+			if !dirHasSpecs(t, dir) {
+				continue
+			}
+			doc := "doc/e2e/" + e.Name() + ".md"
+			if existing, ok := suites[doc]; ok {
+				t.Fatalf("doc name collision: %s maps to both %s and %s", doc, existing, filepath.ToSlash(dir))
+			}
+			suites[doc] = filepath.ToSlash(dir)
+		}
+	}
+	return suites
+}
+
+var (
+	// makeDocOutRe extracts each doc/e2e/<name>.md target from the Makefile
+	// `docs` recipe's `atago doc --out` lines.
+	makeDocOutRe = regexp.MustCompile(`doc/e2e/([a-zA-Z0-9_-]+)\.md`)
+	// thirdpartyDirRe extracts each suite directory the thirdparty.yml CI matrix
+	// runs (`dir: ./test/e2e/thirdparty/<name>`).
+	thirdpartyDirRe = regexp.MustCompile(`dir:\s*\./test/e2e/thirdparty/([a-zA-Z0-9_-]+)`)
+)
 
 // collectSpecs mirrors cli.collectSpecFiles for a single directory target: every
 // *.atago.yaml/.yml under dir in filepath.WalkDir's lexical order, cleaned. The
@@ -127,7 +169,7 @@ func firstDiff(want, got []byte) string {
 //
 //	atago doc --out doc/e2e/<tool>.md ./test/e2e/tools/<tool>
 func TestDocs_E2EDocsInSync(t *testing.T) {
-	for docPath, specDir := range e2eDocSuites {
+	for docPath, specDir := range e2eDocSuites(t) {
 		t.Run(docPath, func(t *testing.T) {
 			specs := collectSpecs(t, specDir)
 			if len(specs) == 0 {
@@ -159,6 +201,93 @@ func TestDocs_E2EDocsInSync(t *testing.T) {
 					docPath, specDir, docPath, specDir, firstDiff(want, buf.Bytes()))
 			}
 		})
+	}
+}
+
+// TestDocs_E2EDocSetMatchesCommitted asserts the derived suite set is exactly
+// the committed doc/e2e/*.md set (minus the README index), so a doc whose spec
+// directory was deleted — or a spec directory whose generated doc was never
+// committed — fails the build instead of rotting unnoticed.
+func TestDocs_E2EDocSetMatchesCommitted(t *testing.T) {
+	suites := e2eDocSuites(t)
+	committed := map[string]bool{}
+	entries, err := os.ReadDir("doc/e2e")
+	if err != nil {
+		t.Fatalf("read doc/e2e: %v", err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") || e.Name() == "README.md" {
+			continue
+		}
+		committed["doc/e2e/"+e.Name()] = true
+	}
+	for doc := range suites {
+		if !committed[doc] {
+			t.Errorf("%s derives from a spec directory but is not committed; run `make docs`", doc)
+		}
+	}
+	for doc := range committed {
+		if _, ok := suites[doc]; !ok {
+			t.Errorf("%s is committed but derives from no spec directory (stale doc, or a suite missing from docSkipDirs)", doc)
+		}
+	}
+}
+
+// TestDocs_MakefileGeneratesEverySuite asserts the `make docs` recipe emits a
+// doc for exactly the derived suite set, so adding a suite directory forces a
+// matching `atago doc --out` line and nothing generates an orphan doc. This is
+// what keeps the one remaining hand-maintained doc list — the Makefile recipe —
+// from drifting away from the specs on disk.
+func TestDocs_MakefileGeneratesEverySuite(t *testing.T) {
+	data, err := os.ReadFile("Makefile")
+	if err != nil {
+		t.Fatalf("read Makefile: %v", err)
+	}
+	generated := map[string]bool{}
+	for _, m := range makeDocOutRe.FindAllSubmatch(data, -1) {
+		generated["doc/e2e/"+string(m[1])+".md"] = true
+	}
+	suites := e2eDocSuites(t)
+	for doc := range suites {
+		if !generated[doc] {
+			t.Errorf("Makefile `docs` target does not generate %s; add an `atago doc --out %s ...` line", doc, doc)
+		}
+	}
+	for doc := range generated {
+		if _, ok := suites[doc]; !ok {
+			t.Errorf("Makefile `docs` generates %s but no spec directory derives it", doc)
+		}
+	}
+}
+
+// TestThirdParty_MatrixCoversEverySuite asserts the scheduled thirdparty.yml
+// matrix runs every test/e2e/thirdparty/* suite, so a suite with specs but no
+// matrix leg (which would silently never run in CI) fails the build. git is
+// exempt: it is push-gated in e2e.yml rather than in the scheduled matrix.
+func TestThirdParty_MatrixCoversEverySuite(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/thirdparty.yml")
+	if err != nil {
+		t.Fatalf("read thirdparty.yml: %v", err)
+	}
+	inMatrix := map[string]bool{}
+	for _, m := range thirdpartyDirRe.FindAllSubmatch(data, -1) {
+		inMatrix[string(m[1])] = true
+	}
+	entries, err := os.ReadDir("test/e2e/thirdparty")
+	if err != nil {
+		t.Fatalf("read test/e2e/thirdparty: %v", err)
+	}
+	exempt := map[string]bool{"git": true}
+	for _, e := range entries {
+		if !e.IsDir() || exempt[e.Name()] {
+			continue
+		}
+		if !dirHasSpecs(t, filepath.Join("test/e2e/thirdparty", e.Name())) {
+			continue
+		}
+		if !inMatrix[e.Name()] {
+			t.Errorf("test/e2e/thirdparty/%s has specs but no matrix leg in .github/workflows/thirdparty.yml", e.Name())
+		}
 	}
 }
 

--- a/scripts/windows_portable_specs.sh
+++ b/scripts/windows_portable_specs.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Single source of truth for the Windows "portable subset" of the self-hosted
+# E2E specs: specs whose commands are shell builtins of both /bin/sh and
+# cmd.exe, or that only drive atago itself. Both the push-gated e2e-windows job
+# (.github/workflows/e2e.yml) and the scheduled cross-platform drift check
+# (.github/workflows/e2e-cross.yml) run `atago run $(bash scripts/windows_portable_specs.sh)`,
+# so the list lives in exactly one place and the two workflows cannot drift.
+#
+# Print the targets space-separated for word-splitting by the caller. Every path
+# below must resolve to a real file or directory; TestWindowsPortableSubset_Exists
+# enforces that so a spec rename fails a unit test instead of only the Windows CI.
+set -euo pipefail
+
+printf '%s\n' \
+  ./test/e2e/atago/version.atago.yaml \
+  ./test/e2e/atago/completion.atago.yaml \
+  ./test/e2e/atago/list.atago.yaml \
+  ./test/e2e/atago/manifest.atago.yaml \
+  ./test/e2e/atago/doc.atago.yaml \
+  ./test/e2e/atago/explain.atago.yaml \
+  ./test/e2e/atago/init.atago.yaml \
+  ./test/e2e/atago/init_templates.atago.yaml \
+  ./test/e2e/atago/edge.atago.yaml \
+  ./test/e2e/atago/matrix.atago.yaml \
+  ./test/e2e/atago/parallel.atago.yaml \
+  ./test/e2e/atago/run.atago.yaml \
+  ./test/e2e/atago/select.atago.yaml \
+  ./test/e2e/atago/skip_command.atago.yaml \
+  ./test/e2e/atago/rerun.atago.yaml \
+  ./test/e2e/atago/db.atago.yaml \
+  ./test/e2e/atago/http.atago.yaml \
+  ./test/e2e/atago/mock_server.atago.yaml \
+  ./test/e2e/atago/dir_tree.atago.yaml \
+  ./test/e2e/atago/changes.atago.yaml \
+  ./test/e2e/atago/record.atago.yaml \
+  ./test/e2e/atago/duration.atago.yaml \
+  ./test/e2e/atago/sandbox_home.atago.yaml \
+  ./test/e2e/atago/grpc.atago.yaml \
+  ./test/e2e/atago/ssh.atago.yaml \
+  ./test/e2e/atago/cdp.atago.yaml \
+  ./test/e2e/atago/pdf.atago.yaml \
+  ./test/e2e/thirdparty/git


### PR DESCRIPTION
## Summary

Harden the CI drift guards and remove hand-maintained duplication across the
E2E metadata. Addresses three findings from a review of how the repo's growing
suite/example/CI surface stays consistent.

One reported finding was **not** acted on because it does not hold: the README's
claim that `examples/` are "loaded, validated, and executed in CI on Linux,
macOS, and Windows" is accurate — `drift_test.go`'s `TestExamples_Valid`,
`TestExamples_HermeticRunGreen`, and `TestExamples_EveryFileCategorized` do
exactly that under the standard `go test ./...` matrix (`unit_test.yml` runs all
three OSes). The `dogfoodRoots` guard in `main_test.go` is a separate check for
`test/` and `doc/` specs, not the examples guard.

## Changes

### 1. Derive the `doc/e2e` drift guard from the filesystem (real bug fixed)

The `e2eDocSuites` map was hand-maintained and covered only **25 of the 44**
docs that `make docs` generates and commits. The other 19 (actionlint, age,
aqua, awscli, ecspresso, ffmpeg, fzf, htop, hugo, jq, kustomize, openssl,
pandoc, python, redis, sops, sqlite3, ssh-keygen, terraform) were never
drift-checked — and `doc/e2e/{age,fzf,jq}.md` had **already silently rotted**
(new fzf scenario, changed age/jq assertions) because nothing caught it.

- Derive the suite set from the filesystem (atago + every `thirdparty/*` + every
  `tools/*` minus an explicit skip set), so a new suite is guarded the moment
  its specs land.
- Add `TestDocs_MakefileGeneratesEverySuite` (the Makefile `docs` recipe must
  emit exactly the derived set) and `TestThirdParty_MatrixCoversEverySuite` (the
  scheduled `thirdparty.yml` matrix must run every third-party suite).
- Regenerate the three docs that had drifted.

### 2. Single-source the Windows portable E2E subset

The portable spec subset was duplicated verbatim in `e2e.yml` (e2e-windows) and
`e2e-cross.yml` (Windows matrix leg), with a "keep in sync" comment. Move the
list to `scripts/windows_portable_specs.sh`; both workflows now run
`atago run $(bash scripts/windows_portable_specs.sh)`.
`TestWindowsPortableSubset_Exists` asserts every listed path resolves, so a spec
rename fails a fast unit test instead of only the Windows CI legs.

### 3. Run mutation fuzzing on a schedule

The loader, `${...}` expander, and JSON matcher ship fuzz targets, but the
push/PR workflows only exercise their seed corpus. Add a scheduled `Fuzz`
workflow running real mutation fuzzing (3m/target) against `FuzzLoadBytes`,
`FuzzExpand`, `FuzzCheckJSON`, and `FuzzValuesEqual`. Scheduled/on-demand only,
so a newly found crasher never blocks a PR.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` — all green
- `golangci-lint run` — 0 issues
- `actionlint` on the three changed/added workflows — clean
- Each fuzz target smoke-run locally (no crashers)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a scheduled daily fuzzing workflow to catch crashes earlier.
  * Expanded end-to-end coverage with a new interactive finder scenario.
  * Standardized the Windows portable E2E spec set so it’s managed in one place.

* **Bug Fixes**
  * Relaxed one command’s expected exit code to handle valid alternate behavior.
  * Improved isolated-home handling in key-generation tests to better protect user environment settings.

* **Tests**
  * Added drift checks to keep docs, workflows, and spec lists aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->