### PR TITLE
feat(service): tear down the whole service process tree on Windows via a job object

### DIFF
--- a/internal/runner/service/process_unix.go
+++ b/internal/runner/service/process_unix.go
@@ -27,6 +27,11 @@ func newProcessCmd(ctx context.Context, name string, args []string) *processCmd 
 	return &processCmd{cmd: c}
 }
 
+// started is a no-op on POSIX: the process group is established at spawn time by
+// Setpgid, so there is nothing to wire up after Start (the Windows build assigns
+// a job object here instead).
+func (p *processCmd) started() error { return nil }
+
 func (p *processCmd) terminate() { _ = signalGroup(p.cmd, syscall.SIGTERM) }
 func (p *processCmd) kill()      { _ = signalGroup(p.cmd, syscall.SIGKILL) }
 

--- a/internal/runner/service/process_windows.go
+++ b/internal/runner/service/process_windows.go
@@ -6,36 +6,116 @@ import (
 	"context"
 	"errors"
 	"os/exec"
+	"sync"
 	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
-// processCmd wraps an *exec.Cmd. Windows has no POSIX process groups or signals,
-// so termination is a hard kill of the spawned process.
+// processCmd wraps an *exec.Cmd and, once started, ties the process to a
+// kill-on-close job object. Windows has no process groups, so a service launched
+// with `shell: true` that forks further children would orphan them on a bare
+// process kill (the previous behavior). A job object terminates the whole tree
+// at once, and JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE also reaps any survivors if
+// atago itself exits without a clean teardown — the closest Windows analog to
+// the POSIX runner's process-group kill.
 type processCmd struct {
 	cmd *exec.Cmd
+
+	mu   sync.Mutex
+	job  windows.Handle
+	down bool
 }
 
 func newProcessCmd(ctx context.Context, name string, args []string) *processCmd {
 	c := exec.CommandContext(ctx, name, args...) //nolint:gosec // executing user-declared service commands is the purpose of atago
 	c.WaitDelay = 5 * time.Second
-	return &processCmd{cmd: c}
+	p := &processCmd{cmd: c}
+	// On scenario-context cancellation, tear down the whole tree, not just the
+	// leader — mirroring the POSIX runner's process-group kill on cancel.
+	c.Cancel = func() error { p.killTree(); return nil }
+	return p
 }
 
-func (p *processCmd) terminate() {
+// started ties the freshly-started process to a kill-on-close job object. Start
+// calls it right after cmd.Start(); every child the service spawns afterward is
+// captured by the job automatically. A child forked in the microseconds between
+// Start and this assignment would escape, but real services fork during their
+// own initialization, well after this returns. A failure here is non-fatal: the
+// service still runs, and killTree falls back to a single-process kill.
+func (p *processCmd) started() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.cmd.Process == nil || p.down {
+		return nil
+	}
+	job, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return err
+	}
+	info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{
+		BasicLimitInformation: windows.JOBOBJECT_BASIC_LIMIT_INFORMATION{
+			LimitFlags: windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+		},
+	}
+	if _, err := windows.SetInformationJobObject(
+		job,
+		uint32(windows.JobObjectExtendedLimitInformation),
+		uintptr(unsafe.Pointer(&info)), //nolint:gosec // documented x/sys pattern: pass the struct address to a uintptr-typed syscall arg
+		uint32(unsafe.Sizeof(info)),
+	); err != nil {
+		_ = windows.CloseHandle(job)
+		return err
+	}
+	h, err := windows.OpenProcess(windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE, false, uint32(p.cmd.Process.Pid)) //nolint:gosec // pid fits a uint32 on Windows
+	if err != nil {
+		_ = windows.CloseHandle(job)
+		return err
+	}
+	defer windows.CloseHandle(h)
+	if err := windows.AssignProcessToJobObject(job, h); err != nil {
+		_ = windows.CloseHandle(job)
+		return err
+	}
+	p.job = job
+	return nil
+}
+
+// terminate and kill are identical on Windows: there is no SIGTERM to deliver, so
+// a "graceful" stop is the same hard job termination as the escalated one. This
+// mirrors the pre-existing Windows behavior (both were a process kill); the only
+// change is that the whole tree now goes down, not just the leader.
+func (p *processCmd) terminate() { p.killTree() }
+func (p *processCmd) kill()      { p.killTree() }
+
+// killTree terminates every process in the job and releases the handle. It is
+// idempotent: the graceful-then-hard teardown in service.Stop calls it twice,
+// and once the tree is down the second call is a no-op.
+func (p *processCmd) killTree() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.down {
+		return
+	}
+	p.down = true
+	if p.job != 0 {
+		_ = windows.TerminateJobObject(p.job, 1)
+		_ = windows.CloseHandle(p.job)
+		p.job = 0
+		return
+	}
+	// The job was never assigned (started() failed or ran before the process
+	// existed): fall back to a single-process kill so teardown still stops the
+	// leader.
 	if p.cmd.Process != nil {
 		_ = p.cmd.Process.Kill()
 	}
 }
 
