### PR TITLE
feat(pty): run pty steps on Windows via a self-contained ConPTY runner

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -102,3 +102,18 @@ jobs:
         run: |
           mapfile -t targets < <(bash scripts/windows_portable_specs.sh)
           go run . run "${targets[@]}"
+
+      # Real-world proof that the ConPTY pty runner drives an INTERACTIVE CLI on
+      # Windows, not just self-terminating output: sqly's shell is a readline
+      # REPL (built on nao1215/prompt) that only starts when stdin is a TTY. A
+      # pinned sqly runs one pty spec that sends a query and `.exit` and asserts
+      # the result — exercising the ConPTY send path end to end.
+      - name: Install pinned sqly for the interactive pty check
+        shell: bash
+        run: |
+          go install github.com/nao1215/sqly@v0.26.0
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Drive sqly's interactive shell over a Windows pty
+        shell: bash
+        run: go run . run ./test/e2e/tools/sqly/repl_pty.atago.yaml

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ scenarios:
           exit_code: 0
 ```
 
-Named keys (`send: {key: enter}`) and asserts on the RENDERED terminal screen cover full TUIs — see [pty](examples/pty.atago.yaml) and [pty_screen](examples/pty_screen.atago.yaml) (POSIX-only).
+Named keys (`send: {key: enter}`) and asserts on the RENDERED terminal screen cover full TUIs — see [pty](examples/pty.atago.yaml), [pty_screen](examples/pty_screen.atago.yaml), and the cross-platform [pty_portable](examples/pty_portable.atago.yaml). `pty` steps run on Linux, macOS, and Windows (where they drive a ConPTY pseudo-console); only `record --pty` and `signal:` stay POSIX-only. The `pty`/`pty_screen` examples skip on Windows because their inner commands (`[ -t 0 ]`, `cat -v`, a SIGINT trap) are POSIX-specific, not because the `pty` mechanism is.
 
 ### When your CLI talks to a server
 
@@ -225,8 +225,9 @@ Every feature has a commented, runnable spec under [examples/](examples/). The e
 | [stdin](examples/stdin.atago.yaml) | stdin sources: inline text, `stdin: {file: ...}` from a workdir file, and binary input via `stdin: {base64: ...}` |
 | [matrix](examples/matrix.atago.yaml) | one template scenario expanded per parameter row |
 | [mock_server](examples/mock_server.atago.yaml) | test API-client CLIs offline: `mock_servers` serve canned routes, record every request, and `mock:` asserts what the client actually sent |
-| [pty](examples/pty.atago.yaml) | interactive testing in a real pseudo-terminal: expect/send sessions, named keys (`send: {key: enter}`), TTY-detection (POSIX-only) |
-| [pty_screen](examples/pty_screen.atago.yaml) | TUI testing on the RENDERED terminal screen: vt100 emulation, row-addressed asserts, and screen snapshots (POSIX-only) |
+| [pty](examples/pty.atago.yaml) | interactive testing in a real pseudo-terminal: expect/send sessions, named keys (`send: {key: enter}`), TTY-detection (scenarios use POSIX-only inner commands) |
+| [pty_portable](examples/pty_portable.atago.yaml) | the same `pty` mechanism on every OS — Linux, macOS, and Windows (ConPTY): drive a self-terminating command, match its output, assert the rendered screen |
+| [pty_screen](examples/pty_screen.atago.yaml) | TUI testing on the RENDERED terminal screen: vt100 emulation, row-addressed asserts, and screen snapshots (scenarios use POSIX-only inner commands) |
 | [retry](examples/retry.atago.yaml) | polling a command until an assertion passes |
 | [snapshot](examples/snapshot.atago.yaml) | golden-file testing with normalized output |
 | [scrub](examples/scrub.atago.yaml) | `scrub:` rewrites volatile output patterns (auto-increment IDs, request identifiers, epoch times) to a placeholder before a snapshot compares — the flake-killer the built-in normalizers do not cover |

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-73 suites · 366 scenarios
+74 suites · 374 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -279,6 +279,15 @@
   - [a screen snapshot round-trips through update and compare](#scenario-a-screen-snapshot-round-trips-through-update-and-compare)
   - [a screen assert without a pty step is a load-time error](#scenario-a-screen-assert-without-a-pty-step-is-a-load-time-error)
   - [a send referencing an undefined variable is an execution error, not typed literally](#scenario-a-send-referencing-an-undefined-variable-is-an-execution-error-not-typed-literally)
+- [atago self-hosting / pty (portable)](#atago-self-hosting--pty-portable) — 8 scenarios
+  - [a pty step starts a command, captures its output, and reports exit 0](#scenario-a-pty-step-starts-a-command-captures-its-output-and-reports-exit-0)
+  - [a pty step surfaces a command's non-zero exit code](#scenario-a-pty-step-surfaces-a-commands-non-zero-exit-code)
+  - [sequential expects match successive output in declaration order](#scenario-sequential-expects-match-successive-output-in-declaration-order)
+  - [an expect pattern is a regular expression, not a literal](#scenario-an-expect-pattern-is-a-regular-expression-not-a-literal)
+  - [a screen assert reads the rendered frame sized by rows and cols](#scenario-a-screen-assert-reads-the-rendered-frame-sized-by-rows-and-cols)
+  - [a pty step drives the atago binary directly with no shell](#scenario-a-pty-step-drives-the-atago-binary-directly-with-no-shell)
+  - [a pty drives atago running an inner spec to a green result](#scenario-a-pty-drives-atago-running-an-inner-spec-to-a-green-result)
+  - [a never-matching expect fails and names the pattern in the transcript](#scenario-a-never-matching-expect-fails-and-names-the-pattern-in-the-transcript)
 - [atago self-hosting / record (spec skeleton from an observed run)](#atago-self-hosting--record-spec-skeleton-from-an-observed-run) — 13 scenarios
   - [record then run round-trips green](#scenario-record-then-run-round-trips-green)
   - [refusing to overwrite without --force](#scenario-refusing-to-overwrite-without---force)
@@ -4700,6 +4709,107 @@ ${atago} run typo.atago.yaml
 #### Then
 - exit code is `4`
 - stdout contains `no variable with that name is defined`, `$${no_such_var}`
+## atago self-hosting / pty (portable)
+Source: `test/e2e/atago/pty_portable.atago.yaml`
+### Scenario: a pty step starts a command, captures its output, and reports exit 0
+#### When
+```shell
+# interactive (pty): echo hello from a pty
+```
+#### Then
+- exit code is `0`
+- stdout contains `hello from a pty`
+### Scenario: a pty step surfaces a command's non-zero exit code
+#### When
+```shell
+# interactive (pty): echo bye && exit 3
+```
+#### Then
+- exit code is `3`
+### Scenario: sequential expects match successive output in declaration order
+#### When
+```shell
+# interactive (pty): echo first && echo second && echo third
+```
+#### Then
+- exit code is `0`
+- stdout contains `first`, `third`
+### Scenario: an expect pattern is a regular expression, not a literal
+#### When
+```shell
+# interactive (pty): echo item-42-done
+```
+#### Then
+- exit code is `0`
+### Scenario: a screen assert reads the rendered frame sized by rows and cols
+#### When
+```shell
+# interactive (pty): echo rendered line
+```
+#### Then
+- exit code is `0`
+- rendered screen contains `rendered line`
+### Scenario: a pty step drives the atago binary directly with no shell
+#### When
+```shell
+# interactive (pty): ${atago} version
+```
+#### Then
+- exit code is `0`
+- stdout contains `atago`
+### Scenario: a pty drives atago running an inner spec to a green result
+#### Given
+- Fixture file `inner.atago.yaml` is created.
+#### Inputs
+_Fixture `inner.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: inner
+scenarios:
+  - name: echo
+    steps:
+      - run:
+          shell: true
+          command: echo inner-ok
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: inner-ok
+```
+#### When
+```shell
+# interactive (pty): ${atago} run inner.atago.yaml
+```
+#### Then
+- exit code is `0`
+- stdout contains `1 passed`
+### Scenario: a never-matching expect fails and names the pattern in the transcript
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: inner
+scenarios:
+  - name: waits for output that never comes
+    steps:
+      - pty:
+          shell: true
+          command: echo present
+          timeout: 2s
+          session:
+            - expect: "absent-forever"
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `pty expect /absent-forever/`, `never appeared in the terminal transcript`
 ## atago self-hosting / record (spec skeleton from an observed run)
 Source: `test/e2e/atago/record.atago.yaml`
 ### Scenario: record then run round-trips green

--- a/doc/e2e/sqly.md
+++ b/doc/e2e/sqly.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-46 suites · 393 scenarios
+47 suites · 397 scenarios
 ## Contents
 - [sqly ACH/Fedwire native write-back](#sqly-achfedwire-native-write-back) — 4 scenarios
   - [round-trips an ACH file through --save --force after an UPDATE](#scenario-round-trips-an-ach-file-through---save---force-after-an-update)
@@ -226,6 +226,11 @@
   - [loads ACH records into multiple tables](#scenario-loads-ach-records-into-multiple-tables)
   - [queries the ACH entries table](#scenario-queries-the-ach-entries-table)
   - [loads a Fedwire file into a single message table](#scenario-loads-a-fedwire-file-into-a-single-message-table)
+- [sqly interactive shell (pty)](#sqly-interactive-shell-pty) — 4 scenarios
+  - [run a query and read its rendered result table over a pty](#scenario-run-a-query-and-read-its-rendered-result-table-over-a-pty)
+  - [the .tables dot-command renders the imported table over a pty](#scenario-the-tables-dot-command-renders-the-imported-table-over-a-pty)
+  - [a computed aggregate round-trips through the pty shell](#scenario-a-computed-aggregate-round-trips-through-the-pty-shell)
+  - [the prompt reflects a live .mode switch over a pty](#scenario-the-prompt-reflects-a-live-mode-switch-over-a-pty)
 - [sqly sandbox_home + changes (history DB isolation)](#sqly-sandbox_home--changes-history-db-isolation) — 2 scenarios
   - [sqly --sql writes exactly its history DB, only inside the sandbox home](#scenario-sqly---sql-writes-exactly-its-history-db-only-inside-the-sandbox-home)
   - [a second sqly batch run leaves its sandbox home byte-identical](#scenario-a-second-sqly-batch-run-leaves-its-sandbox-home-byte-identical)
@@ -4245,6 +4250,76 @@ sqly customer-transfer.fed
 #### Then
 - exit code is `0`
 - stdout contains `customer_transfer_message`
+## sqly interactive shell (pty)
+Source: `test/e2e/tools/sqly/repl_pty.atago.yaml`
+### Scenario: run a query and read its rendered result table over a pty
+#### Given
+- Fixture file `actor.csv` is created.
+#### Inputs
+_Fixture `actor.csv`:_
+```text
+actor,gross
+Harrison Ford,4871
+Samuel L. Jackson,4772
+```
+#### When
+```shell
+# interactive (pty): sqly actor.csv
+```
+#### Then
+- exit code is `0`
+- stdout contains `Harrison Ford`, `+--`
+- rendered screen contains `Harrison Ford`
+### Scenario: the .tables dot-command renders the imported table over a pty
+#### Given
+- Fixture file `actor.csv` is created.
+#### Inputs
+_Fixture `actor.csv`:_
+```text
+actor,gross
+Harrison Ford,4871
+Samuel L. Jackson,4772
+```
+#### When
+```shell
+# interactive (pty): sqly actor.csv
+```
+#### Then
+- exit code is `0`
+- stdout contains `TABLE NAME`, `actor`
+### Scenario: a computed aggregate round-trips through the pty shell
+#### Given
+- Fixture file `actor.csv` is created.
+#### Inputs
+_Fixture `actor.csv`:_
+```text
+actor,gross
+Harrison Ford,4871
+Samuel L. Jackson,4772
+```
+#### When
+```shell
+# interactive (pty): sqly actor.csv
+```
+#### Then
+- exit code is `0`
+- stdout contains `ROWS=2`
+### Scenario: the prompt reflects a live .mode switch over a pty
+#### Given
+- Fixture file `actor.csv` is created.
+#### Inputs
+_Fixture `actor.csv`:_
+```text
+actor,gross
+Harrison Ford,4871
+Samuel L. Jackson,4772
+```
+#### When
+```shell
+# interactive (pty): sqly actor.csv
+```
+#### Then
+- exit code is `0`
 ## sqly sandbox_home + changes (history DB isolation)
 Source: `test/e2e/tools/sqly/sandbox_home.atago.yaml`
 ### Scenario: sqly --sql writes exactly its history DB, only inside the sandbox home

--- a/drift_test.go
+++ b/drift_test.go
@@ -410,6 +410,7 @@ var exampleSpecs = map[string]bool{ // path -> hermetic (run, not just validate)
 	"examples/matrix.atago.yaml":              true,
 	"examples/mock_server.atago.yaml":         true,
 	"examples/pty.atago.yaml":                 true,
+	"examples/pty_portable.atago.yaml":        true,
 	"examples/pty_screen.atago.yaml":          true,
 	"examples/retry.atago.yaml":               true,
 	"examples/run_and_assert.atago.yaml":      true,

--- a/examples/pty_portable.atago.yaml
+++ b/examples/pty_portable.atago.yaml
@@ -1,0 +1,39 @@
+# A `pty` step works on every platform atago supports — Linux, macOS, and
+# Windows, where it drives a ConPTY pseudo-console instead of a POSIX pty. This
+# example stays portable by running a shell builtin (echo) that self-terminates,
+# so it needs no POSIX-only program and is exercised in CI on all three OSes.
+#
+# The sibling pty.atago.yaml / pty_screen.atago.yaml examples show richer
+# sessions (named keys, TTY detection, screen snapshots) but use POSIX-only
+# inner commands, so their scenarios skip on Windows. Only `record --pty` and
+# `signal:` remain POSIX-only features.
+version: "1"
+
+suite:
+  name: pty (portable across OSes)
+
+scenarios:
+  - name: a pty runs a command, matches its output, and reports exit 0
+    steps:
+      - pty:
+          shell: true # echo is a shell builtin on both /bin/sh and cmd.exe
+          command: echo hello from a pty
+          session:
+            - expect: "hello from a pty"
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "hello from a pty"
+
+  - name: a screen assert reads the rendered frame on every platform
+    steps:
+      - pty:
+          shell: true
+          command: echo rendered line
+          rows: 10
+          cols: 40
+      - assert:
+          # The rendered screen (vt10x emulation) is derived from the same bytes
+          # on every platform, so a screen assert is portable too.
+          screen:
+            contains: "rendered line"

--- a/internal/runner/ptyrun/conpty_windows.go
+++ b/internal/runner/ptyrun/conpty_windows.go
@@ -1,0 +1,245 @@
+//go:build windows
+
+package ptyrun
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// conPTY is a self-contained Windows pseudo-console (ConPTY). It wires a child
+// process's console I/O to a pipe pair through a PseudoConsole and exposes
+// Read/Write/Resize/wait/Close. It calls the ConPTY and process-creation APIs
+// directly through golang.org/x/sys/windows (already a dependency), so atago
+// carries no third-party ConPTY library: the surface is small and the Win32
+// calls are stable since Windows 10 (1809).
+//
+// It follows Microsoft's documented pseudo-console recipe: CreatePseudoConsole
+// over a pipe pair, a PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE attribute list, then
+// CreateProcess with EXTENDED_STARTUPINFO_PRESENT.
+type conPTY struct {
+	hpc       windows.Handle // the pseudo console (HPCON)
+	inWrite   windows.Handle // parent → child (sends)
+	outRead   windows.Handle // child → parent (transcript)
+	process   windows.Handle // child process handle, for wait/kill
+	pid       uint32
+	attrList  *windows.ProcThreadAttributeListContainer
+	closeOnce sync.Once
+}
+
+// isConPTYAvailable reports whether the host exposes the ConPTY API (Windows 10
+// version 1809 and later), so an older host gets a clear error instead of a
+// missing-proc failure deep in start.
+func isConPTYAvailable() bool {
+	return windows.NewLazySystemDLL("kernel32.dll").NewProc("CreatePseudoConsole").Find() == nil
+}
+
+// startConPTY launches commandLine inside a fresh pseudo console sized rows×cols,
+// in workDir, with env (nil inherits the parent's environment; a non-nil slice,
+// even empty, starts the child from exactly that set). The returned conPTY must
+// be Closed.
+func startConPTY(commandLine, workDir string, env []string, rows, cols int) (*conPTY, error) {
+	// Two anonymous pipes: one carries parent→child input, the other
+	// child→parent output. CreatePseudoConsole takes the child's ends (inRead,
+	// outWrite); the parent keeps inWrite and outRead.
+	var inRead, inWrite, outRead, outWrite windows.Handle
+	if err := windows.CreatePipe(&inRead, &inWrite, nil, 0); err != nil {
+		return nil, fmt.Errorf("create input pipe: %w", err)
+	}
+	if err := windows.CreatePipe(&outRead, &outWrite, nil, 0); err != nil {
+		closeHandles(inRead, inWrite)
+		return nil, fmt.Errorf("create output pipe: %w", err)
+	}
+
+	var hpc windows.Handle
+	size := windows.Coord{X: termDim(cols), Y: termDim(rows)}
+	if err := windows.CreatePseudoConsole(size, inRead, outWrite, 0, &hpc); err != nil {
+		closeHandles(inRead, inWrite, outRead, outWrite)
+		return nil, fmt.Errorf("create pseudo console: %w", err)
+	}
+	// The child owns inRead/outWrite through the pseudo console now; the parent's
+	// copies are done. Leaving outWrite open would keep the read side from ever
+	// seeing EOF when the child exits.
+	closeHandles(inRead, outWrite)
+
+	attrList, err := windows.NewProcThreadAttributeList(1)
+	if err != nil {
+		windows.ClosePseudoConsole(hpc)
+		closeHandles(inWrite, outRead)
+		return nil, fmt.Errorf("alloc attribute list: %w", err)
+	}
+	// The PSEUDOCONSOLE attribute value IS the HPCON handle itself (passed by
+	// value as the documented Win32 idiom), sized as one handle.
+	if err := attrList.Update(
+		windows.PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE,
+		unsafe.Pointer(hpc), //nolint:govet,gosec // Win32 ConPTY idiom: the HPCON handle value IS the attribute payload (a by-value handle, not a Go pointer, so it is GC-safe)
+		unsafe.Sizeof(hpc),
+	); err != nil {
+		attrList.Delete()
+		windows.ClosePseudoConsole(hpc)
+		closeHandles(inWrite, outRead)
+		return nil, fmt.Errorf("set pseudo-console attribute: %w", err)
+	}
+
+	si := new(windows.StartupInfoEx)
+	si.Cb = uint32(unsafe.Sizeof(*si))
+	si.ProcThreadAttributeList = attrList.List()
+
+	argv, err := windows.UTF16PtrFromString(commandLine)
+	if err != nil {
+		attrList.Delete()
+		windows.ClosePseudoConsole(hpc)
+		closeHandles(inWrite, outRead)
+		return nil, fmt.Errorf("encode command line: %w", err)
+	}
+	var dir *uint16
+	if workDir != "" {
+		if dir, err = windows.UTF16PtrFromString(workDir); err != nil {
+			attrList.Delete()
+			windows.ClosePseudoConsole(hpc)
+			closeHandles(inWrite, outRead)
+			return nil, fmt.Errorf("encode workdir: %w", err)
+		}
+	}
+	var envBlock *uint16
+	if env != nil {
+		envBlock = utf16EnvBlock(env)
+	}
+
+	pi := new(windows.ProcessInformation)
+	// EXTENDED_STARTUPINFO_PRESENT makes CreateProcess read the attribute list;
+	// CREATE_UNICODE_ENVIRONMENT matches the UTF-16 env block. bInheritHandles is
+	// false: the child reaches the console through the attribute, not inheritance.
+	flags := uint32(windows.EXTENDED_STARTUPINFO_PRESENT | windows.CREATE_UNICODE_ENVIRONMENT)
+	if err := windows.CreateProcess(
+		nil, argv, nil, nil, false, flags, envBlock, dir, &si.StartupInfo, pi,
+	); err != nil {
+		attrList.Delete()
+		windows.ClosePseudoConsole(hpc)
+		closeHandles(inWrite, outRead)
+		return nil, fmt.Errorf("create process: %w", err)
+	}
+	// The primary thread handle is unused; keep the process handle for wait/kill.
+	closeHandles(pi.Thread)
+
+	return &conPTY{
+		hpc:      hpc,
+		inWrite:  inWrite,
+		outRead:  outRead,
+		process:  pi.Process,
+		pid:      pi.ProcessId,
+		attrList: attrList,
+	}, nil
+}
+
+// Read drains the child's output (the transcript source). A broken/closed pipe
+// once the child exits is the ConPTY analogue of POSIX EIO: it surfaces as an
+// error so the reader loop ends cleanly (after appending any final bytes).
+func (c *conPTY) Read(p []byte) (int, error) {
+	var done uint32
+	if err := windows.ReadFile(c.outRead, p, &done, nil); err != nil {
+		return int(done), os.ErrClosed
+	}
+	return int(done), nil
+}
+
+// Write delivers a send to the child.
+func (c *conPTY) Write(p []byte) (int, error) {
+	var done uint32
+	if err := windows.WriteFile(c.inWrite, p, &done, nil); err != nil {
+		return int(done), err
+	}
+	return int(done), nil
+}
+
+// Resize changes the pseudo console's dimensions.
+func (c *conPTY) Resize(rows, cols int) error {
+	return windows.ResizePseudoConsole(c.hpc, windows.Coord{X: termDim(cols), Y: termDim(rows)})
+}
+
+// termDim clamps a terminal dimension into the positive int16 range a Coord
+// carries, so an out-of-range rows/cols can never wrap to a negative or zero
+// size (a 24x80 default and small authored sizes are the norm).
+func termDim(n int) int16 {
+	const maxDim = 0x7fff
+	switch {
+	case n < 1:
+		return 1
+	case n > maxDim:
+		return maxDim
+	default:
+		return int16(n)
+	}
+}
+
+// wait blocks until the child exits (or ctx is done) and returns its exit code;
+// a wait that cannot read the code, or a ctx that fires first, returns -1.
+func (c *conPTY) wait(ctx context.Context) int {
+	done := make(chan int, 1)
+	go func() {
+		if _, err := windows.WaitForSingleObject(c.process, windows.INFINITE); err != nil {
+			done <- -1
+			return
+		}
+		var code uint32
+		if err := windows.GetExitCodeProcess(c.process, &code); err != nil {
+			done <- -1
+			return
+		}
+		done <- int(code)
+	}()
+	select {
+	case code := <-done:
+		return code
+	case <-ctx.Done():
+		return -1
+	}
+}
+
+// pidValue exposes the child's process id for a tree kill.
+func (c *conPTY) pidValue() int { return int(c.pid) }
+
+// Close tears down the pseudo console and every handle exactly once. Closing the
+// pseudo console signals the child that its console went away; a caller that
+// must not let the child linger kills the tree first.
+func (c *conPTY) Close() error {
+	c.closeOnce.Do(func() {
+		windows.ClosePseudoConsole(c.hpc)
+		closeHandles(c.inWrite, c.outRead, c.process)
+		if c.attrList != nil {
+			c.attrList.Delete()
+		}
+	})
+	return nil
+}
+
+// closeHandles best-effort closes each valid handle.
+func closeHandles(handles ...windows.Handle) {
+	for _, h := range handles {
+		if h != 0 && h != windows.InvalidHandle {
+			_ = windows.CloseHandle(h)
+		}
+	}
+}
+
+// utf16EnvBlock encodes env ("KEY=VALUE" entries) as the NUL-separated,
+// double-NUL-terminated UTF-16 block CreateProcess wants with
+// CREATE_UNICODE_ENVIRONMENT. An empty (non-nil) slice yields just the
+// terminating NUL — an empty environment.
+func utf16EnvBlock(env []string) *uint16 {
+	var buf []uint16
+	for _, e := range env {
+		enc, err := windows.UTF16FromString(e)
+		if err != nil {
+			continue // skip an entry with an embedded NUL rather than fail the run
+		}
+		buf = append(buf, enc...) // UTF16FromString already appends the entry's NUL
+	}
+	buf = append(buf, 0) // final NUL closes the block
+	return &buf[0]
+}

--- a/internal/runner/ptyrun/conpty_windows.go
+++ b/internal/runner/ptyrun/conpty_windows.go
@@ -145,7 +145,7 @@ func startConPTY(commandLine, workDir string, env []string, rows, cols int) (*co
 }
 
 // Read drains the child's output (the transcript source). A broken/closed pipe
-// once the child exits is the ConPTY analogue of POSIX EIO: it surfaces as an
+// once the child exits is the ConPTY analog of POSIX EIO: it surfaces as an
 // error so the reader loop ends cleanly (after appending any final bytes).
 func (c *conPTY) Read(p []byte) (int, error) {
 	var done uint32
@@ -248,5 +248,10 @@ func utf16EnvBlock(env []string) *uint16 {
 		buf = append(buf, enc...) // UTF16FromString already appends the entry's NUL
 	}
 	buf = append(buf, 0) // final NUL closes the block
+	if len(buf) == 1 {
+		// An empty environment still needs the double-NUL terminator, or
+		// CreateProcessW rejects the block with ERROR_INVALID_PARAMETER.
+		buf = append(buf, 0)
+	}
 	return &buf[0]
 }

--- a/internal/runner/ptyrun/conpty_windows.go
+++ b/internal/runner/ptyrun/conpty_windows.go
@@ -88,6 +88,13 @@ func startConPTY(commandLine, workDir string, env []string, rows, cols int) (*co
 
 	si := new(windows.StartupInfoEx)
 	si.Cb = uint32(unsafe.Sizeof(*si))
+	// STARTF_USESTDHANDLES with the std handles left nil is what stops the child
+	// from inheriting the PARENT's console: without it a console app attaches to
+	// atago's own console and writes there instead of through the pseudo-console,
+	// so nothing reaches the transcript pipe. The pseudo-console attribute below
+	// then supplies the child's actual console I/O. This mirrors the established
+	// ConPTY wrappers (aymanbagabas/go-pty, UserExistsError/conpty).
+	si.Flags |= windows.STARTF_USESTDHANDLES
 	si.ProcThreadAttributeList = attrList.List()
 
 	argv, err := windows.UTF16PtrFromString(commandLine)

--- a/internal/runner/ptyrun/ptyrun_unix.go
+++ b/internal/runner/ptyrun/ptyrun_unix.go
@@ -6,11 +6,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
-	"sync"
 	"syscall"
-	"time"
 
 	"github.com/creack/pty"
 
@@ -19,36 +16,20 @@ import (
 	"github.com/nao1215/atago/internal/spec"
 )
 
-// pollInterval is how often an expect re-checks the accumulated transcript.
-const pollInterval = 10 * time.Millisecond
-
-// drainGrace bounds how long finish waits for the reader to hit EIO before
-// closing the master: an orphaned grandchild that inherited the slave can hold
-// the terminal open indefinitely, and its output is not worth hanging for.
-const drainGrace = 2 * time.Second
-
-// Run executes p.Command inside a pseudo-terminal in workdir, drives the
-// expect/send session, waits for the process to exit within the session
-// budget, and returns the transcript as the result's stdout. A never-matching
-// expect is returned as an ExpectFailure (reported like a failed assertion);
-// only "could not start/drive the terminal" conditions are hard errors.
+// Run executes p.Command inside a POSIX pseudo-terminal in workdir and drives
+// the expect/send session against it via the shared driveSession core. The
+// terminal is a creack/pty master and cleanup kills the whole process group
+// (Setsid), so a timed-out or aborted session never leaks the child tree.
 func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runner.Result, *ExpectFailure, error) {
-	expects, err := compileSession(p.Session)
-	if err != nil {
-		return nil, nil, fmt.Errorf("pty: invalid expect regexp: %w", err)
-	}
-
 	name, args, err := runnercmd.CommandLine(p.Command, p.Shell != nil && *p.Shell)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	budget := sessionTimeout(p)
-	ctx, cancel := context.WithTimeout(ctx, budget)
-	defer cancel()
-
-	// CommandContext gives noctx its context; Cancel is overridden below so a
-	// timeout kills the whole process group (Setsid), not only the child.
+	// CommandContext binds the child to the parent context (Ctrl-C / suite
+	// cancel); Cancel is overridden so that cancellation kills the whole process
+	// group (Setsid), not only the direct child. The session-budget timeout is
+	// driveSession's job — it kills via proc.kill on abort.
 	cmd := exec.CommandContext(ctx, name, args...) //nolint:gosec // the spec author's declared command is the subject under test
 	cmd.Cancel = func() error {
 		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
@@ -74,186 +55,33 @@ func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runne
 		return nil, nil, fmt.Errorf("pty: start %q: %w", p.Command, err)
 	}
 
-	start := time.Now()
-
 	// Reap exactly once, from one place: probing a zombie with signal 0 keeps
-	// succeeding, so liveness must come from Wait itself.
-	waitCh := make(chan error, 1)
-	go func() { waitCh <- cmd.Wait() }()
+	// succeeding, so liveness must come from Wait itself. The buffered channel
+	// lets the reaper deliver the code even when a kill path drains it later.
+	exitCh := make(chan int, 1)
+	go func() { exitCh <- waitExitCode(cmd.Wait()) }()
 
-	// Transcript accumulator: one goroutine drains the master so the child
-	// never blocks on a full terminal buffer. Reads end when the child exits
-	// (EIO) or the master is closed.
-	var mu sync.Mutex
-	var transcript []byte
-	readDone := make(chan struct{})
-	go func() {
-		defer close(readDone)
-		buf := make([]byte, 4096)
-		for {
-			n, rerr := master.Read(buf)
-			if n > 0 {
-				mu.Lock()
-				transcript = append(transcript, buf[:n]...)
-				mu.Unlock()
-			}
-			if rerr != nil {
-				return
-			}
-		}
-	}()
-	snapshot := func() []byte {
-		mu.Lock()
-		defer mu.Unlock()
-		return append([]byte(nil), transcript...)
-	}
-
-	kill := func() {
+	proc := ptyProcess{
+		rw:   master,
+		exit: exitCh,
 		// Negative pid signals the whole process group created by Setsid.
-		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		kill:      func() { _ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL) },
+		closeTerm: func() { _ = master.Close() },
+		dir:       cmd.Dir,
 	}
-
-	finish := func(timedOut bool, waitErr error, ef *ExpectFailure) (*runner.Result, *ExpectFailure, error) {
-		// Drain before closing: a fast-exiting child's final output may still
-		// sit in the pty buffer, and closing the master discards it. Once the
-		// last slave fd is gone the reader hits EIO and readDone closes on its
-		// own; drainGrace bounds the wait in case a descendant kept the slave.
-		select {
-		case <-readDone:
-		case <-time.After(drainGrace):
-		}
-		_ = master.Close()
-		<-readDone
-		transcript := snapshot()
-		res := &runner.Result{
-			Command:  p.Command,
-			Stdout:   transcript,
-			Duration: time.Since(start),
-			Workdir:  cmd.Dir,
-			TimedOut: timedOut,
-			IsPTY:    true,
-			// The rendered screen (#27) is derived from the same bytes, so
-			// screen asserts and transcript asserts never disagree about what
-			// happened.
-			Screen: []byte(RenderScreen(transcript, p)),
-		}
-		switch {
-		case timedOut:
-			res.ExitCode = -1
-		case waitErr == nil:
-			res.ExitCode = 0
-		default:
-			var exitErr *exec.ExitError
-			if errors.As(waitErr, &exitErr) {
-				res.ExitCode = exitErr.ExitCode()
-			} else {
-				res.ExitCode = -1
-			}
-		}
-		return res, ef, nil
-	}
-
-	// abort kills the tree and reaps it, then finishes as timed out.
-	abort := func(ef *ExpectFailure) (*runner.Result, *ExpectFailure, error) {
-		kill()
-		waitErr := <-waitCh
-		_ = waitErr
-		return finish(true, nil, ef)
-	}
-
-	// failHard cleans up (kill, reap, close, drain) before surfacing a hard
-	// error, so a failed terminal write never leaks the child or goroutines.
-	failHard := func(err error) (*runner.Result, *ExpectFailure, error) {
-		kill()
-		<-waitCh
-		_ = master.Close()
-		<-readDone
-		return nil, nil, err
-	}
-
-	// canceledResult surfaces a parent-context cancellation (Ctrl-C / suite
-	// cancel) as a hard execution error, so the engine stops the scenario instead
-	// of asserting against a killed terminal — mirroring the cmd runner's
-	// cancel/timeout split (#30). Shared by both ctx.Done() sites below.
-	canceledResult := func() (*runner.Result, *ExpectFailure, error) {
-		return failHard(fmt.Errorf("pty %q canceled: %w", p.Command, ctx.Err()))
-	}
-
-	// Drive the session in order. expect polls the transcript; send writes to
-	// the terminal; an empty send transmits EOF (^D).
-	//
-	// matchOffset is the byte index just past the previously matched expect: each
-	// expect scans only transcript[matchOffset:], so a pattern that recurs (any
-	// shell prompt) waits for its NEXT occurrence instead of matching the stale
-	// earlier one. Without it, a second `expect "PROMPT> "` matches the first
-	// prompt already in the buffer and the session races ahead — a false pass for
-	// exactly the interactive flows this feature exists for.
-	matchOffset := 0
-	for i, a := range p.Session {
-		if expects[i] != nil {
-			matched := false
-			for {
-				if loc := expects[i].FindIndex(snapshot()[matchOffset:]); loc != nil {
-					matchOffset += loc[1]
-					matched = true
-					break
-				}
-				select {
-				case <-ctx.Done():
-					// One last check: bytes may have landed in the final poll
-					// window before the deadline fired.
-					if loc := expects[i].FindIndex(snapshot()[matchOffset:]); loc != nil {
-						matchOffset += loc[1]
-						matched = true
-					}
-				case <-time.After(pollInterval):
-					continue
-				}
-				break
-			}
-			if !matched {
-				// A parent-context cancellation is an execution error that must stop
-				// the scenario; only a genuine session-budget timeout
-				// (DeadlineExceeded) becomes an ExpectFailure.
-				if errors.Is(ctx.Err(), context.Canceled) {
-					return canceledResult()
-				}
-				return abort(&ExpectFailure{Pattern: a.Expect, Transcript: string(snapshot())})
-			}
-			continue
-		}
-		if a.Send != nil {
-			// Bytes resolves named keys to their xterm sequences and keeps the
-			// historical rule that an empty verbatim send transmits EOF (^D,
-			// delivered as VEOF on an empty input line) (#26).
-			if _, werr := master.Write(a.Send.Bytes()); werr != nil {
-				return failHard(fmt.Errorf("pty: send: %w", werr))
-			}
-		}
-	}
-
-	// Session complete: wait for the child to exit within the budget.
-	select {
-	case waitErr := <-waitCh:
-		return finish(false, waitErr, nil)
-	case <-ctx.Done():
-		// A parent cancellation is a hard error; a session-budget timeout is a
-		// normal timed-out result (#30).
-		if errors.Is(ctx.Err(), context.Canceled) {
-			return canceledResult()
-		}
-		return abort(nil)
-	}
+	return driveSession(ctx, p, proc)
 }
 
-// resolveCwd resolves a step cwd against the scenario workdir like the cmd
-// runner does: relative paths nest inside the workdir.
-func resolveCwd(workdir, cwd string) string {
-	if cwd == "" {
-		return workdir
+// waitExitCode maps a cmd.Wait() error to the observed exit code, mirroring the
+// cmd runner: nil is a clean 0, an ExitError carries the process's own code, and
+// any other failure to reap is -1.
+func waitExitCode(err error) int {
+	if err == nil {
+		return 0
 	}
-	if len(cwd) > 0 && cwd[0] == '/' {
-		return cwd
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
 	}
-	return workdir + string(os.PathSeparator) + cwd
+	return -1
 }

--- a/internal/runner/ptyrun/ptyrun_windows.go
+++ b/internal/runner/ptyrun/ptyrun_windows.go
@@ -5,15 +5,103 @@ package ptyrun
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
 
 	"github.com/nao1215/atago/internal/runner"
+	runnercmd "github.com/nao1215/atago/internal/runner/cmd"
 	"github.com/nao1215/atago/internal/spec"
 )
 
-// Run reports that pty steps are POSIX-only for now. The loader accepts the
-// step on every platform so specs stay portable to author; at execution time
-// Windows gets one clear error (an execution error, exit 4) instead of a
-// confusing terminal failure. ConPTY support can lift this later.
-func Run(_ context.Context, _ *spec.PTY, _ string, _ []string) (*runner.Result, *ExpectFailure, error) {
-	return nil, nil, errors.New("pty steps are not supported on Windows yet (POSIX-only; gate the scenario with `skip: {os: windows}`)")
+// Run executes p.Command inside a Windows pseudo-console (ConPTY) and drives the
+// expect/send session against it via the shared driveSession core, so pty specs
+// that were POSIX-only now run on Windows too (follow-up to #78). The loader
+// still accepts pty steps on every platform; here they execute instead of
+// returning the old "unsupported" error. ConPTY needs Windows 10 (1809) or
+// later — an older host gets one clear execution error (exit 4).
+func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runner.Result, *ExpectFailure, error) {
+	if !isConPTYAvailable() {
+		return nil, nil, errors.New("pty steps need ConPTY, which requires Windows 10 version 1809 or later (gate the scenario with `skip: {os: windows}` for older hosts)")
+	}
+
+	cmdLine, err := windowsCommandLine(p.Command, p.Shell != nil && *p.Shell)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	dir := workdir
+	if p.Cwd != "" {
+		dir = resolveCwd(workdir, p.Cwd)
+	}
+
+	rows, cols := defaultRows, defaultCols
+	if p.Rows > 0 {
+		rows = p.Rows
+	}
+	if p.Cols > 0 {
+		cols = p.Cols
+	}
+
+	// env is whatever the engine resolved (clear_env/pass_env already applied):
+	// nil inherits the parent's environment; a non-nil slice starts the child
+	// from exactly that set.
+	cpty, err := startConPTY(cmdLine, dir, env, rows, cols)
+	if err != nil {
+		return nil, nil, fmt.Errorf("pty: start %q: %w", p.Command, err)
+	}
+
+	pid := cpty.pidValue()
+
+	// Reap in one place, mirroring the POSIX runner. cpty.wait blocks on the
+	// process handle and returns its exit code; a parent-context cancel that
+	// unblocks it early, or an unreadable code, maps to -1. On a normal run the
+	// parent context stays alive, so wait blocks until the child exits; on
+	// abort/timeout driveSession kills the tree, which lets wait return. The
+	// buffered channel lets a kill path drain the code later.
+	exitCh := make(chan int, 1)
+	go func() { exitCh <- cpty.wait(ctx) }()
+
+	proc := ptyProcess{
+		rw:        cpty,
+		exit:      exitCh,
+		kill:      func() { killTree(pid) },
+		closeTerm: func() { _ = cpty.Close() },
+		dir:       dir,
+	}
+	return driveSession(ctx, p, proc)
+}
+
+// windowsCommandLine builds the single command-line string ConPTY's CreateProcess
+// receives. A shell step reuses cmd.exe's documented `/S /C "<command>"` contract
+// (strip the outer quotes, run the rest verbatim) so it matches the cmd runner's
+// ConfigureShell. A shell-free step is tokenized with the same splitter the cmd
+// runner uses, then re-escaped with syscall.EscapeArg so the C runtime re-parses
+// it back to the identical argv — keeping pty and run steps in agreement about
+// how a command line splits on Windows.
+func windowsCommandLine(command string, shell bool) (string, error) {
+	if shell {
+		return `cmd /S /C "` + command + `"`, nil
+	}
+	name, args, err := runnercmd.CommandLine(command, false)
+	if err != nil {
+		return "", err
+	}
+	parts := make([]string, 0, len(args)+1)
+	parts = append(parts, syscall.EscapeArg(name))
+	for _, a := range args {
+		parts = append(parts, syscall.EscapeArg(a))
+	}
+	return strings.Join(parts, " "), nil
+}
+
+// killTree force-terminates the child and every descendant. Windows has no
+// process groups, so taskkill /T walks the process tree — the closest analogue
+// to the POSIX runner's kill of the whole Setsid group, so a timed-out or
+// aborted pty session never leaks a running child.
+func killTree(pid int) {
+	// A fire-and-forget teardown; Background is the honest context here.
+	_ = exec.CommandContext(context.Background(), "taskkill", "/T", "/F", "/PID", strconv.Itoa(pid)).Run() //nolint:gosec // fixed argv, pid from our own child
 }

--- a/internal/runner/ptyrun/ptyrun_windows.go
+++ b/internal/runner/ptyrun/ptyrun_windows.go
@@ -98,7 +98,7 @@ func windowsCommandLine(command string, shell bool) (string, error) {
 }
 
 // killTree force-terminates the child and every descendant. Windows has no
-// process groups, so taskkill /T walks the process tree — the closest analogue
+// process groups, so taskkill /T walks the process tree — the closest analog
 // to the POSIX runner's kill of the whole Setsid group, so a timed-out or
 // aborted pty session never leaks a running child.
 func killTree(pid int) {

--- a/internal/runner/ptyrun/ptyrun_windows_test.go
+++ b/internal/runner/ptyrun/ptyrun_windows_test.go
@@ -1,0 +1,104 @@
+//go:build windows
+
+package ptyrun
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nao1215/atago/internal/spec"
+)
+
+// TestWindowsCommandLine covers how a pty command becomes the single command
+// line ConPTY hands to CreateProcess: a shell step reuses cmd.exe's `/S /C
+// "<command>"` contract verbatim, and a shell-free step is tokenized with the
+// cmd runner's splitter and re-escaped so the C runtime re-parses it to the same
+// argv (plain words stay bare, a path with spaces gets quoted).
+func TestWindowsCommandLine(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		command string
+		shell   bool
+		want    string
+	}{
+		{"shell wraps in cmd /S /C", `echo hi & echo bye`, true, `cmd /S /C "echo hi & echo bye"`},
+		{"plain words stay bare", `tool --flag value`, false, `tool --flag value`},
+		{"quoted path with spaces re-quotes", `"C:\Program Files\t.exe" run`, false, `"C:\Program Files\t.exe" run`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := windowsCommandLine(c.command, c.shell)
+			if err != nil {
+				t.Fatalf("windowsCommandLine(%q, %v): unexpected error: %v", c.command, c.shell, err)
+			}
+			if got != c.want {
+				t.Errorf("windowsCommandLine(%q, %v) = %q, want %q", c.command, c.shell, got, c.want)
+			}
+		})
+	}
+}
+
+// TestRun_Windows_CapturesOutputAndExit exercises the real ConPTY path on the
+// Windows CI runner: a fast-exiting shell command runs inside a pseudo-console,
+// its output is captured through the transcript reader, an expect matches it,
+// and the child's exit code surfaces as 0. This is the self-contained proof that
+// pty steps are no longer POSIX-only.
+func TestRun_Windows_CapturesOutputAndExit(t *testing.T) {
+	t.Parallel()
+	shell := true
+	p := &spec.PTY{
+		Shell:   &shell,
+		Command: "echo hello-conpty",
+		Session: []spec.PTYAction{{Expect: "hello-conpty"}},
+	}
+	res, ef, err := Run(context.Background(), p, t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("Run: unexpected error: %v", err)
+	}
+	if ef != nil {
+		t.Fatalf("Run: unexpected expect failure: %+v", ef)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("exit code = %d, want 0 (transcript %q)", res.ExitCode, res.Stdout)
+	}
+	if !strings.Contains(string(res.Stdout), "hello-conpty") {
+		t.Errorf("transcript missing the child's output: %q", res.Stdout)
+	}
+	if !strings.Contains(string(res.Screen), "hello-conpty") {
+		t.Errorf("rendered screen missing the child's output: %q", res.Screen)
+	}
+}
+
+// TestRun_Windows_ExpectTimeoutAborts exercises the abort path: an expect that
+// never matches must fail within the session budget (reported as an
+// ExpectFailure, not a hard error) and the whole process tree must be killed via
+// taskkill, so a long-running child never leaks past the step.
+func TestRun_Windows_ExpectTimeoutAborts(t *testing.T) {
+	t.Parallel()
+	shell := true
+	start := time.Now()
+	p := &spec.PTY{
+		Shell:   &shell,
+		Command: "ping -n 20 127.0.0.1",
+		Timeout: "2s",
+		Session: []spec.PTYAction{{Expect: "a-pattern-that-never-appears"}},
+	}
+	res, ef, err := Run(context.Background(), p, t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("Run: unexpected hard error: %v", err)
+	}
+	if ef == nil {
+		t.Fatalf("expected an ExpectFailure for the never-matching expect, got none (transcript %q)", res.Stdout)
+	}
+	if !res.TimedOut {
+		t.Errorf("result should be marked timed out")
+	}
+	// The 2s budget must dominate; ping -n 20 would otherwise run ~19s.
+	if elapsed := time.Since(start); elapsed > 15*time.Second {
+		t.Errorf("session ran %v, want it bounded near the 2s budget (kill did not take)", elapsed)
+	}
+}

