### PR TITLE
fix(cmd): unify single-quote tokenization across Windows and POSIX (#154)

### DIFF
--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,7 +1,10 @@
 # atago Behavior Specs
 ## Summary
-56 suites · 226 scenarios
+57 suites · 228 scenarios
 ## Contents
+- [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 2 scenarios
+  - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
+  - [a single-quoted argument with a space stays one argument](#scenario-a-single-quoted-argument-with-a-space-stays-one-argument)
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 6 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
   - [stdout.contains and not_contains expand a stored variable](#scenario-stdoutcontains-and-not_contains-expand-a-stored-variable)
@@ -284,6 +287,24 @@
 - [atago self-hosting / yaml stream matcher](#atago-self-hosting--yaml-stream-matcher) — 2 scenarios
   - [a yaml stream matcher selects and asserts a decoded value (#9)](#scenario-a-yaml-stream-matcher-selects-and-asserts-a-decoded-value-9)
   - [a yaml matcher mismatch fails the inner spec (#9)](#scenario-a-yaml-matcher-mismatch-fails-the-inner-spec-9)
+## atago self-hosting / cross-platform no-shell argv tokenization (#154)
+Source: `test/e2e/atago/argv_quotes.atago.yaml`
+### Scenario: a single-quoted JSON argument survives tokenization
+#### When
+```shell
+${atago} run '{"k":"v"}'
+```
+#### Then
+- exit code is `3`
+- stderr contains `{"k":"v"}`
+### Scenario: a single-quoted argument with a space stays one argument
+#### When
+```shell
+${atago} run 'no such file.yaml'
+```
+#### Then
+- exit code is `3`
+- stderr contains `no such file.yaml`
 ## atago self-hosting / variable expansion in assertion matcher values
 Source: `test/e2e/atago/assert_expand.atago.yaml`
 ### Scenario: stdout.equals expands ${workdir}

--- a/internal/runner/cmd/cmd.go
+++ b/internal/runner/cmd/cmd.go
@@ -226,9 +226,10 @@ func CommandLine(command string, shell bool) (string, []string, error) {
 // sh-style — `\t`/`\n` become a real tab/newline (sh would drop the backslash
 // and keep the letter), and a trailing `\` is an error rather than a line
 // continuation. Quote your command or set shell: true if you need a literal
-// backslash. Windows uses windowsFields, where a backslash is an ordinary path
-// character — sh backslash-escape semantics would corrupt every C:\ path (e.g.
-// the expanded ${atago} binary path).
+// backslash. Windows uses windowsFields, which groups the same single/double
+// quotes as go-shellwords (so a single-quoted argument tokenizes identically on
+// both OSes) but keeps a backslash literal — sh backslash-escape semantics would
+// corrupt every C:\ path (e.g. the expanded ${atago} binary path).
 func splitArgv(command string) ([]string, error) {
 	if runtime.GOOS == "windows" {
 		return windowsFields(command)
@@ -236,19 +237,32 @@ func splitArgv(command string) ([]string, error) {
 	return shellwords.Parse(command)
 }
 
-// windowsFields splits command on unquoted whitespace. Double quotes group a
-// field (and are stripped); every other character — including backslash — is
-// literal.
+// windowsFields splits command on unquoted whitespace. Both double and single
+// quotes group a field (and are stripped): inside a double-quoted group a single
+// quote is literal, and inside a single-quoted group a double quote is literal —
+// so a shell-free command tokenizes to the SAME argv on Windows as on POSIX
+// (go-shellwords), where a single-quoted segment groups and strips too (#154).
+// Before this, a single quote was an ordinary character on Windows only, so a
+// cross-platform spec passing single-quoted inline JSON (`'{"k":"v"}'`) reached
+// the CLI as non-JSON on Windows and broke there alone.
+//
+// A backslash stays literal OUTSIDE quotes so a bare C:\ path survives (sh
+// backslash-escape semantics would corrupt it); it is also literal inside either
+// quote. This keeps the deliberate Windows-path behavior while removing the
+// single-quote divergence, which was an unintended side effect, not a design goal.
 func windowsFields(command string) ([]string, error) {
 	var fields []string
 	var cur strings.Builder
-	inQuote, started := false, false
+	inDouble, inSingle, started := false, false, false
 	for _, r := range command {
 		switch {
-		case r == '"':
-			inQuote = !inQuote
+		case r == '"' && !inSingle:
+			inDouble = !inDouble
 			started = true
-		case !inQuote && (r == ' ' || r == '\t'):
+		case r == '\'' && !inDouble:
+			inSingle = !inSingle
+			started = true
+		case !inDouble && !inSingle && (r == ' ' || r == '\t'):
 			if started {
 				fields = append(fields, cur.String())
 				cur.Reset()
@@ -259,8 +273,11 @@ func windowsFields(command string) ([]string, error) {
 			started = true
 		}
 	}
-	if inQuote {
+	if inDouble {
 		return nil, fmt.Errorf("unclosed double quote")
+	}
+	if inSingle {
+		return nil, fmt.Errorf("unclosed single quote")
 	}
 	if started {
 		fields = append(fields, cur.String())

--- a/internal/runner/cmd/cmd_test.go
+++ b/internal/runner/cmd/cmd_test.go
@@ -7,10 +7,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
+
+	shellwords "github.com/mattn/go-shellwords"
 
 	"github.com/nao1215/atago/internal/spec"
 )
@@ -414,7 +417,8 @@ func TestRun_ShellEmbeddedQuotes(t *testing.T) {
 }
 
 // TestWindowsFields pins the Windows argv tokenizer: backslashes are literal
-// (they are path separators, not escapes) and double quotes group fields.
+// (they are path separators, not escapes) and both single and double quotes
+// group fields.
 func TestWindowsFields(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -426,6 +430,13 @@ func TestWindowsFields(t *testing.T) {
 		{`tool --path "C:\Program Files\x"`, []string{"tool", "--path", `C:\Program Files\x`}},
 		{"  spaced   out  ", []string{"spaced", "out"}},
 		{`empty ""`, []string{"empty", ""}},
+		// A single-quoted group strips like a double-quoted one, and a double
+		// quote inside it is literal — so inline JSON survives (#154).
+		{`a '{"k":"v"}' b`, []string{"a", `{"k":"v"}`, "b"}},
+		{`x 'has space' y`, []string{"x", "has space", "y"}},
+		{`empty ''`, []string{"empty", ""}},
+		// A single quote inside a double-quoted group is literal (and vice versa).
+		{`tool "it's" x`, []string{"tool", "it's", "x"}},
 	}
 	for _, tt := range tests {
 		got, err := windowsFields(tt.in)
@@ -444,7 +455,51 @@ func TestWindowsFields(t *testing.T) {
 		}
 	}
 	if _, err := windowsFields(`broken "quote`); err == nil {
-		t.Error("windowsFields with an unclosed quote should error")
+		t.Error("windowsFields with an unclosed double quote should error")
+	}
+	if _, err := windowsFields(`broken 'quote`); err == nil {
+		t.Error("windowsFields with an unclosed single quote should error")
+	}
+}
+
+// TestWindowsFields_MatchesShellwords is the #154 cross-platform guard: for a
+// no-shell command, windowsFields must tokenize to the SAME argv that
+// go-shellwords (the POSIX tokenizer) produces, so a single spec cannot silently
+// diverge on Windows. The one deliberate exception is a bare backslash path,
+// which windowsFields keeps literal while shellwords treats as a C-style escape;
+// that case is asserted separately as a regression guard, not for parity.
+func TestWindowsFields_MatchesShellwords(t *testing.T) {
+	t.Parallel()
+	// Quote handling must be identical on both OSes.
+	parity := []string{
+		`a '{"k":"v"}' b`,
+		`x 'has space' y`,
+		`tool "a b" c`,
+		`plain args here`,
+	}
+	for _, in := range parity {
+		win, werr := windowsFields(in)
+		posix, perr := shellwords.Parse(in)
+		if werr != nil || perr != nil {
+			t.Errorf("tokenize(%q): windows err=%v, posix err=%v", in, werr, perr)
+			continue
+		}
+		if !reflect.DeepEqual(win, posix) {
+			t.Errorf("tokenize(%q): windows=%#v, posix=%#v (must be identical)", in, win, posix)
+		}
+	}
+	// Regression guard for the deliberate divergence: a bare Windows path stays
+	// literal under windowsFields (shellwords would mangle the backslashes).
+	if got, err := windowsFields(`run C:\tmp\x`); err != nil || !reflect.DeepEqual(got, []string{"run", `C:\tmp\x`}) {
+		t.Errorf(`windowsFields("run C:\tmp\x") = %#v, %v; want ["run" "C:\\tmp\\x"]`, got, err)
+	}
+	// An unmatched single quote is an error on both, mirroring the unmatched
+	// double-quote error.
+	if _, err := windowsFields(`bad 'quote`); err == nil {
+		t.Error("windowsFields: unmatched single quote should error")
+	}
+	if _, err := shellwords.Parse(`bad 'quote`); err == nil {
+		t.Error("shellwords: unmatched single quote should error")
 	}
 }
 

--- a/scripts/windows_portable_specs.sh
+++ b/scripts/windows_portable_specs.sh
@@ -21,6 +21,7 @@ printf '%s\n' \
   ./test/e2e/atago/init.atago.yaml \
   ./test/e2e/atago/init_templates.atago.yaml \
   ./test/e2e/atago/edge.atago.yaml \
+  ./test/e2e/atago/argv_quotes.atago.yaml \
   ./test/e2e/atago/matrix.atago.yaml \
   ./test/e2e/atago/parallel.atago.yaml \
   ./test/e2e/atago/run.atago.yaml \

--- a/test/e2e/atago/argv_quotes.atago.yaml
+++ b/test/e2e/atago/argv_quotes.atago.yaml
@@ -1,0 +1,38 @@
+version: "1"
+
+suite:
+  name: atago self-hosting / cross-platform no-shell argv tokenization (#154)
+
+# A no-shell command (shell: false, the default) must tokenize to the SAME argv
+# on every OS. Before #154, a single-quoted segment was stripped on POSIX but
+# kept literal on Windows, so single-quoted inline JSON reached the CLI as
+# non-JSON on Windows alone — invisible until Windows CI ran.
+#
+# These scenarios drive atago itself: `atago run <path>` echoes the path it
+# could not access in its error, so a single-quoted argument round-trips through
+# atago's own tokenizer and we can assert what the argument actually became.
+# They use only the atago binary, so they belong in the Windows portable subset.
+scenarios:
+  - name: a single-quoted JSON argument survives tokenization
+    steps:
+      # The command carries a single-quoted '{"k":"v"}'. After tokenization the
+      # inner double quotes must be preserved literally and the single quotes
+      # stripped, so atago receives the JSON as one argument on every OS.
+      - run:
+          command: "${atago} run '{\"k\":\"v\"}'"
+      - assert:
+          exit_code: 3
+          stderr:
+            contains: '{"k":"v"}'
+
+  - name: a single-quoted argument with a space stays one argument
+    steps:
+      - run:
+          command: "${atago} run 'no such file.yaml'"
+      - assert:
+          exit_code: 3
+          # The space is inside the single quotes, so the whole phrase is one
+          # path argument; a broken tokenizer would split it and never mention
+          # the full "no such file.yaml".
+          stderr:
+            contains: "no such file.yaml"


### PR DESCRIPTION
Closes #154.

## Problem

A non-shell command (`shell: false`, the default) was tokenized differently on Windows than on POSIX:

- POSIX (`go-shellwords`): a **single-quoted** segment groups and is stripped; its contents (including double quotes) are literal.
- Windows (`windowsFields`): **only** double quotes grouped; a single quote was an ordinary literal character.

So `mycli '{"k":"v"}'` yielded `{"k":"v"}` on Linux/macOS but `'{k:v}'` on Windows. This broke iso8583tool's atago suite on `windows-latest` alone — invisible until Windows CI ran.

## Change

`windowsFields` now groups **both** single and double quotes (each is stripped; the other quote is literal inside), matching go-shellwords. A backslash stays literal both outside and inside quotes, so a bare `C:\...` path is unaffected — the deliberate Windows-path behavior is preserved while the unintended single-quote divergence is removed. An unmatched single quote is now an error, mirroring the existing unmatched-double-quote error.

## Verify

- **Unit** (`TestWindowsFields`, `TestWindowsFields_MatchesShellwords`): `windowsFields` and `shellwords.Parse` return identical argv for single-quoted JSON / single-quoted spaces / double-quoted forms; a bare `run C:\tmp\x` stays literal (regression guard); unmatched single quote errors on both.
- **E2E** (`test/e2e/atago/argv_quotes.atago.yaml`, in the Windows portable subset): drives atago's own no-shell tokenizer with single-quoted arguments and asserts the reconstructed value; runs on `windows-latest`.

https://claude.ai/code/session_01UdJLmQRNg12Sk9U2xY8hyB