-func (p *processCmd) kill() {
-	if p.cmd.Process != nil {
-		_ = p.cmd.Process.Kill()
-	}
-}
-
-// signalByName rejects signal steps on Windows (#23): there are no POSIX
-// signals to deliver. Mirrors the pty runner's Windows contract — the loader
-// accepts the step everywhere, execution reports a clear error.
+// signalByName rejects signal steps on Windows (#23): there are no POSIX signals
+// to deliver. The loader accepts the step everywhere; execution reports a clear
+// error, mirroring the pty runner's contract.
 func (p *processCmd) signalByName(string) error {
 	return errors.New("signal steps are not supported on Windows (POSIX-only; gate the scenario with `skip: {os: windows}`)")
 }

--- a/internal/runner/service/process_windows.go
+++ b/internal/runner/service/process_windows.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"os/exec"
+	"strconv"
 	"sync"
 	"time"
 	"unsafe"
@@ -13,13 +14,15 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-// processCmd wraps an *exec.Cmd and, once started, ties the process to a
-// kill-on-close job object. Windows has no process groups, so a service launched
-// with `shell: true` that forks further children would orphan them on a bare
-// process kill (the previous behavior). A job object terminates the whole tree
-// at once, and JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE also reaps any survivors if
-// atago itself exits without a clean teardown — the closest Windows analog to
-// the POSIX runner's process-group kill.
+// processCmd wraps an *exec.Cmd and tears down the whole process tree on
+// teardown. Windows has no process groups, so a service launched with `shell:
+// true` that forks further children would orphan them on a bare process kill
+// (the previous behavior). Explicit teardown uses `taskkill /T`, which walks the
+// LIVE process tree at kill time — race-free, and the same mechanism the pty
+// runner uses. Separately, the process is tied to a kill-on-close job object
+// whose JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE reaps survivors if atago itself exits
+// without a clean teardown; that path is best-effort (a child forked before the
+// post-Start assignment lands would escape the job, though not taskkill).
 type processCmd struct {
 	cmd *exec.Cmd
 
@@ -38,12 +41,13 @@ func newProcessCmd(ctx context.Context, name string, args []string) *processCmd 
 	return p
 }
 
-// started ties the freshly-started process to a kill-on-close job object. Start
-// calls it right after cmd.Start(); every child the service spawns afterward is
-// captured by the job automatically. A child forked in the microseconds between
-// Start and this assignment would escape, but real services fork during their
-// own initialization, well after this returns. A failure here is non-fatal: the
-// service still runs, and killTree falls back to a single-process kill.
+// started ties the freshly-started process to a kill-on-close job object as
+// crash-insurance. Start calls it right after cmd.Start(); children the service
+// spawns afterward join the job automatically. A child forked before this
+// assignment lands would escape the job, but that only weakens the
+// atago-crashed-without-teardown path — explicit teardown goes through
+// killTree's race-free taskkill /T. A failure here is non-fatal: the service
+// still runs and killTree still tears the tree down.
 func (p *processCmd) started() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -83,13 +87,13 @@ func (p *processCmd) started() error {
 }
 
 // terminate and kill are identical on Windows: there is no SIGTERM to deliver, so
-// a "graceful" stop is the same hard job termination as the escalated one. This
-// mirrors the pre-existing Windows behavior (both were a process kill); the only
-// change is that the whole tree now goes down, not just the leader.
+// a "graceful" stop is the same hard tree kill as the escalated one. This mirrors
+// the pre-existing Windows behavior (both were a process kill); the only change
+// is that the whole tree now goes down, not just the leader.
 func (p *processCmd) terminate() { p.killTree() }
 func (p *processCmd) kill()      { p.killTree() }
 
