### PR TITLE
test(e2e): pin CLI scenario-selection set semantics

### DIFF
--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-68 suites · 329 scenarios
+69 suites · 336 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -34,6 +34,14 @@
   - [a pty step feeds the delta scan just like a run step (POSIX)](#scenario-a-pty-step-feeds-the-delta-scan-just-like-a-run-step-posix)
   - [a doublestar glob pins an arbitrary-depth generated tree exactly (POSIX)](#scenario-a-doublestar-glob-pins-an-arbitrary-depth-generated-tree-exactly-posix)
   - [a stray file outside the doublestar prefix breaks the exact contract (POSIX)](#scenario-a-stray-file-outside-the-doublestar-prefix-breaks-the-exact-contract-posix)
+- [atago self-hosting / CLI scenario selection](#atago-self-hosting--cli-scenario-selection) — 7 scenarios
+  - [filter selects by a name substring](#scenario-filter-selects-by-a-name-substring)
+  - [filter is OR across a comma-separated list](#scenario-filter-is-or-across-a-comma-separated-list)
+  - [tag selects scenarios carrying the tag](#scenario-tag-selects-scenarios-carrying-the-tag)
+  - [a repeated tag flag is OR](#scenario-a-repeated-tag-flag-is-or)
+  - [skip-tag removes scenarios carrying the tag](#scenario-skip-tag-removes-scenarios-carrying-the-tag)
+  - [tag and skip-tag compose as selected minus skipped](#scenario-tag-and-skip-tag-compose-as-selected-minus-skipped)
+  - [a filter that matches nothing selects an empty set and still exits zero](#scenario-a-filter-that-matches-nothing-selects-an-empty-set-and-still-exits-zero)
 - [atago self-hosting / completion](#atago-self-hosting--completion) — 5 scenarios
   - [bash completion emits a recognizable script](#scenario-bash-completion-emits-a-recognizable-script)
   - [zsh completion emits a compdef script](#scenario-zsh-completion-emits-a-compdef-script)
@@ -891,6 +899,195 @@ ${atago} run check.atago.yaml
 #### Then
 - exit code is `1`
 - stdout contains `unexpected created file`
+## atago self-hosting / CLI scenario selection
+Source: `test/e2e/atago/cli_selection.atago.yaml`
+### Scenario: filter selects by a name substring
+#### Given
+- Fixture file `inner.atago.yaml` is created.
+#### Inputs
+_Fixture `inner.atago.yaml`:_
+```text
+version: "1"
+suite: {name: inner}
+scenarios:
+  - name: alpha
+    tags: [fast]
+    steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+  - name: beta
+    tags: [slow]
+    steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+  - name: gamma
+    tags: [fast, slow]
+    steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+```
+#### When
+```shell
+${atago} run --ci --report json --filter alpha inner.atago.yaml
+```
+#### Then
+- exit code is `0`
+- stdout at `$.suites[0].scenarios` has length 1
+- stdout contains `"alpha"`
+### Scenario: filter is OR across a comma-separated list
+#### Given
+- Fixture file `inner.atago.yaml` is created.
+#### Inputs
+_Fixture `inner.atago.yaml`:_
+```text
+version: "1"
+suite: {name: inner}
+scenarios:
+  - name: alpha
+    tags: [fast]
+    steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+  - name: beta
+    tags: [slow]
+    steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+  - name: gamma
+    tags: [fast, slow]
+    steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+```
+#### When
+```shell
+${atago} run --ci --report json --filter alpha,beta inner.atago.yaml
+```
+#### Then
+- exit code is `0`
+- stdout at `$.suites[0].scenarios` has length 2
+- stdout contains `"alpha"`, `"beta"`
+### Scenario: tag selects scenarios carrying the tag
+#### Given
+- Fixture file `inner.atago.yaml` is created.
+#### Inputs
+_Fixture `inner.atago.yaml`:_
+```text
+version: "1"
+suite: {name: inner}
+scenarios:
+  - name: alpha
+    tags: [fast]
+    steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+  - name: beta
+    tags: [slow]
+    steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+  - name: gamma
+    tags: [fast, slow]
+    steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+```
+#### When
+```shell
+${atago} run --ci --report json --tag fast inner.atago.yaml
+```
+#### Then
+- exit code is `0`
+- stdout at `$.suites[0].scenarios` has length 2
+- stdout contains `"alpha"`, `"gamma"`
+### Scenario: a repeated tag flag is OR
+#### Given
+- Fixture file `inner.atago.yaml` is created.
+#### Inputs
+_Fixture `inner.atago.yaml`:_
+```text
+version: "1"
+suite: {name: inner}
+scenarios:
+  - name: alpha
+    tags: [fast]
+    steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+  - name: beta
+    tags: [slow]
+    steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+  - name: gamma
+    tags: [fast, slow]
+    steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+```
+#### When
+```shell
+${atago} run --ci --report json --tag fast --tag slow inner.atago.yaml
+```
+#### Then
+- exit code is `0`
+- stdout at `$.suites[0].scenarios` has length 3
+### Scenario: skip-tag removes scenarios carrying the tag
+#### Given
+- Fixture file `inner.atago.yaml` is created.
+#### Inputs
+_Fixture `inner.atago.yaml`:_
+```text
+version: "1"
+suite: {name: inner}
+scenarios:
+  - name: alpha
+    tags: [fast]
+    steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+  - name: beta
+    tags: [slow]
+    steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+  - name: gamma
+    tags: [fast, slow]
+    steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+```
+#### When
+```shell
+${atago} run --ci --report json --skip-tag slow inner.atago.yaml
+```
+#### Then
+- exit code is `0`
+- stdout at `$.suites[0].scenarios` has length 1
+- stdout contains `"alpha"`
+### Scenario: tag and skip-tag compose as selected minus skipped
+#### Given
+- Fixture file `inner.atago.yaml` is created.
+#### Inputs
+_Fixture `inner.atago.yaml`:_
+```text
+version: "1"
+suite: {name: inner}
+scenarios:
+  - name: alpha
+    tags: [fast]
+    steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+  - name: beta
+    tags: [slow]
+    steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+  - name: gamma
+    tags: [fast, slow]
+    steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+```
+#### When
+```shell
+${atago} run --ci --report json --tag fast --skip-tag slow inner.atago.yaml
+```
+#### Then
+- exit code is `0`
+- stdout at `$.suites[0].scenarios` has length 1
+- stdout contains `"alpha"`
+### Scenario: a filter that matches nothing selects an empty set and still exits zero
+#### Given
+- Fixture file `inner.atago.yaml` is created.
+#### Inputs
+_Fixture `inner.atago.yaml`:_
+```text
+version: "1"
+suite: {name: inner}
+scenarios:
+  - name: alpha
+    tags: [fast]
+    steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+  - name: beta
+    tags: [slow]
+    steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+  - name: gamma
+    tags: [fast, slow]
+    steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+```
+#### When
+```shell
+${atago} run --ci --report json --filter no_such_name inner.atago.yaml
+```
+#### Then
+- exit code is `0`
+- stdout at `$.suites[0].scenarios` has length 0
 ## atago self-hosting / completion
 Source: `test/e2e/atago/completion.atago.yaml`
 ### Scenario: bash completion emits a recognizable script

--- a/scripts/windows_portable_specs.sh
+++ b/scripts/windows_portable_specs.sh
@@ -25,6 +25,7 @@ printf '%s\n' \
   ./test/e2e/atago/paths_portable.atago.yaml \
   ./test/e2e/atago/exit_codes.atago.yaml \
   ./test/e2e/atago/loader_errors.atago.yaml \
+  ./test/e2e/atago/cli_selection.atago.yaml \
   ./test/e2e/atago/file_equals.atago.yaml \
   ./test/e2e/atago/store_whole.atago.yaml \
   ./test/e2e/atago/json_list.atago.yaml \

--- a/test/e2e/atago/cli_selection.atago.yaml
+++ b/test/e2e/atago/cli_selection.atago.yaml
@@ -1,0 +1,123 @@
+version: "1"
+
+suite:
+  name: atago self-hosting / CLI scenario selection
+
+# Pins the set semantics of the run-selection flags against a fixed inner suite
+# of three scenarios — alpha [fast], beta [slow], gamma [fast, slow]. --filter
+# selects by name substring (OR across a comma list), --tag by tag membership
+# (OR when repeated), --skip-tag removes by tag, and the two compose as
+# (tag-selected \ skip-tagged). Selection is read back from the json report:
+# deselected scenarios are absent, so the scenarios array length is the size of
+# the selected set. exit 0 is a builtin of both shells, so this runs on Windows.
+scenarios:
+  - name: filter selects by a name substring
+    steps:
+      - fixture:
+          file: inner.atago.yaml
+          content: &inner |
+            version: "1"
+            suite: {name: inner}
+            scenarios:
+              - name: alpha
+                tags: [fast]
+                steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+              - name: beta
+                tags: [slow]
+                steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+              - name: gamma
+                tags: [fast, slow]
+                steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+      - run: {command: "${atago} run --ci --report json --filter alpha inner.atago.yaml"}
+      - assert:
+          exit_code: 0
+          stdout:
+            json:
+              - path: "$.suites[0].scenarios"
+                length: 1
+      - assert:
+          stdout:
+            contains: '"alpha"'
+            not_contains: ['"beta"', '"gamma"']
+
+  - name: filter is OR across a comma-separated list
+    steps:
+      - fixture: {file: inner.atago.yaml, content: *inner}
+      - run: {command: "${atago} run --ci --report json --filter alpha,beta inner.atago.yaml"}
+      - assert:
+          exit_code: 0
+          stdout:
+            json:
+              - path: "$.suites[0].scenarios"
+                length: 2
+      - assert:
+          stdout:
+            contains: ['"alpha"', '"beta"']
+            not_contains: '"gamma"'
+
+  - name: tag selects scenarios carrying the tag
+    steps:
+      - fixture: {file: inner.atago.yaml, content: *inner}
+      - run: {command: "${atago} run --ci --report json --tag fast inner.atago.yaml"}
+      - assert:
+          exit_code: 0
+          stdout:
+            json:
+              - path: "$.suites[0].scenarios"
+                length: 2
+      - assert:
+          stdout:
+            contains: ['"alpha"', '"gamma"']
+            not_contains: '"beta"'
+
+  - name: a repeated tag flag is OR
+    steps:
+      - fixture: {file: inner.atago.yaml, content: *inner}
+      - run: {command: "${atago} run --ci --report json --tag fast --tag slow inner.atago.yaml"}
+      - assert:
+          exit_code: 0
+          stdout:
+            json:
+              - path: "$.suites[0].scenarios"
+                length: 3
+
+  - name: skip-tag removes scenarios carrying the tag
+    steps:
+      - fixture: {file: inner.atago.yaml, content: *inner}
+      - run: {command: "${atago} run --ci --report json --skip-tag slow inner.atago.yaml"}
+      - assert:
+          exit_code: 0
+          stdout:
+            json:
+              - path: "$.suites[0].scenarios"
+                length: 1
+      - assert:
+          stdout:
+            contains: '"alpha"'
+            not_contains: ['"beta"', '"gamma"']
+
+  - name: tag and skip-tag compose as selected minus skipped
+    steps:
+      - fixture: {file: inner.atago.yaml, content: *inner}
+      - run: {command: "${atago} run --ci --report json --tag fast --skip-tag slow inner.atago.yaml"}
+      - assert:
+          exit_code: 0
+          stdout:
+            json:
+              - path: "$.suites[0].scenarios"
+                length: 1
+      - assert:
+          stdout:
+            contains: '"alpha"'
+            not_contains: '"gamma"'
+
+  - name: a filter that matches nothing selects an empty set and still exits zero
+    steps:
+      - fixture: {file: inner.atago.yaml, content: *inner}
+      - run: {command: "${atago} run --ci --report json --filter no_such_name inner.atago.yaml"}
+      - assert:
+          exit_code: 0
+          stdout:
+            json:
+              - path: "$.suites[0].scenarios"
+                length: 0


### PR DESCRIPTION
Adds a self-hosted E2E suite that drives ${atago} run with the selection flags against a fixed inner suite (alpha [fast], beta [slow], gamma [fast, slow]) and reads the selected set back from the json report, whose scenarios array omits deselected scenarios. Covers --filter by name substring, --filter as OR across a comma list, --tag by membership, a repeated --tag as OR, --skip-tag removal, --tag composed with --skip-tag as (selected minus skipped), and a filter that matches nothing selecting an empty set while still exiting zero.

The inner scenarios run exit 0, a builtin of both shells, and selection is OS-independent, so the suite joins the Windows portable subset.

make test, make lint, and make e2e all pass (344 scenarios, 342 passed, 2 skipped).