### PR TITLE
fix(assert): fold CRLF in every stream text matcher so multi-line specs match on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project follows [Semantic Versioning](https://semver.org/).
   onto an argument on Windows alone, silently breaking a cross-platform suite on
   `windows-latest`. Windows now treats carriage return and newline as field
   separators too, completing the tokenization parity begun in #154.
+- Every stdout/stderr text matcher folds CRLF, matching the `equals` matcher.
+  `contains`, `not_contains`, `matches`, and `not_matches` compared raw bytes, so
+  a multi-line `contains` needle or a `(?m)`-anchored `matches` written with LF
+  passed against POSIX output but failed against cmd.exe's CRLF output on
+  Windows, while `equals` on the same output passed everywhere. Line endings are
+  an OS artifact for all stream text matchers now; byte-exact comparison
+  (including the exact line ending) stays with the file matchers (`equals_file`,
+  `dir` `sha256`).
 
 ## [0.6.0] - 2026-07-07
 

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-60 suites · 241 scenarios
+61 suites · 253 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -153,6 +153,19 @@
   - [line selector narrows stdout to a single 1-based line](#scenario-line-selector-narrows-stdout-to-a-single-1-based-line)
   - [a trailing newline does not add a phantom final line](#scenario-a-trailing-newline-does-not-add-a-phantom-final-line)
   - [an out-of-range line fails the inner spec](#scenario-an-out-of-range-line-fails-the-inner-spec)
+- [atago self-hosting / stream text matchers fold CRLF](#atago-self-hosting--stream-text-matchers-fold-crlf) — 12 scenarios
+  - [equals folds a CRLF body to its LF form](#scenario-equals-folds-a-crlf-body-to-its-lf-form)
+  - [equals tolerates the phantom trailing CRLF](#scenario-equals-tolerates-the-phantom-trailing-crlf)
+  - [contains folds CRLF for a multi-line needle](#scenario-contains-folds-crlf-for-a-multi-line-needle)
+  - [contains authored with CRLF matches LF-folded output](#scenario-contains-authored-with-crlf-matches-lf-folded-output)
+  - [contains list every multi-line element folds](#scenario-contains-list-every-multi-line-element-folds)
+  - [matches anchors a line over CRLF with the multiline flag](#scenario-matches-anchors-a-line-over-crlf-with-the-multiline-flag)
+  - [matches a literal newline in the pattern over CRLF](#scenario-matches-a-literal-newline-in-the-pattern-over-crlf)
+  - [not_contains stays clear of an absent multi-line needle](#scenario-not_contains-stays-clear-of-an-absent-multi-line-needle)
+  - [not_matches passes for an anchored line that is absent](#scenario-not_matches-passes-for-an-anchored-line-that-is-absent)
+  - [the line selector strips the trailing CR](#scenario-the-line-selector-strips-the-trailing-cr)
+  - [json parses a CRLF-formatted document](#scenario-json-parses-a-crlf-formatted-document)
+  - [folding does not make an absent multi-line needle match](#scenario-folding-does-not-make-an-absent-multi-line-needle-match)
 - [atago self-hosting / list](#atago-self-hosting--list) — 2 scenarios
   - [list surfaces suites, scenarios, tags, and gates](#scenario-list-surfaces-suites-scenarios-tags-and-gates)
   - [list --json is a stable machine contract](#scenario-list---json-is-a-stable-machine-contract)
@@ -2686,6 +2699,123 @@ ${atago} run oor.atago.yaml
 #### Then
 - exit code is `1`
 - stdout contains `out of range`
+## atago self-hosting / stream text matchers fold CRLF
+Source: `test/e2e/atago/line_endings.atago.yaml`
+### Scenario: equals folds a CRLF body to its LF form
+#### When
+```shell
+printf 'first\r\nsecond\r\n'
+```
+#### Then
+- stdout equals an exact value
+#### Expected output
+_expected stdout:_
+```text
+first
+second
+```
+### Scenario: equals tolerates the phantom trailing CRLF
+#### When
+```shell
+printf 'only\r\n'
+```
+#### Then
+- stdout equals an exact value
+### Scenario: contains folds CRLF for a multi-line needle
+#### When
+```shell
+printf 'alpha\r\nbeta\r\ngamma\r\n'
+```
+#### Then
+- stdout contains `alpha
+beta`
+### Scenario: contains authored with CRLF matches LF-folded output
+#### When
+```shell
+printf 'alpha\r\nbeta\r\n'
+```
+#### Then
+- stdout contains `alpha
+beta`
+### Scenario: contains list every multi-line element folds
+#### When
+```shell
+printf 'a\r\nb\r\nc\r\nd\r\n'
+```
+#### Then
+- stdout contains `a
+b`, `c
+d`
+### Scenario: matches anchors a line over CRLF with the multiline flag
+#### When
+```shell
+printf 'hello\r\nworld\r\n'
+```
+#### Then
+- stdout matches `/(?m)^world$/`
+### Scenario: matches a literal newline in the pattern over CRLF
+#### When
+```shell
+printf 'up\r\ndown\r\n'
+```
+#### Then
+- stdout matches `/up
+down/`
+### Scenario: not_contains stays clear of an absent multi-line needle
+#### When
+```shell
+printf 'red\r\ngreen\r\n'
+```
+#### Then
+- stdout does not contain `red
+blue`
+### Scenario: not_matches passes for an anchored line that is absent
+#### When
+```shell
+printf 'north\r\nsouth\r\n'
+```
+#### Then
+- stdout does not match `/(?m)^east$/`
+### Scenario: the line selector strips the trailing CR
+#### When
+```shell
+printf 'header\r\npayload\r\n'
+```
+#### Then
+- stdout equals an exact value
+### Scenario: json parses a CRLF-formatted document
+#### When
+```shell
+printf '{\r\n"count":3\r\n}\r\n'
+```
+#### Then
+- stdout at `$.count` equals `3`
+### Scenario: folding does not make an absent multi-line needle match
+#### Given
+- Fixture file `inner.atago.yaml` is created.
+#### Inputs
+_Fixture `inner.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: inner
+scenarios:
+  - name: an absent multi-line needle still fails
+    steps:
+      - run:
+          shell: true
+          command: printf 'one\r\ntwo\r\n'
+      - assert:
+          stdout:
+            contains: "one\nMISSING"
+```
+#### When
+```shell
+${atago} run inner.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `was not present`
 ## atago self-hosting / list
 Source: `test/e2e/atago/list.atago.yaml`
 ### Scenario: list surfaces suites, scenarios, tags, and gates

--- a/internal/assert/assert_test.go
+++ b/internal/assert/assert_test.go
@@ -163,9 +163,11 @@ func TestCheck_Stream(t *testing.T) {
 	}
 }
 
-// TestCheck_Stream_CRLF proves `equals` treats CRLF output (cmd.exe on Windows)
-// like LF output, so the same spec asserts the same behavior on every OS. Line
-// endings are an OS artifact, not observable CLI behavior.
+// TestCheck_Stream_CRLF proves every stream text matcher treats CRLF output
+// (cmd.exe on Windows) like LF output, so the same spec asserts the same
+// behavior on every OS. Line endings are an OS artifact, not observable CLI
+// behavior; byte-exact comparison is the file matchers' job (equals_file /
+// sha256), not the stream text matchers'.
 func TestCheck_Stream_CRLF(t *testing.T) {
 	t.Parallel()
 	res := &runner.Result{Stdout: []byte("Alice and Bob\r\nsecond line\r\n")}
@@ -178,6 +180,15 @@ func TestCheck_Stream_CRLF(t *testing.T) {
 		{"equals still exact per line", &spec.Assert{Stdout: &spec.StreamAssert{Equals: strp("Alice and Bob\nsecond")}}, false},
 		{"not_equals folds CRLF", &spec.Assert{Stdout: &spec.StreamAssert{NotEquals: strp("Alice and Bob\nsecond line")}}, false},
 		{"line selector strips CR", &spec.Assert{Stdout: &spec.StreamAssert{Line: intp(2), Equals: strp("second line")}}, true},
+		// A multi-line contains/regex written with LF must match CRLF output the
+		// same way equals does, or a spec silently fails on Windows alone.
+		{"contains folds CRLF for a multi-line needle", &spec.Assert{Stdout: &spec.StreamAssert{Contains: spec.StringList{"Alice and Bob\nsecond line"}}}, true},
+		{"contains still misses an absent multi-line needle", &spec.Assert{Stdout: &spec.StreamAssert{Contains: spec.StringList{"Alice\nCarol"}}}, false},
+		{"not_contains sees the folded multi-line needle as present", &spec.Assert{Stdout: &spec.StreamAssert{NotContains: spec.StringList{"Alice and Bob\nsecond line"}}}, false},
+		{"not_contains stays clear of an absent multi-line needle", &spec.Assert{Stdout: &spec.StreamAssert{NotContains: spec.StringList{"Alice\nCarol"}}}, true},
+		{"matches folds CRLF for a multiline anchor", &spec.Assert{Stdout: &spec.StreamAssert{Matches: strp("(?m)^second line$")}}, true},
+		{"not_matches folds CRLF for a multiline anchor", &spec.Assert{Stdout: &spec.StreamAssert{NotMatches: strp("(?m)^second line$")}}, false},
+		{"contains needle authored with CRLF also folds", &spec.Assert{Stdout: &spec.StreamAssert{Contains: spec.StringList{"Alice and Bob\r\nsecond line"}}}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -822,6 +833,37 @@ func TestCheck_File(t *testing.T) {
 			got := Check(&spec.Assert{File: tt.f}, nil, Env{Workdir: dir})
 			if got.OK != tt.wantOK {
 				t.Errorf("OK = %v, want %v (%s)", got.OK, tt.wantOK, got.Hint)
+			}
+		})
+	}
+}
+
+// TestCheck_File_ContainsByteExact pins the deliberate asymmetry between the
+// stream and file matchers: stream contains folds CRLF (line endings are an OS
+// artifact of a process's output), but file contains is byte-exact, so an LF
+// needle does NOT match a CRLF file and a CRLF needle does. A test author who
+// needs to observe a file's exact bytes (including line endings) relies on this;
+// making file contains fold would silently hide a CRLF-vs-LF file difference.
+func TestCheck_File_ContainsByteExact(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "crlf.txt"), []byte("a\r\nb\r\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name   string
+		needle string
+		wantOK bool
+	}{
+		{"LF needle does not match a CRLF file", "a\nb", false},
+		{"CRLF needle matches byte-for-byte", "a\r\nb", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			got := Check(&spec.Assert{File: &spec.FileAssert{Path: "crlf.txt", Contains: spec.StringList{c.needle}}}, nil, Env{Workdir: dir})
+			if got.OK != c.wantOK {
+				t.Errorf("OK = %v, want %v (%s)", got.OK, c.wantOK, got.Hint)
 			}
 		})
 	}

--- a/internal/assert/stream.go
+++ b/internal/assert/stream.go
@@ -103,12 +103,19 @@ func checkStream(name string, s *spec.StreamAssert, data []byte, hasData bool, e
 
 	// The text matchers compose: every one that is set must hold (AND). Return
 	// the first failure; if all pass, return the last passing result.
+	//
+	// They run on a CRLF-folded copy so line endings are an OS artifact here too,
+	// matching the equals matcher: a multi-line contains or a (?m)-anchored regex
+	// authored with LF matches cmd.exe's CRLF output on Windows exactly as it
+	// matches POSIX LF output. Byte-exact comparison (including CRLF) is the file
+	// matchers' domain (equals_file / sha256), not the stream text matchers'.
+	folded := foldCRLF(got)
 	var last *CheckResult
 	for _, r := range []*CheckResult{
-		streamContains(name, got, s.Contains),
-		streamNotContains(name, got, s.NotContains),
-		streamMatches(name, got, s.Matches),
-		streamNotMatches(name, got, s.NotMatches),
+		streamContains(name, folded, s.Contains),
+		streamNotContains(name, folded, s.NotContains),
+		streamMatches(name, folded, s.Matches),
+		streamNotMatches(name, folded, s.NotMatches),
 	} {
 		if r == nil {
 			continue
@@ -124,12 +131,14 @@ func checkStream(name string, s *spec.StreamAssert, data []byte, hasData bool, e
 	return &CheckResult{Desc: "assert " + name, Hint: "matcher not supported yet"}
 }
 
-// streamContains runs the contains matcher, or returns nil when it is unset.
+// streamContains runs the contains matcher, or returns nil when it is unset. The
+// needles are CRLF-folded to match the folded stream, so a needle authored with
+// CRLF (a spec written in a CRLF editor) still compares equal to LF output.
 func streamContains(name, got string, subs spec.StringList) *CheckResult {
 	if subs == nil {
 		return nil
 	}
-	return checkContainsAll(name, got, subs)
+	return checkContainsAll(name, got, foldCRLFList(subs))
 }
 
 // streamNotContains runs the not_contains matcher, or returns nil when unset.
@@ -137,7 +146,7 @@ func streamNotContains(name, got string, subs spec.StringList) *CheckResult {
 	if subs == nil {
 		return nil
 	}
-	return checkNotContainsAll(name, got, subs)
+	return checkNotContainsAll(name, got, foldCRLFList(subs))
 }
 
 // streamMatches runs the matches matcher, or returns nil when it is unset.
@@ -240,9 +249,23 @@ func containsDesc(name string, subs spec.StringList, want bool) string {
 // does against POSIX output — line endings are an OS artifact, not observable
 // CLI behavior.
 func equalsNormalized(got, want string) bool {
-	got = strings.ReplaceAll(got, "\r\n", "\n")
-	want = strings.ReplaceAll(want, "\r\n", "\n")
-	return strings.TrimSuffix(got, "\n") == strings.TrimSuffix(want, "\n")
+	return strings.TrimSuffix(foldCRLF(got), "\n") == strings.TrimSuffix(foldCRLF(want), "\n")
+}
+
+// foldCRLF collapses Windows CRLF line endings to LF so text comparison treats
+// line endings as an OS artifact. A lone CR (an old-Mac line ending) stays
+// observable, matching equalsNormalized — only the CR that precedes an LF is
+// dropped.
+func foldCRLF(s string) string { return strings.ReplaceAll(s, "\r\n", "\n") }
+
+// foldCRLFList folds CRLF in every element so a needle authored with CRLF
+// compares equal to LF-folded output.
+func foldCRLFList(list spec.StringList) spec.StringList {
+	out := make(spec.StringList, len(list))
+	for i, s := range list {
+		out[i] = foldCRLF(s)
+	}
+	return out
 }
 
 // selectLine returns the n-th (1-based) line of s, ignoring a single trailing

--- a/test/e2e/atago/line_endings.atago.yaml
+++ b/test/e2e/atago/line_endings.atago.yaml
@@ -1,0 +1,142 @@
+version: "1"
+
+suite:
+  name: atago self-hosting / stream text matchers fold CRLF
+
+# Every stdout/stderr text matcher treats line endings as an OS artifact: a spec
+# written with LF asserts the same behavior whether the program emits LF (POSIX)
+# or CRLF (cmd.exe on Windows). equals already folded CRLF; contains, matches,
+# not_contains, and not_matches now fold too, so a multi-line assertion no longer
+# passes on Linux/macOS and fails on windows-latest alone. Byte-exact comparison
+# (including the exact line ending) stays the file matchers' job — see
+# file_equals.atago.yaml. printf emits CRLF deterministically so these run the
+# same on every POSIX host; the Windows guarantee is pinned by the assert unit
+# tests, which run on windows-latest.
+scenarios:
+  - name: equals folds a CRLF body to its LF form
+    steps:
+      - run:
+          shell: true
+          command: printf 'first\r\nsecond\r\n'
+      - assert:
+          stdout:
+            equals: "first\nsecond"
+
+  - name: equals tolerates the phantom trailing CRLF
+    steps:
+      - run:
+          shell: true
+          command: printf 'only\r\n'
+      - assert:
+          stdout:
+            equals: "only"
+
+  - name: contains folds CRLF for a multi-line needle
+    steps:
+      - run:
+          shell: true
+          command: printf 'alpha\r\nbeta\r\ngamma\r\n'
+      - assert:
+          stdout:
+            contains: "alpha\nbeta"
+
+  - name: contains authored with CRLF matches LF-folded output
+    steps:
+      - run:
+          shell: true
+          command: printf 'alpha\r\nbeta\r\n'
+      - assert:
+          stdout:
+            contains: "alpha\r\nbeta"
+
+  - name: contains list every multi-line element folds
+    steps:
+      - run:
+          shell: true
+          command: printf 'a\r\nb\r\nc\r\nd\r\n'
+      - assert:
+          stdout:
+            contains:
+              - "a\nb"
+              - "c\nd"
+
+  - name: matches anchors a line over CRLF with the multiline flag
+    steps:
+      - run:
+          shell: true
+          command: printf 'hello\r\nworld\r\n'
+      - assert:
+          stdout:
+            matches: "(?m)^world$"
+
+  - name: matches a literal newline in the pattern over CRLF
+    steps:
+      - run:
+          shell: true
+          command: printf 'up\r\ndown\r\n'
+      - assert:
+          stdout:
+            matches: "up\ndown"
+
+  - name: not_contains stays clear of an absent multi-line needle
+    steps:
+      - run:
+          shell: true
+          command: printf 'red\r\ngreen\r\n'
+      - assert:
+          stdout:
+            not_contains: "red\nblue"
+
+  - name: not_matches passes for an anchored line that is absent
+    steps:
+      - run:
+          shell: true
+          command: printf 'north\r\nsouth\r\n'
+      - assert:
+          stdout:
+            not_matches: "(?m)^east$"
+
+  - name: the line selector strips the trailing CR
+    steps:
+      - run:
+          shell: true
+          command: printf 'header\r\npayload\r\n'
+      - assert:
+          stdout:
+            line: 2
+            equals: "payload"
+
+  - name: json parses a CRLF-formatted document
+    steps:
+      - run:
+          shell: true
+          command: printf '{\r\n"count":3\r\n}\r\n'
+      - assert:
+          stdout:
+            json:
+              - path: "$.count"
+                equals: 3
+
+  - name: folding does not make an absent multi-line needle match
+    steps:
+      - fixture:
+          file: inner.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: inner
+            scenarios:
+              - name: an absent multi-line needle still fails
+                steps:
+                  - run:
+                      shell: true
+                      command: printf 'one\r\ntwo\r\n'
+                  - assert:
+                      stdout:
+                        contains: "one\nMISSING"
+      - run:
+          command: ${atago} run inner.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains: "was not present"


### PR DESCRIPTION
The stdout/stderr equals matcher folds CRLF so a spec written with LF asserts the same behavior whether a command emits LF on POSIX or CRLF on Windows cmd.exe. The other stream text matchers did not: contains, not_contains, matches, and not_matches compared raw bytes. So a multi-line contains needle, or a (?m)-anchored matches regex, written with LF passed on Linux and macOS but failed on windows-latest alone, where the captured bytes carry CRLF. The equals matcher already avoided this divergence; the other four did not.

This folds CRLF to LF in the whole-stream copy those four matchers run against, and folds the contains/not_contains needles too so a needle authored in a CRLF editor still compares equal. The regex pattern is not folded. File matchers stay byte-exact: file contains, equals, equals_file, and the dir sha256 manifest still compare raw bytes, because observing a file exact line endings is a legitimate assertion. A new unit test pins that asymmetry.

Adds the folding cases to the assert unit tests and a self-hosted E2E suite (line_endings.atago.yaml) that drives every matcher against printf-emitted CRLF output. The suite is POSIX-only (printf is not a cmd builtin); the Windows guarantee is pinned by the assert unit tests, which run on windows-latest.

make test, make lint, and make e2e all pass (261 scenarios, 259 passed, 2 skipped).