--- a/internal/runner/ptyrun/session.go
+++ b/internal/runner/ptyrun/session.go
@@ -1,0 +1,223 @@
+package ptyrun
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/nao1215/atago/internal/runner"
+	"github.com/nao1215/atago/internal/spec"
+)
+
+// pollInterval is how often an expect re-checks the accumulated transcript.
+const pollInterval = 10 * time.Millisecond
+
+// drainGrace bounds how long finish waits for the reader to hit EOF before
+// closing the terminal: an orphaned grandchild that inherited the pty can hold
+// it open indefinitely, and its output is not worth hanging for.
+const drainGrace = 2 * time.Second
+
+// ptyProcess is the platform-specific pty surface driveSession drives. The
+// POSIX runner builds one over creack/pty and the Windows runner over ConPTY,
+// then both hand it to driveSession — so the expect/send loop, transcript
+// accumulation, and Result shaping live in exactly one place (#8; Windows
+// follow-up to #78).
+type ptyProcess struct {
+	// rw is the terminal master: reads yield the child's output (terminal echo
+	// included, ANSI intact), writes deliver sends to the child.
+	rw io.ReadWriter
+	// exit receives the child's observed exit code exactly once, when the
+	// process is reaped. It must be buffered (cap 1) so the reaper never blocks
+	// waiting for a receiver that a kill path drains later.
+	exit <-chan int
+	// kill force-terminates the whole process tree (a timed-out or aborted
+	// session must not leak a running child or its descendants).
+	kill func()
+	// closeTerm releases the terminal master so the read goroutine unblocks and
+	// finish can snapshot a complete transcript.
+	closeTerm func()
+	// dir is the resolved workdir the child ran in, surfaced as Result.Workdir.
+	dir string
+}
+
+// driveSession runs the platform-neutral half of a pty step: it drains the
+// transcript, walks the expect/send session in order, and shapes the Result.
+// Every terminal- and process-specific detail is behind proc, so POSIX and
+// Windows share this exact control flow. A never-matching expect is returned as
+// an ExpectFailure (reported like a failed assertion); only "could not
+// start/drive the terminal" conditions are hard errors.
+func driveSession(ctx context.Context, p *spec.PTY, proc ptyProcess) (*runner.Result, *ExpectFailure, error) {
+	expects, err := compileSession(p.Session)
+	if err != nil {
+		return nil, nil, fmt.Errorf("pty: invalid expect regexp: %w", err)
+	}
+
+	budget := sessionTimeout(p)
+	ctx, cancel := context.WithTimeout(ctx, budget)
+	defer cancel()
+
+	start := time.Now()
+
+	// Transcript accumulator: one goroutine drains the master so the child never
+	// blocks on a full terminal buffer. Reads end when the child exits (EOF/EIO)
+	// or the master is closed.
+	var mu sync.Mutex
+	var transcript []byte
+	readDone := make(chan struct{})
+	go func() {
+		defer close(readDone)
+		buf := make([]byte, 4096)
+		for {
+			n, rerr := proc.rw.Read(buf)
+			if n > 0 {
+				mu.Lock()
+				transcript = append(transcript, buf[:n]...)
+				mu.Unlock()
+			}
+			if rerr != nil {
+				return
+			}
+		}
+	}()
+	snapshot := func() []byte {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]byte(nil), transcript...)
+	}
+
+	finish := func(timedOut bool, code int, ef *ExpectFailure) (*runner.Result, *ExpectFailure, error) {
+		// Drain before closing: a fast-exiting child's final output may still sit
+		// in the pty buffer, and closing the master discards it. Once the last
+		// handle is gone the reader hits EOF and readDone closes on its own;
+		// drainGrace bounds the wait in case a descendant kept the terminal open.
+		select {
+		case <-readDone:
+		case <-time.After(drainGrace):
+		}
+		proc.closeTerm()
+		<-readDone
+		tr := snapshot()
+		res := &runner.Result{
+			Command:  p.Command,
+			Stdout:   tr,
+			Duration: time.Since(start),
+			Workdir:  proc.dir,
+			TimedOut: timedOut,
+			IsPTY:    true,
+			// The rendered screen (#27) is derived from the same bytes, so screen
+			// asserts and transcript asserts never disagree about what happened.
+			Screen: []byte(RenderScreen(tr, p)),
+		}
+		if timedOut {
+			res.ExitCode = -1
+		} else {
+			res.ExitCode = code
+		}
+		return res, ef, nil
+	}
+
+	// abort kills the tree and reaps it, then finishes as timed out.
+	abort := func(ef *ExpectFailure) (*runner.Result, *ExpectFailure, error) {
+		proc.kill()
+		<-proc.exit
+		return finish(true, -1, ef)
+	}
+
+	// failHard cleans up (kill, reap, close, drain) before surfacing a hard
+	// error, so a failed terminal write never leaks the child or goroutines.
+	failHard := func(err error) (*runner.Result, *ExpectFailure, error) {
+		proc.kill()
+		<-proc.exit
+		proc.closeTerm()
+		<-readDone
+		return nil, nil, err
+	}
+
+	// canceledResult surfaces a parent-context cancellation (Ctrl-C / suite
+	// cancel) as a hard execution error, so the engine stops the scenario instead
+	// of asserting against a killed terminal — mirroring the cmd runner's
+	// cancel/timeout split (#30).
+	canceledResult := func() (*runner.Result, *ExpectFailure, error) {
+		return failHard(fmt.Errorf("pty %q canceled: %w", p.Command, ctx.Err()))
+	}
+
+	// Drive the session in order. expect polls the transcript; send writes to the
+	// terminal; an empty send transmits EOF (^D).
+	//
+	// matchOffset is the byte index just past the previously matched expect: each
+	// expect scans only transcript[matchOffset:], so a pattern that recurs (any
+	// shell prompt) waits for its NEXT occurrence instead of matching the stale
+	// earlier one.
+	matchOffset := 0
+	for i, a := range p.Session {
+		if expects[i] != nil {
+			matched := false
+			for {
+				if loc := expects[i].FindIndex(snapshot()[matchOffset:]); loc != nil {
+					matchOffset += loc[1]
+					matched = true
+					break
+				}
+				select {
+				case <-ctx.Done():
+					// One last check: bytes may have landed in the final poll
+					// window before the deadline fired.
+					if loc := expects[i].FindIndex(snapshot()[matchOffset:]); loc != nil {
+						matchOffset += loc[1]
+						matched = true
+					}
+				case <-time.After(pollInterval):
+					continue
+				}
+				break
+			}
+			if !matched {
+				// A parent-context cancellation is an execution error that must stop
+				// the scenario; only a genuine session-budget timeout
+				// (DeadlineExceeded) becomes an ExpectFailure.
+				if errors.Is(ctx.Err(), context.Canceled) {
+					return canceledResult()
+				}
+				return abort(&ExpectFailure{Pattern: a.Expect, Transcript: string(snapshot())})
+			}
+			continue
+		}
+		if a.Send != nil {
+			// Bytes resolves named keys to their xterm sequences and keeps the
+			// historical rule that an empty verbatim send transmits EOF (^D).
+			if _, werr := proc.rw.Write(a.Send.Bytes()); werr != nil {
+				return failHard(fmt.Errorf("pty: send: %w", werr))
+			}
+		}
+	}
+
+	// Session complete: wait for the child to exit within the budget.
+	select {
+	case code := <-proc.exit:
+		return finish(false, code, nil)
+	case <-ctx.Done():
+		// A parent cancellation is a hard error; a session-budget timeout is a
+		// normal timed-out result (#30).
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return canceledResult()
+		}
+		return abort(nil)
+	}
+}
+
+// resolveCwd resolves a step cwd against the scenario workdir like the cmd
+// runner does: an absolute path is used verbatim, a relative path nests inside
+// the workdir, and an empty cwd stays at the workdir.
+func resolveCwd(workdir, cwd string) string {
+	if cwd == "" {
+		return workdir
+	}
+	if filepath.IsAbs(cwd) {
+		return cwd
+	}
+	return filepath.Join(workdir, cwd)
+}

