### PR TITLE
docs(readme): name the real fixture source key content: (#157)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Hint:
 
 ### 2. Check generated files and snapshots
 
-`fixture:` writes input files into the isolated workdir; `file:`/`dir:` assertions check what the command produced, and `snapshot:` pins output to a committed golden file (volatile details like temp paths, UUIDs, and timestamps are normalized):
+`fixture:` writes input files into the isolated workdir; `file:`/`dir:` assertions check what the command produced, and `snapshot:` pins output to a committed golden file (volatile details like temp paths, UUIDs, and timestamps are normalized). A fixture's source is one of `content:` (inline text), `base64:` (inline bytes), `from:` (copy an existing file), or `symlink:` (link to a target):
 
 ```yaml
 scenarios:
@@ -217,7 +217,7 @@ Every feature has a commented, runnable spec under [examples/](examples/). The e
 | [run_and_assert](examples/run_and_assert.atago.yaml) | exit code (exact, `not`, `in: [0, 2]` sets), stdout/stderr matchers (`contains`, `equals`, `matches`/`not_matches`, `empty: true`/`false`, lists, `line`), combining `contains`/`not_contains`/`matches`/`not_matches` in one block, multi-target asserts |
 | [shell_and_redirect](examples/shell_and_redirect.atago.yaml) | `shell: true` vs direct argv execution, `stdout_to`/`stderr_to` redirects |
 | [json_and_yaml](examples/json_and_yaml.atago.yaml) | JSONPath assertions, numeric bounds (`gt`/`lte`), the `yaml` matcher |
-| [files_and_fixtures](examples/files_and_fixtures.atago.yaml) | input fixtures (text and base64), `file` and `dir` assertions |
+| [files_and_fixtures](examples/files_and_fixtures.atago.yaml) | input fixtures (inline `content:` and `base64:`), `file` and `dir` assertions |
 | [store_and_variables](examples/store_and_variables.atago.yaml) | capturing values into `${name}`, `${workdir}`, `${env:NAME}` host-environment reads, the `$${...}` literal escape |
 | [teardown](examples/teardown.atago.yaml) | cleanup steps that always run — pass or fail — sharing the scenario's variables |
 | [hermetic_env](examples/hermetic_env.atago.yaml) | `clear_env: true` starts commands from an empty environment, `pass_env` re-admits an allowlist of host variables, `sandbox_home: true` isolates HOME and per-OS config/cache dirs |

--- a/drift_test.go
+++ b/drift_test.go
@@ -44,6 +44,18 @@ func TestDocs_NoStaleLintReferences(t *testing.T) {
 	}
 }
 
+// TestDocs_FixtureSourceKeyNamed guards #157: the README prose that introduces
+// fixtures must name the real inline-source key `content:` — not just the word
+// "text" — so a reader who skims the prose cannot guess a non-existent `text:`
+// key and hit an "unknown field" loader error. The example file uses `content:`;
+// this keeps the prose from drifting away from that schema.
+func TestDocs_FixtureSourceKeyNamed(t *testing.T) {
+	readme := readDoc(t, "README.md")
+	if !strings.Contains(readme, "`content:`") {
+		t.Errorf("README does not name the literal fixture source key `content:`; a reader could guess `text:` from prose and hit an unknown-field error")
+	}
+}
+
 // docSkipDirs are spec directories that deliberately ship no committed doc under
 // doc/e2e/. gup-offline is the fully offline variant of the gup suite, exercised
 // only by `make dogfood-gup`; it intentionally has no generated behavior doc.


### PR DESCRIPTION
Closes #157.

## Problem

The README described a fixture's inline source as "text", but the actual YAML key is `content:`. A reader who skims the prose (e.g. the "text and base64" wording in the examples table) could reasonably try `fixture: { text: ... }` and hit an "unknown field" schema error (exit 2).

## Change

- Name the real fixture source keys in the prose: `content:` (inline text), `base64:` (inline bytes), `from:` (copy a file), `symlink:` (link) — mirroring how the `stdin:` sources are already spelled out.
- Update the examples table row from "text and base64" to "inline `content:` and `base64:`".
- Add `TestDocs_FixtureSourceKeyNamed` asserting the README names the literal key `content:`, so the prose and schema can't drift apart again.

Docs-only; `examples/files_and_fixtures.atago.yaml` already uses the real `content:` key.

https://claude.ai/code/session_01UdJLmQRNg12Sk9U2xY8hyB