### PR TITLE
fix(assert,engine): recover from a JSON parser panic on malformed output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- A `json` assertion or a `store` capture no longer crashes on malformed JSON
+  from the program under test. The third-party JSON parser (ojg) panics with
+  "assignment to entry in nil map" on some inputs, and the panic propagated out
+  and aborted atago. Both the matcher and the store capture now recover from a
+  parser panic and report invalid JSON, so a broken payload is a normal
+  assertion failure or capture error, not a crash. Found by FuzzValuesEqual.
+
 - Loading a spec no longer crashes on malformed YAML. Some inputs (a bare `!`
   tag over a broken mapping) made the underlying goccy/go-yaml decoder panic
   with a nil pointer dereference, which propagated out of the loader and aborted

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-72 suites · 357 scenarios
+72 suites · 358 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -74,11 +74,12 @@
   - [an impossible bound fails and shows the measured duration](#scenario-an-impossible-bound-fails-and-shows-the-measured-duration)
   - [a deliberate wait satisfies a lower bound](#scenario-a-deliberate-wait-satisfies-a-lower-bound)
   - [a duration assert with no preceding step is a load-time error](#scenario-a-duration-assert-with-no-preceding-step-is-a-load-time-error)
-- [atago self-hosting / edge cases](#atago-self-hosting--edge-cases) — 4 scenarios
+- [atago self-hosting / edge cases](#atago-self-hosting--edge-cases) — 5 scenarios
   - [JSON assertion on empty stdout reports an empty stream](#scenario-json-assertion-on-empty-stdout-reports-an-empty-stream)
   - [an unsupported matcher is a parse error](#scenario-an-unsupported-matcher-is-a-parse-error)
   - [a mixed valid+invalid run reads FAILED and counts the dropped spec](#scenario-a-mixed-validinvalid-run-reads-failed-and-counts-the-dropped-spec)
   - [a snapshot update error names the snapshot command, not run](#scenario-a-snapshot-update-error-names-the-snapshot-command-not-run)
+  - [a json assertion on malformed input fails cleanly, without a crash](#scenario-a-json-assertion-on-malformed-input-fails-cleanly-without-a-crash)
 - [atago self-hosting / workdir + scenario env + not_contains](#atago-self-hosting--workdir--scenario-env--not_contains) — 6 scenarios
   - [run.stdout_to redirects stdout to a workdir file without a shell](#scenario-runstdout_to-redirects-stdout-to-a-workdir-file-without-a-shell)
   - [scenario env is shared by every run step and overridable per step](#scenario-scenario-env-is-shared-by-every-run-step-and-overridable-per-step)
@@ -1771,6 +1772,27 @@ ${atago} snapshot update no-such-spec.atago.yaml
 #### Then
 - exit code is `3`
 - stderr contains `atago snapshot update: cannot access`
+### Scenario: a json assertion on malformed input fails cleanly, without a crash
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: badjson}
+scenarios:
+  - name: json on broken bytes
+    steps:
+      - fixture: {file: broken.json, content: '{"":f,"":0 0'}
+      - assert: {file: {path: broken.json, json: {path: "$.x", equals: 1}}}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `not valid JSON`
 ## atago self-hosting / workdir + scenario env + not_contains
 Source: `test/e2e/atago/env_workdir.atago.yaml`
 ### Scenario: run.stdout_to redirects stdout to a workdir file without a shell

--- a/internal/assert/assert_test.go
+++ b/internal/assert/assert_test.go
@@ -680,6 +680,24 @@ func TestCheck_JSON_EmptyStdout(t *testing.T) {
 	}
 }
 
+// TestCheck_JSON_MalformedDoesNotPanic pins the no-panic contract on the
+// untrusted output of the program under test: some malformed JSON makes the
+// third-party ojg parser panic ("assignment to entry in nil map", found by
+// FuzzValuesEqual). A json assertion must report invalid JSON, not crash.
+func TestCheck_JSON_MalformedDoesNotPanic(t *testing.T) {
+	t.Parallel()
+	for _, data := range []string{`{"":f,"":0 0`, `{"a":`, `[1,2,`, `{`} {
+		res := &runner.Result{Stdout: []byte(data)}
+		got := Check(&spec.Assert{Stdout: &spec.StreamAssert{JSON: spec.JSONChecks{{Path: "$.x", Equals: 1}}}}, res, Env{})
+		if got.OK {
+			t.Errorf("malformed JSON %q unexpectedly passed the assertion", data)
+		}
+		if !strings.Contains(got.Hint, "not valid JSON") {
+			t.Errorf("hint = %q, want it to name invalid JSON", got.Hint)
+		}
+	}
+}
+
 // Issue #32: json length and stream empty matchers were only tested on their
 // passing direction. Cover the failure and value-type branches.
 func TestCheck_JSON_Length(t *testing.T) {

--- a/internal/assert/fuzz_test.go
+++ b/internal/assert/fuzz_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/nao1215/atago/internal/spec"
-	"github.com/ohler55/ojg/oj"
 )
 
 // FuzzCheckJSON feeds arbitrary document bytes and an arbitrary JSONPath to the
@@ -35,14 +34,16 @@ func FuzzCheckJSON(f *testing.F) {
 
 // FuzzValuesEqual asserts that structural comparison of decoded JSON values is
 // reflexive and total: a parsed value always equals itself, and comparing any
-// two parsed values never panics (issue #46, #40).
+// two parsed values never panics (issue #46, #40). It parses through the same
+// panic-recovering parseJSON the matcher uses, so an ojg parser panic on
+// malformed input is a skipped case here, not a fuzz failure.
 func FuzzValuesEqual(f *testing.F) {
 	for _, s := range []string{`1`, `"s"`, `[1,2]`, `{"a":1,"b":[2,3]}`, `null`, `true`, `1.5`} {
 		f.Add([]byte(s), []byte(`{"a":1}`))
 	}
 	f.Fuzz(func(t *testing.T, a, b []byte) {
-		va, errA := oj.Parse(a)
-		vb, errB := oj.Parse(b)
+		va, errA := parseJSON(a)
+		vb, errB := parseJSON(b)
 		if errA != nil || errB != nil {
 			return
 		}

--- a/internal/assert/jsonmatch.go
+++ b/internal/assert/jsonmatch.go
@@ -2,6 +2,7 @@ package assert
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -68,7 +69,7 @@ func parseDoc(desc, name string, data []byte, isYAML bool) (any, *CheckResult) {
 	if isYAML {
 		err = yaml.Unmarshal(data, &parsed)
 	} else {
-		parsed, err = oj.Parse(data)
+		parsed, err = parseJSON(data)
 	}
 	if err != nil {
 		return nil, &CheckResult{
@@ -79,6 +80,20 @@ func parseDoc(desc, name string, data []byte, isYAML bool) (any, *CheckResult) {
 		}
 	}
 	return parsed, nil
+}
+
+// parseJSON decodes JSON, converting a panic from the third-party parser into an
+// error. ojg's oj.Parse can panic ("assignment to entry in nil map") on some
+// malformed input; the payload is the untrusted output of the program under
+// test, so atago must report invalid JSON rather than crash. Found by
+// FuzzValuesEqual.
+func parseJSON(data []byte) (v any, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			v, err = nil, errors.New("the parser could not decode it")
+		}
+	}()
+	return oj.Parse(data)
 }
 
 // checkJSON parses data as JSON, selects nodes with a JSONPath, and applies the

--- a/internal/assert/testdata/fuzz/FuzzValuesEqual/7f02a039449eb0c2
+++ b/internal/assert/testdata/fuzz/FuzzValuesEqual/7f02a039449eb0c2
@@ -1,0 +1,3 @@
+go test fuzz v1
+[]byte("{\"\":f,\"\":0 0")
+[]byte("0")

--- a/internal/engine/store.go
+++ b/internal/engine/store.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -101,9 +102,23 @@ func extractStream(s *spec.StreamAssert, data []byte) (string, error) {
 	}
 }
 
+// parseJSON decodes JSON, converting a panic from the third-party parser into an
+// error. ojg's oj.Parse can panic ("assignment to entry in nil map") on some
+// malformed input; a store captures from the untrusted output of the program
+// under test, so report invalid JSON rather than crash — the same defense the
+// assert matcher applies.
+func parseJSON(data []byte) (v any, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			v, err = nil, errors.New("the parser could not decode it")
+		}
+	}()
+	return oj.Parse(data)
+}
+
 // jsonValue selects exactly one value at path and returns it as a string.
 func jsonValue(data []byte, path string) (string, error) {
-	v, err := oj.Parse(data)
+	v, err := parseJSON(data)
 	if err != nil {
 		return "", fmt.Errorf("invalid JSON: %w", err)
 	}

--- a/internal/engine/store_test.go
+++ b/internal/engine/store_test.go
@@ -42,6 +42,20 @@ func TestJSONValue(t *testing.T) {
 	}
 }
 
+// TestJSONValue_MalformedDoesNotPanic pins the no-panic contract for a store
+// capture over the untrusted output of the program under test: some malformed
+// JSON makes the third-party ojg parser panic; jsonValue must report invalid
+// JSON instead of crashing the run.
+func TestJSONValue_MalformedDoesNotPanic(t *testing.T) {
+	t.Parallel()
+	for _, data := range []string{`{"":f,"":0 0`, `{"a":`, `[1,2,`, `{`} {
+		_, err := jsonValue([]byte(data), "$.x")
+		if err == nil {
+			t.Errorf("jsonValue(%q) err = nil, want an invalid-JSON error", data)
+		}
+	}
+}
+
 func TestRegexValue(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/test/e2e/atago/edge.atago.yaml
+++ b/test/e2e/atago/edge.atago.yaml
@@ -103,3 +103,26 @@ scenarios:
           stderr:
             contains: "atago snapshot update: cannot access"
             not_contains: "atago run:"
+
+  # Malformed JSON from the program under test must be reported as invalid JSON,
+  # not crash atago: the third-party parser can panic on some inputs, and the
+  # loader/matcher recover from it. The fixture holds the exact broken bytes so
+  # this runs on every OS (no shell heredoc needed).
+  - name: a json assertion on malformed input fails cleanly, without a crash
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: badjson}
+            scenarios:
+              - name: json on broken bytes
+                steps:
+                  - fixture: {file: broken.json, content: '{"":f,"":0 0'}
+                  - assert: {file: {path: broken.json, json: {path: "$.x", equals: 1}}}
+      - run:
+          command: ${atago} run bad.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains: "not valid JSON"


### PR DESCRIPTION
A json assertion or a store capture crashed atago when the program under test emitted malformed JSON: the third-party parser (ohler55/ojg) panics with "assignment to entry in nil map" on some inputs, and the panic propagated out of both call sites and aborted the run. atago parses the untrusted output of the program under test, so it must diagnose invalid JSON, not crash.

Both call sites now decode through a helper that recovers from a parser panic and returns an error, so a broken payload is a normal assertion failure (not valid JSON) or a store capture error. JSONPath support is why atago depends on ojg, so atago keeps the parser; the fix is a defensive recover on the atago side, not a change to the dependency.

Adds unit tests in internal/assert and internal/engine that a malformed payload is reported rather than crashing the run, a Windows-portable self-hosted E2E driving a json assertion over broken bytes, and a fuzz crasher kept as a regression seed. FuzzValuesEqual now parses through the same recovering helper.

make test, make lint, and make e2e all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JSON assertions and stored JSON captures now fail gracefully on malformed input instead of crashing.
  * Invalid JSON is reported as a normal error message, helping runs exit cleanly with a clear “not valid JSON” indication.
  * Added regression coverage for malformed JSON cases to prevent this issue from returning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->