--- a/scripts/windows_portable_specs.sh
+++ b/scripts/windows_portable_specs.sh
@@ -48,4 +48,5 @@ printf '%s\n' \
   ./test/e2e/atago/ssh.atago.yaml \
   ./test/e2e/atago/cdp.atago.yaml \
   ./test/e2e/atago/pdf.atago.yaml \
+  ./test/e2e/atago/pty_portable.atago.yaml \
   ./test/e2e/thirdparty/git

--- a/test/e2e/atago/pty_portable.atago.yaml
+++ b/test/e2e/atago/pty_portable.atago.yaml
@@ -1,0 +1,152 @@
+# Portable pty coverage (#8; Windows follow-up to #78).
+#
+# Unlike pty.atago.yaml — whose scenarios drive POSIX-only inner commands
+# (`[ -t 0 ]`, `cat -v`, a SIGINT trap, bash `printf '\r'`) and therefore skip
+# on Windows — every scenario here uses only shell builtins portable to both
+# /bin/sh and cmd.exe, or drives the cross-platform atago binary itself. So this
+# suite runs on Windows (ConPTY) as well as POSIX, thickly exercising the pty
+# contract: output capture, exit-code propagation, ordered expects, regex
+# matching, the rendered screen, shell and no-shell commands, and the
+# never-matching-expect failure. It is listed in
+# scripts/windows_portable_specs.sh and executed by the Windows CI leg.
+version: "1"
+
+suite:
+  name: atago self-hosting / pty (portable)
+
+scenarios:
+  - name: a pty step starts a command, captures its output, and reports exit 0
+    steps:
+      # No send: the command self-terminates. This exercises the whole runner —
+      # start the process in a pseudo-terminal, drain the transcript, match an
+      # expect against it, and reap the real exit code — on both POSIX and Windows.
+      - pty:
+          shell: true # echo is a shell builtin on both /bin/sh and cmd.exe
+          command: echo hello from a pty
+          session:
+            - expect: "hello from a pty"
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "hello from a pty"
+
+  - name: a pty step surfaces a command's non-zero exit code
+    steps:
+      # `&&` and `exit N` behave the same in /bin/sh and cmd.exe, so a failing
+      # command's code propagates through the pty identically on both.
+      - pty:
+          shell: true
+          command: echo bye && exit 3
+          session:
+            - expect: "bye"
+      - assert:
+          exit_code: 3
+
+  - name: sequential expects match successive output in declaration order
+    steps:
+      # matchOffset advances past each match, so a recurring token waits for its
+      # NEXT occurrence instead of re-matching stale output.
+      - pty:
+          shell: true
+          command: echo first && echo second && echo third
+          session:
+            - expect: "first"
+            - expect: "second"
+            - expect: "third"
+      - assert:
+          exit_code: 0
+          stdout:
+            contains:
+              - "first"
+              - "third"
+
+  - name: an expect pattern is a regular expression, not a literal
+    steps:
+      - pty:
+          shell: true
+          command: echo item-42-done
+          session:
+            - expect: 'item-[0-9]+-done'
+      - assert:
+          exit_code: 0
+
+  - name: a screen assert reads the rendered frame sized by rows and cols
+    steps:
+      - pty:
+          shell: true
+          command: echo rendered line
+          rows: 10
+          cols: 40
+      - assert:
+          exit_code: 0
+          # The rendered screen (vt10x emulation) is derived from the same bytes
+          # on every platform, so a screen assert is portable too.
+          screen:
+            contains: "rendered line"
+
+  - name: a pty step drives the atago binary directly with no shell
+    steps:
+      - pty:
+          command: ${atago} version
+          session:
+            - expect: atago
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: atago
+
+  - name: a pty drives atago running an inner spec to a green result
+    steps:
+      - fixture:
+          file: inner.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: inner
+            scenarios:
+              - name: echo
+                steps:
+                  - run:
+                      shell: true
+                      command: echo inner-ok
+                  - assert:
+                      exit_code: 0
+                      stdout:
+                        contains: inner-ok
+      - pty:
+          command: ${atago} run inner.atago.yaml
+          session:
+            - expect: "PASSED"
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "1 passed"
+
+  - name: a never-matching expect fails and names the pattern in the transcript
+    steps:
+      # The inner pty command exits at once but its output never matches; the
+      # expect keeps polling until the 2s session budget elapses, then fails the
+      # step (reported like an assertion). Portable: `echo` is the only command.
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: inner
+            scenarios:
+              - name: waits for output that never comes
+                steps:
+                  - pty:
+                      shell: true
+                      command: echo present
+                      timeout: 2s
+                      session:
+                        - expect: "absent-forever"
+      - run:
+          command: ${atago} run bad.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "pty expect /absent-forever/"
+              - "never appeared in the terminal transcript"