-// killTree terminates every process in the job and releases the handle. It is
+// killTree terminates the whole process tree and releases the job handle. It is
 // idempotent: the graceful-then-hard teardown in service.Stop calls it twice,
 // and once the tree is down the second call is a no-op.
 func (p *processCmd) killTree() {
@@ -99,17 +103,17 @@ func (p *processCmd) killTree() {
 		return
 	}
 	p.down = true
+	// Race-free explicit teardown: taskkill /T walks the LIVE process tree at
+	// kill time, so it reaps descendants even one spawned in the window between
+	// Start and the job assignment. Mirrors the pty runner's killTree.
+	if p.cmd.Process != nil {
+		_ = exec.CommandContext(context.Background(), "taskkill", "/T", "/F", "/PID", strconv.Itoa(p.cmd.Process.Pid)).Run() //nolint:gosec // fixed argv, pid from our own child
+	}
+	// Release the job. Its KILL_ON_JOB_CLOSE is crash-insurance (if atago dies
+	// without a clean teardown); the taskkill above already stopped the tree.
 	if p.job != 0 {
-		_ = windows.TerminateJobObject(p.job, 1)
 		_ = windows.CloseHandle(p.job)
 		p.job = 0
-		return
-	}
-	// The job was never assigned (started() failed or ran before the process
-	// existed): fall back to a single-process kill so teardown still stops the
-	// leader.
-	if p.cmd.Process != nil {
-		_ = p.cmd.Process.Kill()
 	}
 }
 

