### PR TITLE
refactor(record): share one cross-platform terminalSize helper across capture backends

### DIFF
--- a/internal/record/capture.go
+++ b/internal/record/capture.go
@@ -1,0 +1,18 @@
+package record
+
+import (
+	"os"
+
+	"golang.org/x/term"
+)
+
+// terminalSize returns the invoking terminal's rows/cols, or the pty default
+// (24x80) when out is not a terminal. golang.org/x/term.GetSize reads a POSIX
+// terminal and a Windows console alike, so one helper serves both the POSIX and
+// ConPTY capture backends.
+func terminalSize(out *os.File) (rows, cols int) {
+	if w, h, err := term.GetSize(int(out.Fd())); err == nil && w > 0 && h > 0 {
+		return h, w
+	}
+	return 24, 80
+}

--- a/internal/record/capture_unix.go
+++ b/internal/record/capture_unix.go
@@ -122,15 +122,6 @@ func CapturePTY(command string, shell bool, in, out *os.File) (PTYRecording, err
 	return rec, nil
 }
 
-// terminalSize returns the invoking terminal's rows/cols, or the pty default
-// (24x80) when out is not a terminal.
-func terminalSize(out *os.File) (rows, cols int) {
-	if r, c, err := pty.Getsize(out); err == nil && r > 0 && c > 0 {
-		return r, c
-	}
-	return 24, 80
-}
-
 // echoDisabled reports whether the pty's terminal echo is currently off — the
 // signal of a password prompt, whose typed bytes must not be recorded (#69).
 func echoDisabled(master *os.File) bool {

--- a/internal/record/capture_windows.go
+++ b/internal/record/capture_windows.go
@@ -122,15 +122,6 @@ func CapturePTY(command string, shell bool, in, out *os.File) (PTYRecording, err
 	return rec, nil
 }
 
-// terminalSize returns the developer console's rows/cols, or the pty default
-// (24x80) when out is not a console.
-func terminalSize(out *os.File) (rows, cols int) {
-	if w, h, err := term.GetSize(int(out.Fd())); err == nil && w > 0 && h > 0 {
-		return h, w
-	}
-	return 24, 80
-}
-
 // enableVTOutput turns on ENABLE_VIRTUAL_TERMINAL_PROCESSING for the developer's
 // output console so the ConPTY's ANSI stream renders, and returns a func that
 // restores the previous mode. When out is not a console it is a no-op.


### PR DESCRIPTION
## Summary

The POSIX and ConPTY capture backends each carried their own \`terminalSize\` helper (one over \`creack/pty.Getsize\`, one over \`golang.org/x/term.GetSize\`). \`term.GetSize\` reads a POSIX terminal and a Windows console alike, so this collapses them into one non-tagged helper — the small duplication left over from the record --pty Windows work.

## Changes

- \`internal/record/capture.go\` (new): one \`terminalSize\` used by both backends.
- \`internal/record/capture_unix.go\`, \`internal/record/capture_windows.go\`: drop the per-platform copies.

## Design Decisions

This is the only clean dedup left after the record --pty work — the ConPTY wrapper was already extracted into \`internal/conpty\` and the pty runner already shares \`driveSession\`. A larger symmetric refactor (extracting a shared capture core the way the runner shares \`driveSession\`) was considered and deliberately skipped: the interactive INPUT path has no cross-platform test (a stdin-reading command plus EOF differs between ^D on POSIX and ^Z on Windows), so extracting it would move unverified code into a shared core for no test-backed safety. The exit-code helpers in the pty runner and the recorder look duplicable but carry different semantics from the cmd runner's signal-mapping variant, so they are left alone too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal recording by detecting the current terminal size more reliably across platforms.
  * Added a safe fallback size when terminal dimensions can’t be determined, helping recordings continue in non-terminal or error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->