### PR TITLE
test(e2e): pin matrix expansion boundary values

### DIFF
--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-69 suites · 337 scenarios
+70 suites · 342 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -224,6 +224,12 @@
 - [atago self-hosting / matrix scenarios](#atago-self-hosting--matrix-scenarios) — 2 scenarios
   - [matrix expands into one scenario per row](#scenario-matrix-expands-into-one-scenario-per-row)
   - [matrix without a templated name gets a deterministic suffix](#scenario-matrix-without-a-templated-name-gets-a-deterministic-suffix)
+- [atago self-hosting / matrix expansion boundary values](#atago-self-hosting--matrix-expansion-boundary-values) — 5 scenarios
+  - [each row substitutes into the scenario name](#scenario-each-row-substitutes-into-the-scenario-name)
+  - [a row with several variables substitutes all of them](#scenario-a-row-with-several-variables-substitutes-all-of-them)
+  - [a single-row matrix expands to exactly one scenario](#scenario-a-single-row-matrix-expands-to-exactly-one-scenario)
+  - [an empty matrix row list is a load-time error](#scenario-an-empty-matrix-row-list-is-a-load-time-error)
+  - [rows that expand to the same name are rejected as duplicates](#scenario-rows-that-expand-to-the-same-name-are-rejected-as-duplicates)
 - [atago self-hosting / mock http server (offline API-client testing)](#atago-self-hosting--mock-http-server-offline-api-client-testing) — 3 scenarios
   - [count, header, and body-json asserts pass against a real client](#scenario-count-header-and-body-json-asserts-pass-against-a-real-client)
   - [a failing count summarizes the recorded requests](#scenario-a-failing-count-summarizes-the-recorded-requests)
@@ -3763,6 +3769,116 @@ ${atago} run --report junit suffix.atago.yaml
 #### Then
 - exit code is `0`
 - stdout contains `name="row [n=1]"`, `name="row [n=2]"`
+## atago self-hosting / matrix expansion boundary values
+Source: `test/e2e/atago/matrix_edges.atago.yaml`
+### Scenario: each row substitutes into the scenario name
+#### Given
+- Fixture file `names.atago.yaml` is created.
+#### Inputs
+_Fixture `names.atago.yaml`:_
+```text
+version: "1"
+suite: {name: names}
+scenarios:
+  - name: "case ${n}"
+    matrix:
+      - {n: "1"}
+      - {n: "2"}
+      - {n: "3"}
+    steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+```
+#### When
+```shell
+${atago} run --ci --report json names.atago.yaml
+```
+#### Then
+- exit code is `0`
+- stdout at `$.suites[0].scenarios` has length 3; at `$.suites[0].scenarios[0].name` equals `case 1`; at `$.suites[0].scenarios[2].name` equals `case 3`
+### Scenario: a row with several variables substitutes all of them
+#### Given
+- Fixture file `multi.atago.yaml` is created.
+#### Inputs
+_Fixture `multi.atago.yaml`:_
+```text
+version: "1"
+suite: {name: multi}
+scenarios:
+  - name: "${who} speaks ${lang}"
+    matrix:
+      - {who: Alice, lang: en}
+      - {who: Bob, lang: fr}
+    steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+```
+#### When
+```shell
+${atago} run --ci --report json multi.atago.yaml
+```
+#### Then
+- exit code is `0`
+- stdout at `$.suites[0].scenarios[0].name` equals `Alice speaks en`; at `$.suites[0].scenarios[1].name` equals `Bob speaks fr`
+### Scenario: a single-row matrix expands to exactly one scenario
+#### Given
+- Fixture file `single.atago.yaml` is created.
+#### Inputs
+_Fixture `single.atago.yaml`:_
+```text
+version: "1"
+suite: {name: single}
+scenarios:
+  - name: "only ${k}"
+    matrix:
+      - {k: solo}
+    steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+```
+#### When
+```shell
+${atago} run --ci --report json single.atago.yaml
+```
+#### Then
+- exit code is `0`
+- stdout at `$.suites[0].scenarios` has length 1; at `$.suites[0].scenarios[0].name` equals `only solo`
+### Scenario: an empty matrix row list is a load-time error
+#### Given
+- Fixture file `emptymx.atago.yaml` is created.
+#### Inputs
+_Fixture `emptymx.atago.yaml`:_
+```text
+version: "1"
+suite: {name: emptymx}
+scenarios:
+  - name: "e ${n}"
+    matrix: []
+    steps: [{run: {shell: true, command: "exit 0"}}]
+```
+#### When
+```shell
+${atago} run emptymx.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `matrix must contain at least one row`
+### Scenario: rows that expand to the same name are rejected as duplicates
+#### Given
+- Fixture file `dupmx.atago.yaml` is created.
+#### Inputs
+_Fixture `dupmx.atago.yaml`:_
+```text
+version: "1"
+suite: {name: dupmx}
+scenarios:
+  - name: "dup ${n}"
+    matrix:
+      - {n: same}
+      - {n: same}
+    steps: [{run: {shell: true, command: "exit 0"}}]
+```
+#### When
+```shell
+${atago} run dupmx.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `duplicate scenario name "dup same"`
 ## atago self-hosting / mock http server (offline API-client testing)
 Source: `test/e2e/atago/mock_server.atago.yaml`
 ### Scenario: count, header, and body-json asserts pass against a real client

--- a/scripts/windows_portable_specs.sh
+++ b/scripts/windows_portable_specs.sh
@@ -26,6 +26,7 @@ printf '%s\n' \
   ./test/e2e/atago/exit_codes.atago.yaml \
   ./test/e2e/atago/loader_errors.atago.yaml \
   ./test/e2e/atago/cli_selection.atago.yaml \
+  ./test/e2e/atago/matrix_edges.atago.yaml \
   ./test/e2e/atago/file_equals.atago.yaml \
   ./test/e2e/atago/store_whole.atago.yaml \
   ./test/e2e/atago/json_list.atago.yaml \

--- a/test/e2e/atago/matrix_edges.atago.yaml
+++ b/test/e2e/atago/matrix_edges.atago.yaml
@@ -1,0 +1,119 @@
+version: "1"
+
+suite:
+  name: atago self-hosting / matrix expansion boundary values
+
+# A matrix turns one template scenario into one concrete scenario per row, with
+# each row's variables seeded for ${name} substitution — including in the
+# scenario name. These pin the boundaries: name substitution across rows, a
+# multi-variable row, a single row, and the two load-time rejections (an empty
+# row list, and rows that expand to the same name). Selection and validation are
+# OS-independent, and the commands are exit 0, a builtin of both shells, so the
+# suite runs in the Windows portable subset.
+scenarios:
+  - name: each row substitutes into the scenario name
+    steps:
+      - fixture:
+          file: names.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: names}
+            scenarios:
+              - name: "case ${n}"
+                matrix:
+                  - {n: "1"}
+                  - {n: "2"}
+                  - {n: "3"}
+                steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+      - run: {command: "${atago} run --ci --report json names.atago.yaml"}
+      - assert:
+          exit_code: 0
+          stdout:
+            json:
+              - path: "$.suites[0].scenarios"
+                length: 3
+              - path: "$.suites[0].scenarios[0].name"
+                equals: "case 1"
+              - path: "$.suites[0].scenarios[2].name"
+                equals: "case 3"
+
+  - name: a row with several variables substitutes all of them
+    steps:
+      - fixture:
+          file: multi.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: multi}
+            scenarios:
+              - name: "${who} speaks ${lang}"
+                matrix:
+                  - {who: Alice, lang: en}
+                  - {who: Bob, lang: fr}
+                steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+      - run: {command: "${atago} run --ci --report json multi.atago.yaml"}
+      - assert:
+          exit_code: 0
+          stdout:
+            json:
+              - path: "$.suites[0].scenarios[0].name"
+                equals: "Alice speaks en"
+              - path: "$.suites[0].scenarios[1].name"
+                equals: "Bob speaks fr"
+
+  - name: a single-row matrix expands to exactly one scenario
+    steps:
+      - fixture:
+          file: single.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: single}
+            scenarios:
+              - name: "only ${k}"
+                matrix:
+                  - {k: solo}
+                steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+      - run: {command: "${atago} run --ci --report json single.atago.yaml"}
+      - assert:
+          exit_code: 0
+          stdout:
+            json:
+              - path: "$.suites[0].scenarios"
+                length: 1
+              - path: "$.suites[0].scenarios[0].name"
+                equals: "only solo"
+
+  - name: an empty matrix row list is a load-time error
+    steps:
+      - fixture:
+          file: emptymx.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: emptymx}
+            scenarios:
+              - name: "e ${n}"
+                matrix: []
+                steps: [{run: {shell: true, command: "exit 0"}}]
+      - run: {command: "${atago} run emptymx.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr:
+            contains: "matrix must contain at least one row"
+
+  - name: rows that expand to the same name are rejected as duplicates
+    steps:
+      - fixture:
+          file: dupmx.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: dupmx}
+            scenarios:
+              - name: "dup ${n}"
+                matrix:
+                  - {n: same}
+                  - {n: same}
+                steps: [{run: {shell: true, command: "exit 0"}}]
+      - run: {command: "${atago} run dupmx.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr:
+            contains: 'duplicate scenario name "dup same"'


### PR DESCRIPTION
Adds a self-hosted E2E suite covering matrix expansion at its boundaries: a row variables substitute into the scenario name (read back from the json report), a multi-variable row substitutes all of them, a single row expands to exactly one scenario, an empty row list is a load-time error, and rows that expand to the same scenario name are rejected as duplicates after expansion.

Commands are exit 0, a builtin of both shells, and expansion, selection, and validation are OS-independent, so the suite joins the Windows portable subset.

make test, make lint, and make e2e all pass (350 scenarios, 348 passed, 2 skipped).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end coverage for matrix expansion boundary cases.
  * Documented new scenarios for variable substitution in scenario names, single-row matrices, empty matrix rows, and duplicate expanded names.
* **Documentation**
  * Updated the behavior specs documentation and table of contents to include the new matrix expansion section.
* **Tests**
  * Included the new matrix expansion test suite in Windows portable spec targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->