### PR TITLE
test(e2e): make the quoted-string json fixture shell-agnostic

### DIFF
--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -2906,9 +2906,16 @@ printf '{"pi":3.14}'
 #### Then
 - stdout at `$.pi` equals `3.14`
 ### Scenario: a string carrying a quote compares equal
+#### Given
+- Fixture file `quoted.json` is created.
+#### Inputs
+_Fixture `quoted.json`:_
+```text
+{"s":"a\"b"}
+```
 #### When
 ```shell
-printf '{"s":"a\"b"}'
+cat quoted.json
 ```
 #### Then
 - stdout at `$.s` equals `a"b`

--- a/test/e2e/atago/json_matcher_edges.atago.yaml
+++ b/test/e2e/atago/json_matcher_edges.atago.yaml
@@ -75,7 +75,13 @@ scenarios:
 
   - name: a string carrying a quote compares equal
     steps:
-      - run: {shell: true, command: 'printf ''{"s":"a\"b"}'''}
+      # The document is written by a fixture (byte-exact) and echoed with cat, so
+      # the embedded \" does not depend on a printf implementation's handling of
+      # an unrecognized escape, which varies across shells.
+      - fixture:
+          file: quoted.json
+          content: '{"s":"a\"b"}'
+      - run: {shell: true, command: "cat quoted.json"}
       - assert:
           stdout:
             json:


### PR DESCRIPTION
Follow-up to a CodeRabbit note on #176. The "string carrying a quote" scenario emitted its JSON with printf '{"s":"a\"b"}', which relies on how a printf implementation handles the unrecognized \" escape. That is consistent on bash and dash but not guaranteed across every runner shell. Write the document with a byte-exact fixture and echo it with cat so the embedded quote is independent of printf escape handling. The assertion is unchanged.

make e2e passes (337 scenarios, 335 passed, 2 skipped).