### PR TITLE
test(e2e): pin variable resolution semantics

### DIFF
--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-66 suites · 313 scenarios
+67 suites · 320 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -370,6 +370,14 @@
   - [an explicit TERM overrides the default](#scenario-an-explicit-term-overrides-the-default)
   - [an expect does not re-match a consumed pattern](#scenario-an-expect-does-not-re-match-a-consumed-pattern)
   - [less -X renders a real pager onto the screen](#scenario-less--x-renders-a-real-pager-onto-the-screen)
+- [atago self-hosting / variable resolution semantics](#atago-self-hosting--variable-resolution-semantics) — 7 scenarios
+  - [a doubled dollar keeps the braces literal](#scenario-a-doubled-dollar-keeps-the-braces-literal)
+  - [the workdir builtin expands to the scenario directory](#scenario-the-workdir-builtin-expands-to-the-scenario-directory)
+  - [the atago builtin resolves to the binary under test](#scenario-the-atago-builtin-resolves-to-the-binary-under-test)
+  - [an env reference expands from the host environment](#scenario-an-env-reference-expands-from-the-host-environment)
+  - [shell true defers an unknown reference to the shell](#scenario-shell-true-defers-an-unknown-reference-to-the-shell)
+  - [an unresolved variable is a hard error, not a silent empty](#scenario-an-unresolved-variable-is-a-hard-error-not-a-silent-empty)
+  - [an unset env reference names the missing variable](#scenario-an-unset-env-reference-names-the-missing-variable)
 - [atago self-hosting / verbose](#atago-self-hosting--verbose) — 4 scenarios
   - [verbose shows a passing scenario's command, output, and verdicts](#scenario-verbose-shows-a-passing-scenarios-command-output-and-verdicts)
   - [without --verbose the trace is absent](#scenario-without---verbose-the-trace-is-absent)
@@ -6222,6 +6230,85 @@ Gamma line
 #### Then
 - rendered screen contains `Alpha line`
 - rendered screen contains `Gamma line`
+## atago self-hosting / variable resolution semantics
+Source: `test/e2e/atago/var_resolution.atago.yaml`
+### Scenario: a doubled dollar keeps the braces literal
+#### When
+```shell
+echo pre-$${keep}-post
+```
+#### Then
+- stdout contains `${keep}`
+### Scenario: the workdir builtin expands to the scenario directory
+#### When
+```shell
+echo at=${workdir}
+```
+#### Then
+- stdout does not contain `$${workdir}`
+### Scenario: the atago builtin resolves to the binary under test
+#### When
+```shell
+${atago} --version
+```
+#### Then
+- exit code is `0`
+- stdout contains `atago`
+### Scenario: an env reference expands from the host environment
+#### When
+```shell
+echo path=${env:PATH}
+```
+#### Then
+- stdout matches `/path=.+/`
+### Scenario: shell true defers an unknown reference to the shell
+#### When
+```shell
+echo [${undefined_in_atago}]
+```
+#### Then
+- exit code is `0`
+- stdout equals an exact value
+### Scenario: an unresolved variable is a hard error, not a silent empty
+#### Given
+- Fixture file `typo.atago.yaml` is created.
+#### Inputs
+_Fixture `typo.atago.yaml`:_
+```text
+version: "1"
+suite: {name: typo}
+scenarios:
+  - name: a misspelled variable stops the run
+    steps:
+      - run: {command: "echo ${reuslt}"}
+```
+#### When
+```shell
+${atago} run typo.atago.yaml
+```
+#### Then
+- exit code is `4`
+- stdout contains `references ${reuslt}`, `no variable with that name is defined`
+### Scenario: an unset env reference names the missing variable
+#### Given
+- Fixture file `unsetenv.atago.yaml` is created.
+#### Inputs
+_Fixture `unsetenv.atago.yaml`:_
+```text
+version: "1"
+suite: {name: unsetenv}
+scenarios:
+  - name: an unset env var stops the run
+    steps:
+      - run: {command: "echo ${env:ATAGO_SURELY_UNSET_VAR}"}
+```
+#### When
+```shell
+${atago} run unsetenv.atago.yaml
+```
+#### Then
+- exit code is `4`
+- stdout contains `environment variable ATAGO_SURELY_UNSET_VAR is not set`
 ## atago self-hosting / verbose
 Source: `test/e2e/atago/verbose.atago.yaml`
 ### Scenario: verbose shows a passing scenario's command, output, and verdicts

--- a/test/e2e/atago/var_resolution.atago.yaml
+++ b/test/e2e/atago/var_resolution.atago.yaml
@@ -1,0 +1,87 @@
+version: "1"
+
+suite:
+  name: atago self-hosting / variable resolution semantics
+
+# atago interpolates ${...} before a command runs. This pins the resolution
+# contract: builtins (${workdir}, ${atago}) and ${env:NAME} expand; a `$${...}`
+# escape stays literal; an unresolved reference is a hard error (not a silent
+# empty) when shell: false so a typo cannot pass unnoticed; and with shell: true
+# an unknown ${...} is deferred to the shell instead. echo is a POSIX builtin, so
+# this suite runs on make e2e; the resolver itself is OS-independent (unit tests
+# in internal/store cover Windows).
+scenarios:
+  - name: a doubled dollar keeps the braces literal
+    steps:
+      - run: {command: "echo pre-$${keep}-post"}
+      - assert:
+          stdout:
+            contains: "${keep}"
+
+  - name: the workdir builtin expands to the scenario directory
+    steps:
+      - run: {command: "echo at=${workdir}"}
+      - assert:
+          stdout:
+            # The assertion value is expanded too, so the escaped literal proves
+            # the command output no longer contains an unexpanded ${workdir}.
+            not_contains: "$${workdir}"
+
+  - name: the atago builtin resolves to the binary under test
+    steps:
+      - run: {command: "${atago} --version"}
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "atago"
+
+  - name: an env reference expands from the host environment
+    steps:
+      - run: {command: "echo path=${env:PATH}"}
+      - assert:
+          stdout:
+            matches: "path=.+"
+
+  - name: shell true defers an unknown reference to the shell
+    steps:
+      - run: {shell: true, command: "echo [${undefined_in_atago}]"}
+      - assert:
+          exit_code: 0
+          stdout:
+            equals: "[]"
+
+  - name: an unresolved variable is a hard error, not a silent empty
+    steps:
+      - fixture:
+          file: typo.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: typo}
+            scenarios:
+              - name: a misspelled variable stops the run
+                steps:
+                  - run: {command: "echo ${reuslt}"}
+      - run: {command: "${atago} run typo.atago.yaml"}
+      - assert:
+          exit_code: 4
+          stdout:
+            contains:
+              - "references ${reuslt}"
+              - "no variable with that name is defined"
+
+  - name: an unset env reference names the missing variable
+    steps:
+      - fixture:
+          file: unsetenv.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: unsetenv}
+            scenarios:
+              - name: an unset env var stops the run
+                steps:
+                  - run: {command: "echo ${env:ATAGO_SURELY_UNSET_VAR}"}
+      - run: {command: "${atago} run unsetenv.atago.yaml"}
+      - assert:
+          exit_code: 4
+          stdout:
+            contains: "environment variable ATAGO_SURELY_UNSET_VAR is not set"


### PR DESCRIPTION
Adds a self-hosted E2E suite for atago ${...} interpolation contract: the ${workdir} and ${atago} builtins expand, ${env:NAME} reads the host environment, a $${...} escape stays literal, an unresolved reference is a hard error naming the variable (with shell: false, so a typo cannot slip through as a silent empty), an unset ${env:...} names the missing variable, and with shell: true an unknown ${...} is deferred to the shell instead of erroring.

echo is a POSIX builtin so the suite runs on make e2e; the resolver is OS-independent and already unit-tested for Windows in internal/store.

make test, make lint, and make e2e all pass (328 scenarios, 326 passed, 2 skipped).