### PR TITLE
fix(cmd): create the parent directory for a nested stdout_to / stderr_to target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project follows [Semantic Versioning](https://semver.org/).
   an OS artifact for all stream text matchers now; byte-exact comparison
   (including the exact line ending) stays with the file matchers (`equals_file`,
   `dir` `sha256`).
+- `stdout_to` / `stderr_to` create the parent directory of a nested redirect
+  target, mirroring the fixture writer. A redirect to `logs/out.txt` failed with
+  a raw "no such file or directory" when `logs/` did not exist yet, while a
+  fixture at the same path created it; the two path-taking features now behave
+  the same. The parent stays inside the scenario workdir.
 
 ## [0.6.0] - 2026-07-07
 

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-61 suites · 253 scenarios
+62 suites · 260 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -194,6 +194,14 @@
 - [atago self-hosting / parallel](#atago-self-hosting--parallel) — 2 scenarios
   - [parallel run passes and stays deterministic](#scenario-parallel-run-passes-and-stays-deterministic)
   - [fail-fast stops after the first failure](#scenario-fail-fast-stops-after-the-first-failure)
+- [atago self-hosting / forward-slash spec paths resolve on every OS](#atago-self-hosting--forward-slash-spec-paths-resolve-on-every-os) — 7 scenarios
+  - [stdout_to creates a nested parent directory](#scenario-stdout_to-creates-a-nested-parent-directory)
+  - [stderr_to creates its own nested parent directory](#scenario-stderr_to-creates-its-own-nested-parent-directory)
+  - [a fixture at a nested forward-slash path is created and addressable](#scenario-a-fixture-at-a-nested-forward-slash-path-is-created-and-addressable)
+  - [a file assert reaches a deeply nested fixture by forward-slash path](#scenario-a-file-assert-reaches-a-deeply-nested-fixture-by-forward-slash-path)
+  - [a dir assert addresses a nested tree and child by forward-slash path](#scenario-a-dir-assert-addresses-a-nested-tree-and-child-by-forward-slash-path)
+  - [equals_file compares two files addressed by forward-slash paths](#scenario-equals_file-compares-two-files-addressed-by-forward-slash-paths)
+  - [a redirect path may not escape the workdir via a nested traversal](#scenario-a-redirect-path-may-not-escape-the-workdir-via-a-nested-traversal)
 - [atago self-hosting / pdf assertion](#atago-self-hosting--pdf-assertion) — 2 scenarios
   - [pdf assertions cover page count, metadata, and text](#scenario-pdf-assertions-cover-page-count-metadata-and-text)
   - [a non-pdf file fails the pdf target](#scenario-a-non-pdf-file-fails-the-pdf-target)
@@ -3274,6 +3282,98 @@ ${atago} run --parallel 1 --fail-fast ff.atago.yaml
 #### Then
 - exit code is `1`
 - stdout contains `1 skipped`
+## atago self-hosting / forward-slash spec paths resolve on every OS
+Source: `test/e2e/atago/paths_portable.atago.yaml`
+### Scenario: stdout_to creates a nested parent directory
+#### When
+```shell
+echo produced
+```
+#### Then
+- exit code is `0`
+- file `out/logs/result.txt` contains `produced`
+#### Generated artifacts
+- `out/logs/result.txt`
+### Scenario: stderr_to creates its own nested parent directory
+#### When
+```shell
+echo oops 1>&2
+```
+#### Then
+- exit code is `0`
+- file `errs/deep/err.txt` contains `oops`
+#### Generated artifacts
+- `errs/deep/err.txt`
+### Scenario: a fixture at a nested forward-slash path is created and addressable
+#### Given
+- Fixture file `data/config/app.json` is created.
+#### Inputs
+_Fixture `data/config/app.json`:_
+```text
+{"k":1}
+```
+#### Then
+- file `data/config/app.json` at `$.k` equals `1`
+### Scenario: a file assert reaches a deeply nested fixture by forward-slash path
+#### Given
+- Fixture file `a/b/c/leaf.txt` is created.
+#### Inputs
+_Fixture `a/b/c/leaf.txt`:_
+```text
+at the bottom
+```
+#### Then
+- file `a/b/c/leaf.txt` contains `at the bottom`
+### Scenario: a dir assert addresses a nested tree and child by forward-slash path
+#### Given
+- Fixture file `pkg/mod/one.go` is created.
+- Fixture file `pkg/mod/two.go` is created.
+- Fixture file `pkg/mod/sub/three.go` is created.
+#### Inputs
+_Fixture `pkg/mod/one.go`:_
+```text
+package mod
+```
+_Fixture `pkg/mod/two.go`:_
+```text
+package mod
+```
+_Fixture `pkg/mod/sub/three.go`:_
+```text
+package sub
+```
+#### Then
+- dir `pkg/mod` exists, contains `one.go`, contains `two.go`, contains `sub/three.go`, does not contain `missing.go`
+### Scenario: equals_file compares two files addressed by forward-slash paths
+#### Given
+- Fixture file `golden/expected.bin` is created.
+- Fixture file `build/actual.bin` is created.
+#### Then
+- file `build/actual.bin` is byte-identical to `golden/expected.bin`
+### Scenario: a redirect path may not escape the workdir via a nested traversal
+#### Given
+- Fixture file `probe.atago.yaml` is created.
+#### Inputs
+_Fixture `probe.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: escape
+scenarios:
+  - name: nested traversal is rejected
+    steps:
+      - run:
+          shell: true
+          command: echo x
+          stdout_to: sub/../../escape.txt
+```
+#### When
+```shell
+${atago} run probe.atago.yaml
+```
+#### Then
+- exit code is `4`
+- stdout contains `escapes the scenario workdir`
 ## atago self-hosting / pdf assertion
 Source: `test/e2e/atago/pdf.atago.yaml`
 ### Scenario: pdf assertions cover page count, metadata, and text

--- a/internal/runner/cmd/cmd.go
+++ b/internal/runner/cmd/cmd.go
@@ -182,6 +182,13 @@ func writeRedirects(run *spec.Run, workdir, stdout, stderr string) error {
 		if err != nil {
 			return err
 		}
+		// Create the parent directory so a redirect to a nested path (stdout_to:
+		// logs/out.txt) works without a prior mkdir step, mirroring the fixture
+		// writer. The parent is inside the workdir (ResolveWorkdirPath confined it),
+		// so this creates only scenario-local directories.
+		if err := os.MkdirAll(filepath.Dir(abs), 0o750); err != nil {
+			return fmt.Errorf("%s: %w", r.field, err)
+		}
 		// The program under test may have planted a symlink at the redirect target
 		// pointing outside the workdir; write without following it (issue #16).
 		if err := security.WriteFileNoFollow(abs, []byte(r.data), 0o644); err != nil {

--- a/internal/runner/cmd/cmd_test.go
+++ b/internal/runner/cmd/cmd_test.go
@@ -72,6 +72,33 @@ func TestRun_StdoutToStderrTo(t *testing.T) {
 	}
 }
 
+// TestRun_StdoutToCreatesParentDir proves a redirect to a nested path creates
+// the parent directory, mirroring the fixture writer, so a spec can declare
+// stdout_to: logs/out.txt without a prior mkdir step. Without this the write
+// failed with a raw "no such file or directory" on every OS.
+func TestRun_StdoutToCreatesParentDir(t *testing.T) {
+	t.Parallel()
+	wd := t.TempDir()
+	r := New()
+	res, err := r.Run(context.Background(), &spec.Run{
+		Command:  argvCommand("echo produced", "cmd /c echo produced"),
+		StdoutTo: "logs/deep/out.txt",
+		StderrTo: "errs/err.txt",
+	}, wd)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", res.ExitCode)
+	}
+	if got := readTrim(t, filepath.Join(wd, "logs", "deep", "out.txt")); got != "produced" {
+		t.Errorf("nested stdout_to = %q, want produced", got)
+	}
+	if _, err := os.Stat(filepath.Join(wd, "errs", "err.txt")); err != nil {
+		t.Errorf("nested stderr_to file missing: %v", err)
+	}
+}
+
 // TestRun_StdoutToConfinedToWorkdir proves a redirect path may not escape the
 // scenario workdir.
 func TestRun_StdoutToConfinedToWorkdir(t *testing.T) {

--- a/internal/security/path_test.go
+++ b/internal/security/path_test.go
@@ -169,7 +169,36 @@ func TestResolveWorkdirPath_Windows(t *testing.T) {
 	if _, err := ResolveWorkdirPath("f", root, `sub\out.txt`); err != nil {
 		t.Fatalf("in-workdir windows path rejected: %v", err)
 	}
+	// A spec written for portability uses forward slashes; on Windows they must
+	// resolve to the native separator and land inside the workdir.
+	got, err := ResolveWorkdirPath("f", root, "sub/out.txt")
+	if err != nil {
+		t.Fatalf("forward-slash windows path rejected: %v", err)
+	}
+	if want := `C:\work\scn\sub\out.txt`; got != want {
+		t.Errorf("forward-slash resolve = %q, want %q", got, want)
+	}
 	if _, err := ResolveWorkdirPath("f", root, `..\escape.txt`); err == nil {
 		t.Fatal("windows parent traversal accepted")
+	}
+}
+
+// TestResolveWorkdirPath_ForwardSlashRelative proves a forward-slash relative
+// path (how a portable spec is authored) resolves to the host's native separator
+// and stays inside the workdir on every OS — so the same spec addresses the same
+// file on Windows as on POSIX. On windows-latest CI this is the positive proof
+// that `/`-separated spec paths are normalized to `\`.
+func TestResolveWorkdirPath_ForwardSlashRelative(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	got, err := ResolveWorkdirPath("f", root, "sub/deep/out.txt")
+	if err != nil {
+		t.Fatalf("forward-slash relative path rejected: %v", err)
+	}
+	if want := filepath.Join(root, "sub", "deep", "out.txt"); got != want {
+		t.Errorf("resolve = %q, want %q (native separators)", got, want)
+	}
+	if !WithinRoot(root, got) {
+		t.Errorf("resolved path %q is not within root %q", got, root)
 	}
 }

--- a/scripts/windows_portable_specs.sh
+++ b/scripts/windows_portable_specs.sh
@@ -22,6 +22,7 @@ printf '%s\n' \
   ./test/e2e/atago/init_templates.atago.yaml \
   ./test/e2e/atago/edge.atago.yaml \
   ./test/e2e/atago/argv_quotes.atago.yaml \
+  ./test/e2e/atago/paths_portable.atago.yaml \
   ./test/e2e/atago/file_equals.atago.yaml \
   ./test/e2e/atago/store_whole.atago.yaml \
   ./test/e2e/atago/json_list.atago.yaml \

--- a/test/e2e/atago/paths_portable.atago.yaml
+++ b/test/e2e/atago/paths_portable.atago.yaml
@@ -1,0 +1,111 @@
+version: "1"
+
+suite:
+  name: atago self-hosting / forward-slash spec paths resolve on every OS
+
+# A portable spec writes paths with forward slashes; atago resolves them to the
+# host's native separator (backslash on Windows) at every path-taking feature, so
+# the same spec addresses the same file on Windows as on POSIX. These drive atago
+# itself with only builtins shared by /bin/sh and cmd.exe (echo, `1>&2`), so they
+# run in the Windows portable subset and prove `/` handling on windows-latest —
+# not just via the security unit tests. Content assertions use contains, not a
+# byte-exact equals, because cmd.exe's echo appends CRLF where /bin/sh appends LF.
+scenarios:
+  - name: stdout_to creates a nested parent directory
+    steps:
+      - run:
+          shell: true
+          command: echo produced
+          stdout_to: out/logs/result.txt
+      - assert:
+          exit_code: 0
+          file:
+            path: out/logs/result.txt
+            contains: "produced"
+
+  - name: stderr_to creates its own nested parent directory
+    steps:
+      - run:
+          shell: true
+          command: echo oops 1>&2
+          stderr_to: errs/deep/err.txt
+      - assert:
+          exit_code: 0
+          file:
+            path: errs/deep/err.txt
+            contains: "oops"
+
+  - name: a fixture at a nested forward-slash path is created and addressable
+    steps:
+      - fixture:
+          file: data/config/app.json
+          content: '{"k":1}'
+      - assert:
+          file:
+            path: data/config/app.json
+            json:
+              - path: "$.k"
+                equals: 1
+
+  - name: a file assert reaches a deeply nested fixture by forward-slash path
+    steps:
+      - fixture:
+          file: a/b/c/leaf.txt
+          content: "at the bottom"
+      - assert:
+          file:
+            path: a/b/c/leaf.txt
+            contains: "at the bottom"
+
+  - name: a dir assert addresses a nested tree and child by forward-slash path
+    steps:
+      - fixture:
+          file: pkg/mod/one.go
+          content: "package mod\n"
+      - fixture:
+          file: pkg/mod/two.go
+          content: "package mod\n"
+      - fixture:
+          file: pkg/mod/sub/three.go
+          content: "package sub\n"
+      - assert:
+          dir:
+            path: pkg/mod
+            exists: true
+            contains: [one.go, two.go, sub/three.go]
+            not_contains: [missing.go]
+
+  - name: equals_file compares two files addressed by forward-slash paths
+    steps:
+      - fixture:
+          file: golden/expected.bin
+          base64: "AAEC/w=="
+      - fixture:
+          file: build/actual.bin
+          base64: "AAEC/w=="
+      - assert:
+          file:
+            path: build/actual.bin
+            equals_file: golden/expected.bin
+
+  - name: a redirect path may not escape the workdir via a nested traversal
+    steps:
+      - fixture:
+          file: probe.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: escape
+            scenarios:
+              - name: nested traversal is rejected
+                steps:
+                  - run:
+                      shell: true
+                      command: echo x
+                      stdout_to: sub/../../escape.txt
+      - run:
+          command: ${atago} run probe.atago.yaml
+      - assert:
+          exit_code: 4
+          stdout:
+            contains: "escapes the scenario workdir"


### PR DESCRIPTION
A run step redirect to a nested path failed when the parent directory did not exist yet: stdout_to: logs/out.txt raised a raw "open .../logs/out.txt: no such file or directory" while a fixture declared at the same path created logs/. The two path-taking features disagreed, and the error leaked the scenario temp workdir path.

writeRedirects now creates the parent directory before writing, mirroring the fixture writer (os.MkdirAll on the resolved parent). The target is already confined to the scenario workdir by ResolveWorkdirPath, so only scenario-local directories are created; the symlink-no-follow write guard is unchanged.

This also adds the positive forward-slash path test the security resolver lacked: a spec authored with forward slashes (sub/deep/out.txt) resolves to the host native separator and stays within the workdir on every OS, which on windows-latest proves the slash is normalized to a backslash. A new self-hosted E2E suite (paths_portable.atago.yaml, in the Windows portable subset) drives stdout_to, stderr_to, fixture, file, dir, and equals_file with forward-slash paths so the same spec resolves on Windows, not just POSIX.

make test, make lint, and make e2e all pass (268 scenarios, 266 passed, 2 skipped).