### PR TITLE
test(service): deflake TestSignal_GroupDelivery

### DIFF
--- a/internal/runner/service/signal_test.go
+++ b/internal/runner/service/signal_test.go
@@ -52,9 +52,15 @@ func TestSignal_GroupDelivery(t *testing.T) {
 	svc := &spec.Service{
 		Name:  "family",
 		Shell: spec.Bool(true),
-		// The backgrounded child writes its own marker when TERM arrives —
-		// it only can if the signal went to the whole group.
-		Command: `( trap 'echo child-got-term > child.txt; exit 0' TERM; while true; do sleep 0.1; done ) & echo ready; wait`,
+		// The backgrounded child writes its own marker when TERM arrives — it only
+		// can if the signal went to the whole group, not just the shell leader.
+		//
+		// The child prints the readiness marker itself, AFTER installing its trap,
+		// so "ready" proves the handler is armed. Emitting it from the parent (before
+		// the backgrounded subshell had run `trap`) raced: a TERM delivered in that
+		// window hit the default action and the child died without writing child.txt,
+		// flaking the test on a loaded runner.
+		Command: `( trap 'echo child-got-term > child.txt; exit 0' TERM; echo ready; while true; do sleep 0.1; done ) & wait`,
 		Ready:   &spec.Ready{Log: "ready", Timeout: "5s"},
 	}
 	p, _, err := Start(context.Background(), svc, wd)


### PR DESCRIPTION
TestSignal_GroupDelivery backgrounded a subshell that installs a TERM trap, then printed the readiness marker from the parent shell. Readiness therefore did not prove the child trap was armed: on a loaded runner the subshell had not yet run trap when the test delivered TERM, so the child took the default action and died without writing its marker, failing the 5s wait. This surfaced as an intermittent failure on the ubuntu Go 1.x unit-test job.

The fix prints the readiness marker from inside the subshell, after the trap is installed, so ready is a correct barrier for handler-armed. The test still proves group delivery — the backgrounded child writes child.txt only if the signal reached the whole group, not just the leader.

Verified stable over 60 iterations under CPU load. A forced pre-trap delay reproduces the old race (child.txt missing) and is fixed by the reordering (child.txt written).