### PR TITLE
release: v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-06
+
 A correctness pass across `record`, `snapshot`, the report formats, the loader,
 the assertion matchers, secret masking, and the run engine. Each defect was
 surfaced by an edge-case bug hunt and fixed with a reproduction test first, plus


### PR DESCRIPTION
Release **v0.5.0**. Promotes the accumulated `[Unreleased]` changelog to a dated
release; the tag push after merge triggers the goreleaser workflow.

Minor bump per SemVer: this cycle adds user-facing features (composable stream
matchers and the `scrub:` output-normalization block) on top of a broad
correctness pass.

### Added
- Composable stream matchers — `contains`/`not_contains`/`matches`/`not_matches`
  on one `stdout`/`stderr`/`body` block.
- `scrub:` (#137) — spec-wide declarative output normalization for snapshots.

### Changed
- `--repeat` (#138) now folds a partially-failing run to `flaky`, not `failed`.

### Fixed
- Correctness fixes across `record --pty`, dir-tree/path snapshot normalization,
  unified-diff hunk headers, `--report tap`/`junit`, the console duration
  headline, `--fail-fast` across files, repeatable `--tag`/`--skip-tag`,
  large-integer and boolean JSON/YAML comparisons, secret masking, and several
  loader validations (see CHANGELOG for the full list).