--- a/test/e2e/tools/sqly/repl_pty.atago.yaml
+++ b/test/e2e/tools/sqly/repl_pty.atago.yaml
@@ -1,0 +1,128 @@
+# Drive sqly's INTERACTIVE shell (its readline REPL, built on nao1215/prompt)
+# over a real pseudo-terminal — the path every other sqly spec here skips by
+# using the non-interactive `--sql` flag. sqly only starts the prompt when stdin
+# is a TTY (config.IsInputFromTTY), so a pty is the only way to exercise the line
+# editor, the colored `sqly:...(mode)$ ` prompt, dot-commands, and the
+# box-drawn result tables a real user sees.
+#
+# It is deliberately NOT gated off Windows: once atago's pty runner speaks
+# ConPTY, this is the real-world proof that an interactive, ANSI-coloring nao1215
+# CLI renders correctly through it. Two authoring rules keep the sessions robust:
+#
+#   * Enter is `{key: enter}` (a raw CR, 0x0d); a bare "\n" is not the Return key
+#     a raw-mode line editor waits for.
+#   * After sending a query + Enter, wait for a token that appears ONLY in the
+#     executed result (e.g. a value or "TABLE NAME") before expecting the prompt
+#     again — the prompt string is echoed on every keystroke while typing, so
+#     matching it too early would fire mid-input and desync the session.
+version: "1"
+
+suite:
+  name: sqly interactive shell (pty)
+
+scenarios:
+  - name: run a query and read its rendered result table over a pty
+    steps:
+      - fixture:
+          file: actor.csv
+          content: |
+            actor,gross
+            Harrison Ford,4871
+            Samuel L. Jackson,4772
+      - pty:
+          command: sqly actor.csv
+          rows: 24
+          cols: 80
+          timeout: 30s
+          session:
+            - expect: 'sqly:' # the interactive prompt appeared
+            - send: "SELECT actor FROM actor WHERE actor LIKE 'Harrison%';"
+            - send: { key: enter } # submit the query (CR, not LF)
+            - expect: "Harrison Ford" # result token: only present post-execution
+            - expect: 'sqly:' # the prompt returned, editor idle again
+            - send: ".exit"
+            - send: { key: enter }
+      - assert:
+          exit_code: 0
+          stdout:
+            contains:
+              - "Harrison Ford"
+              - "+--" # the box-drawn result table sqly renders to the terminal
+      - assert:
+          # The rendered screen (vt10x) still shows the result frame after quit.
+          screen:
+            contains: "Harrison Ford"
+
+  - name: the .tables dot-command renders the imported table over a pty
+    steps:
+      - fixture:
+          file: actor.csv
+          content: |
+            actor,gross
+            Harrison Ford,4871
+            Samuel L. Jackson,4772
+      - pty:
+          command: sqly actor.csv
+          timeout: 30s
+          session:
+            - expect: 'sqly:'
+            - send: ".tables"
+            - send: { key: enter }
+            - expect: "TABLE NAME" # the boxed .tables header, post-execution
+            - expect: "actor" # the imported CSV became the "actor" table
+            - expect: 'sqly:'
+            - send: ".exit"
+            - send: { key: enter }
+      - assert:
+          exit_code: 0
+          stdout:
+            contains:
+              - "TABLE NAME"
+              - "actor"
+
+  - name: a computed aggregate round-trips through the pty shell
+    steps:
+      - fixture:
+          file: actor.csv
+          content: |
+            actor,gross
+            Harrison Ford,4871
+            Samuel L. Jackson,4772
+      - pty:
+          command: sqly actor.csv
+          timeout: 30s
+          session:
+            - expect: 'sqly:'
+            # A distinctive, self-labeling result so the wait cannot match stray
+            # output — the count of the two imported rows.
+            - send: "SELECT 'ROWS=' || COUNT(*) AS r FROM actor;"
+            - send: { key: enter }
+            - expect: "ROWS=2"
+            - expect: 'sqly:'
+            - send: ".exit"
+            - send: { key: enter }
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "ROWS=2"
+
+  - name: the prompt reflects a live .mode switch over a pty
+    steps:
+      - fixture:
+          file: actor.csv
+          content: |
+            actor,gross
+            Harrison Ford,4871
+            Samuel L. Jackson,4772
+      - pty:
+          command: sqly actor.csv
+          timeout: 30s
+          session:
+            - expect: '\(table\)\$' # the prompt advertises the default table mode
+            - send: ".mode csv"
+            - send: { key: enter }
+            - expect: '\(csv\)\$' # the switch is live: the prompt now says csv
+            - send: ".exit"
+            - send: { key: enter }
+      - assert:
+          exit_code: 0


