### PR TITLE
feat(record): bound record --pty with a --timeout so it never hangs forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `atago record --pty` takes a `--timeout` flag (default 30s) that bounds how
+  long it waits for the recorded program to exit. Previously the recorder waited
+  forever: a server-like process, or an interactive program whose quit keystroke
+  was lost to a read-readiness race, would wedge `record --pty` with no output
+  and no way out but Ctrl-C. When the timeout elapses atago now kills the child
+  process tree (a process-group kill on POSIX, a `taskkill /T` tree kill on
+  Windows), still writes whatever transcript was captured, and exits non-zero
+  with a clear `did not exit within …` message — mirroring the `pty:` spec
+  step's own `timeout:` bound. ([#194](https://github.com/nao1215/atago/issues/194))
+
 ## [0.7.0] - 2026-07-07
 
 Windows completes its interactive-terminal story. `pty:` steps and

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ $ atago run mytool.atago.yaml
 PASSED  1 scenario: 1 passed, 0 failed, 0 errored, 0 skipped (12ms)
 ```
 
-Interactive tools record too: `atago record --pty -- <command>` runs it in a real terminal, lets you drive one session by hand, and writes a `pty:` step that replays your keystrokes as expect/send pairs. It works on Linux, macOS, and Windows (a ConPTY); on POSIX a password prompt becomes an `${env:...}` placeholder automatically, while on Windows — where a ConPTY exposes no echo state — you convert a secret send to `${env:...}` by hand:
+Interactive tools record too: `atago record --pty -- <command>` runs it in a real terminal, lets you drive one session by hand, and writes a `pty:` step that replays your keystrokes as expect/send pairs. It works on Linux, macOS, and Windows (a ConPTY); on POSIX a password prompt becomes an `${env:...}` placeholder automatically, while on Windows — where a ConPTY exposes no echo state — you convert a secret send to `${env:...}` by hand. A `--pty` session is bounded by `--timeout` (default 30s): if the program never exits, atago kills it, writes whatever was captured, and fails instead of hanging forever:
 
 ```shell
 $ atago record --pty --out wizard.atago.yaml -- mytool init

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 374 scenarios
+74 suites · 375 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -288,7 +288,7 @@
   - [a pty step drives the atago binary directly with no shell](#scenario-a-pty-step-drives-the-atago-binary-directly-with-no-shell)
   - [a pty drives atago running an inner spec to a green result](#scenario-a-pty-drives-atago-running-an-inner-spec-to-a-green-result)
   - [a never-matching expect fails and names the pattern in the transcript](#scenario-a-never-matching-expect-fails-and-names-the-pattern-in-the-transcript)
-- [atago self-hosting / record (spec skeleton from an observed run)](#atago-self-hosting--record-spec-skeleton-from-an-observed-run) — 13 scenarios
+- [atago self-hosting / record (spec skeleton from an observed run)](#atago-self-hosting--record-spec-skeleton-from-an-observed-run) — 14 scenarios
   - [record then run round-trips green](#scenario-record-then-run-round-trips-green)
   - [refusing to overwrite without --force](#scenario-refusing-to-overwrite-without---force)
   - [record --pty refuses an existing --out before driving the session](#scenario-record---pty-refuses-an-existing---out-before-driving-the-session)
@@ -302,6 +302,7 @@
   - [a prompt with regex metacharacters is escaped in the generated expect](#scenario-a-prompt-with-regex-metacharacters-is-escaped-in-the-generated-expect)
   - [recorded text containing dollar-brace round-trips as literal text](#scenario-recorded-text-containing-dollar-brace-round-trips-as-literal-text)
   - [a recorded secret placeholder replays green with the env set and is guarded when unset](#scenario-a-recorded-secret-placeholder-replays-green-with-the-env-set-and-is-guarded-when-unset)
+  - [record --pty of a never-exiting program times out instead of hanging](#scenario-record---pty-of-a-never-exiting-program-times-out-instead-of-hanging)
 - [atago self-hosting / report formats agree on outcomes](#atago-self-hosting--report-formats-agree-on-outcomes) — 7 scenarios
   - [json report carries per-scenario verdicts and a failures array](#scenario-json-report-carries-per-scenario-verdicts-and-a-failures-array)
   - [junit report tallies tests, failures, skipped, and errors](#scenario-junit-report-tallies-tests-failures-skipped-and-errors)
@@ -4999,6 +5000,17 @@ ${atago} run sec.atago.yaml
 - after `${atago} run sec.atago.yaml`:
   - exit code is `4`
   - stdout contains `ATAGO_SECRET_1 is not set`
+### Scenario: record --pty of a never-exiting program times out instead of hanging
+_skipped on windows_
+#### When
+```shell
+${atago} record --pty --timeout 2s --out wedged.atago.yaml -- tail -f /dev/null
+```
+#### Then
+- exit code is `4`
+- stderr contains `did not exit within 2s`
+- stderr contains `use --timeout to adjust`
+- file `wedged.atago.yaml` contains `- pty:`
 ## atago self-hosting / report formats agree on outcomes
 Source: `test/e2e/atago/report_formats.atago.yaml`
 ### Scenario: json report carries per-scenario verdicts and a failures array

--- a/internal/cli/record.go
+++ b/internal/cli/record.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/nao1215/atago/internal/record"
 	runnercmd "github.com/nao1215/atago/internal/runner/cmd"
@@ -31,9 +32,10 @@ func recordCmd(args []string, stdout, stderr io.Writer) int {
 	shell := fs.Bool("shell", false, "record the command line verbatim with shell: true")
 	snap := fs.Bool("snapshot", false, "assert stdout against a snapshot golden (requires --out; the golden is written next to it)")
 	ptyMode := fs.Bool("pty", false, "record an interactive pty session and generate an expect/send spec")
+	ptyTimeout := fs.Duration("timeout", record.DefaultCaptureTimeout, "kill the pty session and fail if the program does not exit within this bound (--pty only)")
 	fs.Usage = func() {
 		fmt.Fprint(stderr, `Usage: atago record [--out FILE] [--force] [--shell] [--snapshot] -- <command> [args...]
-       atago record --pty [--out FILE] [--force] [--shell] -- <command> [args...]
+       atago record --pty [--out FILE] [--force] [--shell] [--timeout DUR] -- <command> [args...]
 
 Runs the command once in a scratch directory and prints a spec skeleton
 derived from what it observed: exit code, first stdout line, empty stderr,
@@ -43,8 +45,10 @@ With --pty, runs the command in a real pseudo-terminal wired to your
 terminal, lets you drive one interactive session by hand, and generates a
 spec whose pty: step replays it as expect/send pairs. On Windows it drives a
 ConPTY; a ConPTY exposes no echo state, so typed passwords are not auto-masked
-there — convert a secret send to a ${env:...} placeholder by hand. HTTP
-recording is a non-goal for now — write those steps by hand.
+there — convert a secret send to a ${env:...} placeholder by hand. A --pty
+session is bounded by --timeout (default 30s): if the program never exits,
+atago kills it, writes whatever was captured, and fails. HTTP recording is a
+non-goal for now — write those steps by hand.
 `)
 		fs.PrintDefaults()
 	}
@@ -69,7 +73,7 @@ recording is a non-goal for now — write those steps by hand.
 		return ExitConfig
 	}
 	if *ptyMode {
-		return recordPTY(cmdArgs, *shell, *out, *force, stdout, stderr)
+		return recordPTY(cmdArgs, *shell, *out, *force, *ptyTimeout, stdout, stderr)
 	}
 
 	// Preserve argv boundaries: the runner (and later the generated spec)
@@ -160,7 +164,7 @@ recording is a non-goal for now — write those steps by hand.
 // pseudo-terminal wired to the developer's own terminal, let them drive one
 // interactive session by hand, and generate a spec whose pty: step replays it
 // as expect/send pairs. Runs on POSIX (a real pty) and Windows (a ConPTY).
-func recordPTY(cmdArgs []string, shell bool, out string, force bool, stdout, stderr io.Writer) int {
+func recordPTY(cmdArgs []string, shell bool, out string, force bool, timeout time.Duration, stdout, stderr io.Writer) int {
 	// Refuse an existing --out up front, before driving the session: otherwise
 	// a user hand-drives the whole interactive session only to be told the file
 	// already exists once it is too late to save the transcript.
@@ -175,8 +179,12 @@ func recordPTY(cmdArgs []string, shell bool, out string, force bool, stdout, std
 	}
 
 	fmt.Fprintln(stderr, "recording pty session — drive it by hand; it ends when the program exits")
-	rec, err := record.CapturePTY(command, shell, os.Stdin, os.Stdout)
-	if err != nil {
+	rec, err := record.CapturePTY(command, shell, os.Stdin, os.Stdout, timeout)
+	// A timeout is not a hard failure: the child was killed but the transcript
+	// captured before the deadline is still worth writing. Any other error means
+	// the session never got off the ground, so there is nothing to save.
+	timedOut := errors.Is(err, record.ErrCaptureTimeout)
+	if err != nil && !timedOut {
 		fmt.Fprintf(stderr, "atago record: %v\n", err)
 		return ExitExec
 	}
@@ -198,7 +206,7 @@ func recordPTY(cmdArgs []string, shell bool, out string, force bool, stdout, std
 
 	if out == "" {
 		fmt.Fprint(stdout, string(generated))
-		return ExitOK
+		return ptyExitCode(timedOut, timeout, stderr)
 	}
 	if dir := filepath.Dir(out); dir != "." {
 		if err := os.MkdirAll(dir, 0o750); err != nil {
@@ -211,7 +219,23 @@ func recordPTY(cmdArgs []string, shell bool, out string, force bool, stdout, std
 		return ExitExec
 	}
 	fmt.Fprintf(stderr, "wrote %s\n", out)
-	return ExitOK
+	return ptyExitCode(timedOut, timeout, stderr)
+}
+
+// ptyExitCode reports the final status of a --pty recording: a clean ExitOK, or
+// — when the program never exited within the timeout — a clear message plus
+// ExitExec, so a wedged interactive recording never masquerades as success
+// (#194).
+func ptyExitCode(timedOut bool, timeout time.Duration, stderr io.Writer) int {
+	if !timedOut {
+		return ExitOK
+	}
+	effective := timeout
+	if effective <= 0 {
+		effective = record.DefaultCaptureTimeout
+	}
+	fmt.Fprintf(stderr, "atago record --pty: the program did not exit within %s (use --timeout to adjust)\n", effective)
+	return ExitExec
 }
 
 // listFiles walks the scratch dir and returns every file as a sorted,

--- a/internal/cli/record_test.go
+++ b/internal/cli/record_test.go
@@ -7,8 +7,11 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	shellwords "github.com/mattn/go-shellwords"
+
+	"github.com/nao1215/atago/internal/record"
 )
 
 // TestPOSIXJoin_RoundTrip proves posixJoin's output re-tokenizes to the same
@@ -63,6 +66,40 @@ func TestRecordPTY_ExistingOutExitsEarly(t *testing.T) {
 	}
 	if b, _ := os.ReadFile(out); string(b) != "precious" {
 		t.Errorf("existing file was modified: %q", b)
+	}
+}
+
+// TestPTYExitCode covers the --pty timeout verdict (#194): a clean session is
+// ExitOK and silent, while a timed-out one prints a specific, actionable
+// message (the elapsed bound plus the --timeout hint) and returns ExitExec so a
+// wedged recording never reports success. A non-positive timeout reports the
+// default bound, matching the value CapturePTY actually applied.
+func TestPTYExitCode(t *testing.T) {
+	t.Parallel()
+
+	var ok bytes.Buffer
+	if code := ptyExitCode(false, 30*time.Second, &ok); code != ExitOK {
+		t.Errorf("clean session exit = %d, want %d", code, ExitOK)
+	}
+	if ok.Len() != 0 {
+		t.Errorf("clean session wrote to stderr: %q", ok.String())
+	}
+
+	var timedOut bytes.Buffer
+	if code := ptyExitCode(true, 2*time.Second, &timedOut); code != ExitExec {
+		t.Errorf("timed-out session exit = %d, want %d", code, ExitExec)
+	}
+	msg := timedOut.String()
+	for _, want := range []string{"did not exit within 2s", "--timeout"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("timeout message %q missing %q", msg, want)
+		}
+	}
+
+	var defaulted bytes.Buffer
+	ptyExitCode(true, 0, &defaulted)
+	if want := "did not exit within " + record.DefaultCaptureTimeout.String(); !strings.Contains(defaulted.String(), want) {
+		t.Errorf("non-positive timeout message %q missing %q", defaulted.String(), want)
 	}
 }
 

--- a/internal/record/capture.go
+++ b/internal/record/capture.go
@@ -1,10 +1,35 @@
 package record
 
 import (
+	"errors"
 	"os"
+	"time"
 
 	"golang.org/x/term"
 )
+
+// DefaultCaptureTimeout bounds a `record --pty` session when the caller passes a
+// non-positive timeout: an interactive program that never exits (a server, or a
+// prompt whose quit keystroke was lost to a read-readiness race) must fail
+// loudly instead of hanging the recorder forever (#194). It mirrors the pty:
+// spec step's default so the CLI and the spec step agree on "how long is too
+// long".
+const DefaultCaptureTimeout = 30 * time.Second
+
+// ErrCaptureTimeout is returned by CapturePTY — together with the transcript
+// captured so far — when the recorded program does not exit within the timeout.
+// The child process tree is killed before it is returned, so the caller can
+// still write the partial spec and nothing is left running (#194).
+var ErrCaptureTimeout = errors.New("record --pty: the program did not exit within the timeout")
+
+// resolveCaptureTimeout applies DefaultCaptureTimeout when the caller passes a
+// non-positive duration, matching sessionTimeout in the pty: runner.
+func resolveCaptureTimeout(d time.Duration) time.Duration {
+	if d <= 0 {
+		return DefaultCaptureTimeout
+	}
+	return d
+}
 
 // terminalSize returns the invoking terminal's rows/cols, or the pty default
 // (24x80) when out is not a terminal. golang.org/x/term.GetSize reads a POSIX

--- a/internal/record/capture_test.go
+++ b/internal/record/capture_test.go
@@ -1,10 +1,13 @@
 package record
 
 import (
+	"errors"
 	"io"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestCapturePTY_RecordsOutputAndExit drives the whole capture path with a
@@ -28,7 +31,7 @@ func TestCapturePTY_RecordsOutputAndExit(t *testing.T) {
 	go func() { _, _ = io.Copy(io.Discard, outR) }()
 
 	// shell:true → `sh -c` / `cmd /S /C`, so echo is a builtin on both shells.
-	rec, err := CapturePTY("echo capture-marker", true, inR, outW)
+	rec, err := CapturePTY("echo capture-marker", true, inR, outW, 30*time.Second)
 	if err != nil {
 		t.Fatalf("CapturePTY() error = %v", err)
 	}
@@ -41,5 +44,63 @@ func TestCapturePTY_RecordsOutputAndExit(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "capture-marker") {
 		t.Errorf("recording missing the child's output: %q", out.String())
+	}
+}
+
+// TestCapturePTY_TimesOutOnNonExitingChild is the cross-platform backstop for
+// #194: a program that never exits must not hang the recorder forever. It runs
+// a child that ignores stdin and outlives the timeout, and asserts CapturePTY
+// returns within a bound carrying ErrCaptureTimeout instead of blocking. It
+// exercises both the POSIX pty process-group kill and the Windows ConPTY tree
+// kill, since that timeout path has no other automated coverage.
+func TestCapturePTY_TimesOutOnNonExitingChild(t *testing.T) {
+	inR, inW, err := os.Pipe() // the child ignores input; the pipe just gives it a stdin
+	if err != nil {
+		t.Fatalf("input pipe: %v", err)
+	}
+	defer func() { _ = inR.Close(); _ = inW.Close() }()
+	outR, outW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("output pipe: %v", err)
+	}
+	defer func() { _ = outR.Close(); _ = outW.Close() }()
+	go func() { _, _ = io.Copy(io.Discard, outR) }()
+
+	// A command that ignores stdin and runs far longer than the timeout, so the
+	// only way CapturePTY returns is the timeout firing — not the child exiting.
+	// `sleep 60` on POSIX; `ping -n 60 127.0.0.1` is the closest builtin-free
+	// Windows equivalent (it runs ~60s and never reads stdin).
+	command := "sleep 60"
+	if runtime.GOOS == "windows" {
+		command = "ping -n 60 127.0.0.1"
+	}
+
+	const timeout = 500 * time.Millisecond
+	done := make(chan struct{})
+	var rec PTYRecording
+	var capErr error
+	start := time.Now()
+	go func() {
+		defer close(done)
+		rec, capErr = CapturePTY(command, true, inR, outW, timeout)
+	}()
+
+	// Generously bound the whole call: the timeout plus teardown (tree kill,
+	// drain grace) must complete well under this, or the recorder is hanging.
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatalf("CapturePTY did not return within 15s — it hung on a non-exiting child")
+	}
+
+	if !errors.Is(capErr, ErrCaptureTimeout) {
+		t.Fatalf("CapturePTY() error = %v, want ErrCaptureTimeout", capErr)
+	}
+	if elapsed := time.Since(start); elapsed < timeout {
+		t.Errorf("returned in %v, before the %v timeout could have elapsed", elapsed, timeout)
+	}
+	// The killed child never exits cleanly, so the recorded code is non-zero.
+	if rec.ExitCode == 0 {
+		t.Errorf("exit code = 0, want a non-zero code for a killed child")
 	}
 }

--- a/internal/record/capture_unix.go
+++ b/internal/record/capture_unix.go
@@ -32,15 +32,21 @@ const captureDrainGrace = 500 * time.Millisecond
 // developer's terminal), puts in into raw mode, forwards keystrokes and output
 // until the program exits, and returns the recorded session (#69). This is the
 // POSIX build; capture_windows.go implements the same contract over a ConPTY.
-func CapturePTY(command string, shell bool, in, out *os.File) (PTYRecording, error) {
+//
+// timeout bounds the wait for the child to exit: a program that never exits (a
+// server, or a prompt whose quit keystroke was lost) would otherwise hang the
+// recorder forever. When it elapses the whole child process tree is killed and
+// the transcript captured so far is returned with ErrCaptureTimeout (#194). A
+// non-positive timeout falls back to DefaultCaptureTimeout.
+func CapturePTY(command string, shell bool, in, out *os.File, timeout time.Duration) (PTYRecording, error) {
 	name, args, err := runnercmd.CommandLine(command, shell)
 	if err != nil {
 		return PTYRecording{}, err
 	}
 
-	// The session runs until the child exits under the developer's own hand, so
-	// there is no timeout to bound — Background gives the interactive session no
-	// deadline while still satisfying the context-aware exec contract.
+	// Background: the child is bounded by the timeout below (a killed process
+	// group), not by context cancellation, so a plain Background satisfies the
+	// context-aware exec contract without a redundant second deadline.
 	cmd := exec.CommandContext(context.Background(), name, args...) //nolint:gosec // recording the user's declared command is the purpose
 	cmd.Env = os.Environ()
 	// A fresh session so the child owns the pty and a stray descendant does not
@@ -106,7 +112,24 @@ func CapturePTY(command string, shell bool, in, out *os.File) (PTYRecording, err
 		}
 	}()
 
-	waitErr := cmd.Wait()
+	// Reap the child from one goroutine so the wait can be raced against the
+	// timeout. The buffered channel lets the timeout path deliver the code even
+	// after it kills the tree — the reaper never blocks on a drained receiver.
+	waitCh := make(chan int, 1)
+	go func() { waitCh <- exitCode(cmd.Wait()) }()
+
+	timedOut := false
+	var code int
+	select {
+	case code = <-waitCh:
+	case <-time.After(resolveCaptureTimeout(timeout)):
+		timedOut = true
+		// Kill the whole process group (Setsid) so a never-exiting child and any
+		// descendant are torn down, not just the direct child, then reap it.
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		code = <-waitCh
+	}
+
 	// Drain the pty's final bytes before closing the master, then stop the
 	// output reader. A bounded grace keeps a lingering descendant from hanging us.
 	select {
@@ -117,8 +140,11 @@ func CapturePTY(command string, shell bool, in, out *os.File) (PTYRecording, err
 	<-outDone
 
 	mu.Lock()
-	rec.ExitCode = exitCode(waitErr)
+	rec.ExitCode = code
 	mu.Unlock()
+	if timedOut {
+		return rec, ErrCaptureTimeout
+	}
 	return rec, nil
 }
 

--- a/internal/record/capture_windows.go
+++ b/internal/record/capture_windows.go
@@ -17,6 +17,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
+	"strconv"
 	"sync"
 	"time"
 
@@ -34,7 +36,13 @@ const captureDrainGrace = 500 * time.Millisecond
 // console), puts in into raw mode, forwards keystrokes and output until the
 // program exits, and returns the recorded session (#69). Needs Windows 10 (1809)
 // or later for the ConPTY API.
-func CapturePTY(command string, shell bool, in, out *os.File) (PTYRecording, error) {
+//
+// timeout bounds the wait for the child to exit: a program that never exits (a
+// server, or a prompt whose quit keystroke was lost) would otherwise hang the
+// recorder forever. When it elapses the whole child process tree is killed and
+// the transcript captured so far is returned with ErrCaptureTimeout (#194). A
+// non-positive timeout falls back to DefaultCaptureTimeout.
+func CapturePTY(command string, shell bool, in, out *os.File, timeout time.Duration) (PTYRecording, error) {
 	if !conpty.IsAvailable() {
 		return PTYRecording{}, fmt.Errorf("record --pty needs ConPTY, which requires Windows 10 version 1809 or later")
 	}
@@ -106,7 +114,19 @@ func CapturePTY(command string, shell bool, in, out *os.File) (PTYRecording, err
 		}
 	}()
 
-	code := cpty.Wait(context.Background())
+	// Bound the wait: cpty.Wait returns early when ctx fires, letting a
+	// never-exiting child be torn down instead of hanging the recorder.
+	ctx, cancel := context.WithTimeout(context.Background(), resolveCaptureTimeout(timeout))
+	defer cancel()
+	code := cpty.Wait(ctx)
+	timedOut := false
+	if ctx.Err() != nil {
+		// The wait unblocked because the deadline fired, not because the child
+		// exited. Kill the whole tree (Windows has no process groups, so taskkill
+		// /T walks descendants) so nothing is left running, then record a timeout.
+		timedOut = true
+		killTree(cpty.Pid())
+	}
 	// Drain the pseudo console's final bytes before closing it, then stop the
 	// output reader. A bounded grace keeps a lingering descendant from hanging us.
 	select {
@@ -119,7 +139,19 @@ func CapturePTY(command string, shell bool, in, out *os.File) (PTYRecording, err
 	mu.Lock()
 	rec.ExitCode = code
 	mu.Unlock()
+	if timedOut {
+		return rec, ErrCaptureTimeout
+	}
 	return rec, nil
+}
+
+// killTree force-terminates the child and every descendant. Windows has no
+// process groups, so taskkill /T walks the process tree — the closest analog to
+// the POSIX capture's kill of the whole Setsid group, so a timed-out session
+// never leaks a running child (#194).
+func killTree(pid int) {
+	// A fire-and-forget teardown; Background is the honest context here.
+	_ = exec.CommandContext(context.Background(), "taskkill", "/T", "/F", "/PID", strconv.Itoa(pid)).Run() //nolint:gosec // fixed argv, pid from our own child
 }
 
 // enableVTOutput turns on ENABLE_VIRTUAL_TERMINAL_PROCESSING for the developer's

--- a/test/e2e/atago/record.atago.yaml
+++ b/test/e2e/atago/record.atago.yaml
@@ -346,3 +346,33 @@ scenarios:
           exit_code: 4
           stdout:
             contains: "ATAGO_SECRET_1 is not set"
+
+  - name: record --pty of a never-exiting program times out instead of hanging
+    skip:
+      os: windows
+    steps:
+      # #194: `record --pty` used to wait forever for the child to exit, so a
+      # server-like or wedged interactive program (here `tail -f /dev/null`,
+      # which ignores stdin and never exits) would hang with no way out but
+      # Ctrl-C. --timeout now bounds that wait. A plain run step drives the
+      # recorder from a non-terminal stdin — record --pty tolerates that (raw
+      # mode is best-effort) — so the bound is exercisable in CI without a
+      # pseudo-terminal on the driving side. taskkill/`tail` are POSIX here;
+      # the Windows ConPTY timeout path is covered by the record unit test.
+      - run:
+          command: ${atago} record --pty --timeout 2s --out wedged.atago.yaml -- tail -f /dev/null
+      # Non-zero exit (execution error) and a clear, actionable message — never a
+      # silent, unbounded block.
+      - assert:
+          exit_code: 4
+          stderr:
+            contains: "did not exit within 2s"
+      - assert:
+          stderr:
+            contains: "use --timeout to adjust"
+      # The transcript captured before the deadline is still written, so the
+      # partial recording is not thrown away.
+      - assert:
+          file:
+            path: wedged.atago.yaml
+            contains: "- pty:"


### PR DESCRIPTION
## Summary

`atago record --pty -- <command>` waited for the recorded program to exit and put no upper bound on that wait. If the program never exits — a server-like process, or an interactive program whose quit keystroke is lost or never sent — `record --pty` blocked indefinitely with no output and no way out except Ctrl-C. This was inconsistent with the `pty:` spec step, which bounds its session with a `timeout:` and fails cleanly instead of hanging. This PR gives `record --pty` the same bound.

## Changes

`CapturePTY` now takes a `timeout` and, on both POSIX and Windows, reaps the child through a goroutine and races the wait against the deadline. When the timeout elapses it kills the whole child process tree — a process-group kill on POSIX (the existing `Setsid` group), a `taskkill /T` tree kill on Windows (ConPTY) — returns the transcript captured so far, and reports the new `record.ErrCaptureTimeout` sentinel. A non-positive timeout falls back to `record.DefaultCaptureTimeout` (30s), mirroring `sessionTimeout` in the `pty:` runner.

The `record` command exposes this as a `--timeout` flag (default 30s). On timeout it still writes whatever transcript was captured (so a partial spec is never thrown away), prints a clear `atago record --pty: the program did not exit within Ns (use --timeout to adjust)` message, and exits non-zero (`ExitExec`). A clean session is unchanged: silent, exit 0.

## Tests

Unit (cross-platform), `internal/record/capture_test.go`: `TestCapturePTY_TimesOutOnNonExitingChild` drives a child that ignores stdin and outlives the timeout (`sleep 60` on POSIX, `ping -n 60 127.0.0.1` on Windows) and asserts `CapturePTY` returns well within a wall-clock bound carrying `ErrCaptureTimeout` — exercising both the POSIX pty process-group kill and the Windows ConPTY tree kill, which had no other automated coverage.

Unit, `internal/cli/record_test.go`: `TestPTYExitCode` pins the timeout verdict — `ExitOK` and silent on a clean session, `ExitExec` with the elapsed-bound-and-`--timeout` message on timeout, and the default bound reported for a non-positive timeout.

Self-hosted CLI E2E, `test/e2e/atago/record.atago.yaml`: a new scenario runs `atago record --pty --timeout 2s -- tail -f /dev/null` from a non-terminal stdin (a plain `run` step; `record --pty` tolerates that since raw-mode setup is best-effort) and asserts the non-zero exit, the `did not exit within 2s` / `use --timeout to adjust` messages, and that the partial spec was still written.

## Notes

`README.md`, `CHANGELOG.md`, and the generated `doc/e2e/atago.md` are updated to match. The E2E scenario skips Windows (its inner `tail` is POSIX-only); the Windows ConPTY timeout path is covered by the cross-platform unit test.

Closes #194

https://claude.ai/code/session_01DgY14acsLifSspVLZD5auT