### PR TITLE
fix(cli): name snapshot update in its own error messages, not run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- An error from `atago snapshot update` now names that command instead of the
+  `atago run` it delegates to internally. A missing target or a bad flag printed
+  `atago run: ...` even though the user typed `snapshot update`; the diagnostic
+  prefix now matches the invoked command.
+
 - A no-shell command (`shell: false`, the default) authored as a YAML block
   scalar now tokenizes to the same argv on every OS. `windowsFields` split only
   on spaces and tabs while POSIX (`go-shellwords`) also splits on carriage

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-69 suites · 336 scenarios
+69 suites · 337 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -74,10 +74,11 @@
   - [an impossible bound fails and shows the measured duration](#scenario-an-impossible-bound-fails-and-shows-the-measured-duration)
   - [a deliberate wait satisfies a lower bound](#scenario-a-deliberate-wait-satisfies-a-lower-bound)
   - [a duration assert with no preceding step is a load-time error](#scenario-a-duration-assert-with-no-preceding-step-is-a-load-time-error)
-- [atago self-hosting / edge cases](#atago-self-hosting--edge-cases) — 3 scenarios
+- [atago self-hosting / edge cases](#atago-self-hosting--edge-cases) — 4 scenarios
   - [JSON assertion on empty stdout reports an empty stream](#scenario-json-assertion-on-empty-stdout-reports-an-empty-stream)
   - [an unsupported matcher is a parse error](#scenario-an-unsupported-matcher-is-a-parse-error)
   - [a mixed valid+invalid run reads FAILED and counts the dropped spec](#scenario-a-mixed-validinvalid-run-reads-failed-and-counts-the-dropped-spec)
+  - [a snapshot update error names the snapshot command, not run](#scenario-a-snapshot-update-error-names-the-snapshot-command-not-run)
 - [atago self-hosting / workdir + scenario env + not_contains](#atago-self-hosting--workdir--scenario-env--not_contains) — 6 scenarios
   - [run.stdout_to redirects stdout to a workdir file without a shell](#scenario-runstdout_to-redirects-stdout-to-a-workdir-file-without-a-shell)
   - [scenario env is shared by every run step and overridable per step](#scenario-scenario-env-is-shared-by-every-run-step-and-overridable-per-step)
@@ -1739,6 +1740,14 @@ ${atago} run good.atago.yaml broken.atago.yaml
 - exit code is `2`
 - stdout contains `1 spec failed to load`
 - stdout does not contain `PASSED`
+### Scenario: a snapshot update error names the snapshot command, not run
+#### When
+```shell
+${atago} snapshot update no-such-spec.atago.yaml
+```
+#### Then
+- exit code is `3`
+- stderr contains `atago snapshot update: cannot access`
 ## atago self-hosting / workdir + scenario env + not_contains
 Source: `test/e2e/atago/env_workdir.atago.yaml`
 ### Scenario: run.stdout_to redirects stdout to a workdir file without a shell

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -30,7 +30,7 @@ func Main(args []string, stdout, stderr io.Writer) int {
 	cmd, rest := args[0], args[1:]
 	switch cmd {
 	case "run":
-		return runCmd(rest, stdout, stderr)
+		return runCmd("atago run", rest, stdout, stderr)
 	case "init":
 		return initCmd(rest, stdout, stderr)
 	case "record":
@@ -116,5 +116,5 @@ func snapshotCmd(args []string, stdout, stderr io.Writer) int {
 		return ExitConfig
 	}
 	// `snapshot update` is `run` with snapshots written instead of compared.
-	return runCmd(append([]string{"--update-snapshots"}, args[1:]...), stdout, stderr)
+	return runCmd("atago snapshot update", append([]string{"--update-snapshots"}, args[1:]...), stdout, stderr)
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -911,6 +911,21 @@ func TestSnapshotCmd_BadInvocation(t *testing.T) {
 	}
 }
 
+// TestSnapshotCmd_ErrorNamesSnapshot proves an error from `snapshot update`
+// names that command, not the `run` it delegates to. Reporting "atago run:" for
+// a `snapshot update` invocation misidentifies the command the user typed.
+func TestSnapshotCmd_ErrorNamesSnapshot(t *testing.T) {
+	t.Parallel()
+	var out, errb bytes.Buffer
+	got := Main([]string{"snapshot", "update", filepath.Join(t.TempDir(), "missing.atago.yaml")}, &out, &errb)
+	if got != ExitConfig {
+		t.Errorf("exit = %d, want %d", got, ExitConfig)
+	}
+	if s := errb.String(); !strings.Contains(s, "atago snapshot update:") || strings.Contains(s, "atago run:") {
+		t.Errorf("stderr = %q, want it to name 'atago snapshot update:' and not 'atago run:'", s)
+	}
+}
+
 // --- run argument parsing ---------------------------------------------------
 
 func TestRunCmd_ArgParsingErrors(t *testing.T) {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -23,9 +23,11 @@ import (
 	"github.com/nao1215/atago/internal/report"
 )
 
-// runCmd implements `atago run`.
-func runCmd(args []string, stdout, stderr io.Writer) int {
-	fs := flag.NewFlagSet("atago run", flag.ContinueOnError)
+// runCmd implements `atago run`. label is the command name to name in error
+// messages ("atago run", or "atago snapshot update" when snapshotCmd delegates
+// here), so a diagnostic identifies the command the user actually invoked.
+func runCmd(label string, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet(label, flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	reportFmt := fs.String("report", "console", "report format: console|json|junit|gha|tap")
 	updateSnapshots := fs.Bool("update-snapshots", false, "create or overwrite snapshot files instead of comparing")
@@ -60,7 +62,7 @@ func runCmd(args []string, stdout, stderr io.Writer) int {
 
 	format := report.Format(*reportFmt)
 	if !format.Valid() {
-		fmt.Fprintf(stderr, "atago run: unknown --report %q (want console, json, junit, gha, or tap)\n", *reportFmt)
+		fmt.Fprintf(stderr, label+": unknown --report %q (want console, json, junit, gha, or tap)\n", *reportFmt)
 		return ExitConfig
 	}
 
@@ -71,22 +73,22 @@ func runCmd(args []string, stdout, stderr io.Writer) int {
 
 	paths, err := collectSpecFiles(targets)
 	if err != nil {
-		fmt.Fprintf(stderr, "atago run: %v\n", err)
+		fmt.Fprintf(stderr, label+": %v\n", err)
 		return ExitConfig
 	}
 	if len(paths) == 0 {
-		fmt.Fprintln(stderr, "atago run: no *.atago.yaml files found")
+		fmt.Fprintln(stderr, label+": no *.atago.yaml files found")
 		return ExitConfig
 	}
 
 	// --repeat and --retry-failed answer opposite questions (does it flake? /
 	// keep CI green despite flakes) and would fight over the attempt loop.
 	if *repeat > 0 && *retryFailed > 0 {
-		fmt.Fprintln(stderr, "atago run: --repeat and --retry-failed are mutually exclusive (repeat detects flakiness, retry-failed tolerates it)")
+		fmt.Fprintln(stderr, label+": --repeat and --retry-failed are mutually exclusive (repeat detects flakiness, retry-failed tolerates it)")
 		return ExitConfig
 	}
 	if *repeat < 0 || *retryFailed < 0 {
-		fmt.Fprintln(stderr, "atago run: --repeat and --retry-failed must be >= 0")
+		fmt.Fprintln(stderr, label+": --repeat and --retry-failed must be >= 0")
 		return ExitConfig
 	}
 
@@ -118,17 +120,17 @@ func runCmd(args []string, stdout, stderr io.Writer) int {
 	if *rerunFailed {
 		state, lerr := loadRerunState()
 		if lerr != nil {
-			fmt.Fprintf(stderr, "atago run: cannot read %s: %v\n", rerunStatePath(), lerr)
+			fmt.Fprintf(stderr, label+": cannot read %s: %v\n", rerunStatePath(), lerr)
 			return ExitConfig
 		}
 		sel := state.selectSet()
 		if len(sel) == 0 {
-			fmt.Fprintln(stderr, "atago run: no previously failed scenarios recorded; nothing to rerun")
+			fmt.Fprintln(stderr, label+": no previously failed scenarios recorded; nothing to rerun")
 			return ExitOK
 		}
 		paths = intersectPaths(paths, state.specPaths())
 		if len(paths) == 0 {
-			fmt.Fprintln(stderr, "atago run: no previously failed scenarios under the given targets")
+			fmt.Fprintln(stderr, label+": no previously failed scenarios under the given targets")
 			return ExitOK
 		}
 		inScope := make(map[string]bool, len(paths))
@@ -213,7 +215,7 @@ func runCmd(args []string, stdout, stderr io.Writer) int {
 	// (already printed) are the real story, not a "renamed or removed" scenario.
 	rerunMatchedNothing := *rerunFailed && len(results) > 0 && ranScenarios == 0 && ctx.Err() == nil
 	if rerunMatchedNothing {
-		fmt.Fprintln(stderr, "atago run: warning: no recorded failing scenarios matched the current specs (renamed or removed?); the recorded failures were kept, not cleared")
+		fmt.Fprintln(stderr, label+": warning: no recorded failing scenarios matched the current specs (renamed or removed?); the recorded failures were kept, not cleared")
 		exit = worseExit(exit, ExitConfig)
 	}
 
@@ -230,7 +232,7 @@ func runCmd(args []string, stdout, stderr io.Writer) int {
 	// is a warning, not a fatal exit.
 	if len(results) > 0 && !rerunMatchedNothing {
 		if err := saveRerunState(append(collectFailures(results), rerunPreserved...)); err != nil {
-			fmt.Fprintf(stderr, "atago run: could not update %s: %v\n", rerunStatePath(), err)
+			fmt.Fprintf(stderr, label+": could not update %s: %v\n", rerunStatePath(), err)
 		}
 	}
 
@@ -239,7 +241,7 @@ func runCmd(args []string, stdout, stderr io.Writer) int {
 	// that was interrupted before completing must never exit 0.
 	if len(results) == 0 {
 		if ctx.Err() != nil {
-			fmt.Fprintln(stderr, "atago run: interrupted")
+			fmt.Fprintln(stderr, label+": interrupted")
 			return worseExit(exit, ExitExec)
 		}
 		return exit
@@ -264,19 +266,19 @@ func runCmd(args []string, stdout, stderr io.Writer) int {
 			if len(skipTag) > 0 {
 				sel = append(sel, fmt.Sprintf("--skip-tag %q", strings.Join(skipTag, ",")))
 			}
-			fmt.Fprintf(stderr, "atago run: warning: no scenarios matched %s (name matching is a case-sensitive substring)\n", strings.Join(sel, " "))
+			fmt.Fprintf(stderr, label+": warning: no scenarios matched %s (name matching is a case-sensitive substring)\n", strings.Join(sel, " "))
 		}
 	}
 
 	if err := report.Render(stdout, format, results, report.WithLoadFailures(loadFailures), report.WithElapsed(elapsed)); err != nil {
-		fmt.Fprintf(stderr, "atago run: failed to write report: %v\n", err)
+		fmt.Fprintf(stderr, label+": failed to write report: %v\n", err)
 		return worseExit(exit, ExitInternal)
 	}
 	// An interrupted run never reports success, even in the rare case where the
 	// signal landed between scenarios and every scheduled one was skipped: the run
 	// did not complete, so the exit code is at least an execution error (4).
 	if ctx.Err() != nil {
-		fmt.Fprintln(stderr, "atago run: interrupted")
+		fmt.Fprintln(stderr, label+": interrupted")
 		exit = worseExit(exit, ExitExec)
 	}
 	return exit

--- a/test/e2e/atago/edge.atago.yaml
+++ b/test/e2e/atago/edge.atago.yaml
@@ -91,3 +91,15 @@ scenarios:
       - assert:
           stdout:
             not_contains: "PASSED"
+
+  # A snapshot-update error must name `snapshot update`, not the `run` it
+  # delegates to, so the diagnostic matches the command the user typed.
+  - name: a snapshot update error names the snapshot command, not run
+    steps:
+      - run:
+          command: ${atago} snapshot update no-such-spec.atago.yaml
+      - assert:
+          exit_code: 3
+          stderr:
+            contains: "atago snapshot update: cannot access"
+            not_contains: "atago run:"


### PR DESCRIPTION
atago snapshot update delegates to the run command with --update-snapshots and inherited run error prefix. A missing target or a bad flag printed "atago run: cannot access ..." even though the user invoked snapshot update, so the diagnostic named a command they never typed.

runCmd now takes the invoked command label and uses it for every diagnostic and the flag-set name. The run path passes "atago run" (unchanged output); the snapshot path passes "atago snapshot update". A unit test asserts a snapshot-update error names snapshot update and not run, and a self-hosted E2E scenario checks the same behavior through the binary.

make test, make lint, and make e2e all pass (345 scenarios, 343 passed, 2 skipped).