### PR TITLE
feat(shell): honor ATAGO_SHELL for shell:true on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `shell: true` now honors the `ATAGO_SHELL` environment variable on Windows.
+  Previously a shell command always ran through `cmd.exe` there, so a spec that
+  used POSIX syntax (pipes, `$(...)`, single-quoted JSON) could not run on
+  Windows CI. Setting `ATAGO_SHELL` to a POSIX shell (for example Git Bash's
+  `sh.exe`) routes shell commands through `<sh> -c <command>` instead, matching
+  the override atago already honored on POSIX. The default (no `ATAGO_SHELL`)
+  is unchanged: `cmd.exe` on Windows, `/bin/sh` on POSIX. See
+  [examples/shell_and_redirect.atago.yaml](examples/shell_and_redirect.atago.yaml).
+
 ## [0.5.1] - 2026-07-06
 
 A security and robustness patch, each fix landed with a reproduction test first.

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Every feature has a commented, runnable spec under [examples/](examples/). The e
 | Example | Shows |
 |---------|-------|
 | [run_and_assert](examples/run_and_assert.atago.yaml) | exit code (exact, `not`, `in: [0, 2]` sets), stdout/stderr matchers (`contains`, `equals`, `matches`/`not_matches`, `empty: true`/`false`, lists, `line`), combining `contains`/`not_contains`/`matches`/`not_matches` in one block, multi-target asserts |
-| [shell_and_redirect](examples/shell_and_redirect.atago.yaml) | `shell: true` vs direct argv execution, `stdout_to`/`stderr_to` redirects |
+| [shell_and_redirect](examples/shell_and_redirect.atago.yaml) | `shell: true` vs direct argv execution, `stdout_to`/`stderr_to` redirects, `ATAGO_SHELL` to run POSIX-syntax specs under Git Bash on Windows |
 | [json_and_yaml](examples/json_and_yaml.atago.yaml) | JSONPath assertions, numeric bounds (`gt`/`lte`), the `yaml` matcher |
 | [files_and_fixtures](examples/files_and_fixtures.atago.yaml) | input fixtures (text and base64), `file` and `dir` assertions |
 | [store_and_variables](examples/store_and_variables.atago.yaml) | capturing values into `${name}`, `${workdir}`, `${env:NAME}` host-environment reads, the `$${...}` literal escape |

--- a/examples/shell_and_redirect.atago.yaml
+++ b/examples/shell_and_redirect.atago.yaml
@@ -5,6 +5,15 @@ version: "1"
 # shell: true). For "write output to a file" you do not need a shell at all:
 # stdout_to / stderr_to redirect the captured streams to workdir-relative files.
 # Runs green as-is: atago run examples/shell_and_redirect.atago.yaml
+#
+# Cross-platform shell: `shell: true` uses /bin/sh on POSIX and cmd.exe on
+# Windows, so keep shared specs portable (echo is a builtin in both). To run a
+# spec that relies on POSIX syntax (pipes, $(...), single-quoted JSON) on
+# Windows CI, point atago at a POSIX shell with the ATAGO_SHELL environment
+# variable — for example Git Bash's sh:
+#   ATAGO_SHELL="C:\\Program Files\\Git\\usr\\bin\\sh.exe" atago run ./specs
+# atago then runs `<sh> -c <command>` instead of cmd.exe. On POSIX ATAGO_SHELL
+# already overrides the default /bin/sh the same way.
 
 suite:
   name: shell and redirect
@@ -13,7 +22,7 @@ scenarios:
   - name: shell true runs the command through the shell
     steps:
       - run:
-          shell: true   # /bin/sh on POSIX, cmd.exe on Windows
+          shell: true   # /bin/sh on POSIX, cmd.exe on Windows (or ATAGO_SHELL)
           command: echo piped
       - assert:
           stdout:

