### PR TITLE
feat(store): capture a whole stream or file without a regex (#158)

### DIFF
--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-58 suites · 232 scenarios
+59 suites · 234 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 2 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -266,6 +266,9 @@
 - [atago self-hosting / store](#atago-self-hosting--store) — 2 scenarios
   - [a stored JSON value is reusable in later commands](#scenario-a-stored-json-value-is-reusable-in-later-commands)
   - [storing from a missing JSON path is an execution error](#scenario-storing-from-a-missing-json-path-is-an-execution-error)
+- [atago self-hosting / store whole-content trim and text selectors (#158)](#atago-self-hosting--store-whole-content-trim-and-text-selectors-158) — 2 scenarios
+  - [trim captures an opaque token and round-trips it as an argument](#scenario-trim-captures-an-opaque-token-and-round-trips-it-as-an-argument)
+  - [text captures a whole multi-line file verbatim](#scenario-text-captures-a-whole-multi-line-file-verbatim)
 - [atago self-hosting / suite setup](#atago-self-hosting--suite-setup) — 4 scenarios
   - [setup runs once, shares stores and env, and teardown always runs](#scenario-setup-runs-once-shares-stores-and-env-and-teardown-always-runs)
   - [a failing setup errors every scenario and none runs (exit 4)](#scenario-a-failing-setup-errors-every-scenario-and-none-runs-exit-4)
@@ -4772,6 +4775,39 @@ ${atago} run bad-store.atago.yaml
 #### Then
 - exit code is `4`
 - stdout contains `ERROR`
+## atago self-hosting / store whole-content trim and text selectors (#158)
+Source: `test/e2e/atago/store_whole.atago.yaml`
+### Scenario: trim captures an opaque token and round-trips it as an argument
+#### When
+```shell
+echo opaque-token-abc123
+# capture ${token} from stdout
+${atago} run ${token}
+```
+#### Then
+- after `${atago} run ${token}`:
+  - exit code is `3`
+  - stderr contains `opaque-token-abc123`
+### Scenario: text captures a whole multi-line file verbatim
+#### Given
+- Fixture file `blob.txt` is created.
+- Fixture file `copy.txt` is created.
+#### Inputs
+_Fixture `blob.txt`:_
+```text
+first line
+second line
+```
+_Fixture `copy.txt`:_
+```text
+${blob}
+```
+#### When
+```shell
+# capture ${blob} from file blob.txt
+```
+#### Then
+- file `copy.txt` contains `first line`, `second line`
 ## atago self-hosting / suite setup
 Source: `test/e2e/atago/suite_setup.atago.yaml`
 ### Scenario: setup runs once, shares stores and env, and teardown always runs

--- a/examples/store_and_variables.atago.yaml
+++ b/examples/store_and_variables.atago.yaml
@@ -48,6 +48,46 @@ scenarios:
           stdout:
             equals: releasing 1.2.3
 
+  - name: capture a whole opaque value with trim, no regex
+    steps:
+      # For an opaque single value (a token, an id, a signed blob) there is
+      # nothing to match — trim: true captures the entire stdout and drops the
+      # trailing newline, so you no longer need a whole-string regex.
+      - run:
+          shell: true
+          command: echo opaque-token-xyz
+      - store:
+          name: token
+          from:
+            stdout:
+              trim: true
+      - run:
+          shell: true
+          command: echo using ${token}
+      - assert:
+          stdout:
+            equals: using opaque-token-xyz
+
+  - name: capture a whole file verbatim with text
+    steps:
+      - fixture:
+          file: token.bin
+          content: "signed-blob-9f8e"
+      # text: true reads the whole file content into the variable verbatim,
+      # without a json path — the natural way to grab an opaque file value.
+      - store:
+          name: blob
+          from:
+            file:
+              path: token.bin
+              text: true
+      - run:
+          shell: true
+          command: echo verifying ${blob}
+      - assert:
+          stdout:
+            equals: verifying signed-blob-9f8e
+
   - name: read the host environment with env
     steps:
       # ${env:NAME} expands from the invoking environment — unlike shell `$VAR`

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -847,17 +847,17 @@ func TestExtractValue_FileNeedsJSONSelector(t *testing.T) {
 	}
 	sp := &spec.Store{Name: "x", From: &spec.StoreFrom{File: &spec.FileAssert{Path: "f.json"}}}
 	_, err := extractValue(sp, &runner.Result{}, dir)
-	if err == nil || !strings.Contains(err.Error(), "needs a json selector") {
-		t.Fatalf("want json-selector error, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "needs a json or text selector") {
+		t.Fatalf("want json/text-selector error, got %v", err)
 	}
 }
 
-// TestExtractStream_NoSelector proves a stream source that sets neither json nor
-// matches is a clean error.
+// TestExtractStream_NoSelector proves a stream source that sets neither json,
+// matches, nor trim is a clean error.
 func TestExtractStream_NoSelector(t *testing.T) {
 	t.Parallel()
 	_, err := extractStream(&spec.StreamAssert{}, []byte("data"))
-	if err == nil || !strings.Contains(err.Error(), "json or matches") {
+	if err == nil || !strings.Contains(err.Error(), "json, matches, or trim") {
 		t.Fatalf("want selector error, got %v", err)
 	}
 }

--- a/internal/engine/store.go
+++ b/internal/engine/store.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 
 	"github.com/ohler55/ojg/jp"
 	"github.com/ohler55/ojg/oj"
@@ -36,10 +37,16 @@ func extractValue(sp *spec.Store, current *runner.Result, workdir string) (strin
 		if err != nil {
 			return "", fmt.Errorf("store %q: %w", sp.Name, err)
 		}
-		if from.File.JSON == nil {
-			return "", fmt.Errorf("store %q: a file source needs a json selector", sp.Name)
+		switch {
+		case from.File.Text != nil:
+			// Capture the whole file verbatim (#158); no json path needed for an
+			// opaque blob.
+			return string(data), nil
+		case from.File.JSON != nil:
+			return jsonValue(data, from.File.JSON.Path)
+		default:
+			return "", fmt.Errorf("store %q: a file source needs a json or text selector", sp.Name)
 		}
-		return jsonValue(data, from.File.JSON.Path)
 	case from.Body != nil:
 		if current == nil || !current.IsHTTP {
 			return "", fmt.Errorf("store %q: no HTTP request has run in this scenario yet", sp.Name)
@@ -80,8 +87,17 @@ func extractStream(s *spec.StreamAssert, data []byte) (string, error) {
 		return jsonValue(data, s.JSON.Path)
 	case s.Matches != nil:
 		return regexValue(data, *s.Matches)
+	case s.Trim != nil:
+		// Capture the whole stream (#158). trim: true strips surrounding
+		// whitespace (the common "grab the whole token, drop the trailing
+		// newline" case); trim: false keeps the bytes verbatim.
+		out := string(data)
+		if *s.Trim {
+			out = strings.TrimSpace(out)
+		}
+		return out, nil
 	default:
-		return "", fmt.Errorf("a stdout store source needs a json or matches selector")
+		return "", fmt.Errorf("a stdout store source needs a json, matches, or trim selector")
 	}
 }
 

--- a/internal/engine/store_test.go
+++ b/internal/engine/store_test.go
@@ -66,6 +66,63 @@ func TestRegexValue(t *testing.T) {
 	}
 }
 
+// TestExtractStream_Trim covers the #158 whole-stream selector: trim captures
+// the entire stream without a regex, optionally stripping surrounding
+// whitespace.
+func TestExtractStream_Trim(t *testing.T) {
+	t.Parallel()
+	yes, no := true, false
+	multiline := "line one\nline two\n"
+	tests := []struct {
+		name string
+		s    *spec.StreamAssert
+		data string
+		want string
+		err  bool
+	}{
+		{"trim true strips trailing newline", &spec.StreamAssert{Trim: &yes}, "token-abc\n", "token-abc", false},
+		{"trim true strips surrounding whitespace", &spec.StreamAssert{Trim: &yes}, "  spaced  ", "spaced", false},
+		{"trim false keeps bytes verbatim", &spec.StreamAssert{Trim: &no}, "token-abc\n", "token-abc\n", false},
+		{"trim true captures whole multi-line content", &spec.StreamAssert{Trim: &yes}, multiline, "line one\nline two", false},
+		{"trim false captures whole multi-line content verbatim", &spec.StreamAssert{Trim: &no}, multiline, multiline, false},
+		{"no selector errors", &spec.StreamAssert{}, "x", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := extractStream(tt.s, []byte(tt.data))
+			if tt.err {
+				if err == nil {
+					t.Errorf("extractStream(%+v) err = nil, want error", tt.s)
+				}
+				return
+			}
+			if err != nil || got != tt.want {
+				t.Errorf("extractStream = %q,%v, want %q", got, err, tt.want)
+			}
+		})
+	}
+}
+
+// TestExtractValue_FromFileText covers the #158 whole-file selector: text: true
+// captures the entire file content verbatim, with no json path.
+func TestExtractValue_FromFileText(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	content := "opaque\nmulti-line\nblob\n"
+	if err := os.WriteFile(filepath.Join(dir, "blob.txt"), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	yes := true
+	sp := &spec.Store{Name: "t", From: &spec.StoreFrom{
+		File: &spec.FileAssert{Path: "blob.txt", Text: &yes},
+	}}
+	got, err := extractValue(sp, &runner.Result{}, dir)
+	if err != nil || got != content {
+		t.Fatalf("extractValue file text = %q,%v, want %q verbatim", got, err, content)
+	}
+}
+
 func TestExtractValue_NoCommand(t *testing.T) {
 	t.Parallel()
 	sp := &spec.Store{Name: "x", From: &spec.StoreFrom{Stdout: &spec.StreamAssert{JSON: &spec.JSONAssert{Path: "$.id"}}}}

--- a/internal/loader/http_test.go
+++ b/internal/loader/http_test.go
@@ -65,7 +65,7 @@ func TestLoadBytes_HTTPValidation(t *testing.T) {
 		{
 			name:    "store stdout without json or matches is rejected",
 			src:     "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps:\n      - run: {command: echo hi}\n      - store:\n          name: v\n          from:\n            stdout: {contains: hi}",
-			wantMsg: "json path or a matches regexp",
+			wantMsg: "json path, a matches regexp, or trim",
 		},
 		{
 			name:    "store name shadowing a built-in is rejected",

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -817,10 +817,15 @@ func TestBugHunt_Rejections(t *testing.T) {
 		{"store from required", specSteps("store: {name: v}"), "store.from is required"},
 		{"store from empty", specSteps("store: {name: v, from: {}}"), "must set one of stdout/body/file/header/rows/message/value"},
 		{"store from two sources", specSteps("store: {name: v, from: {header: X, stdout: {json: {path: \"$.a\"}}}}"), "must set exactly one source"},
-		{"store selector no json/matches", specSteps("store: {name: v, from: {stdout: {}}}"), "must set a json path or a matches regexp"},
+		{"store selector no json/matches", specSteps("store: {name: v, from: {stdout: {}}}"), "must set a json path, a matches regexp, or trim"},
 		{"store selector bad matches", specSteps("store: {name: v, from: {stdout: {matches: \"a[\"}}}"), "is not a valid regexp"},
 		{"store selector json path required", specSteps("store: {name: v, from: {stdout: {json: {}}}}"), "path is required"},
 		{"store selector bad json path", specSteps("store: {name: v, from: {stdout: {json: {path: \"$[\"}}}}"), "is not a valid JSON path"},
+		{"store selector json and trim", specSteps("store: {name: v, from: {stdout: {json: {path: \"$.a\"}, trim: true}}}"), "must set exactly one selector (json, matches, or trim)"},
+		{"store file no json/text", specSteps("store: {name: v, from: {file: {path: out.txt}}}"), "must set a json path or text: true"},
+		{"store file json and text", specSteps("store: {name: v, from: {file: {path: out.txt, json: {path: \"$.a\"}, text: true}}}"), "must set exactly one selector (json or text)"},
+		{"assert stream rejects trim", specSteps("assert: {stdout: {trim: true}}"), "trim is only valid in a store source"},
+		{"assert file rejects text", specSteps("assert: {file: {path: out.txt, text: true}}"), "text is only valid in a store source"},
 		{"store file bad json path", specSteps("store: {name: v, from: {file: {path: out.txt, json: {path: \"$.\"}}}}"), "is not a valid JSON path"},
 
 		// ---- validateAssert / validateAssertTarget ----

--- a/internal/loader/validate_assert.go
+++ b/internal/loader/validate_assert.go
@@ -110,6 +110,10 @@ var streamExclusiveMatchers = map[string]bool{
 }
 
 func validateStream(add func(string, ...any), where string, s *spec.StreamAssert) {
+	// trim is a store-only selector (#158), not an assertion matcher.
+	if s.Trim != nil {
+		add("%s: trim is only valid in a store source, not an assertion", where)
+	}
 	matchers := s.SetMatchers()
 	if len(matchers) == 0 {
 		add("%s: must set at least one matcher (empty/contains/not_contains/matches/not_matches/equals/not_equals/json/yaml/snapshot)", where)
@@ -155,6 +159,10 @@ func validateStream(add func(string, ...any), where string, s *spec.StreamAssert
 func validateFile(add func(string, ...any), where string, f *spec.FileAssert) {
 	if f.Path == "" {
 		add("%s.path is required", where)
+	}
+	// text is a store-only selector (#158), not an assertion matcher.
+	if f.Text != nil {
+		add("%s: text is only valid in a store source, not an assertion", where)
 	}
 	n := 0
 	if f.Exists != nil {

--- a/internal/loader/validate_store.go
+++ b/internal/loader/validate_store.go
@@ -73,24 +73,57 @@ func validateStore(add func(string, ...any), where string, s *spec.Store) {
 			validateStoreSelector(add, where+".store.from."+sel.name, sel.s)
 		}
 	}
-	if s.From.File != nil && s.From.File.JSON != nil {
-		validateStoreJSONPath(add, where+".store.from.file.json", s.From.File.JSON.Path)
+	if s.From.File != nil {
+		validateStoreFileSelector(add, where+".store.from.file", s.From.File)
 	}
 }
 
-// validateStoreSelector checks a store.from stream selector: it must carry a
-// json path or a matches regexp (the only two the extractor understands), and
-// whichever is present must be well-formed.
+// validateStoreFileSelector checks a store.from.file selector: exactly one of a
+// json path (extract a value) or text: true (capture the whole file verbatim,
+// #158).
+func validateStoreFileSelector(add func(string, ...any), where string, f *spec.FileAssert) {
+	n := 0
+	if f.JSON != nil {
+		n++
+		validateStoreJSONPath(add, where+".json", f.JSON.Path)
+	}
+	if f.Text != nil {
+		n++
+	}
+	switch n {
+	case 0:
+		add("%s must set a json path or text: true to capture a value", where)
+	case 1:
+	default:
+		add("%s must set exactly one selector (json or text)", where)
+	}
+}
+
+// validateStoreSelector checks a store.from stream selector: it must carry
+// exactly one of a json path, a matches regexp, or trim (capture the whole
+// stream, #158) — the selectors the extractor understands — and whichever is
+// present must be well-formed.
 func validateStoreSelector(add func(string, ...any), where string, s *spec.StreamAssert) {
-	switch {
-	case s.JSON != nil:
+	n := 0
+	if s.JSON != nil {
+		n++
 		validateStoreJSONPath(add, where+".json", s.JSON.Path)
-	case s.Matches != nil:
+	}
+	if s.Matches != nil {
+		n++
 		if _, err := regexp.Compile(*s.Matches); err != nil {
 			add("%s.matches %q is not a valid regexp: %v", where, *s.Matches, err)
 		}
+	}
+	if s.Trim != nil {
+		n++
+	}
+	switch n {
+	case 0:
+		add("%s must set a json path, a matches regexp, or trim to extract a value", where)
+	case 1:
 	default:
-		add("%s must set a json path or a matches regexp to extract a value", where)
+		add("%s must set exactly one selector (json, matches, or trim)", where)
 	}
 }
 

--- a/internal/spec/assert.go
+++ b/internal/spec/assert.go
@@ -304,6 +304,14 @@ type StreamAssert struct {
 	JSON        *JSONAssert `yaml:"json,omitempty"`
 	YAML        *JSONAssert `yaml:"yaml,omitempty"`
 	Snapshot    string      `yaml:"snapshot,omitempty"`
+
+	// Trim is a store-only selector (#158): when set, `store` captures the
+	// whole stream verbatim instead of extracting via a json path or regex.
+	// trim: true strips surrounding whitespace (the common "grab the whole
+	// token, drop the trailing newline" case, matching how the console trims);
+	// trim: false keeps the bytes verbatim. It is not an assertion matcher —
+	// the loader rejects it outside a store source.
+	Trim *bool `yaml:"trim,omitempty"`
 }
 
 // StringList is a matcher argument that accepts either a single YAML scalar
@@ -352,6 +360,12 @@ type FileAssert struct {
 	EqualsFile  *string     `yaml:"equals_file,omitempty"`
 	JSON        *JSONAssert `yaml:"json,omitempty"`
 	Snapshot    string      `yaml:"snapshot,omitempty"`
+
+	// Text is a store-only selector (#158): when true, `store` captures the
+	// whole file content verbatim instead of extracting a value via a json path.
+	// It is not an assertion matcher — the loader rejects it outside a store
+	// source.
+	Text *bool `yaml:"text,omitempty"`
 }
 
 // JSONAssert matches a value selected by a JSONPath. One matcher.

--- a/schema/atago.schema.json
+++ b/schema/atago.schema.json
@@ -791,6 +791,7 @@
         { "required": ["json"] },
         { "required": ["yaml"] },
         { "required": ["snapshot"] },
+        { "required": ["trim"] },
         {
           "comment": "The text matchers contains/not_contains/matches/not_matches may be combined (all must hold); the whole-stream matchers above are each used alone.",
           "anyOf": [
@@ -812,7 +813,8 @@
         "not_equals": { "type": "string" },
         "json": { "$ref": "#/$defs/jsonAssert" },
         "yaml": { "$ref": "#/$defs/jsonAssert" },
-        "snapshot": { "type": "string" }
+        "snapshot": { "type": "string" },
+        "trim": { "type": "boolean", "description": "Store-only (#158): capture the whole stream. trim: true strips surrounding whitespace; trim: false keeps bytes verbatim." }
       }
     },
     "file": {
@@ -827,7 +829,8 @@
         { "required": ["equals"] },
         { "required": ["equals_file"] },
         { "required": ["json"] },
-        { "required": ["snapshot"] }
+        { "required": ["snapshot"] },
+        { "required": ["text"] }
       ],
       "properties": {
         "path": { "type": "string", "minLength": 1 },
@@ -838,7 +841,8 @@
         "equals": { "type": "string", "description": "Byte-exact content match against an inline literal (no CRLF/newline normalization)." },
         "equals_file": { "type": "string", "minLength": 1, "description": "Byte-exact content match against another workdir-confined file (round-trip/idempotence; no CRLF/newline normalization)." },
         "json": { "$ref": "#/$defs/jsonAssert" },
-        "snapshot": { "type": "string" }
+        "snapshot": { "type": "string" },
+        "text": { "type": "boolean", "description": "Store-only (#158): capture the whole file content verbatim instead of extracting a value via a json path." }
       }
     },
     "image": {

--- a/scripts/windows_portable_specs.sh
+++ b/scripts/windows_portable_specs.sh
@@ -23,6 +23,7 @@ printf '%s\n' \
   ./test/e2e/atago/edge.atago.yaml \
   ./test/e2e/atago/argv_quotes.atago.yaml \
   ./test/e2e/atago/file_equals.atago.yaml \
+  ./test/e2e/atago/store_whole.atago.yaml \
   ./test/e2e/atago/matrix.atago.yaml \
   ./test/e2e/atago/parallel.atago.yaml \
   ./test/e2e/atago/run.atago.yaml \

--- a/test/e2e/atago/store_whole.atago.yaml
+++ b/test/e2e/atago/store_whole.atago.yaml
@@ -1,0 +1,55 @@
+version: "1"
+
+suite:
+  name: atago self-hosting / store whole-content trim and text selectors (#158)
+
+# `store` can capture the entire stream/file into a variable without inventing a
+# regex that happens to match the whole thing. `trim` grabs the whole stream
+# (trim: true drops the trailing newline); `text: true` grabs a whole file
+# verbatim. These drive atago itself (and cross-platform echo/fixtures), so they
+# belong in the Windows portable subset.
+scenarios:
+  - name: trim captures an opaque token and round-trips it as an argument
+    steps:
+      - run:
+          shell: true
+          command: echo opaque-token-abc123
+      - store:
+          name: token
+          from:
+            stdout:
+              trim: true
+      # Reuse the captured token verbatim as a positional argument; atago echoes
+      # the path it cannot access, so the round-tripped value comes back exactly.
+      # A broken capture (trailing newline kept) would change the path.
+      - run:
+          command: ${atago} run ${token}
+      - assert:
+          exit_code: 3
+          stderr:
+            contains: "opaque-token-abc123"
+
+  - name: text captures a whole multi-line file verbatim
+    steps:
+      - fixture:
+          file: blob.txt
+          content: |
+            first line
+            second line
+      - store:
+          name: blob
+          from:
+            file:
+              path: blob.txt
+              text: true
+      # A later step receives the multi-line content unchanged: re-expanding
+      # ${blob} into a new file must reproduce both lines.
+      - fixture:
+          file: copy.txt
+          content: "${blob}"
+      - assert:
+          file:
+            path: copy.txt
+            contains:
+              - "first line"
+              - "second line"


### PR DESCRIPTION
Closes #158.

## Problem

`store` could only capture through a **json path** or a **matches regexp**. So the most common capture — "take the command's whole output and reuse it as a later argument" — forced authors to invent a whole-string regex for opaque values (a token, an id, a signed blob, a URL):

```yaml
from: { stdout: { matches: "[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+" } }  # "the whole JWS"
```

That is unintuitive, and because `matches` does not trim, trailing-newline handling had to be baked into the pattern. This was real friction writing shell-free round-trip specs for jose (sign → capture → pass the token back).

## Change

Two regex-free store selectors:

```yaml
- store: { name: token, from: { stdout: { trim: true } } }        # whole stdout, trailing newline stripped
- store: { name: raw,   from: { file: { path: out.bin, text: true } } }  # whole file, verbatim
```

- stream `trim`: capture the whole stream. `trim: true` strips surrounding whitespace (matching how the console trims); `trim: false` keeps bytes verbatim.
- file `text: true`: capture a whole file's content verbatim.

Exactly one selector per source stays enforced (`json` + `trim` is a load-time error). Both are **store-only** — the loader rejects `trim`/`text` in an assertion. Wired through store extraction, loader validation, and the JSON schema.

## Verify

- **Unit** (`TestExtractStream_Trim`, `TestExtractValue_FromFileText`): whole content / trimmed / verbatim / no-selector; plus loader cases for multi-selector and the assert-context rejection.
- **E2E** (`test/e2e/atago/store_whole.atago.yaml`, Windows portable subset): trim round-trips an opaque token as an argument; text captures a multi-line file verbatim and a later step receives it unchanged.
- **Example**: two scenarios in `examples/store_and_variables.atago.yaml`, linked from the README.

https://claude.ai/code/session_01UdJLmQRNg12Sk9U2xY8hyB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for capturing full command output with optional trimming, making it easier to reuse opaque values in later steps.
  * Added support for storing entire file contents verbatim, without requiring JSON-path extraction.
  * Expanded end-to-end coverage and documentation to include these new capture options.

* **Bug Fixes**
  * Improved validation and error messages when store selectors are missing, invalid, or combined incorrectly.
  * Clarified that certain capture options are only available in store scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->