### PR TITLE
fix(cmd): report 128+signal exit code for a signal-terminated run command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ and this project follows [Semantic Versioning](https://semver.org/).
   a raw "no such file or directory" when `logs/` did not exist yet, while a
   fixture at the same path created it; the two path-taking features now behave
   the same. The parent stays inside the scenario workdir.
+- A run command terminated by a POSIX signal reports the 128+signal exit code
+  (130 for SIGINT, 137 for SIGKILL, 143 for SIGTERM) instead of a bare `-1`, so a
+  spec can assert a CLI's signal-handling contract. Go's `ExitCode()` collapses
+  every signal to `-1`, which is also indistinguishable from atago's
+  timeout/cancel sentinel; the timeout and parent-cancel paths are resolved
+  before this point, so a signal here is the program's own termination. Windows
+  has no POSIX signals and is unaffected.
 
 ## [0.6.0] - 2026-07-07
 

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-63 suites · 278 scenarios
+64 suites · 292 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -82,6 +82,21 @@
   - [an unlisted exit code fails and the output lists the set](#scenario-an-unlisted-exit-code-fails-and-the-output-lists-the-set)
   - [mixing not and in is a load-time error](#scenario-mixing-not-and-in-is-a-load-time-error)
   - [an empty in list is a load-time error](#scenario-an-empty-in-list-is-a-load-time-error)
+- [atago self-hosting / exit code semantics](#atago-self-hosting--exit-code-semantics) — 14 scenarios
+  - [a clean exit is zero](#scenario-a-clean-exit-is-zero)
+  - [a general error is one](#scenario-a-general-error-is-one)
+  - [a usage error is two](#scenario-a-usage-error-is-two)
+  - [an arbitrary code passes through unchanged](#scenario-an-arbitrary-code-passes-through-unchanged)
+  - [the single-byte ceiling is 255](#scenario-the-single-byte-ceiling-is-255)
+  - [the not matcher excludes a specific code](#scenario-the-not-matcher-excludes-a-specific-code)
+  - [the in matcher accepts any listed code](#scenario-the-in-matcher-accepts-any-listed-code)
+  - [an unlisted code fails the in matcher and names the set](#scenario-an-unlisted-code-fails-the-in-matcher-and-names-the-set)
+  - [SIGKILL is reported as 137](#scenario-sigkill-is-reported-as-137)
+  - [SIGTERM is reported as 143](#scenario-sigterm-is-reported-as-143)
+  - [SIGINT is reported as 130](#scenario-sigint-is-reported-as-130)
+  - [a signal exit composes with the in matcher alongside normal codes](#scenario-a-signal-exit-composes-with-the-in-matcher-alongside-normal-codes)
+  - [a missing command is 127 under the shell](#scenario-a-missing-command-is-127-under-the-shell)
+  - [POSIX exit codes wrap modulo 256](#scenario-posix-exit-codes-wrap-modulo-256)
 - [atago self-hosting / explain](#atago-self-hosting--explain) — 1 scenario
   - [explain summarizes a spec without running it](#scenario-explain-summarizes-a-spec-without-running-it)
 - [atago self-hosting / file equals and equals_file byte-equality (#155)](#atago-self-hosting--file-equals-and-equals_file-byte-equality-155) — 4 scenarios
@@ -1665,6 +1680,129 @@ ${atago} run empty.atago.yaml
 #### Then
 - exit code is `2`
 - stderr contains `at least one accepted exit code`
+## atago self-hosting / exit code semantics
+Source: `test/e2e/atago/exit_codes.atago.yaml`
+### Scenario: a clean exit is zero
+#### When
+```shell
+exit 0
+```
+#### Then
+- exit code is `0`
+### Scenario: a general error is one
+#### When
+```shell
+exit 1
+```
+#### Then
+- exit code is `1`
+### Scenario: a usage error is two
+#### When
+```shell
+exit 2
+```
+#### Then
+- exit code is `2`
+### Scenario: an arbitrary code passes through unchanged
+#### When
+```shell
+exit 42
+```
+#### Then
+- exit code is `42`
+### Scenario: the single-byte ceiling is 255
+#### When
+```shell
+exit 255
+```
+#### Then
+- exit code is `255`
+### Scenario: the not matcher excludes a specific code
+#### When
+```shell
+exit 3
+```
+#### Then
+- exit code is not `0`
+### Scenario: the in matcher accepts any listed code
+#### When
+```shell
+exit 2
+```
+#### Then
+- exit code is one of `0`, `1`, `2`
+### Scenario: an unlisted code fails the in matcher and names the set
+#### Given
+- Fixture file `inner.atago.yaml` is created.
+#### Inputs
+_Fixture `inner.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: inner
+scenarios:
+  - name: five is not in the accepted set
+    steps:
+      - run: {shell: true, command: "exit 5"}
+      - assert:
+          exit_code:
+            in: [0, 1, 2]
+```
+#### When
+```shell
+${atago} run inner.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `exit code in [0, 1, 2]`
+### Scenario: SIGKILL is reported as 137
+_skipped on windows_
+#### When
+```shell
+kill -KILL $$
+```
+#### Then
+- exit code is `137`
+### Scenario: SIGTERM is reported as 143
+_skipped on windows_
+#### When
+```shell
+kill -TERM $$
+```
+#### Then
+- exit code is `143`
+### Scenario: SIGINT is reported as 130
+_skipped on windows_
+#### When
+```shell
+kill -INT $$
+```
+#### Then
+- exit code is `130`
+### Scenario: a signal exit composes with the in matcher alongside normal codes
+_skipped on windows_
+#### When
+```shell
+kill -TERM $$
+```
+#### Then
+- exit code is one of `0`, `143`
+### Scenario: a missing command is 127 under the shell
+_skipped on windows_
+#### When
+```shell
+no_such_command_zzz
+```
+#### Then
+- exit code is `127`
+### Scenario: POSIX exit codes wrap modulo 256
+_skipped on windows_
+#### When
+```shell
+exit 257
+```
+#### Then
+- exit code is `1`
 ## atago self-hosting / explain
 Source: `test/e2e/atago/explain.atago.yaml`
 ### Scenario: explain summarizes a spec without running it

--- a/internal/runner/cmd/cmd.go
+++ b/internal/runner/cmd/cmd.go
@@ -126,7 +126,7 @@ func (r *Runner) Run(ctx context.Context, run *spec.Run, workdir string) (*runne
 	case runErr == nil:
 		res.ExitCode = 0
 	case errors.As(runErr, &exitErr):
-		res.ExitCode = exitErr.ExitCode()
+		res.ExitCode = exitCodeFor(exitErr)
 	default:
 		// Could not start the process at all (not found, permission, ...).
 		return nil, fmt.Errorf("failed to execute %q: %w", run.Command, runErr)

--- a/internal/runner/cmd/cmd_test.go
+++ b/internal/runner/cmd/cmd_test.go
@@ -544,6 +544,45 @@ func TestWindowsFields_MatchesShellwords(t *testing.T) {
 	}
 }
 
+// TestRun_SignalExitCode proves a process terminated by a signal reports the
+// POSIX 128+signal convention (SIGKILL→137, SIGTERM→143, SIGINT→130) rather than
+// Go's raw -1, so a spec can assert a CLI's signal-handling contract. atago's own
+// timeout/cancel is handled earlier and stays -1; a signal reaching here is the
+// program's own termination.
+func TestRun_SignalExitCode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX signals only; Windows has no 128+signal convention")
+	}
+	t.Parallel()
+	cases := []struct {
+		name   string
+		signal string
+		want   int
+	}{
+		{"SIGKILL", "KILL", 137},
+		{"SIGTERM", "TERM", 143},
+		{"SIGINT", "INT", 130},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			res, err := New().Run(context.Background(), &spec.Run{
+				Shell:   spec.Bool(true),
+				Command: "kill -" + c.signal + " $$",
+			}, t.TempDir())
+			if err != nil {
+				t.Fatalf("Run() error = %v", err)
+			}
+			if res.ExitCode != c.want {
+				t.Errorf("exit code = %d, want %d (128+signal)", res.ExitCode, c.want)
+			}
+			if res.TimedOut {
+				t.Error("TimedOut = true; a self-delivered signal is not an atago timeout")
+			}
+		})
+	}
+}
+
 func TestRun_CommandNotFound(t *testing.T) {
 	t.Parallel()
 	r := New()

--- a/internal/runner/cmd/exitcode_unix.go
+++ b/internal/runner/cmd/exitcode_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// exitCodeFor returns the exit code atago reports for a finished process. A
+// process terminated by a signal has no exit code of its own; POSIX shells
+// report it as 128+signal (130 for SIGINT, 137 for SIGKILL, 143 for SIGTERM),
+// and atago mirrors that so a spec can assert a CLI's signal-handling contract.
+//
+// Go's ExitError.ExitCode() returns -1 for a signaled process, which collides
+// with atago's own timeout/cancel sentinel; the caller resolves timeout and
+// parent-cancel before reaching here, so a signal at this point is always the
+// program's own termination.
+func exitCodeFor(err *exec.ExitError) int {
+	if ws, ok := err.Sys().(syscall.WaitStatus); ok && ws.Signaled() {
+		return 128 + int(ws.Signal())
+	}
+	return err.ExitCode()
+}

--- a/internal/runner/cmd/exitcode_windows.go
+++ b/internal/runner/cmd/exitcode_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package cmd
+
+import "os/exec"
+
+// exitCodeFor returns the process exit code verbatim. Windows has no POSIX
+// signals, so there is no 128+signal convention to apply.
+func exitCodeFor(err *exec.ExitError) int {
+	return err.ExitCode()
+}

--- a/scripts/windows_portable_specs.sh
+++ b/scripts/windows_portable_specs.sh
@@ -23,6 +23,7 @@ printf '%s\n' \
   ./test/e2e/atago/edge.atago.yaml \
   ./test/e2e/atago/argv_quotes.atago.yaml \
   ./test/e2e/atago/paths_portable.atago.yaml \
+  ./test/e2e/atago/exit_codes.atago.yaml \
   ./test/e2e/atago/file_equals.atago.yaml \
   ./test/e2e/atago/store_whole.atago.yaml \
   ./test/e2e/atago/json_list.atago.yaml \

--- a/test/e2e/atago/exit_codes.atago.yaml
+++ b/test/e2e/atago/exit_codes.atago.yaml
@@ -1,0 +1,122 @@
+version: "1"
+
+suite:
+  name: atago self-hosting / exit code semantics
+
+# The exit_code matcher is the most fundamental CLI contract atago checks.
+# These pin the whole equivalence set: a clean zero, the conventional 1/2, an
+# arbitrary pass-through code, the 255 single-byte ceiling, the not/in matchers,
+# and the POSIX 128+signal convention for a process a signal terminates (130
+# SIGINT, 137 SIGKILL, 143 SIGTERM) — atago reports that instead of a bare -1 so
+# a CLI's signal handling is assertable. `exit N` is a builtin of both /bin/sh
+# and cmd.exe, so the plain-code scenarios run on Windows; signals, 127, and
+# POSIX exit-code wrapping are POSIX-only and skip there.
+scenarios:
+  - name: a clean exit is zero
+    steps:
+      - run: {shell: true, command: "exit 0"}
+      - assert:
+          exit_code: 0
+
+  - name: a general error is one
+    steps:
+      - run: {shell: true, command: "exit 1"}
+      - assert:
+          exit_code: 1
+
+  - name: a usage error is two
+    steps:
+      - run: {shell: true, command: "exit 2"}
+      - assert:
+          exit_code: 2
+
+  - name: an arbitrary code passes through unchanged
+    steps:
+      - run: {shell: true, command: "exit 42"}
+      - assert:
+          exit_code: 42
+
+  - name: the single-byte ceiling is 255
+    steps:
+      - run: {shell: true, command: "exit 255"}
+      - assert:
+          exit_code: 255
+
+  - name: the not matcher excludes a specific code
+    steps:
+      - run: {shell: true, command: "exit 3"}
+      - assert:
+          exit_code:
+            not: 0
+
+  - name: the in matcher accepts any listed code
+    steps:
+      - run: {shell: true, command: "exit 2"}
+      - assert:
+          exit_code:
+            in: [0, 1, 2]
+
+  - name: an unlisted code fails the in matcher and names the set
+    steps:
+      - fixture:
+          file: inner.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: inner
+            scenarios:
+              - name: five is not in the accepted set
+                steps:
+                  - run: {shell: true, command: "exit 5"}
+                  - assert:
+                      exit_code:
+                        in: [0, 1, 2]
+      - run:
+          command: ${atago} run inner.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains: "exit code in [0, 1, 2]"
+
+  - name: SIGKILL is reported as 137
+    skip: {os: windows}
+    steps:
+      - run: {shell: true, command: "kill -KILL $$"}
+      - assert:
+          exit_code: 137
+
+  - name: SIGTERM is reported as 143
+    skip: {os: windows}
+    steps:
+      - run: {shell: true, command: "kill -TERM $$"}
+      - assert:
+          exit_code: 143
+
+  - name: SIGINT is reported as 130
+    skip: {os: windows}
+    steps:
+      - run: {shell: true, command: "kill -INT $$"}
+      - assert:
+          exit_code: 130
+
+  - name: a signal exit composes with the in matcher alongside normal codes
+    skip: {os: windows}
+    steps:
+      - run: {shell: true, command: "kill -TERM $$"}
+      - assert:
+          exit_code:
+            in: [0, 143]
+
+  - name: a missing command is 127 under the shell
+    skip: {os: windows}
+    steps:
+      - run: {shell: true, command: "no_such_command_zzz"}
+      - assert:
+          exit_code: 127
+
+  - name: POSIX exit codes wrap modulo 256
+    skip: {os: windows}
+    steps:
+      - run: {shell: true, command: "exit 257"}
+      - assert:
+          exit_code: 1


### PR DESCRIPTION
A run command terminated by a POSIX signal reported exit code -1, so a spec could not assert a CLI signal-handling contract — that a tool exits 130 on SIGINT, 137 on SIGKILL, or 143 on SIGTERM, the codes a POSIX shell reports in $?. Go ExitError.ExitCode() collapses every signal to -1, which is also atago timeout/cancel sentinel.

atago now reports 128+signal for a signaled process. The timeout and parent-cancel paths already resolve earlier and keep their -1, so a signal reaching the exit-code branch is the program own termination, not an atago-initiated kill. The mapping lives in a build-tagged helper: POSIX reads the WaitStatus signal, Windows (no POSIX signals) returns the code verbatim.

Adds a unit test asserting SIGKILL/SIGTERM/SIGINT map to 137/143/130, and a self-hosted E2E suite (exit_codes.atago.yaml) that pins the whole exit-code equivalence set — 0, 1, 2, an arbitrary code, the 255 ceiling, the not and in matchers, the signal codes, command-not-found 127, and POSIX modulo-256 wrapping. The plain-code scenarios are in the Windows portable subset; signals and 127 skip there.

make test, make lint, and make e2e all pass (300 scenarios, 298 passed, 2 skipped).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end coverage for exit-code behavior, including standard mappings for signal-based terminations, pass-through values, ceiling/wrapping cases, and matcher interactions.
  * Included the new exit-code spec in Windows portable test runs where applicable.

* **Bug Fixes**
  * Updated reported exit codes so signal-terminated runs now return standard POSIX values like 130, 137, and 143 instead of `-1`.
  * Kept Windows behavior unchanged for platforms without POSIX signals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->