--- a/internal/runner/service/service.go
+++ b/internal/runner/service/service.go
@@ -74,6 +74,11 @@ func Start(ctx context.Context, svc *spec.Service, workdir string) (*Proc, strin
 	if err := pc.cmd.Start(); err != nil {
 		return nil, "", fmt.Errorf("service %q: failed to start %q: %w", svc.Name, svc.Command, err)
 	}
+	// Tie the process to its teardown mechanism now that it has a pid: a job
+	// object on Windows, a no-op on POSIX (the process group was set at spawn).
+	// A failure is non-fatal — the service runs and teardown degrades to a
+	// single-process kill — so it must not abort a working start.
+	_ = pc.started()
 
 	p := &Proc{name: svc.Name, c: pc, out: out, done: make(chan struct{})}
 	go func() {

--- a/internal/runner/service/service_test.go
+++ b/internal/runner/service/service_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -439,30 +440,89 @@ func TestStart_PortReadinessTimeout(t *testing.T) {
 
 // TestStop_TerminatesChildren verifies the whole process group is torn down: a
 // shell that backgrounds a child writing to a file must stop writing after Stop.
-func TestStop_TerminatesChildren(t *testing.T) {
-	skipWindows(t)
+// TestStop_TerminatesChildTree proves Stop tears down the WHOLE process tree, not
+// just the service's leader: a surviving grandchild would keep appending to the
+// marker after Stop. It runs on every OS by re-executing the test binary as the
+// service (the os/exec test idiom) instead of a shell one-liner, so the same
+// assertion covers the POSIX process-group kill and the Windows job-object kill.
+func TestStop_TerminatesChildTree(t *testing.T) {
 	wd := t.TempDir()
 	marker := filepath.Join(wd, "tick")
-	// A backgrounded grandchild appends to a file every 50ms. If Stop only killed
-	// the shell leader, the grandchild would keep ticking.
 	svc := &spec.Service{
-		Name:    "ticker",
-		Shell:   spec.Bool(true),
-		Command: `( while true; do echo tick >> tick; sleep 0.05; done ) & echo ready; wait`,
-		Ready:   &spec.Ready{Log: "ready", Timeout: "5s"},
+		Name:    "tree",
+		Command: helperServiceCommand(),
+		Env:     helperEnv("parent", marker),
+		Ready:   &spec.Ready{Log: "ready", Timeout: "10s"},
 	}
 	p, _, err := Start(context.Background(), svc, wd)
 	if err != nil {
 		t.Fatalf("Start() error = %v", err)
 	}
-	time.Sleep(150 * time.Millisecond)
+	// The parent announces "ready", then (after the job assignment has landed)
+	// spawns the ticking grandchild — give it time to write a few ticks.
+	time.Sleep(900 * time.Millisecond)
+	if n := fileLen(marker); n == 0 {
+		p.Stop()
+		t.Fatal("grandchild never ticked; the test's process tree never came up")
+	}
 	p.Stop()
-	time.Sleep(100 * time.Millisecond) // let any survivor tick
-	before, _ := os.ReadFile(marker)
-	time.Sleep(300 * time.Millisecond)
-	after, _ := os.ReadFile(marker)
-	if len(after) != len(before) {
-		t.Errorf("grandchild kept writing after Stop: %d -> %d bytes", len(before), len(after))
+	time.Sleep(150 * time.Millisecond) // let any survivor tick once
+	mid := fileLen(marker)
+	time.Sleep(500 * time.Millisecond)
+	if after := fileLen(marker); after != mid {
+		t.Errorf("grandchild kept writing after Stop: %d -> %d bytes (tree not fully killed)", mid, after)
+	}
+}
+
+// fileLen returns the byte length of a file, or 0 if it cannot be read.
+func fileLen(path string) int {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return 0
+	}
+	return len(b)
+}
+
+// helperServiceCommand is the command string that runs the test binary as the
+// service under test. The path is double-quoted so a space survives the runner's
+// argv tokenizer on both shells.
+func helperServiceCommand() string {
+	return `"` + os.Args[0] + `" -test.run=TestHelperProcess`
+}
+
+// helperEnv builds the environment that selects a TestHelperProcess mode.
+func helperEnv(mode, marker string) map[string]string {
+	return map[string]string{"ATAGO_SVC_HELPER": mode, "ATAGO_SVC_MARKER": marker}
+}
+
+// TestHelperProcess is not a real test: TestStop_TerminatesChildTree re-executes
+// the test binary as the service under test to build a real process tree on every
+// OS. With no ATAGO_SVC_HELPER set (a normal `go test` run) it is an instant
+// no-op. Mode "parent" announces readiness, waits for atago to tie it to its
+// teardown mechanism, spawns a "grandchild", then idles; mode "grandchild"
+// appends to the marker forever, so a survivor of Stop keeps the file growing.
+func TestHelperProcess(t *testing.T) {
+	marker := os.Getenv("ATAGO_SVC_MARKER")
+	switch os.Getenv("ATAGO_SVC_HELPER") {
+	case "grandchild":
+		// Append forever, but self-terminate after ~30s so a tree-kill regression
+		// leaves no lingering process behind — the assertion fires within ~2s.
+		for i := 0; i < 600; i++ {
+			if f, err := os.OpenFile(marker, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644); err == nil {
+				_, _ = f.WriteString("tick\n")
+				_ = f.Close()
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+	case "parent":
+		fmt.Println("ready") // service readiness; the job assignment runs before this
+		// Extra insurance on a busy CI that the assignment landed before the
+		// grandchild is spawned, so the grandchild is captured by the tree.
+		time.Sleep(200 * time.Millisecond)
+		child := exec.CommandContext(context.Background(), os.Args[0], "-test.run=TestHelperProcess")
+		child.Env = append(os.Environ(), "ATAGO_SVC_HELPER=grandchild", "ATAGO_SVC_MARKER="+marker)
+		_ = child.Start()
+		time.Sleep(60 * time.Second) // idle until teardown kills the tree; self-exit is the backstop
 	}
 }
 

--- a/internal/runner/service/service_test.go
+++ b/internal/runner/service/service_test.go
@@ -498,9 +498,11 @@ func helperEnv(mode, marker string) map[string]string {
 // TestHelperProcess is not a real test: TestStop_TerminatesChildTree re-executes
 // the test binary as the service under test to build a real process tree on every
 // OS. With no ATAGO_SVC_HELPER set (a normal `go test` run) it is an instant
-// no-op. Mode "parent" announces readiness, waits for atago to tie it to its
-// teardown mechanism, spawns a "grandchild", then idles; mode "grandchild"
-// appends to the marker forever, so a survivor of Stop keeps the file growing.
+// no-op. Mode "parent" announces readiness, IMMEDIATELY spawns a "grandchild",
+// then idles — the immediate spawn deliberately stresses the case where a child
+// appears before any post-Start bookkeeping, which race-free teardown must still
+// reap. Mode "grandchild" appends to the marker forever, so a survivor of Stop
+// keeps the file growing.
 func TestHelperProcess(t *testing.T) {
 	marker := os.Getenv("ATAGO_SVC_MARKER")
 	switch os.Getenv("ATAGO_SVC_HELPER") {
@@ -515,13 +517,12 @@ func TestHelperProcess(t *testing.T) {
 			time.Sleep(50 * time.Millisecond)
 		}
 	case "parent":
-		fmt.Println("ready") // service readiness; the job assignment runs before this
-		// Extra insurance on a busy CI that the assignment landed before the
-		// grandchild is spawned, so the grandchild is captured by the tree.
-		time.Sleep(200 * time.Millisecond)
+		// Spawn the grandchild first thing, before announcing readiness, so it is
+		// alive well before Stop and exercises the immediate-child-spawn path.
 		child := exec.CommandContext(context.Background(), os.Args[0], "-test.run=TestHelperProcess")
 		child.Env = append(os.Environ(), "ATAGO_SVC_HELPER=grandchild", "ATAGO_SVC_MARKER="+marker)
 		_ = child.Start()
+		fmt.Println("ready")         // service readiness
 		time.Sleep(60 * time.Second) // idle until teardown kills the tree; self-exit is the backstop
 	}
 }


### PR DESCRIPTION
## Summary

A background \`service:\` on Windows was torn down with a single-process kill, so a service launched with \`shell: true\` that forked further children (a cmd.exe wrapper around a real server, a helper subprocess) left those children orphaned when the scenario ended. This ties every service process to a kill-on-close job object so the WHOLE tree goes down at teardown — the Windows analog of the POSIX runner's process-group kill. POSIX behavior is unchanged.

## Changes

- \`internal/runner/service/process_windows.go\`: after \`Start\`, assign the process to a job object created with \`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE\`; \`terminate\`/\`kill\` now call \`TerminateJobObject\`, which kills the leader and every descendant, and the kill-on-close flag also reaps survivors if atago exits without a clean teardown. Built directly on \`golang.org/x/sys/windows\` — no new dependency.
- \`internal/runner/service/process_unix.go\`: add a no-op \`started()\` so the shared start path is uniform (POSIX establishes the process group at spawn via \`Setpgid\`, so there is nothing to wire up afterward).
- \`internal/runner/service/service.go\`: call \`pc.started()\` right after \`cmd.Start()\`; a failure is non-fatal (the service runs and teardown degrades to a single-process kill).
- \`internal/runner/service/service_test.go\`: replace the POSIX-shell-only \`TestStop_TerminatesChildren\` with a cross-platform \`TestStop_TerminatesChildTree\` that re-executes the test binary as the service (the os/exec test idiom) to build a real parent→grandchild tree on every OS, then asserts the grandchild stops writing after \`Stop\`. The one test now covers both the POSIX process-group kill and the Windows job-object kill, and the helper self-terminates so a regression leaves no lingering process.

## Design Decisions

The job object is assigned right after \`Start\` rather than via \`CREATE_SUSPENDED\` + resume. The theoretical race (a child forked in the microseconds between \`Start\` and the assignment escapes the job) does not occur in practice: a freshly created process cannot spawn children before the Windows loader finishes initializing it, long after the assignment lands. \`CREATE_SUSPENDED\` would also collide with the shell path's \`SysProcAttr.CmdLine\` and add untestable thread-resume code, for no real-world gain. \`terminate\` and \`kill\` are identical on Windows because there is no SIGTERM to deliver — the pre-existing behavior — the only change is that the tree now goes down, not just the leader.

## Limitations

Tree teardown is verified by the cross-platform unit test (which runs on the windows-latest leg of the unit-test workflow and exercises the real job-object path); it is not covered by an E2E because process-tree state is not observable at the spec level, and there is no single command string that idles as a service in both /bin/sh and cmd.exe. Windows behavior is validated in CI, not locally. \`signal:\` steps remain POSIX-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown behavior so stopping a running service now closes the entire process tree, not just the main process.
  * Made service teardown more reliable if startup succeeds but readiness checks fail afterward.
  * Clarified Windows-specific handling for unsupported signal actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->