--- a/internal/runner/cmd/cmd.go
+++ b/internal/runner/cmd/cmd.go
@@ -206,10 +206,8 @@ func commandLine(run *spec.Run) (string, []string, error) {
 // by Go with MSVCRT quoting rules that cmd.exe does not follow.
 func CommandLine(command string, shell bool) (string, []string, error) {
 	if shell {
-		if runtime.GOOS == "windows" {
-			return "cmd", []string{"/c", command}, nil
-		}
-		return shellPath(), []string{"-c", command}, nil
+		name, args := shellArgv(runtime.GOOS, command, os.Getenv("ATAGO_SHELL"), shellPath())
+		return name, args, nil
 	}
 	fields, err := splitArgv(command)
 	if err != nil {
@@ -266,6 +264,34 @@ func windowsFields(command string) ([]string, error) {
 		fields = append(fields, cur.String())
 	}
 	return fields, nil
+}
+
+// shellArgv returns the program name and argument prefix that run `command`
+// through a shell on the given GOOS. POSIX always uses `<posixShell> -c
+// <command>`. Windows defaults to `cmd /c <command>`, but when the operator
+// sets ATAGO_SHELL (atagoShell != "") it switches to `<atagoShell> -c
+// <command>` so POSIX-syntax specs — pipes, `$(...)`, single-quoted JSON —
+// run under Git Bash on Windows CI instead of failing under cmd.exe. The
+// override mirrors the ATAGO_SHELL escape hatch shellPath already honors on
+// POSIX; atagoShell is ignored on non-Windows because posixShell (from
+// shellPath) has already resolved it there.
+func shellArgv(goos, command, atagoShell, posixShell string) (string, []string) {
+	if goos == "windows" {
+		if atagoShell != "" {
+			return atagoShell, []string{"-c", command}
+		}
+		return "cmd", []string{"/c", command}
+	}
+	return posixShell, []string{"-c", command}
+}
+
+// windowsUsesCmdExe reports whether a `shell: true` command runs through
+// cmd.exe on the given GOOS. It is true only on Windows and only when no
+// ATAGO_SHELL override selects a POSIX shell. It gates the cmd.exe raw
+// command-line quoting in ConfigureShell: a POSIX shell reached via
+// ATAGO_SHELL takes the same no-op path as POSIX.
+func windowsUsesCmdExe(goos, atagoShell string) bool {
+	return goos == "windows" && atagoShell == ""
 }
 
 // shellPath returns an absolute path to the POSIX shell used for `shell: true`.

--- a/internal/runner/cmd/cmd_test.go
+++ b/internal/runner/cmd/cmd_test.go
@@ -654,6 +654,95 @@ func lastValue(env []string, key string) string {
 	return val
 }
 
+// TestShellArgv pins the argv prefix chosen for a `shell: true` command per
+// GOOS. POSIX always runs `<posixShell> -c <command>`. Windows runs `cmd /c`
+// by default, but an explicit ATAGO_SHELL override switches it to
+// `<shell> -c <command>` so POSIX-syntax specs (pipes, $(), quoting) run under
+// Git Bash on Windows CI.
+func TestShellArgv(t *testing.T) {
+	t.Parallel()
+	const cmdStr = "printf x | cat"
+	tests := []struct {
+		name       string
+		goos       string
+		atagoShell string
+		posixShell string
+		wantName   string
+		wantArgs   []string
+	}{
+		{"linux default", "linux", "", "/bin/sh", "/bin/sh", []string{"-c", cmdStr}},
+		{"linux ignores atago_shell here", "linux", "/opt/bash", "/bin/sh", "/bin/sh", []string{"-c", cmdStr}},
+		{"darwin default", "darwin", "", "/bin/sh", "/bin/sh", []string{"-c", cmdStr}},
+		{"windows default cmd.exe", "windows", "", "/bin/sh", "cmd", []string{"/c", cmdStr}},
+		{"windows atago_shell override", "windows", `C:\Git\usr\bin\sh.exe`, "/bin/sh", `C:\Git\usr\bin\sh.exe`, []string{"-c", cmdStr}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, gotArgs := shellArgv(tt.goos, cmdStr, tt.atagoShell, tt.posixShell)
+			if gotName != tt.wantName {
+				t.Errorf("shellArgv name = %q, want %q", gotName, tt.wantName)
+			}
+			if len(gotArgs) != len(tt.wantArgs) {
+				t.Fatalf("shellArgv args = %#v, want %#v", gotArgs, tt.wantArgs)
+			}
+			for i := range gotArgs {
+				if gotArgs[i] != tt.wantArgs[i] {
+					t.Errorf("shellArgv args[%d] = %q, want %q", i, gotArgs[i], tt.wantArgs[i])
+				}
+			}
+		})
+	}
+}
+
+// TestWindowsUsesCmdExe pins when the cmd.exe raw-command-line quoting hack
+// applies: only on Windows AND only when no ATAGO_SHELL override is in effect.
+// A POSIX shell reached via ATAGO_SHELL must NOT get the cmd.exe treatment.
+func TestWindowsUsesCmdExe(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		goos       string
+		atagoShell string
+		want       bool
+	}{
+		{"windows", "", true},
+		{"windows", `C:\Git\usr\bin\sh.exe`, false},
+		{"linux", "", false},
+		{"linux", "/opt/bash", false},
+		{"darwin", "", false},
+	}
+	for _, tt := range tests {
+		if got := windowsUsesCmdExe(tt.goos, tt.atagoShell); got != tt.want {
+			t.Errorf("windowsUsesCmdExe(%q, %q) = %v, want %v", tt.goos, tt.atagoShell, got, tt.want)
+		}
+	}
+}
+
+// TestRun_WindowsPOSIXShellViaAtagoShell drives the end-to-end Windows path: a
+// POSIX-syntax pipe command run under `shell: true` with ATAGO_SHELL pointing at
+// Git Bash's sh must produce the piped output, proving atago no longer forces
+// cmd.exe on Windows. It runs only on Windows where a `sh` is discoverable;
+// POSIX already uses sh -c so nothing new is exercised there.
+func TestRun_WindowsPOSIXShellViaAtagoShell(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("exercises the Windows-only ATAGO_SHELL routing; POSIX already uses sh -c")
+	}
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("no POSIX sh on PATH (Git Bash not installed)")
+	}
+	t.Setenv("ATAGO_SHELL", sh)
+	res, err := New().Run(context.Background(), &spec.Run{
+		Shell:   spec.Bool(true),
+		Command: `printf 'a\nb\nc\n' | grep b`,
+	}, t.TempDir())
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got := strings.TrimSpace(string(res.Stdout)); got != "b" {
+		t.Errorf("stdout = %q, want %q (POSIX pipe must run via ATAGO_SHELL on Windows)", got, "b")
+	}
+}
+
 // TestConfigureShell_NoopOnPOSIX covers the POSIX ConfigureShell, which is a
 // deliberate no-op (the sh -c argv from CommandLine needs no re-quoting). It must
 // not panic or mutate the command.

