### PR TITLE
fix(loader): recover from a decoder panic on malformed YAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Loading a spec no longer crashes on malformed YAML. Some inputs (a bare `!`
+  tag over a broken mapping) made the underlying goccy/go-yaml decoder panic
+  with a nil pointer dereference, which propagated out of the loader and aborted
+  atago. Loading now recovers from a decoder panic and reports a clean parse
+  error, honoring the contract that loading untrusted spec bytes never crashes.
+  Found by FuzzLoadBytes; the crasher is kept as a regression seed.
+
 - An error from `atago snapshot update` now names that command instead of the
   `atago run` it delegates to internally. A missing target or a bad flag printed
   `atago run: ...` even though the user typed `snapshot update`; the diagnostic

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -50,6 +50,23 @@ func Load(path string) (*spec.Spec, error) {
 	return LoadBytes(path, data)
 }
 
+// decodeSpec decodes one YAML document into s, converting a panic from the
+// third-party decoder into an ordinary error. goccy/go-yaml can nil-panic on
+// some malformed input (a bare `!` tag over a broken mapping, found by
+// FuzzLoadBytes); atago's contract is that loading untrusted spec bytes never
+// crashes the process, so recover here and let the caller report a parse error.
+func decodeSpec(dec *yaml.Decoder, s *spec.Spec) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			// Report a spec problem, not the raw runtime panic: "nil pointer
+			// dereference" reads like an atago crash, but the cause is malformed
+			// input the third-party decoder mishandled.
+			err = fmt.Errorf("malformed YAML: the document could not be parsed")
+		}
+	}()
+	return dec.Decode(s)
+}
+
 // LoadBytes parses and validates spec bytes, labeling errors with path.
 func LoadBytes(path string, data []byte) (*spec.Spec, error) {
 	// Strip a leading UTF-8 byte-order mark. Windows/Notepad-family editors emit
@@ -60,7 +77,7 @@ func LoadBytes(path string, data []byte) (*spec.Spec, error) {
 	data = bytes.TrimPrefix(data, []byte("\ufeff"))
 	var s spec.Spec
 	dec := yaml.NewDecoder(bytes.NewReader(data), yaml.Strict())
-	if err := dec.Decode(&s); err != nil {
+	if err := decodeSpec(dec, &s); err != nil {
 		// An empty document (empty file, whitespace, or comments only) decodes to
 		// io.EOF, whose bare "EOF" tells the user nothing. Name the problem and
 		// what a spec needs instead.

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -742,6 +742,32 @@ func TestLoadBytes_Errors(t *testing.T) {
 	}
 }
 
+// TestLoadBytes_MalformedYAMLDoesNotPanic pins the loader's no-panic contract on
+// untrusted input: some malformed YAML makes the underlying goccy/go-yaml decoder
+// nil-panic (found by FuzzLoadBytes). LoadBytes must recover and return a clean
+// parse error instead of crashing the process.
+func TestLoadBytes_MalformedYAMLDoesNotPanic(t *testing.T) {
+	t.Parallel()
+	// Reduced from the fuzz crasher testdata/fuzz/FuzzLoadBytes/230de42ba4751bda.
+	inputs := []string{
+		"A: 0\nrunners:\n 0: {0000000000000\"}\nscenarios:\n  ! 00",
+		"scenarios:\n  ! 0",
+	}
+	for _, src := range inputs {
+		s, err := LoadBytes("t.atago.yaml", []byte(src))
+		if err == nil {
+			t.Errorf("LoadBytes(%q) = nil error, want a parse error for malformed YAML", src)
+		}
+		if s != nil {
+			t.Errorf("LoadBytes(%q) returned a non-nil spec with a parse error", src)
+		}
+		var lerr *Error
+		if errors.As(err, &lerr) && lerr.Kind != KindParse {
+			t.Errorf("LoadBytes(%q) kind = %v, want KindParse", src, lerr.Kind)
+		}
+	}
+}
+
 // specSteps assembles a minimal one-scenario spec whose steps are the given
 // flow-style step entries (each is the text after "- " in a steps list). It
 // keeps the many one-off validation cases readable without hand-indenting YAML.

--- a/internal/loader/testdata/fuzz/FuzzLoadBytes/230de42ba4751bda
+++ b/internal/loader/testdata/fuzz/FuzzLoadBytes/230de42ba4751bda
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("A: 0\nrunners:\n 0: {0000000000000\"}\nscenarios:\n  ! 00")


### PR DESCRIPTION
Loading a spec crashed the process on some malformed input: a bare ! tag over a broken mapping made the underlying goccy/go-yaml decoder nil-panic, and the panic propagated out of LoadBytes and aborted atago. The loader contract — loading untrusted spec bytes never crashes, however malformed the YAML — was violated.

The decode is now wrapped in a helper that recovers from a decoder panic and returns a parse error, so a malformed spec is rejected cleanly (exit 2) instead of crashing. The message names the input as the problem rather than surfacing the raw runtime panic, which read like an atago bug.

Found by FuzzLoadBytes; the crasher is committed as a regression seed and a reduced deterministic case is added to the loader tests. A 200s re-fuzz over 1.7M executions surfaced no further crashers.

make test, make lint, and make e2e all pass.