### PR TITLE
fix(security): refuse symlink-escaping I/O and honor zero readiness timeout

### DIFF
--- a/internal/assert/assert_test.go
+++ b/internal/assert/assert_test.go
@@ -805,6 +805,35 @@ func TestCheck_File_TraversalRejected(t *testing.T) {
 	}
 }
 
+// TestCheck_File_SymlinkEscapeRejected proves that lexical containment is not
+// enough: a file assertion target that is a symlink inside the workdir but points
+// at a host file outside it must not be read through (issue #16). The untrusted
+// program under test could plant such a link to disclose /etc/passwd et al. into
+// the report; checkFile must refuse to follow it.
+func TestCheck_File_SymlinkEscapeRejected(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is not reliably available on Windows CI")
+	}
+	t.Parallel()
+	workdir := t.TempDir()
+	secret := filepath.Join(t.TempDir(), "secret.txt")
+	if err := os.WriteFile(secret, []byte("top-secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// A link planted inside the workdir (so lexical containment passes) that
+	// resolves to the out-of-root secret.
+	if err := os.Symlink(secret, filepath.Join(workdir, "leak.txt")); err != nil {
+		t.Fatal(err)
+	}
+	got := Check(&spec.Assert{File: &spec.FileAssert{Path: "leak.txt", Contains: spec.StringList{"top-secret"}}}, nil, Env{Workdir: workdir})
+	if got.OK {
+		t.Fatalf("read through a workdir symlink pointing outside the root")
+	}
+	if strings.Contains(got.Actual, "top-secret") || strings.Contains(got.Hint, "top-secret") || strings.Contains(string(got.ArtifactActual), "top-secret") {
+		t.Errorf("the out-of-root secret leaked into the result: %+v", got)
+	}
+}
+
 // TestCheck_Snapshot_TraversalRejected proves a relative snapshot path may not
 // escape the spec directory.
 func TestCheck_Snapshot_TraversalRejected(t *testing.T) {

--- a/internal/assert/file.go
+++ b/internal/assert/file.go
@@ -125,7 +125,10 @@ func checkFile(f *spec.FileAssert, env Env) *CheckResult {
 }
 
 func readFile(label, path string) ([]byte, *CheckResult) {
-	data, err := os.ReadFile(path) //nolint:gosec // path is the user-declared assertion target
+	// The program under test may have planted a symlink at the assertion target
+	// pointing outside the workdir; reading through it would disclose an arbitrary
+	// host file into the report/artifacts, so refuse to follow it (issue #16).
+	data, err := security.ReadFileNoFollow(path)
 	if err != nil {
 		return nil, &CheckResult{
 			Desc:     fmt.Sprintf("assert file %q", label),

--- a/internal/fixture/fixture.go
+++ b/internal/fixture/fixture.go
@@ -87,7 +87,7 @@ func Write(f *spec.Fixture, workdir, specDir string) error {
 	// dest is contained within workdir by safeJoin above (cannot escape) — but the
 	// untrusted program under test may have planted a symlink at dest pointing
 	// outside the workdir; writing must not follow it (TOCTOU, issue #16).
-	if err := writeNoFollow(dest, data, 0o600); err != nil {
+	if err := security.WriteFileNoFollow(dest, data, 0o600); err != nil {
 		return fmt.Errorf("fixture %q: %w", f.File, err)
 	}
 	if err := applyMode(f, dest); err != nil {
@@ -145,34 +145,6 @@ func checkSymlinkTarget(workdir, dest, target string) error {
 		return fmt.Errorf("symlink target %q escapes the scenario workdir", target)
 	}
 	return nil
-}
-
-// writeNoFollow writes data to dest without following a symlink planted at dest.
-// The untrusted program under test may have created a link there pointing outside
-// the workdir; following it on write would escape containment (issue #16). An
-// existing symlink is rejected outright; an existing regular file is removed and
-// re-created with O_EXCL so a link planted in the race is never written through
-// (O_EXCL fails atomically on any existing path). This is portable — unlike
-// O_NOFOLLOW, which is not available on all platforms.
-func writeNoFollow(dest string, data []byte, perm os.FileMode) error {
-	if fi, err := os.Lstat(dest); err == nil {
-		if fi.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("refusing to write through the existing symlink %q", dest)
-		}
-		if err := os.Remove(dest); err != nil {
-			return err
-		}
-	}
-	f, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_EXCL, perm) //nolint:gosec // dest sanitized by safeJoin; O_EXCL guards against a planted link
-	if err != nil {
-		return err
-	}
-	_, werr := f.Write(data)
-	cerr := f.Close()
-	if werr != nil {
-		return werr
-	}
-	return cerr
 }
 
 // safeJoin joins rel onto base and ensures the result stays within base, so a

--- a/internal/runner/browser/browser.go
+++ b/internal/runner/browser/browser.go
@@ -153,7 +153,9 @@ func (r *Runner) Run(ctx context.Context, actions []spec.CDPAction, workdir stri
 	// Persist any screenshots after the run completes, so the captured bytes are
 	// on disk before the scenario's file/image assertions read them (#50).
 	for _, s := range shots {
-		if err := os.WriteFile(s.path, *s.buf, 0o600); err != nil {
+		// The page under test may have planted a symlink at the screenshot target
+		// pointing outside the workdir; write without following it (issue #16).
+		if err := security.WriteFileNoFollow(s.path, *s.buf, 0o600); err != nil {
 			return nil, fmt.Errorf("cdp screenshot: writing %q: %w", s.path, err)
 		}
 	}

--- a/internal/runner/cmd/cmd.go
+++ b/internal/runner/cmd/cmd.go
@@ -182,7 +182,9 @@ func writeRedirects(run *spec.Run, workdir, stdout, stderr string) error {
 		if err != nil {
 			return err
 		}
-		if err := os.WriteFile(abs, []byte(r.data), 0o644); err != nil { //nolint:gosec // user-declared redirect target inside the workdir
+		// The program under test may have planted a symlink at the redirect target
+		// pointing outside the workdir; write without following it (issue #16).
+		if err := security.WriteFileNoFollow(abs, []byte(r.data), 0o644); err != nil {
 			return fmt.Errorf("%s: %w", r.field, err)
 		}
 	}

--- a/internal/runner/http/http.go
+++ b/internal/runner/http/http.go
@@ -154,7 +154,9 @@ func (r *Runner) Do(ctx context.Context, h *spec.HTTP) (*runner.Result, error) {
 		if perr := os.MkdirAll(filepath.Dir(dst), 0o750); perr != nil {
 			return nil, fmt.Errorf("creating directory for http.body_to %q: %w", h.BodyTo, perr)
 		}
-		if perr := os.WriteFile(dst, data, 0o600); perr != nil {
+		// The program under test may have planted a symlink at the body_to target
+		// pointing outside the workdir; write without following it (issue #16).
+		if perr := security.WriteFileNoFollow(dst, data, 0o600); perr != nil {
 			return nil, fmt.Errorf("writing http.body_to %q: %w", h.BodyTo, perr)
 		}
 	}

--- a/internal/runner/service/service.go
+++ b/internal/runner/service/service.go
@@ -256,10 +256,19 @@ func (p *Proc) waitFile(ctx context.Context, path, store string, timeout time.Du
 }
 
 // poll calls check every pollInterval until it returns true, the service exits,
-// the timeout elapses, or ctx is canceled.
+// the timeout elapses, or ctx is canceled. A non-positive timeout means
+// "unbounded" (matching the documented ready semantics and the delay probe): the
+// deadline channel stays nil so it never fires, and the wait is bounded only by
+// the process staying alive or the scenario context. Without this, ready.timeout
+// "0" made the file/port/log probes fail immediately via a zero-duration timer,
+// contradicting the delay probe which already treated 0 as unbounded.
 func (p *Proc) poll(ctx context.Context, timeout time.Duration, check func() bool) error {
-	deadline := time.NewTimer(timeout)
-	defer deadline.Stop()
+	var deadlineC <-chan time.Time
+	if timeout > 0 {
+		deadline := time.NewTimer(timeout)
+		defer deadline.Stop()
+		deadlineC = deadline.C
+	}
 	tick := time.NewTicker(pollInterval)
 	defer tick.Stop()
 	for {
@@ -275,7 +284,7 @@ func (p *Proc) poll(ctx context.Context, timeout time.Duration, check func() boo
 				return nil
 			}
 			return errExitedEarly
-		case <-deadline.C:
+		case <-deadlineC:
 			return fmt.Errorf("timed out after %s waiting for readiness", timeout)
 		case <-ctx.Done():
 			return ctx.Err()

--- a/internal/runner/service/service_test.go
+++ b/internal/runner/service/service_test.go
@@ -160,6 +160,36 @@ func TestStart_DelayBoundedByTimeout(t *testing.T) {
 	}
 }
 
+// TestStart_ZeroTimeoutReadinessIsUnbounded is a regression: ready.timeout "0"
+// documents an unbounded readiness wait, and the delay probe already honored it,
+// but the file/port/log probes handed 0 straight to a zero-duration timer and
+// failed on the first tick. A ready file that appears shortly after start must
+// still be detected under timeout "0", not lose a race to an instant timeout.
+func TestStart_ZeroTimeoutReadinessIsUnbounded(t *testing.T) {
+	skipWindows(t)
+	wd := t.TempDir()
+	svc := &spec.Service{
+		Name:  "late",
+		Shell: spec.Bool(true),
+		// Publish the ready file only after a short delay, so the first poll check
+		// misses it — exactly the case a zero-duration timer would fail instantly.
+		Command: "sleep 0.3; printf '127.0.0.1:5555' > ready.txt; " + sleepCmd(5),
+		Ready:   &spec.Ready{File: "ready.txt", Store: "addr", Timeout: "0"},
+	}
+	start := time.Now()
+	p, captured, err := Start(context.Background(), svc, wd)
+	if err != nil {
+		t.Fatalf("Start() with ready.timeout 0 error = %v; want an unbounded wait to detect the late file", err)
+	}
+	defer p.Stop()
+	if captured != "127.0.0.1:5555" {
+		t.Errorf("captured = %q, want the published address", captured)
+	}
+	if elapsed := time.Since(start); elapsed < 200*time.Millisecond {
+		t.Errorf("returned after %s; a zero timeout must wait for the file, not return before it appears", elapsed)
+	}
+}
+
 // TestStart_BarePortReadyRejected is a regression: a host-less ready.port must
 // fail fast with a clear message, not swallow "missing port in address" and run
 // to the full readiness timeout.

--- a/internal/security/path.go
+++ b/internal/security/path.go
@@ -46,6 +46,50 @@ func resolveInRoot(field, rootLabel, root, p string) (string, error) {
 	return dest, nil
 }
 
+// ReadFileNoFollow reads path but refuses to follow a symlink planted at the
+// leaf. Lexical containment (ResolveWorkdirPath/ResolveSpecPath) proves path is
+// inside its root, but the untrusted program under test may have replaced the
+// leaf with a link pointing outside the root — os.ReadFile would follow it and
+// disclose an arbitrary host file (issue #16). An existing symlink is rejected
+// outright, mirroring WriteFileNoFollow's guard on the write path so every
+// path-taking feature enforces the same rule instead of a plain, link-following
+// os.ReadFile.
+func ReadFileNoFollow(path string) ([]byte, error) {
+	if fi, err := os.Lstat(path); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("refusing to read through the symlink %q (it escapes the scenario root)", path)
+	}
+	return os.ReadFile(path) //nolint:gosec // path is containment-checked by the caller and Lstat-guarded against a leaf symlink
+}
+
+// WriteFileNoFollow writes data to dest without following a symlink planted at
+// dest. Lexical containment proves dest is inside its root, but the untrusted
+// program under test may have created a link there pointing outside the root;
+// following it on write would escape containment and clobber a host file (TOCTOU,
+// issue #16). An existing symlink is rejected outright; an existing regular file
+// is removed and re-created with O_EXCL so a link planted in the race is never
+// written through (O_EXCL fails atomically on any existing path). This is
+// portable — unlike O_NOFOLLOW, which is not available on all platforms.
+func WriteFileNoFollow(dest string, data []byte, perm os.FileMode) error {
+	if fi, err := os.Lstat(dest); err == nil {
+		if fi.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to write through the existing symlink %q (it escapes the scenario root)", dest)
+		}
+		if err := os.Remove(dest); err != nil {
+			return err
+		}
+	}
+	f, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_EXCL, perm) //nolint:gosec // dest is containment-checked by the caller; O_EXCL guards against a planted link
+	if err != nil {
+		return err
+	}
+	_, werr := f.Write(data)
+	cerr := f.Close()
+	if werr != nil {
+		return werr
+	}
+	return cerr
+}
+
 // WithinRoot reports whether resolved lies inside root (root itself counts).
 // Callers that resolve a path with non-default semantics — a symlink target
 // resolved against the link's own directory, say — can reuse this single

--- a/internal/security/path_test.go
+++ b/internal/security/path_test.go
@@ -1,6 +1,7 @@
 package security
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -81,6 +82,82 @@ func TestResolve_RelativeRoot(t *testing.T) {
 	}
 	if _, err := ResolveWorkdirPath("f", ".", "sub/out.txt"); err != nil {
 		t.Fatalf("nested relative path rejected under root %q: %v", ".", err)
+	}
+}
+
+// TestReadFileNoFollow verifies a leaf symlink pointing outside the root is
+// refused (issue #16): the untrusted program under test could plant such a link
+// at an assertion/snapshot read target to disclose an arbitrary host file. A
+// plain regular file inside the root is read normally.
+func TestReadFileNoFollow(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is not reliably available on Windows CI")
+	}
+	t.Parallel()
+	root := t.TempDir()
+
+	regular := filepath.Join(root, "real.txt")
+	if err := os.WriteFile(regular, []byte("in-root"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := ReadFileNoFollow(regular); err != nil || string(got) != "in-root" {
+		t.Fatalf("ReadFileNoFollow(regular) = %q, %v; want %q, nil", got, err, "in-root")
+	}
+
+	// A host secret outside the root, and a link to it planted inside the root.
+	secret := filepath.Join(t.TempDir(), "secret.txt")
+	if err := os.WriteFile(secret, []byte("top-secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "leak.txt")
+	if err := os.Symlink(secret, link); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadFileNoFollow(link)
+	if err == nil {
+		t.Fatalf("ReadFileNoFollow followed the symlink and read %q; want error", got)
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("error %q should name the refused symlink", err)
+	}
+}
+
+// TestWriteFileNoFollow verifies a leaf symlink at the write target is refused
+// (so a redirect/snapshot write cannot clobber a host file through a link the
+// program under test planted), while a fresh write and an overwrite of a plain
+// regular file both succeed.
+func TestWriteFileNoFollow(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is not reliably available on Windows CI")
+	}
+	t.Parallel()
+	root := t.TempDir()
+
+	fresh := filepath.Join(root, "out.txt")
+	if err := WriteFileNoFollow(fresh, []byte("v1"), 0o600); err != nil {
+		t.Fatalf("fresh write: %v", err)
+	}
+	if err := WriteFileNoFollow(fresh, []byte("v2"), 0o600); err != nil {
+		t.Fatalf("overwrite of regular file: %v", err)
+	}
+	if got, err := os.ReadFile(fresh); err != nil || string(got) != "v2" {
+		t.Fatalf("after overwrite = %q, %v; want %q", got, err, "v2")
+	}
+
+	// A host file outside the root must not be clobbered through a planted link.
+	victim := filepath.Join(t.TempDir(), "victim.txt")
+	if err := os.WriteFile(victim, []byte("original"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "redirect.txt")
+	if err := os.Symlink(victim, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteFileNoFollow(link, []byte("pwned"), 0o600); err == nil {
+		t.Fatal("WriteFileNoFollow wrote through the symlink; want error")
+	}
+	if got, _ := os.ReadFile(victim); string(got) != "original" {
+		t.Errorf("host file was modified through the symlink: %q", got)
 	}
 }
 

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/nao1215/atago/internal/security"
 )
 
 // ErrMissing reports that a snapshot file does not exist yet; the caller should
@@ -133,7 +135,7 @@ func isComponentBoundary(c byte) bool {
 // It returns the normalized expected and actual text for diffing. If the
 // snapshot does not exist it returns ErrMissing.
 func Compare(path string, actual []byte, opt Options) (ok bool, expected, actualNorm string, err error) {
-	stored, rerr := os.ReadFile(path) //nolint:gosec // snapshot path is user-declared
+	stored, rerr := security.ReadFileNoFollow(path)
 	if rerr != nil {
 		if os.IsNotExist(rerr) {
 			return false, "", string(Normalize(actual, opt)), ErrMissing
@@ -155,5 +157,7 @@ func Update(path string, actual []byte, opt Options) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		return err
 	}
-	return os.WriteFile(path, Normalize(actual, opt), 0o600)
+	// The program under test may have planted a symlink at the snapshot target
+	// pointing outside the spec directory; write without following it (issue #16).
+	return security.WriteFileNoFollow(path, Normalize(actual, opt), 0o600)
 }


### PR DESCRIPTION
## Summary

Two containment/robustness fixes surfaced by a code review.

### High — symlink escapes lexical path containment (issue #16, now unified)

`security.ResolveWorkdirPath` / `ResolveSpecPath` validated paths only lexically (`Join`/`Clean`/`filepath.Rel`). A symlink planted **inside** the workdir or spec dir by the untrusted program under test passed that check, and the consuming feature then followed the link during I/O — reading or overwriting an arbitrary host file. Only `fixture` self-defended (`writeNoFollow`), so the protection was inconsistent across features.

Affected sinks: file assert reads, `run.stdout_to` / `stderr_to`, `http.body_to`, cdp `screenshot`, and snapshot `update`/`assert`.

- Centralize the guard in the `security` package: `ReadFileNoFollow` (rejects a leaf symlink before reading) and `WriteFileNoFollow` (rejects an existing symlink, `O_EXCL`-creates to close the TOCTOU race — promoted from fixture).
- Wire it into every path-taking read/write site so all features enforce the same rule. `fixture` now shares the promoted helper instead of a private copy.

### Medium — `ready.timeout: "0"` fails readiness probes immediately

`waitReady` documents "a non-positive timeout means unbounded", and the `delay` probe honored it, but `poll()` passed `0` straight to `time.NewTimer(0)`, so the `file`/`port`/`log` probes timed out on the first tick. `poll` now treats a non-positive timeout as unbounded (nil deadline channel), matching the documented semantics and the delay probe. The wait stays bounded by process liveness and the scenario context.

## Tests (TDD)

- `security`: `TestReadFileNoFollow` / `TestWriteFileNoFollow`
- `assert`: `TestCheck_File_SymlinkEscapeRejected` (consumer wiring regression)
- `service`: `TestStart_ZeroTimeoutReadinessIsUnbounded`

Each was verified to **fail on the pre-fix code** (symlink read leaked the out-of-root secret; zero timeout produced `timed out after 0s`) and **pass after** the fix.

`go build ./...`, `go vet ./...`, `golangci-lint run`, and the full `go test ./...` suite are green. Windows skips the symlink tests (symlink creation is unreliable on Windows CI), consistent with existing conventions.