--- a/internal/runner/cmd/shell_windows.go
+++ b/internal/runner/cmd/shell_windows.go
@@ -3,7 +3,9 @@
 package cmd
 
 import (
+	"os"
 	"os/exec"
+	"runtime"
 	"syscall"
 )
 
@@ -14,6 +16,14 @@ import (
 // was the reproducer). `/S /C "<command>"` is cmd's documented contract: strip
 // exactly the first and last quote and run everything between verbatim — the
 // command behaves as if typed at the prompt.
+//
+// When ATAGO_SHELL selects a POSIX shell (Git Bash's sh) the command runs via
+// `<sh> -c <command>` instead, and that shell unquotes MSVCRT-escaped argv like
+// any mingw program — so Go's default escaping is already correct and this hack
+// must be skipped, exactly as on POSIX.
 func ConfigureShell(c *exec.Cmd, command string) {
+	if !windowsUsesCmdExe(runtime.GOOS, os.Getenv("ATAGO_SHELL")) {
+		return
+	}
 	c.SysProcAttr = &syscall.SysProcAttr{CmdLine: `cmd /S /C "` + command + `"`}
 }


### PR DESCRIPTION
## Summary

On Windows a `shell: true` command always ran through `cmd.exe`, so a spec written with POSIX syntax (pipes, `$(...)`, single-quoted JSON) could not run on Windows CI. This makes atago honor the `ATAGO_SHELL` environment variable on Windows: when it points at a POSIX shell (for example Git Bash's `sh.exe`), shell commands run through `<sh> -c <command>` instead of `cmd.exe`, mirroring the `ATAGO_SHELL` override atago already honors on POSIX.

The default is unchanged — `cmd.exe` on Windows, `/bin/sh` on POSIX — so existing behavior is fully backward compatible. The cmd.exe raw-command-line quoting (`ConfigureShell`) is skipped when a POSIX shell is selected, because that shell unquotes MSVCRT-escaped argv like any mingw program, exactly as on POSIX.

This unblocks running the same POSIX-syntax end-to-end specs on Windows CI (the motivating case is the jose project driving its atago suite on `windows-latest` via Git Bash).

## Changes

The shell routing is factored into two pure helpers so both branches are unit-testable on any host:

- `shellArgv(goos, command, atagoShell, posixShell)` returns the program and argv prefix.
- `windowsUsesCmdExe(goos, atagoShell)` gates the cmd.exe quoting hack.

## Tests

- `TestShellArgv` — table over linux/darwin/windows with and without `ATAGO_SHELL`.
- `TestWindowsUsesCmdExe` — pins when the cmd.exe quoting hack applies.
- `TestRun_WindowsPOSIXShellViaAtagoShell` — Windows-only end-to-end: a POSIX pipe runs via `ATAGO_SHELL` and produces the piped output.

## Docs

- `examples/shell_and_redirect.atago.yaml` documents the `ATAGO_SHELL` override.
- README example table row updated.
- CHANGELOG `[Unreleased]` entry added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Windows `shell: true` commands can now use the `ATAGO_SHELL` environment variable to run through a POSIX-style shell instead of always using `cmd.exe`.
  * Added clearer documentation and examples for shell execution, command redirection, and Windows POSIX-syntax compatibility.

* **Bug Fixes**
  * Improved shell handling on Windows so POSIX pipelines and other shell syntax work as expected when `ATAGO_SHELL` is set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->