### PR DESCRIPTION
## Summary

`pty:` steps were POSIX-only: the Windows runner returned a clear "unsupported" error and every pty/screen scenario was gated with `skip: {os: windows}`. This teaches the pty runner to drive a real Windows pseudo-console (ConPTY) so interactive specs run on Windows too, and backs it with real-ConPTY unit tests plus thick cross-platform E2E coverage. `record --pty` and `signal:` stay POSIX-only (a hand-driven capture needs a real terminal; Windows has no POSIX signals).

## Changes

- `internal/runner/ptyrun/conpty_windows.go`: a self-contained ConPTY wrapper built directly on `golang.org/x/sys/windows` (CreatePseudoConsole → a PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE attribute list → CreateProcess), exposing Read/Write/Resize/wait/Close. No third-party ConPTY dependency is added.
- `internal/runner/ptyrun/session.go`: extracts the platform-neutral half of a pty step (transcript drain, the expect/send loop, result shaping) into a shared `driveSession` core so POSIX and Windows share one control flow.
- `internal/runner/ptyrun/ptyrun_unix.go`: the POSIX runner keeps using creack/pty exactly as before and now delegates to `driveSession` — behavior is unchanged and covered by the existing 200-iteration fast-exit regression test.
- `internal/runner/ptyrun/ptyrun_windows.go`: the Windows runner starts a ConPTY, builds the command line (cmd.exe `/S /C` for shell steps, `syscall.EscapeArg` re-join for shell-free steps), kills the process tree with `taskkill /T`, and delegates to `driveSession`.
- `internal/runner/ptyrun/ptyrun_windows_test.go`: Windows-only unit tests that start a real ConPTY (echo happy path, a never-matching expect that must time out and kill the tree) plus command-line construction cases — they run on the windows-latest leg of the unit-test workflow.
- `test/e2e/atago/pty_portable.atago.yaml`: thick portable pty E2E (8 scenarios) driving only shell builtins and the atago binary — output capture, exit-code propagation, ordered expects, regex matching, the rendered screen, shell/no-shell, and the never-matching-expect failure — added to `scripts/windows_portable_specs.sh` so the Windows CI leg runs it.
- `test/e2e/tools/sqly/repl_pty.atago.yaml`: interactive proof that an ANSI-coloring nao1215 CLI (sqly's readline REPL, built on nao1215/prompt) renders correctly through the ConPTY runner — box-drawn result tables, `screen:` on the rendered frame, `.tables`, an aggregate round trip, and a live `.mode` switch. e2e.yml installs a pinned sqly on windows-latest and runs it.
- `examples/pty_portable.atago.yaml`: a cross-platform pty example (registered in `drift_test.go`, linked from the README), exercised by the hermetic-examples test on all three OSes.
- `README.md`, `doc/e2e/*.md`: document that pty steps run on Windows (ConPTY) and regenerate the behavior docs.

## Design Decisions

The ConPTY layer is implemented in-repo on `golang.org/x/sys/windows` (already a transitive dependency) rather than pulling in a third-party ConPTY module: the two obvious candidates were either stale and low-adoption or would have replaced the proven POSIX path, and the Win32 pseudo-console API is small and stable since Windows 10 1809. The POSIX runner is deliberately left on creack/pty and unchanged; only the shared, platform-neutral expect/send loop was extracted, so the stable POSIX behavior is preserved and the local POSIX E2E acts as the regression guard. Enter is sent as a raw CR (`{key: enter}`) in the interactive specs because a raw-mode line editor waits for CR, not LF, and each interactive turn waits for a post-execution result token before matching the prompt again (the prompt echoes on every keystroke, so matching it too early desyncs the session).

## Limitations

Windows pty behavior is validated in CI (unit-test and e2e windows-latest legs), not locally — ConPTY cannot run on the Linux dev host. `record --pty` and `signal:` remain POSIX-only. The sqly/prompt scenarios exercise nao1215/prompt under ConPTY; sqly's own `e2e/atago/pty.atago.yaml` still gates its interactive scenarios off Windows and sends Enter as `\n` — once this ships, those can be unskipped after switching to `{key: enter}` (LF is not the Return key under a Windows ConPTY line editor). sqly's other Windows skips (symlink-to-system-path, `/dev/stdin`) are POSIX-inherent and unrelated to pty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-platform interactive terminal testing support, including Windows ConPTY.
  * Added portable PTY examples and expanded interactive REPL coverage for terminal-based flows.
  * Added new interactive shell checks for sqly, including query output, `.tables`, and prompt behavior.

* **Documentation**
  * Updated terminal testing docs to explain PTY behavior, rendered-screen assertions, and Windows support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->