### PR TITLE
fix(cmd): split no-shell argv on newlines so block-scalar commands match POSIX on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- A no-shell command (`shell: false`, the default) authored as a YAML block
+  scalar now tokenizes to the same argv on every OS. `windowsFields` split only
+  on spaces and tabs while POSIX (`go-shellwords`) also splits on carriage
+  returns and newlines, so a command written with `>` (a trailing newline) or
+  `|` (interior newlines) — or authored in a CRLF file — glued a stray `\r`/`\n`
+  onto an argument on Windows alone, silently breaking a cross-platform suite on
+  `windows-latest`. Windows now treats carriage return and newline as field
+  separators too, completing the tokenization parity begun in #154.
+
 ## [0.6.0] - 2026-07-07
 
 An assertion-and-capture ergonomics release: byte-exact file round-trips,

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,10 +1,12 @@
 # atago Behavior Specs
 ## Summary
-60 suites · 239 scenarios
+60 suites · 241 scenarios
 ## Contents
-- [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 2 scenarios
+- [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
   - [a single-quoted argument with a space stays one argument](#scenario-a-single-quoted-argument-with-a-space-stays-one-argument)
+  - [a block-scalar command splits on newlines like spaces](#scenario-a-block-scalar-command-splits-on-newlines-like-spaces)
+  - [a folded-scalar command drops its trailing newline](#scenario-a-folded-scalar-command-drops-its-trailing-newline)
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 6 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
   - [stdout.contains and not_contains expand a stored variable](#scenario-stdoutcontains-and-not_contains-expand-a-stored-variable)
@@ -319,6 +321,25 @@ ${atago} run 'no such file.yaml'
 #### Then
 - exit code is `3`
 - stderr contains `no such file.yaml`
+### Scenario: a block-scalar command splits on newlines like spaces
+#### When
+```shell
+${atago} run
+no-such-file.yaml
+
+```
+#### Then
+- exit code is `3`
+- stderr contains `no-such-file.yaml`
+### Scenario: a folded-scalar command drops its trailing newline
+#### When
+```shell
+${atago} run no-such-file.yaml
+
+```
+#### Then
+- exit code is `3`
+- stderr contains `no-such-file.yaml`
 ## atago self-hosting / variable expansion in assertion matcher values
 Source: `test/e2e/atago/assert_expand.atago.yaml`
 ### Scenario: stdout.equals expands ${workdir}

--- a/internal/runner/cmd/cmd.go
+++ b/internal/runner/cmd/cmd.go
@@ -246,6 +246,12 @@ func splitArgv(command string) ([]string, error) {
 // cross-platform spec passing single-quoted inline JSON (`'{"k":"v"}'`) reached
 // the CLI as non-JSON on Windows and broke there alone.
 //
+// Unquoted whitespace is space, tab, carriage return, and newline — the same set
+// go-shellwords treats as a field separator. A command authored as a YAML block
+// scalar carries newlines (a trailing one from `>`, interior ones from `|`) and a
+// CRLF-authored spec carries `\r`; splitting on them keeps the argv identical to
+// POSIX instead of gluing a stray `\n` onto the final argument on Windows alone.
+//
 // A backslash stays literal OUTSIDE quotes so a bare C:\ path survives (sh
 // backslash-escape semantics would corrupt it); it is also literal inside either
 // quote. This keeps the deliberate Windows-path behavior while removing the
@@ -262,7 +268,7 @@ func windowsFields(command string) ([]string, error) {
 		case r == '\'' && !inDouble:
 			inSingle = !inSingle
 			started = true
-		case !inDouble && !inSingle && (r == ' ' || r == '\t'):
+		case !inDouble && !inSingle && isFieldSpace(r):
 			if started {
 				fields = append(fields, cur.String())
 				cur.Reset()
@@ -283,6 +289,13 @@ func windowsFields(command string) ([]string, error) {
 		fields = append(fields, cur.String())
 	}
 	return fields, nil
+}
+
+// isFieldSpace reports whether r separates argv fields outside quotes. It matches
+// go-shellwords' whitespace set (space, tab, carriage return, newline) so the
+// no-shell tokenizer agrees with POSIX on where fields begin and end.
+func isFieldSpace(r rune) bool {
+	return r == ' ' || r == '\t' || r == '\r' || r == '\n'
 }
 
 // shellPath returns an absolute path to the POSIX shell used for `shell: true`.

--- a/internal/runner/cmd/cmd_test.go
+++ b/internal/runner/cmd/cmd_test.go
@@ -437,6 +437,14 @@ func TestWindowsFields(t *testing.T) {
 		{`empty ''`, []string{"empty", ""}},
 		// A single quote inside a double-quoted group is literal (and vice versa).
 		{`tool "it's" x`, []string{"tool", "it's", "x"}},
+		// Newline and carriage return separate fields exactly like space/tab, so a
+		// command authored as a YAML block scalar (a trailing newline from `>`, or
+		// interior newlines from `|`) tokenizes to the same argv on every OS (#154).
+		{"tool --flag value\n", []string{"tool", "--flag", "value"}},
+		{"tool\n--flag value", []string{"tool", "--flag", "value"}},
+		{"a\r\nb", []string{"a", "b"}},
+		// A newline inside a quoted group stays literal, as it does under go-shellwords.
+		{"\"a\nb\" c", []string{"a\nb", "c"}},
 	}
 	for _, tt := range tests {
 		got, err := windowsFields(tt.in)
@@ -476,6 +484,12 @@ func TestWindowsFields_MatchesShellwords(t *testing.T) {
 		`x 'has space' y`,
 		`tool "a b" c`,
 		`plain args here`,
+		// Block-scalar commands: a trailing newline (`>`), interior newlines (`|`),
+		// and a CRLF-authored spec must all tokenize identically on Windows and POSIX.
+		"tool --flag value\n",
+		"tool\n--flag value",
+		"a\r\nb c",
+		"\"a\nb\" c",
 	}
 	for _, in := range parity {
 		win, werr := windowsFields(in)

--- a/test/e2e/atago/argv_quotes.atago.yaml
+++ b/test/e2e/atago/argv_quotes.atago.yaml
@@ -36,3 +36,34 @@ scenarios:
           # the full "no such file.yaml".
           stderr:
             contains: "no such file.yaml"
+
+  - name: a block-scalar command splits on newlines like spaces
+    steps:
+      # A YAML literal block scalar carries interior newlines: this command
+      # reaches the tokenizer as "run\nno-such-file.yaml". Newlines must separate
+      # argv fields exactly like spaces, so `run` stays the subcommand and the
+      # path a separate argument (exit 3, file not found). A tokenizer that split
+      # only on spaces would fold "run\nno-such-file.yaml" into one field and
+      # atago would reject it as an unknown subcommand on Windows alone.
+      - run:
+          command: |
+            ${atago} run
+            no-such-file.yaml
+      - assert:
+          exit_code: 3
+          stderr:
+            contains: "no-such-file.yaml"
+
+  - name: a folded-scalar command drops its trailing newline
+    steps:
+      # A YAML folded block scalar appends a trailing newline: this command
+      # reaches the tokenizer as "run no-such-file.yaml\n". The trailing newline
+      # must not glue onto the final argument, so atago looks up the plain path
+      # (exit 3) rather than a path ending in a stray newline.
+      - run:
+          command: >
+            ${atago} run no-such-file.yaml
+      - assert:
+          exit_code: 3
+          stderr:
+            contains: "no-such-file.yaml"


### PR DESCRIPTION
A no-shell command (shell: false, the default) that carried a newline tokenized differently on Windows than on POSIX. windowsFields split only on spaces and tabs, while go-shellwords (POSIX) also splits on carriage return and newline. So a command authored as a YAML block scalar — `>` appends a trailing newline, `|` keeps interior newlines — or written in a CRLF file reached the tokenizer with a `\r` or `\n` that POSIX stripped as whitespace but Windows attached to the adjacent argument. A cross-platform spec then passed on Linux and macOS but broke on windows-latest alone, the same silent-divergence class that #154 addressed for single quotes.

This makes windowsFields treat carriage return and newline as field separators via a shared isFieldSpace helper, matching go-shellwords whitespace set. A backslash stays literal so C:\ paths are unaffected. A 100k-input differential over quoted, newline, and CRLF forms showed zero divergence from go-shellwords except the documented backslash case, so the parity begun in #154 now holds across the whole whitespace dimension.

Adds newline and CRLF parity cases to the windowsFields unit tests and the shellwords differential guard, plus two self-hosted E2E scenarios driving atago with block-scalar and folded-scalar commands. argv_quotes.atago.yaml is already in the Windows-portable subset, so both scenarios run on windows-latest CI.

make test, make lint, and make e2e all pass (249 scenarios, 247 passed, 2 skipped).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command argument handling on Windows so CRLF and multi-line YAML inputs are split consistently with other platforms.
  * Prevented stray line-ending characters from being included in command arguments, which improves file paths and error messages.

* **Documentation**
  * Updated end-to-end documentation to reflect expanded tokenization coverage and additional scenario checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->