### PR TITLE
test(e2e): pin store capture boundary values

### DIFF
--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-71 suites · 351 scenarios
+72 suites · 357 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -368,6 +368,13 @@
 - [atago self-hosting / store](#atago-self-hosting--store) — 2 scenarios
   - [a stored JSON value is reusable in later commands](#scenario-a-stored-json-value-is-reusable-in-later-commands)
   - [storing from a missing JSON path is an execution error](#scenario-storing-from-a-missing-json-path-is-an-execution-error)
+- [atago self-hosting / store capture boundary values](#atago-self-hosting--store-capture-boundary-values) — 6 scenarios
+  - [a regex with a capture group stores the group](#scenario-a-regex-with-a-capture-group-stores-the-group)
+  - [a regex without a group stores the whole match](#scenario-a-regex-without-a-group-stores-the-whole-match)
+  - [a JSON path captures a scalar from stdout](#scenario-a-json-path-captures-a-scalar-from-stdout)
+  - [a JSON path captures a value from a generated file](#scenario-a-json-path-captures-a-value-from-a-generated-file)
+  - [a regex that matches nothing is an execution error](#scenario-a-regex-that-matches-nothing-is-an-execution-error)
+  - [a stored value does not leak into the next scenario](#scenario-a-stored-value-does-not-leak-into-the-next-scenario)
 - [atago self-hosting / store whole-content trim and text selectors (#158)](#atago-self-hosting--store-whole-content-trim-and-text-selectors-158) — 2 scenarios
   - [trim captures an opaque token and round-trips it as an argument](#scenario-trim-captures-an-opaque-token-and-round-trips-it-as-an-argument)
   - [text captures a whole multi-line file verbatim](#scenario-text-captures-a-whole-multi-line-file-verbatim)
@@ -6422,6 +6429,99 @@ ${atago} run bad-store.atago.yaml
 #### Then
 - exit code is `4`
 - stdout contains `ERROR`
+## atago self-hosting / store capture boundary values
+Source: `test/e2e/atago/store_edges.atago.yaml`
+### Scenario: a regex with a capture group stores the group
+#### When
+```shell
+echo release v1.2.3-rc1
+# capture ${ver} from stdout
+echo shipping ${ver}
+```
+#### Then
+- after `echo shipping ${ver}`:
+  - stdout equals an exact value
+### Scenario: a regex without a group stores the whole match
+#### When
+```shell
+echo digest sha=abc123def456
+# capture ${sha} from stdout
+echo checksum ${sha}
+```
+#### Then
+- after `echo checksum ${sha}`:
+  - stdout equals an exact value
+### Scenario: a JSON path captures a scalar from stdout
+#### When
+```shell
+printf '{"port":8080}'
+# capture ${port} from stdout
+echo bound ${port}
+```
+#### Then
+- after `echo bound ${port}`:
+  - stdout equals an exact value
+### Scenario: a JSON path captures a value from a generated file
+#### Given
+- Fixture file `meta.json` is created.
+#### Inputs
+_Fixture `meta.json`:_
+```text
+{"build":{"id":"b-42"}}
+```
+#### When
+```shell
+# capture ${build} from file meta.json
+echo build ${build}
+```
+#### Then
+- stdout equals an exact value
+### Scenario: a regex that matches nothing is an execution error
+#### Given
+- Fixture file `nomatch.atago.yaml` is created.
+#### Inputs
+_Fixture `nomatch.atago.yaml`:_
+```text
+version: "1"
+suite: {name: nomatch}
+scenarios:
+  - name: capture fails
+    steps:
+      - run: {shell: true, command: "echo hello"}
+      - store: {name: x, from: {stdout: {matches: "ABSENT([0-9]+)"}}}
+```
+#### When
+```shell
+${atago} run nomatch.atago.yaml
+```
+#### Then
+- exit code is `4`
+- stdout contains `did not match`
+### Scenario: a stored value does not leak into the next scenario
+#### Given
+- Fixture file `scope.atago.yaml` is created.
+#### Inputs
+_Fixture `scope.atago.yaml`:_
+```text
+version: "1"
+suite: {name: scope}
+scenarios:
+  - name: captures a value
+    steps:
+      - run: {shell: true, command: "echo secret-value"}
+      - store: {name: captured, from: {stdout: {trim: true}}}
+      - assert: {stdout: {contains: secret-value}}
+  - name: cannot reference the earlier value
+    steps:
+      - run: {command: "echo ${captured}"}
+```
+#### When
+```shell
+${atago} run scope.atago.yaml
+```
+#### Then
+- exit code is `4`
+- stdout contains `references ${captured}`, `no variable with that name is defined`
 ## atago self-hosting / store whole-content trim and text selectors (#158)
 Source: `test/e2e/atago/store_whole.atago.yaml`
 ### Scenario: trim captures an opaque token and round-trips it as an argument

--- a/test/e2e/atago/store_edges.atago.yaml
+++ b/test/e2e/atago/store_edges.atago.yaml
@@ -1,0 +1,92 @@
+version: "1"
+
+suite:
+  name: atago self-hosting / store capture boundary values
+
+# store captures a value from a step and later steps reference it as ${name}.
+# These pin the capture contract: a regex with a group captures the group, one
+# without captures the whole match, a JSON path and a file JSON path both work,
+# a regex that matches nothing is an execution error, and a stored value is
+# scenario-scoped — it does not leak into the next scenario. echo/printf are
+# POSIX builtins, so the suite runs on make e2e; store resolution is
+# OS-independent.
+scenarios:
+  - name: a regex with a capture group stores the group
+    steps:
+      - run: {shell: true, command: "echo release v1.2.3-rc1"}
+      - store: {name: ver, from: {stdout: {matches: "v([0-9.]+)-"}}}
+      - run: {shell: true, command: "echo shipping ${ver}"}
+      - assert:
+          stdout:
+            equals: "shipping 1.2.3"
+
+  - name: a regex without a group stores the whole match
+    steps:
+      - run: {shell: true, command: "echo digest sha=abc123def456"}
+      - store: {name: sha, from: {stdout: {matches: "[a-f0-9]{6,}"}}}
+      - run: {shell: true, command: "echo checksum ${sha}"}
+      - assert:
+          stdout:
+            equals: "checksum abc123def456"
+
+  - name: a JSON path captures a scalar from stdout
+    steps:
+      - run: {shell: true, command: "printf '{\"port\":8080}'"}
+      - store: {name: port, from: {stdout: {json: {path: "$.port"}}}}
+      - run: {shell: true, command: "echo bound ${port}"}
+      - assert:
+          stdout:
+            equals: "bound 8080"
+
+  - name: a JSON path captures a value from a generated file
+    steps:
+      - fixture:
+          file: meta.json
+          content: '{"build":{"id":"b-42"}}'
+      - store: {name: build, from: {file: {path: meta.json, json: {path: "$.build.id"}}}}
+      - run: {shell: true, command: "echo build ${build}"}
+      - assert:
+          stdout:
+            equals: "build b-42"
+
+  - name: a regex that matches nothing is an execution error
+    steps:
+      - fixture:
+          file: nomatch.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: nomatch}
+            scenarios:
+              - name: capture fails
+                steps:
+                  - run: {shell: true, command: "echo hello"}
+                  - store: {name: x, from: {stdout: {matches: "ABSENT([0-9]+)"}}}
+      - run: {command: "${atago} run nomatch.atago.yaml"}
+      - assert:
+          exit_code: 4
+          stdout:
+            contains: "did not match"
+
+  - name: a stored value does not leak into the next scenario
+    steps:
+      - fixture:
+          file: scope.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: scope}
+            scenarios:
+              - name: captures a value
+                steps:
+                  - run: {shell: true, command: "echo secret-value"}
+                  - store: {name: captured, from: {stdout: {trim: true}}}
+                  - assert: {stdout: {contains: secret-value}}
+              - name: cannot reference the earlier value
+                steps:
+                  - run: {command: "echo ${captured}"}
+      - run: {command: "${atago} run scope.atago.yaml"}
+      - assert:
+          exit_code: 4
+          stdout:
+            contains:
+              - "references ${captured}"
+              - "no variable with that name is defined"


### PR DESCRIPTION
Adds a self-hosted E2E suite for the store contract: a regex with a capture group stores the group while one without stores the whole match, a JSON path captures a scalar from stdout and from a generated file, a regex that matches nothing is an execution error, and a stored value is scenario-scoped — the next scenario cannot reference it and fails resolution.

echo/printf are POSIX builtins so the suite runs on make e2e; store resolution is OS-independent.

make test, make lint, and make e2e all pass (365 scenarios, 363 passed, 2 skipped).