### PR TITLE
fix: hardening sweep across assert, snapshot, report, run engine, record, and loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,57 @@ and this project follows [Semantic Versioning](https://semver.org/).
   with a clear `did not exit within …` message — mirroring the `pty:` spec
   step's own `timeout:` bound. ([#194](https://github.com/nao1215/atago/issues/194))
 
+### Fixed
+
+- `run` no longer writes redirected output to a literal filename: `stdout_to`
+  and `stderr_to` are now `${name}`-expanded like the assertion paths that read
+  them, so a per-matrix-row or store-keyed target such as `out-${who}.txt`
+  resolves instead of failing the following assert with a spurious "no such
+  file".
+- `dir` `contains`/`not_contains` judged membership by following the symlink, so
+  a dangling symlink was reported absent — a dangerous false pass for
+  `not_contains`. Membership now reflects the directory entry (`Lstat`), matching
+  the recursive and glob paths.
+- `atago record` output containing non-UTF-8 bytes (binary, Latin-1, Shift-JIS)
+  now round-trips: the generated spec re-parsed lossily and failed on its first
+  replay. The recorder emits a `!!binary` scalar for such lines so `record` →
+  `run` is green.
+- `snapshot` normalization is idempotent again and no longer leaks secrets. A
+  stray escape spliced by OSC removal left a raw ANSI byte in the golden, and a
+  multi-line secret whose value uses LF reappeared in the golden when the output
+  used CRLF; both are now closed.
+- `--rerun-failed` combined with `--filter`/`--tag`/`--skip-tag` silently dropped
+  the still-failing scenarios it did not run from the ledger, greenlighting a
+  later rerun; those failures are now preserved, the "renamed or removed?"
+  warning is no longer shown for a filter exclusion, and an equivalent
+  absolute/relative spec path now matches the recorded ledger.
+- `pdf` assertions bound FlateDecode decompression at 64 MiB so a decompression
+  bomb in the tested CLI's output can no longer exhaust memory, and PDF
+  hex-string (`<…>`) metadata and text are now decoded instead of reported as a
+  missing field.
+- A byte-exact `file equals` failure that differs only in line endings now
+  renders `(only the line endings differ: CRLF vs LF)` instead of a blank diff.
+- The GitHub Actions `::notice::` summary counts a suite that errored before any
+  scenario ran, matching the junit and tap counts and its own `::error::`
+  annotation; a `suite.setup` failure is labeled `suite setup`, not
+  `service setup`.
+- `loader` rejects a `not_matches` pattern that also matches the empty string
+  (it can never pass), and explains a matrix name-template collapse by naming the
+  omitted row variable instead of a bare "duplicate scenario name".
+- A negative `--parallel` is rejected with a config error like `--repeat` and
+  `--retry-failed`, and `--repeat 1` no longer trips the `--retry-failed`
+  mutual-exclusion guard (repeat activates only at `> 1`).
+
+### Changed
+
+- An unresolved `${var}` in a run step's `cwd` now fails with an explained error
+  naming the reference, instead of the misleading "executable not found" the
+  child raised when it could not start in a literal `${var}` directory. Bare
+  `${…}` in `env` values and `stdin` keeps its documented literal passthrough.
+- Explicit `--help` on `explain`, `doc`, `list`, `manifest`, and `init` prints to
+  stdout, matching `completion` and the top-level help, so the usage text can be
+  piped.
+
 ## [0.7.0] - 2026-07-07
 
 Windows completes its interactive-terminal story. `pty:` steps and

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 375 scenarios
+74 suites · 379 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -65,9 +65,10 @@
   - [an unsupported defaults field is a load-time error (exit 2)](#scenario-an-unsupported-defaults-field-is-a-load-time-error-exit-2)
   - [defaults.run.env merges per key and a step env wins the collisions](#scenario-defaultsrunenv-merges-per-key-and-a-step-env-wins-the-collisions)
   - [a step opts out of defaults.run.shell with an explicit shell false](#scenario-a-step-opts-out-of-defaultsrunshell-with-an-explicit-shell-false)
-- [atago self-hosting / dir assertion](#atago-self-hosting--dir-assertion) — 2 scenarios
+- [atago self-hosting / dir assertion](#atago-self-hosting--dir-assertion) — 3 scenarios
   - [directory/tree assertions cover a multi-file generator](#scenario-directorytree-assertions-cover-a-multi-file-generator)
   - [a missing directory can be asserted absent](#scenario-a-missing-directory-can-be-asserted-absent)
+  - [a dangling symlink is a present directory entry (membership uses Lstat)](#scenario-a-dangling-symlink-is-a-present-directory-entry-membership-uses-lstat)
 - [atago self-hosting / recursive dir asserts + tree snapshots](#atago-self-hosting--recursive-dir-asserts--tree-snapshots) — 3 scenarios
   - [record, compare green, then a mutation names the changed paths](#scenario-record-compare-green-then-a-mutation-names-the-changed-paths)
   - [recursive matchers and ignore globs walk the tree](#scenario-recursive-matchers-and-ignore-globs-walk-the-tree)
@@ -231,9 +232,11 @@
 - [atago self-hosting / manifest](#atago-self-hosting--manifest) — 2 scenarios
   - [manifest emits a stable JSON summary without running the spec](#scenario-manifest-emits-a-stable-json-summary-without-running-the-spec)
   - [manifest does not execute the spec's commands](#scenario-manifest-does-not-execute-the-specs-commands)
-- [atago self-hosting / matrix scenarios](#atago-self-hosting--matrix-scenarios) — 2 scenarios
+- [atago self-hosting / matrix scenarios](#atago-self-hosting--matrix-scenarios) — 4 scenarios
   - [matrix expands into one scenario per row](#scenario-matrix-expands-into-one-scenario-per-row)
   - [matrix without a templated name gets a deterministic suffix](#scenario-matrix-without-a-templated-name-gets-a-deterministic-suffix)
+  - [stdout_to expands a matrix variable into the redirect target \[who=alice\]](#scenario-stdout_to-expands-a-matrix-variable-into-the-redirect-target-whoalice)
+  - [stdout_to expands a matrix variable into the redirect target \[who=bob\]](#scenario-stdout_to-expands-a-matrix-variable-into-the-redirect-target-whobob)
 - [atago self-hosting / matrix expansion boundary values](#atago-self-hosting--matrix-expansion-boundary-values) — 5 scenarios
   - [each row substitutes into the scenario name](#scenario-each-row-substitutes-into-the-scenario-name)
   - [a row with several variables substitutes all of them](#scenario-a-row-with-several-variables-substitutes-all-of-them)
@@ -317,9 +320,10 @@
   - [TAP report is a numbered TAP 13 stream with ok / not ok points](#scenario-tap-report-is-a-numbered-tap-13-stream-with-ok--not-ok-points)
   - [failure artifacts are written and referenced in the JSON report](#scenario-failure-artifacts-are-written-and-referenced-in-the-json-report)
   - [a multi-line snapshot failure renders a unified diff with hunks](#scenario-a-multi-line-snapshot-failure-renders-a-unified-diff-with-hunks)
-- [atago self-hosting / rerun-failed](#atago-self-hosting--rerun-failed) — 2 scenarios
+- [atago self-hosting / rerun-failed](#atago-self-hosting--rerun-failed) — 3 scenarios
   - [a failing run is recorded and rerun-failed selects only it](#scenario-a-failing-run-is-recorded-and-rerun-failed-selects-only-it)
   - [rerun-failed with nothing recorded is a no-op success](#scenario-rerun-failed-with-nothing-recorded-is-a-no-op-success)
+  - [rerun-failed with a filter preserves the still-failing scenarios it did not run](#scenario-rerun-failed-with-a-filter-preserves-the-still-failing-scenarios-it-did-not-run)
 - [atago self-hosting / retry until](#atago-self-hosting--retry-until) — 3 scenarios
   - [retry polls until the condition becomes true](#scenario-retry-polls-until-the-condition-becomes-true)
   - [retry fails the inner spec when until never holds](#scenario-retry-fails-the-inner-spec-when-until-never-holds)
@@ -1551,6 +1555,15 @@ mkdir -p site/assets && printf '<html>' > site/index.html && printf '<html>' > s
 ### Scenario: a missing directory can be asserted absent
 #### Then
 - dir `never-created` does not exist
+### Scenario: a dangling symlink is a present directory entry (membership uses Lstat)
+_skipped on windows_
+#### When
+```shell
+mkdir -p linkdir && ln -s /nonexistent-target-xyz linkdir/planted
+```
+#### Then
+- exit code is `0`
+- dir `linkdir` contains `planted`, does not contain `never-planted`
 ## atago self-hosting / recursive dir asserts + tree snapshots
 Source: `test/e2e/atago/dir_tree.atago.yaml`
 ### Scenario: record, compare green, then a mutation names the changed paths
@@ -4003,6 +4016,26 @@ ${atago} run --report junit suffix.atago.yaml
 #### Then
 - exit code is `0`
 - stdout contains `name="row [n=1]"`, `name="row [n=2]"`
+### Scenario: stdout_to expands a matrix variable into the redirect target [who=alice]
+#### When
+```shell
+printf hello-alice
+```
+#### Then
+- exit code is `0`
+- file `out-alice.txt` contains `hello-alice`
+#### Generated artifacts
+- `out-${who}.txt`
+### Scenario: stdout_to expands a matrix variable into the redirect target [who=bob]
+#### When
+```shell
+printf hello-bob
+```
+#### Then
+- exit code is `0`
+- file `out-bob.txt` contains `hello-bob`
+#### Generated artifacts
+- `out-${who}.txt`
 ## atago self-hosting / matrix expansion boundary values
 Source: `test/e2e/atago/matrix_edges.atago.yaml`
 ### Scenario: each row substitutes into the scenario name
@@ -5449,6 +5482,36 @@ ${atago} run --rerun-failed green.atago.yaml
 #### Then
 - exit code is `0`
 - stderr contains `nothing to rerun`
+### Scenario: rerun-failed with a filter preserves the still-failing scenarios it did not run
+#### Given
+- Fixture file `two.atago.yaml` is created.
+#### Inputs
+_Fixture `two.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: two
+scenarios:
+  - name: red-a
+    steps:
+      - run: {shell: true, command: "exit 1"}
+      - assert: {exit_code: 0}
+  - name: red-b
+    steps:
+      - run: {shell: true, command: "exit 1"}
+      - assert: {exit_code: 0}
+```
+#### When
+```shell
+${atago} run two.atago.yaml
+${atago} run --rerun-failed --filter red-a two.atago.yaml
+```
+#### Then
+- after `${atago} run two.atago.yaml`:
+  - exit code is `1`
+- after `${atago} run --rerun-failed --filter red-a two.atago.yaml`:
+  - exit code is `1`
+  - file `.atago/last-failed.json` contains `red-a`, `red-b`
 ## atago self-hosting / retry until
 Source: `test/e2e/atago/retry.atago.yaml`
 ### Scenario: retry polls until the condition becomes true

--- a/internal/assert/changes.go
+++ b/internal/assert/changes.go
@@ -52,7 +52,13 @@ func checkCategory(name string, entries *spec.StringList, observed []string, pro
 	if entries == nil {
 		return
 	}
-	pats := []string(*entries)
+	// Normalize a single leading "./": observed paths are workdir-relative
+	// without it, so "./out.txt" must match the observed "out.txt". Safe for
+	// globs like "site/**".
+	pats := make([]string, len(*entries))
+	for i, p := range *entries {
+		pats[i] = strings.TrimPrefix(p, "./")
+	}
 	for _, obs := range observed {
 		if !matchesAny(pats, obs) {
 			*problems = append(*problems, fmt.Sprintf("unexpected %s file %q (no entry matches it)", name, obs))
@@ -60,9 +66,66 @@ func checkCategory(name string, entries *spec.StringList, observed []string, pro
 	}
 	for _, pat := range pats {
 		if !patternMatchesAny(pat, observed) {
-			*problems = append(*problems, fmt.Sprintf("%s entry %q matched no file the step %s", name, pat, name))
+			msg := fmt.Sprintf("%s entry %q matched no file the step %s", name, pat, name)
+			if note := globMetaNote(pat); note != "" {
+				msg += "; " + note
+			}
+			*problems = append(*problems, msg)
 		}
 	}
+}
+
+// globMetaNote explains a common footgun: a changes entry is a doublestar glob,
+// so an unescaped `[ ] * ?` is a metacharacter, not a literal filename byte. When
+// such an entry matches nothing the failure is otherwise baffling (the Expected
+// and Actual read identically), so we point at the first metacharacter and show
+// the escaped spelling that would match a literal filename. It returns "" when
+// the entry has no unescaped metacharacter.
+func globMetaNote(pat string) string {
+	meta := firstUnescapedGlobMeta(pat)
+	if meta == 0 {
+		return ""
+	}
+	return fmt.Sprintf(`note: %q is a glob metacharacter — write "%s" to match a literal filename`, string(meta), escapeGlobMeta(pat))
+}
+
+// firstUnescapedGlobMeta returns the first unescaped glob metacharacter in pat,
+// or 0 when there is none. A backslash escapes the following byte.
+func firstUnescapedGlobMeta(pat string) byte {
+	for i := 0; i < len(pat); i++ {
+		if pat[i] == '\\' {
+			i++ // skip the escaped byte
+			continue
+		}
+		switch pat[i] {
+		case '[', ']', '*', '?':
+			return pat[i]
+		}
+	}
+	return 0
+}
+
+// escapeGlobMeta backslash-escapes every glob metacharacter in pat so it would
+// match a literal filename, leaving already-escaped bytes untouched.
+func escapeGlobMeta(pat string) string {
+	var b strings.Builder
+	for i := 0; i < len(pat); i++ {
+		c := pat[i]
+		if c == '\\' {
+			b.WriteByte(c)
+			if i+1 < len(pat) {
+				i++
+				b.WriteByte(pat[i])
+			}
+			continue
+		}
+		switch c {
+		case '[', ']', '*', '?':
+			b.WriteByte('\\')
+		}
+		b.WriteByte(c)
+	}
+	return b.String()
 }
 
 // matchesAny reports whether p matches at least one pattern (exact path, a

--- a/internal/assert/changes_test.go
+++ b/internal/assert/changes_test.go
@@ -1,6 +1,7 @@
 package assert
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/nao1215/atago/internal/fsdelta"
@@ -131,6 +132,15 @@ func TestCheckChanges(t *testing.T) {
 			delta:  fsdelta.Delta{Created: []string{"a1.txt"}},
 			wantOK: true,
 		},
+		{
+			// A leading "./" on an entry is stripped before matching: observed
+			// paths are workdir-relative without "./", so "./out.txt" must match
+			// "out.txt".
+			name:   "leading ./ on entry is normalized before matching",
+			assert: &spec.ChangesAssert{Created: list("./out.txt")},
+			delta:  fsdelta.Delta{Created: []string{"out.txt"}},
+			wantOK: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -140,6 +150,24 @@ func TestCheckChanges(t *testing.T) {
 				t.Errorf("checkChanges OK = %v, want %v (hint: %s)", got.OK, tt.wantOK, got.Hint)
 			}
 		})
+	}
+}
+
+// TestCheckChanges_GlobMetaHint proves that an entry containing an unescaped
+// glob metacharacter that matches nothing gets a clarifying note appended to the
+// Hint, rather than a byte-identical, self-contradictory Expected/Actual block.
+func TestCheckChanges_GlobMetaHint(t *testing.T) {
+	t.Parallel()
+	got := checkChanges(
+		&spec.ChangesAssert{Created: list("weird[1].txt")},
+		changesResult(fsdelta.Delta{Created: []string{"weird[1].txt"}}),
+	)
+	if got.OK {
+		t.Fatal("an unescaped [ never matches the literal filename, so it should fail")
+	}
+	wantNote := `note: "[" is a glob metacharacter — write "weird\[1\].txt" to match a literal filename`
+	if !strings.Contains(got.Hint, wantNote) {
+		t.Errorf("Hint should carry the glob-metacharacter note.\n got: %s\nwant substring: %s", got.Hint, wantNote)
 	}
 }
 

--- a/internal/assert/dir.go
+++ b/internal/assert/dir.go
@@ -91,7 +91,9 @@ func checkDirChildren(d *spec.DirAssert, dirPath string) *CheckResult {
 		if err != nil {
 			return &CheckResult{Desc: fmt.Sprintf("assert dir %q contains %q", d.Path, child), Hint: err.Error()}
 		}
-		if _, err := os.Stat(childPath); err != nil {
+		// Lstat, not Stat: membership is about the directory entry, not whether a
+		// symlink target resolves. A dangling symlink is still a present entry.
+		if _, err := os.Lstat(childPath); err != nil {
 			return &CheckResult{
 				Desc:     fmt.Sprintf("assert dir %q contains %q", d.Path, child),
 				Expected: fmt.Sprintf("child %q present", child),
@@ -105,7 +107,9 @@ func checkDirChildren(d *spec.DirAssert, dirPath string) *CheckResult {
 		if err != nil {
 			return &CheckResult{Desc: fmt.Sprintf("assert dir %q does not contain %q", d.Path, child), Hint: err.Error()}
 		}
-		if _, err := os.Stat(childPath); err == nil {
+		// Lstat, not Stat: a dangling symlink the step left behind is a present
+		// entry, so not_contains must fail on it rather than follow the dead link.
+		if _, err := os.Lstat(childPath); err == nil {
 			return &CheckResult{
 				Desc:     fmt.Sprintf("assert dir %q does not contain %q", d.Path, child),
 				Expected: fmt.Sprintf("child %q absent", child),

--- a/internal/assert/dir_test.go
+++ b/internal/assert/dir_test.go
@@ -98,6 +98,31 @@ func TestCheckDir_PathConfinement(t *testing.T) {
 	}
 }
 
+// TestCheckDir_BrokenSymlinkMembership pins that contains/not_contains judge
+// membership by the directory entry, not by whether the link target resolves. A
+// dangling symlink is a real dirent, so not_contains must FAIL (the file was
+// left behind) and contains must PASS. Using os.Stat here would follow the link,
+// see IsNotExist, and wrongly report the entry absent — a dangerous false PASS
+// for not_contains.
+func TestCheckDir_BrokenSymlinkMembership(t *testing.T) {
+	wd := t.TempDir()
+	dir := filepath.Join(wd, "out")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	// A symlink whose target does not exist: the dirent "planted" is present, but
+	// os.Stat on it returns IsNotExist.
+	if err := os.Symlink(filepath.Join(dir, "nonexistent-target"), filepath.Join(dir, "planted")); err != nil {
+		t.Skipf("symlinks unsupported on this platform: %v", err)
+	}
+	if cr := checkDirOK(t, wd, &spec.DirAssert{Path: "out", NotContains: []string{"planted"}}); cr.OK {
+		t.Error("not_contains must FAIL for a present (broken-symlink) entry")
+	}
+	if cr := checkDirOK(t, wd, &spec.DirAssert{Path: "out", Contains: []string{"planted"}}); !cr.OK {
+		t.Errorf("contains must PASS for a present (broken-symlink) entry: %+v", cr)
+	}
+}
+
 func TestCheckDir_NotADirectory(t *testing.T) {
 	wd := makeTree(t)
 	if err := os.WriteFile(filepath.Join(wd, "afile"), []byte("x"), 0o600); err != nil {

--- a/internal/assert/pdf.go
+++ b/internal/assert/pdf.go
@@ -134,11 +134,14 @@ type pdfDoc struct {
 var (
 	// A page object is `/Type /Page` not followed by another letter (so it does
 	// not match `/Type /Pages`). Whitespace between token parts is flexible.
-	rePageObj  = regexp.MustCompile(`/Type\s*/Page(?:[^s]|$)`)
-	reCount    = regexp.MustCompile(`/Count\s+(\d+)`)
-	reStream   = regexp.MustCompile(`(?s)stream\r?\n(.*?)\r?\nendstream`)
-	reMetaItem = regexp.MustCompile(`/(Title|Author|Subject|Keywords|Creator|Producer)\s*\(`)
-	reTextOp   = regexp.MustCompile(`\((?:[^()\\]|\\.)*\)`)
+	rePageObj = regexp.MustCompile(`/Type\s*/Page(?:[^s]|$)`)
+	reCount   = regexp.MustCompile(`/Count\s+(\d+)`)
+	reStream  = regexp.MustCompile(`(?s)stream\r?\n(.*?)\r?\nendstream`)
+	// A metadata value is either a "(…)" literal string or a "<…>" hex string.
+	reMetaItem = regexp.MustCompile(`/(Title|Author|Subject|Keywords|Creator|Producer)\s*[(<]`)
+	// A text operand is a "(…)" literal string or a "<…>" hex string (ISO 32000
+	// §7.3.4.3). The hex alternative excludes a leading "<<" dictionary opener.
+	reTextOp = regexp.MustCompile(`\((?:[^()\\]|\\.)*\)|<[0-9A-Fa-f\s]*>`)
 )
 
 // parsePDF extracts a black-box view of a PDF. It is lenient by design: it reads
@@ -176,25 +179,40 @@ func parsePDF(data []byte) pdfDoc {
 	// Info metadata: read the parenthesized value after each known field name.
 	for _, loc := range reMetaItem.FindAllSubmatchIndex(data, -1) {
 		field := strings.ToLower(string(data[loc[2]:loc[3]]))
-		// loc[1] is just past the opening "(" of the value.
-		if val, ok := readPDFString(data, loc[1]-1); ok {
+		// loc[1] is just past the opening delimiter ("(" or "<") of the value.
+		if val, ok := readPDFStringOrHex(data, loc[1]-1); ok {
 			doc.metadata[field] = val
 		}
 	}
 	return doc
 }
 
+// maxPDFStreamBytes caps how many bytes a single FlateDecode stream may inflate
+// to. atago runs the (untrusted) output of the CLI under test through pdf
+// assertions, and a FlateDecode "zip bomb" — a few hundred KB of zeros — inflates
+// to hundreds of megabytes, which would OOM-kill atago. The cap keeps a
+// malicious or degenerate stream from exhausting memory; genuine generated PDFs
+// have content streams far below this ceiling.
+const maxPDFStreamBytes = 64 << 20 // 64 MiB
+
 // inflate decompresses a zlib/FlateDecode stream. A non-Flate (raw) stream
-// returns an error so the caller keeps the raw bytes.
+// returns an error so the caller keeps the raw bytes. Decompression is bounded
+// by maxPDFStreamBytes: a stream that would inflate past the cap returns an
+// error rather than allocating unbounded memory.
 func inflate(b []byte) ([]byte, error) {
 	zr, err := zlib.NewReader(bytes.NewReader(bytes.TrimLeft(b, "\r\n")))
 	if err != nil {
 		return nil, err
 	}
 	defer zr.Close()
-	out, err := io.ReadAll(zr)
+	// Read one byte past the cap so we can tell "exactly at the cap" from
+	// "over the cap".
+	out, err := io.ReadAll(io.LimitReader(zr, maxPDFStreamBytes+1))
 	if err != nil {
 		return nil, err
+	}
+	if len(out) > maxPDFStreamBytes {
+		return nil, fmt.Errorf("decompressed PDF stream exceeds the %d-byte cap", maxPDFStreamBytes)
 	}
 	return out, nil
 }
@@ -259,10 +277,91 @@ func readPDFString(data []byte, open int) (string, bool) {
 	return b.String(), true
 }
 
-// decodePDFString decodes a full "(…)" literal (including the delimiters).
+// decodePDFString decodes a full string operand (including the delimiters):
+// either a "(…)" literal or a "<…>" hex string.
 func decodePDFString(lit []byte) string {
+	if len(lit) > 0 && lit[0] == '<' {
+		return decodePDFHexString(lit)
+	}
 	s, _ := readPDFString(lit, 0)
 	return s
+}
+
+// readPDFStringOrHex reads a PDF string value starting at the opening delimiter
+// at index open: a "(…)" literal or a "<…>" hex string.
+func readPDFStringOrHex(data []byte, open int) (string, bool) {
+	if open < 0 || open >= len(data) {
+		return "", false
+	}
+	if data[open] == '<' {
+		return readPDFHexString(data, open)
+	}
+	return readPDFString(data, open)
+}
+
+// readPDFHexString reads a PDF hex string (ISO 32000 §7.3.4.3) that starts at
+// the "<" at index open and ends at the matching ">". A leading "<<" is a
+// dictionary opener, not a hex string.
+func readPDFHexString(data []byte, open int) (string, bool) {
+	if open < 0 || open >= len(data) || data[open] != '<' {
+		return "", false
+	}
+	if open+1 < len(data) && data[open+1] == '<' {
+		return "", false
+	}
+	for i := open + 1; i < len(data); i++ {
+		c := data[i]
+		if c == '>' {
+			return decodePDFHexString(data[open : i+1]), true
+		}
+		if !isHexDigit(c) && !isPDFSpace(c) {
+			return "", false
+		}
+	}
+	return "", false
+}
+
+// decodePDFHexString decodes a "<…>" hex string. Per spec, whitespace inside is
+// ignored and an odd number of hex digits is padded with a trailing 0.
+func decodePDFHexString(lit []byte) string {
+	digits := make([]byte, 0, len(lit))
+	for _, c := range lit {
+		if isHexDigit(c) {
+			digits = append(digits, c)
+		}
+	}
+	if len(digits)%2 == 1 {
+		digits = append(digits, '0')
+	}
+	var b strings.Builder
+	for i := 0; i+1 < len(digits); i += 2 {
+		b.WriteByte(hexNibble(digits[i])<<4 | hexNibble(digits[i+1]))
+	}
+	return b.String()
+}
+
+func isHexDigit(c byte) bool {
+	return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
+}
+
+func isPDFSpace(c byte) bool {
+	switch c {
+	case ' ', '\t', '\r', '\n', '\f', 0:
+		return true
+	default:
+		return false
+	}
+}
+
+func hexNibble(c byte) byte {
+	switch {
+	case c >= '0' && c <= '9':
+		return c - '0'
+	case c >= 'a' && c <= 'f':
+		return c - 'a' + 10
+	default:
+		return c - 'A' + 10
+	}
 }
 
 func unescapePDFByte(c byte) byte {

--- a/internal/assert/pdf_test.go
+++ b/internal/assert/pdf_test.go
@@ -1,6 +1,8 @@
 package assert
 
 import (
+	"bytes"
+	"compress/zlib"
 	"os"
 	"path/filepath"
 	"testing"
@@ -50,6 +52,34 @@ endobj
 4 0 obj
 << /Type /Page /Parent 2 0 R >>
 endobj
+%%EOF
+`
+
+// hexStringPDF is a 1-page PDF whose /Title and content-stream text-showing
+// operator use PDF hex-string literals (<...>) instead of (...): a form written
+// by LibreOffice/Word/wkhtmltopdf for Unicode. /Title <5265706F7274> is
+// "Report" and <48656C6C6F> Tj is "Hello".
+const hexStringPDF = `%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 40 >>
+stream
+BT /F1 24 Tf 72 700 Td <48656C6C6F> Tj ET
+endstream
+endobj
+6 0 obj
+<< /Title <5265706F7274> /Author (Ada Lovelace) >>
+endobj
+trailer
+<< /Root 1 0 R /Info 6 0 R >>
 %%EOF
 `
 
@@ -116,6 +146,30 @@ func TestCheckPDF_MetadataAndText(t *testing.T) {
 	}
 }
 
+// TestParsePDF_HexStrings pins decoding of PDF hex-string literals (ISO 32000
+// §7.3.4.3) in both the metadata and the text-operator path. A PDF that encodes
+// its /Title and shown text as <...> hex must still satisfy metadata and text
+// assertions; otherwise a valid PDF reports a misleading "field not present".
+func TestParsePDF_HexStrings(t *testing.T) {
+	doc := parsePDF([]byte(hexStringPDF))
+	if doc.metadata["title"] != "Report" {
+		t.Errorf("title = %q, want %q", doc.metadata["title"], "Report")
+	}
+	if !contains(doc.text, "Hello") {
+		t.Errorf("text = %q, want it to contain %q", doc.text, "Hello")
+	}
+}
+
+func TestCheckPDF_HexStrings(t *testing.T) {
+	wd := writePDF(t, hexStringPDF)
+	if cr := checkPDFOK(t, wd, &spec.PDFAssert{Path: "doc.pdf", Metadata: map[string]string{"title": "Report"}}); !cr.OK {
+		t.Errorf("hex-string metadata title should match: %+v", cr)
+	}
+	if cr := checkPDFOK(t, wd, &spec.PDFAssert{Path: "doc.pdf", Text: &spec.StreamAssert{Contains: spec.StringList{"Hello"}}}); !cr.OK {
+		t.Errorf("hex-string text should contain Hello: %+v", cr)
+	}
+}
+
 func TestCheckPDF_NotAPDF(t *testing.T) {
 	wd := t.TempDir()
 	if err := os.WriteFile(filepath.Join(wd, "doc.pdf"), []byte("not a pdf"), 0o600); err != nil {
@@ -130,6 +184,46 @@ func TestCheckPDF_PathConfinement(t *testing.T) {
 	wd := writePDF(t, minimalPDF)
 	if cr := checkPDFOK(t, wd, &spec.PDFAssert{Path: "../escape.pdf", Pages: ptrInt(1)}); cr.OK {
 		t.Error("a path escaping the workdir must be rejected")
+	}
+}
+
+// TestInflate_DecompressionBombCapped proves the FlateDecode inflate path
+// refuses a decompression bomb: a tiny zlib stream that would inflate past the
+// cap returns an error instead of allocating unbounded memory (atago runs
+// untrusted CLI output through pdf assertions). A normal small stream still
+// inflates correctly.
+func TestInflate_DecompressionBombCapped(t *testing.T) {
+	t.Parallel()
+
+	// A highly compressible zero buffer that inflates well beyond the cap.
+	var buf bytes.Buffer
+	zw := zlib.NewWriter(&buf)
+	zeros := make([]byte, maxPDFStreamBytes+(1<<20)) // cap + 1 MiB
+	if _, err := zw.Write(zeros); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := inflate(buf.Bytes()); err == nil {
+		t.Errorf("inflate should reject a stream that inflates past the %d-byte cap", maxPDFStreamBytes)
+	}
+
+	// A normal small stream still round-trips.
+	var small bytes.Buffer
+	sw := zlib.NewWriter(&small)
+	if _, err := sw.Write([]byte("hello pdf stream")); err != nil {
+		t.Fatal(err)
+	}
+	if err := sw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	got, err := inflate(small.Bytes())
+	if err != nil {
+		t.Fatalf("inflate of a small stream should succeed: %v", err)
+	}
+	if string(got) != "hello pdf stream" {
+		t.Errorf("inflate = %q, want %q", got, "hello pdf stream")
 	}
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1438,8 +1438,8 @@ func TestRunCmd_SaveStateWriteErrorWarns(t *testing.T) {
 // --- help flags on FlagSet-based subcommands --------------------------------
 
 // TestSubcommands_HelpFlagExitsOK proves `-h` on the flag-parsing subcommands
-// prints usage to stderr and exits 0 (the flag.ErrHelp path), never treating
-// the flag as a spec path.
+// prints usage and exits 0 (the flag.ErrHelp path), never treating the flag as a
+// spec path. Stream routing per command is asserted in TestSubcommands_HelpToStdout.
 func TestSubcommands_HelpFlagExitsOK(t *testing.T) {
 	t.Parallel()
 	for _, cmd := range []string{"run", "doc", "manifest", "list"} {

--- a/internal/cli/doc.go
+++ b/internal/cli/doc.go
@@ -21,14 +21,21 @@ func docCmd(args []string, stdout, stderr io.Writer) int {
 	out := fs.String("out", "", "write Markdown to this file instead of stdout")
 	outDir := fs.String("out-dir", "", "with --split-by-spec, write one file per spec plus index.md into this directory")
 	split := fs.Bool("split-by-spec", false, "emit one Markdown file per spec and an index.md linking them (requires --out-dir)")
-	fs.Usage = func() {
-		fmt.Fprint(stderr, "Usage: atago doc [--out file.md | --split-by-spec --out-dir DIR] <path | dir>...\n")
+	printUsage := func(w io.Writer) {
+		fmt.Fprint(w, "Usage: atago doc [--out file.md | --split-by-spec --out-dir DIR] <path | dir>...\n")
+		fs.SetOutput(w)
 		fs.PrintDefaults()
 	}
+	// Suppress the flag package's automatic usage print; usage is routed
+	// explicitly below — to stdout for an explicit --help (so it can be piped),
+	// to stderr for a genuine parse error.
+	fs.Usage = func() {}
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
+			printUsage(stdout)
 			return ExitOK
 		}
+		printUsage(stderr)
 		return ExitConfig
 	}
 	if *split && *outDir == "" {

--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -15,14 +15,21 @@ import (
 func explainCmd(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("atago explain", flag.ContinueOnError)
 	fs.SetOutput(stderr)
-	fs.Usage = func() {
-		fmt.Fprint(stderr, "Usage: atago explain <path | dir>...  (directories are searched recursively; default \".\")\n")
+	printUsage := func(w io.Writer) {
+		fmt.Fprint(w, "Usage: atago explain <path | dir>...  (directories are searched recursively; default \".\")\n")
+		fs.SetOutput(w)
 		fs.PrintDefaults()
 	}
+	// Suppress the flag package's automatic usage print; usage is routed
+	// explicitly below — to stdout for an explicit --help (so it can be piped),
+	// to stderr for a genuine parse error.
+	fs.Usage = func() {}
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
+			printUsage(stdout)
 			return ExitOK
 		}
+		printUsage(stderr)
 		return ExitConfig
 	}
 

--- a/internal/cli/features_test.go
+++ b/internal/cli/features_test.go
@@ -584,6 +584,170 @@ func TestRerunFailed_NarrowedGreenKeepsOtherFailures(t *testing.T) {
 	})
 }
 
+// twoFailingSpec has two failing scenarios in ONE spec file, so a --filter can
+// exclude one while the other reruns — the shape that exposes a filtered
+// --rerun-failed silently dropping the excluded (still-failing) scenario.
+const twoFailingSpec = `version: "1"
+suite:
+  name: multi
+scenarios:
+  - name: alpha_fail
+    steps:
+      - run: {shell: true, command: "exit 1"}
+      - assert: {exit_code: 0}
+  - name: beta_fail
+    steps:
+      - run: {shell: true, command: "exit 1"}
+      - assert: {exit_code: 0}
+`
+
+// TestRerunFailed_FilterExcludedFailurePreserved is a regression: a
+// `--rerun-failed --filter` that excludes a recorded failure must not drop it
+// from the ledger. Rewriting the ledger from only the scenarios that ran forgot
+// the filter-excluded failure — a false green the next time the filter is gone.
+func TestRerunFailed_FilterExcludedFailurePreserved(t *testing.T) {
+	dir := t.TempDir()
+	writeSpec(t, dir, "s.atago.yaml", twoFailingSpec)
+
+	withWorkdir(t, dir, func() {
+		var out, errb bytes.Buffer
+		// Full run records both alpha_fail and beta_fail.
+		if got := Main([]string{"run", "."}, &out, &errb); got != ExitFailures {
+			t.Fatalf("first run exit = %d, want %d (stderr=%s)", got, ExitFailures, errb.String())
+		}
+		st, err := loadRerunState()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(st.Failed) != 2 {
+			t.Fatalf("recorded failures = %+v, want both alpha_fail and beta_fail", st.Failed)
+		}
+
+		// Rerun only alpha (still failing). beta was excluded by the filter, not
+		// re-verified, and is still broken — it must survive in the ledger.
+		out.Reset()
+		errb.Reset()
+		if got := Main([]string{"run", "--rerun-failed", "--filter", "alpha", "."}, &out, &errb); got != ExitFailures {
+			t.Fatalf("filtered rerun exit = %d, want %d (stderr=%s)", got, ExitFailures, errb.String())
+		}
+		st, err = loadRerunState()
+		if err != nil {
+			t.Fatal(err)
+		}
+		names := map[string]bool{}
+		for _, e := range st.Failed {
+			names[e.Scenario] = true
+		}
+		if !names["beta_fail"] {
+			t.Errorf("ledger after filtered rerun = %+v, want beta_fail preserved (excluded by --filter, never re-verified)", st.Failed)
+		}
+	})
+}
+
+// TestRerunFailed_FilterExcludesAllNoRenamedWarning is a regression: when a
+// user's own --filter excludes every recorded failure, the run must not blame a
+// rename/removal — that diagnostic is wrong and contradicts the filter warning.
+// The recorded failures must also survive so a later unfiltered rerun finds them.
+func TestRerunFailed_FilterExcludesAllNoRenamedWarning(t *testing.T) {
+	dir := t.TempDir()
+	writeSpec(t, dir, "s.atago.yaml", twoFailingSpec)
+
+	withWorkdir(t, dir, func() {
+		var out, errb bytes.Buffer
+		if got := Main([]string{"run", "."}, &out, &errb); got != ExitFailures {
+			t.Fatalf("first run exit = %d, want %d (stderr=%s)", got, ExitFailures, errb.String())
+		}
+
+		// A filter that matches no recorded scenario: nothing runs because of the
+		// filter, not because anything was renamed or removed.
+		out.Reset()
+		errb.Reset()
+		Main([]string{"run", "--rerun-failed", "--filter", "no-such-scenario", "."}, &out, &errb)
+		if strings.Contains(errb.String(), "renamed or removed") {
+			t.Errorf("stderr claimed a rename/removal when the user's --filter excluded everything:\n%s", errb.String())
+		}
+		// The recorded failures must not be silently forgotten.
+		st, err := loadRerunState()
+		if err != nil {
+			t.Fatalf("rerun state unreadable: %v", err)
+		}
+		if len(st.Failed) != 2 {
+			t.Errorf("ledger = %+v, want both recorded failures preserved when a filter excludes them all", st.Failed)
+		}
+	})
+}
+
+// TestRerunFailed_AbsolutePathMatchesRelativeLedger is a regression: a rerun
+// addressed by an absolute path must match a recorded relative spec_path (and
+// vice versa). Comparing raw path strings meant an equivalent-but-differently
+// spelled target found "nothing" and greenlit despite real failures.
+func TestRerunFailed_AbsolutePathMatchesRelativeLedger(t *testing.T) {
+	dir := t.TempDir()
+	writeSpec(t, dir, "s.atago.yaml", twoScenarioSpec)
+
+	withWorkdir(t, dir, func() {
+		var out, errb bytes.Buffer
+		// Record a RELATIVE spec_path by running with a relative target.
+		if got := Main([]string{"run", "s.atago.yaml"}, &out, &errb); got != ExitFailures {
+			t.Fatalf("first run exit = %d, want %d (stderr=%s)", got, ExitFailures, errb.String())
+		}
+		st, err := loadRerunState()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(st.Failed) != 1 || filepath.IsAbs(st.Failed[0].SpecPath) {
+			t.Fatalf("recorded state = %+v, want one relative-path failure", st.Failed)
+		}
+
+		// Rerun with the ABSOLUTE spelling of the same spec: the recorded failure
+		// must still be selected and re-run (exit fails), not treated as "nothing".
+		out.Reset()
+		errb.Reset()
+		abs := filepath.Join(dir, "s.atago.yaml")
+		if got := Main([]string{"run", "--rerun-failed", abs}, &out, &errb); got != ExitFailures {
+			t.Fatalf("absolute-path rerun exit = %d, want %d (recorded failure was not selected); stderr=%s", got, ExitFailures, errb.String())
+		}
+	})
+}
+
+// TestRunCmd_NegativeParallelRejected proves a negative --parallel is a config
+// error, matching --repeat/--retry-failed, rather than being silently coerced to
+// sequential and exiting 0.
+func TestRunCmd_NegativeParallelRejected(t *testing.T) {
+	dir := t.TempDir()
+	p := writeSpec(t, dir, "ok.atago.yaml", passingSpec)
+
+	var out, errb bytes.Buffer
+	if got := Main([]string{"run", "--parallel", "-1", p}, &out, &errb); got != ExitConfig {
+		t.Errorf("--parallel -1 exit = %d, want %d (stderr=%s)", got, ExitConfig, errb.String())
+	}
+	// A valid positive value still runs.
+	out.Reset()
+	errb.Reset()
+	if got := Main([]string{"run", "--parallel", "2", p}, &out, &errb); got != ExitOK {
+		t.Errorf("--parallel 2 exit = %d, want %d (stderr=%s)", got, ExitOK, errb.String())
+	}
+}
+
+// TestRunCmd_Repeat1WithRetryFailedAccepted proves the mutual-exclusion guard
+// fires only for an ACTIVE --repeat (> 1): --repeat 1 is a documented no-op and
+// must not be rejected alongside --retry-failed, while --repeat 2 still is.
+func TestRunCmd_Repeat1WithRetryFailedAccepted(t *testing.T) {
+	dir := t.TempDir()
+	p := writeSpec(t, dir, "ok.atago.yaml", passingSpec)
+
+	var out, errb bytes.Buffer
+	if got := Main([]string{"run", "--repeat", "1", "--retry-failed", "3", p}, &out, &errb); got == ExitConfig {
+		t.Errorf("--repeat 1 --retry-failed 3 was rejected (exit %d); repeat 1 is a no-op (stderr=%s)", got, errb.String())
+	}
+	// An active --repeat (> 1) with --retry-failed is still mutually exclusive.
+	out.Reset()
+	errb.Reset()
+	if got := Main([]string{"run", "--repeat", "2", "--retry-failed", "1", p}, &out, &errb); got != ExitConfig {
+		t.Errorf("--repeat 2 --retry-failed 1 exit = %d, want %d (must stay mutually exclusive)", got, ExitConfig)
+	}
+}
+
 // TestCompletion_HelpFlag proves --help behaves like every other subcommand's
 // --help (usage on stdout, exit 0) instead of being mistaken for a shell name.
 func TestCompletion_HelpFlag(t *testing.T) {

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -390,14 +390,21 @@ func initCmd(args []string, stdout, stderr io.Writer) int {
 	force := fs.Bool("force", false, "overwrite the file if it already exists")
 	template := fs.String("template", "cli", "starter template: "+strings.Join(initTemplateNames(), "|"))
 	list := fs.Bool("list-templates", false, "list the available templates and exit")
-	fs.Usage = func() {
-		fmt.Fprintf(stderr, "Usage: atago init [--force] [--template %s] [path]\n", strings.Join(initTemplateNames(), "|"))
+	printUsage := func(w io.Writer) {
+		fmt.Fprintf(w, "Usage: atago init [--force] [--template %s] [path]\n", strings.Join(initTemplateNames(), "|"))
+		fs.SetOutput(w)
 		fs.PrintDefaults()
 	}
+	// Suppress the flag package's automatic usage print; usage is routed
+	// explicitly below — to stdout for an explicit --help (so it can be piped),
+	// to stderr for a genuine parse error.
+	fs.Usage = func() {}
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
+			printUsage(stdout)
 			return ExitOK
 		}
+		printUsage(stderr)
 		return ExitConfig
 	}
 

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -26,14 +26,21 @@ func listCmd(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("atago list", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	asJSON := fs.Bool("json", false, "emit a stable JSON document instead of a table")
-	fs.Usage = func() {
-		fmt.Fprint(stderr, "Usage: atago list [--json] <path | dir>...\n  (directories are searched recursively; default \".\")\n")
+	printUsage := func(w io.Writer) {
+		fmt.Fprint(w, "Usage: atago list [--json] <path | dir>...\n  (directories are searched recursively; default \".\")\n")
+		fs.SetOutput(w)
 		fs.PrintDefaults()
 	}
+	// Suppress the flag package's automatic usage print; usage is routed
+	// explicitly below — to stdout for an explicit --help (so it can be piped),
+	// to stderr for a genuine parse error.
+	fs.Usage = func() {}
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
+			printUsage(stdout)
 			return ExitOK
 		}
+		printUsage(stderr)
 		return ExitConfig
 	}
 

--- a/internal/cli/manifest.go
+++ b/internal/cli/manifest.go
@@ -19,14 +19,21 @@ func manifestCmd(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("atago manifest", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	out := fs.String("out", "", "write the JSON manifest to this file instead of stdout")
-	fs.Usage = func() {
-		fmt.Fprint(stderr, "Usage: atago manifest [--out file.json] <path | dir>...\n  (directories are searched recursively)\n")
+	printUsage := func(w io.Writer) {
+		fmt.Fprint(w, "Usage: atago manifest [--out file.json] <path | dir>...\n  (directories are searched recursively)\n")
+		fs.SetOutput(w)
 		fs.PrintDefaults()
 	}
+	// Suppress the flag package's automatic usage print; usage is routed
+	// explicitly below — to stdout for an explicit --help (so it can be piped),
+	// to stderr for a genuine parse error.
+	fs.Usage = func() {}
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
+			printUsage(stdout)
 			return ExitOK
 		}
+		printUsage(stderr)
 		return ExitConfig
 	}
 

--- a/internal/cli/rerun.go
+++ b/internal/cli/rerun.go
@@ -116,17 +116,30 @@ func saveRerunState(failed []failedEntry) error {
 	return os.WriteFile(rerunStatePath(), data, 0o600)
 }
 
+// absClean returns the absolute, cleaned form of p, falling back to a lexical
+// clean when the working directory is unavailable. It lets --rerun-failed match
+// a spec regardless of how its path is spelled (relative vs absolute) between the
+// recording run and the rerun; comparing raw strings would miss equivalent paths.
+func absClean(p string) string {
+	if abs, err := filepath.Abs(p); err == nil {
+		return abs
+	}
+	return filepath.Clean(p)
+}
+
 // intersectPaths returns the members of paths that also appear in keep,
-// preserving the order of paths. Both sides are already filepath.Clean'd by the
-// callers, so a plain string comparison is exact.
+// preserving the order of paths. Both sides are absolutized before comparison so
+// an equivalent-but-differently-spelled path (relative vs absolute) still
+// matches; without this, a rerun target that names the same spec by a different
+// spelling would find "nothing" and silently greenlight despite real failures.
 func intersectPaths(paths, keep []string) []string {
 	want := make(map[string]bool, len(keep))
 	for _, k := range keep {
-		want[k] = true
+		want[absClean(k)] = true
 	}
 	var out []string
 	for _, p := range paths {
-		if want[p] {
+		if want[absClean(p)] {
 			out = append(out, p)
 		}
 	}

--- a/internal/cli/rerun.go
+++ b/internal/cli/rerun.go
@@ -116,15 +116,23 @@ func saveRerunState(failed []failedEntry) error {
 	return os.WriteFile(rerunStatePath(), data, 0o600)
 }
 
-// absClean returns the absolute, cleaned form of p, falling back to a lexical
-// clean when the working directory is unavailable. It lets --rerun-failed match
-// a spec regardless of how its path is spelled (relative vs absolute) between the
-// recording run and the rerun; comparing raw strings would miss equivalent paths.
+// absClean returns a canonical form of p so --rerun-failed matches a spec
+// regardless of how its path is spelled (relative vs absolute) between the
+// recording run and the rerun; comparing raw strings would miss equivalent
+// paths. Symlinks in the prefix are resolved too: os.Getwd (used by Abs) returns
+// the symlink-resolved directory, so on a platform whose temp dir is a symlink
+// (macOS /var -> /private/var) a relative recording and an explicit /var/...
+// target would otherwise canonicalize differently. EvalSymlinks needs the path
+// to exist; fall back to the absolute (then lexical) form when it does not.
 func absClean(p string) string {
-	if abs, err := filepath.Abs(p); err == nil {
-		return abs
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return filepath.Clean(p)
 	}
-	return filepath.Clean(p)
+	if resolved, rerr := filepath.EvalSymlinks(abs); rerr == nil {
+		return resolved
+	}
+	return abs
 }
 
 // intersectPaths returns the members of paths that also appear in keep,

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -82,13 +82,23 @@ func runCmd(label string, args []string, stdout, stderr io.Writer) int {
 	}
 
 	// --repeat and --retry-failed answer opposite questions (does it flake? /
-	// keep CI green despite flakes) and would fight over the attempt loop.
-	if *repeat > 0 && *retryFailed > 0 {
+	// keep CI green despite flakes) and would fight over the attempt loop. --repeat
+	// only ACTIVATES at > 1 (a value < 2 is a documented no-op), so --repeat 1
+	// changes nothing and must not be rejected alongside --retry-failed.
+	if *repeat > 1 && *retryFailed > 0 {
 		fmt.Fprintln(stderr, label+": --repeat and --retry-failed are mutually exclusive (repeat detects flakiness, retry-failed tolerates it)")
 		return ExitConfig
 	}
 	if *repeat < 0 || *retryFailed < 0 {
 		fmt.Fprintln(stderr, label+": --repeat and --retry-failed must be >= 0")
+		return ExitConfig
+	}
+	// A negative --parallel is a typo, not a request: the engine would clamp it to
+	// sequential and exit 0, silently ignoring the mistake. Reject it with the same
+	// config error as --repeat/--retry-failed for consistent bounds checking. Zero
+	// is left to mean the default (like repeat/retry allow 0).
+	if *parallel < 0 {
+		fmt.Fprintln(stderr, label+": --parallel must be >= 0")
 		return ExitConfig
 	}
 
@@ -111,17 +121,34 @@ func runCmd(label string, args []string, stdout, stderr io.Writer) int {
 	// identity selector so only the recorded scenarios execute. With nothing
 	// recorded there is nothing to rerun, which is reported and treated as success.
 	//
-	// rerunPreserved holds recorded failures in specs OUTSIDE this run's target
-	// (a narrowed `--rerun-failed a.atago.yaml` when b.atago.yaml also had
-	// recorded failures). Those scenarios were not re-verified, so they must be
-	// carried back into the saved ledger below; overwriting it with only what ran
-	// would forget still-failing work and could greenlight the loop.
+	// rerunPreserved holds recorded failures this rerun did NOT execute, which must
+	// be carried back into the saved ledger below. A rerun skips a recorded failure
+	// two ways: its spec is outside this run's targets (a narrowed
+	// `--rerun-failed a.atago.yaml` when b.atago.yaml also had recorded failures),
+	// or an active --filter/--tag/--skip-tag excludes it. Either way the scenario
+	// was not re-verified and is still failing, so overwriting the ledger with only
+	// what ran would forget still-failing work and could greenlight the loop. It is
+	// computed after the run from what actually executed, which covers both cases
+	// uniformly (tag exclusion cannot be predicted from the ledger, which stores
+	// only names). recordedFailures carries the loaded ledger to that computation.
 	var rerunPreserved []failedEntry
+	var recordedFailures []failedEntry
 	if *rerunFailed {
 		state, lerr := loadRerunState()
 		if lerr != nil {
 			fmt.Fprintf(stderr, label+": cannot read %s: %v\n", rerunStatePath(), lerr)
 			return ExitConfig
+		}
+		// Absolutize the recorded spec paths and the run targets so a spec matches
+		// regardless of how its path is spelled between the recording run and the
+		// rerun (relative vs absolute). Without this, a rerun addressed by an
+		// equivalent-but-different spelling finds "nothing" and silently greenlights
+		// while the failures are still real.
+		for i := range state.Failed {
+			state.Failed[i].SpecPath = absClean(state.Failed[i].SpecPath)
+		}
+		for i := range paths {
+			paths[i] = absClean(paths[i])
 		}
 		sel := state.selectSet()
 		if len(sel) == 0 {
@@ -133,15 +160,7 @@ func runCmd(label string, args []string, stdout, stderr io.Writer) int {
 			fmt.Fprintln(stderr, label+": no previously failed scenarios under the given targets")
 			return ExitOK
 		}
-		inScope := make(map[string]bool, len(paths))
-		for _, p := range paths {
-			inScope[p] = true
-		}
-		for _, e := range state.Failed {
-			if !inScope[e.SpecPath] {
-				rerunPreserved = append(rerunPreserved, e)
-			}
-		}
+		recordedFailures = state.Failed
 		eng.Select = sel
 	}
 
@@ -207,13 +226,36 @@ func runCmd(label string, args []string, stdout, stderr io.Writer) int {
 	for _, r := range results {
 		ranScenarios += len(r.Scenarios)
 	}
+	// Carry back recorded failures this rerun did not execute (spec outside the
+	// targets, or excluded by an active --filter/--tag/--skip-tag). They were not
+	// re-verified and are still failing, so they stay in the ledger; only scenarios
+	// that actually ran are re-decided below (recorded again if still failing,
+	// dropped if fixed).
+	if *rerunFailed {
+		executed := make(map[string]bool)
+		for _, r := range results {
+			for _, sc := range r.Scenarios {
+				executed[engine.ScenarioID(r.SpecPath, sc.Name)] = true
+			}
+		}
+		for _, e := range recordedFailures {
+			if !executed[engine.ScenarioID(e.SpecPath, e.Scenario)] {
+				rerunPreserved = append(rerunPreserved, e)
+			}
+		}
+	}
 	// A --rerun-failed run that matched NOTHING verified nothing, yet the recorded
 	// failures are still real: greenlighting it and clearing the state would
 	// silently forget still-failing work. Warn loudly, keep the state, and do not
 	// exit green. Require at least one suite to have LOADED, so this stays about a
 	// scenario-name mismatch — when every spec fails to parse, the load errors
 	// (already printed) are the real story, not a "renamed or removed" scenario.
-	rerunMatchedNothing := *rerunFailed && len(results) > 0 && ranScenarios == 0 && ctx.Err() == nil
+	// An active --filter/--tag/--skip-tag is excluded here: when the user's own
+	// selection is why nothing ran, blaming a rename/removal is wrong (and
+	// contradicts the selection warning below). The excluded failures are still
+	// preserved into the ledger via rerunPreserved above, so no work is lost.
+	selectionActive := len(filter) > 0 || len(tag) > 0 || len(skipTag) > 0
+	rerunMatchedNothing := *rerunFailed && !selectionActive && len(results) > 0 && ranScenarios == 0 && ctx.Err() == nil
 	if rerunMatchedNothing {
 		fmt.Fprintln(stderr, label+": warning: no recorded failing scenarios matched the current specs (renamed or removed?); the recorded failures were kept, not cleared")
 		exit = worseExit(exit, ExitConfig)

--- a/internal/cli/subcommands_test.go
+++ b/internal/cli/subcommands_test.go
@@ -160,7 +160,8 @@ func TestExplainCmd_NoArgsDefaultsToDot(t *testing.T) {
 }
 
 // Issue #18: explain must print usage on --help/-h (exit 0) instead of treating
-// the flag as a file path.
+// the flag as a file path. Explicitly-requested help goes to stdout so
+// `atago explain --help | grep` works.
 func TestExplainHelp(t *testing.T) {
 	for _, flag := range []string{"--help", "-h"} {
 		var out, errb bytes.Buffer
@@ -168,8 +169,32 @@ func TestExplainHelp(t *testing.T) {
 		if got != ExitOK {
 			t.Errorf("explain %s exit = %d, want %d (stderr=%s)", flag, got, ExitOK, errb.String())
 		}
-		if !strings.Contains(errb.String(), "Usage: atago explain") {
-			t.Errorf("explain %s missing usage, stderr=%q", flag, errb.String())
+		if !strings.Contains(out.String(), "Usage: atago explain") {
+			t.Errorf("explain %s missing usage on stdout, stdout=%q stderr=%q", flag, out.String(), errb.String())
+		}
+	}
+}
+
+// TestSubcommands_HelpToStdout proves an explicit --help/-h on the read
+// subcommands writes usage to STDOUT (so it can be piped) and exits 0, matching
+// completion/snapshot/top-level help. A genuine parse error still uses stderr.
+func TestSubcommands_HelpToStdout(t *testing.T) {
+	cmds := map[string]string{
+		"explain":  "Usage: atago explain",
+		"doc":      "Usage: atago doc",
+		"list":     "Usage: atago list",
+		"manifest": "Usage: atago manifest",
+		"init":     "Usage: atago init",
+	}
+	for cmd, want := range cmds {
+		for _, flag := range []string{"--help", "-h"} {
+			var out, errb bytes.Buffer
+			if got := Main([]string{cmd, flag}, &out, &errb); got != ExitOK {
+				t.Errorf("%s %s exit = %d, want %d (stderr=%s)", cmd, flag, got, ExitOK, errb.String())
+			}
+			if !strings.Contains(out.String(), want) {
+				t.Errorf("%s %s: stdout = %q, want usage line %q on stdout", cmd, flag, out.String(), want)
+			}
 		}
 	}
 }

--- a/internal/engine/expand.go
+++ b/internal/engine/expand.go
@@ -18,6 +18,11 @@ func expandRun(st *store.Store, r *spec.Run) *spec.Run {
 	// fixture.base64 rule) (#18).
 	c.Stdin.Inline = st.Expand(r.Stdin.Inline)
 	c.Stdin.File = st.Expand(r.Stdin.File)
+	// The stdout_to/stderr_to redirect targets are workdir-relative paths, just
+	// like the assert paths that later read them; expand them so a per-matrix-row
+	// or store-derived filename resolves instead of being written verbatim.
+	c.StdoutTo = st.Expand(r.StdoutTo)
+	c.StderrTo = st.Expand(r.StderrTo)
 	c.Env = st.ExpandMap(r.Env)
 	return &c
 }

--- a/internal/engine/expand_test.go
+++ b/internal/engine/expand_test.go
@@ -174,6 +174,28 @@ func TestExpandService_ReadyLog(t *testing.T) {
 	}
 }
 
+// TestExpandRun_StdoutStderrTo is a regression: the stdout_to/stderr_to redirect
+// targets are workdir-relative paths and must be ${name}-expanded like the
+// assert paths that read them. Leaving them literal wrote the output to a file
+// named "out-${who}.txt" while the assertion looked for the expanded name, so
+// every matrix/store-keyed redirect failed with a spurious "no such file".
+func TestExpandRun_StdoutStderrTo(t *testing.T) {
+	t.Parallel()
+	st := store.New()
+	st.Set("who", "alice")
+	r := &spec.Run{Command: "printf hi", StdoutTo: "out-${who}.txt", StderrTo: "err-${who}.log"}
+	out := expandRun(st, r)
+	if out.StdoutTo != "out-alice.txt" {
+		t.Errorf("stdout_to = %q, want out-alice.txt", out.StdoutTo)
+	}
+	if out.StderrTo != "err-alice.log" {
+		t.Errorf("stderr_to = %q, want err-alice.log", out.StderrTo)
+	}
+	if r.StdoutTo != "out-${who}.txt" {
+		t.Errorf("input mutated: %q", r.StdoutTo)
+	}
+}
+
 func TestMergeScenarioEnv(t *testing.T) {
 	t.Parallel()
 	st := store.New()

--- a/internal/engine/feature_test.go
+++ b/internal/engine/feature_test.go
@@ -137,6 +137,33 @@ scenarios:
 	}
 }
 
+// TestEngine_UnresolvedVarInCwdErrors: a ${name} nothing defines in a run step's
+// cwd is an explained error naming the reference, not the misleading
+// "executable not found" the child raises when it cannot start in a literal
+// "${name}" directory. Go sets cmd.Dir verbatim, so no shell ever expands it.
+func TestEngine_UnresolvedVarInCwdErrors(t *testing.T) {
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: v
+scenarios:
+  - name: typo in cwd
+    steps:
+      - run: {command: "pwd", cwd: "${no_such_dir}"}
+`)
+	if res.Status != StatusError {
+		t.Fatalf("status = %s, want error", res.Status)
+	}
+	msg := res.Scenarios[0].Steps[0].ErrMsg
+	if !strings.Contains(msg, "${no_such_dir}") || !strings.Contains(msg, "cwd") {
+		t.Errorf("error should name the cwd reference, got %q", msg)
+	}
+	if strings.Contains(msg, "fork/exec") {
+		t.Errorf("error should not be the misleading exec failure, got %q", msg)
+	}
+}
+
 // TestEngine_SkipByCommand exercises the probe-command skip predicate.
 func TestEngine_SkipByCommand(t *testing.T) {
 	t.Parallel()

--- a/internal/engine/stepexec.go
+++ b/internal/engine/stepexec.go
@@ -15,6 +15,25 @@ import (
 	"github.com/nao1215/atago/internal/store"
 )
 
+// unresolvedRunRefMsg explains a run field that references a ${name} no variable
+// defines. field names the spec field ("run.command"/"run.cwd"). shellExpandable
+// says whether enabling shell could expand it: true for the command argv, false
+// for cwd, which Go passes to cmd.Dir verbatim so no shell ever touches it.
+func unresolvedRunRefMsg(field, name string, shellExpandable bool) string {
+	if envName, isEnv := strings.CutPrefix(name, "env:"); isEnv {
+		return fmt.Sprintf(
+			"%s references ${env:%s}, but the environment variable %s is not set", field, envName, envName)
+	}
+	if shellExpandable {
+		return fmt.Sprintf(
+			"%s references ${%s}, but no variable with that name is defined (builtins, matrix vars, store, ready.store, env:) and shell is not enabled, so nothing would expand it; define the variable, set shell: true for shell expansion, or write $${%s} for the literal text",
+			field, name, name)
+	}
+	return fmt.Sprintf(
+		"%s references ${%s}, but no variable with that name is defined (builtins, matrix vars, store, ready.store, env:); nothing expands a working directory, so define the variable or write $${%s} for the literal text",
+		field, name, name)
+}
+
 // execStep runs one step and returns its result, its status contribution
 // (passed/failed/error), and whether it breached the security policy. It is
 // shared by the Steps loop and the Teardown loop; only the caller decides
@@ -39,16 +58,19 @@ func (x *scenarioRun) execStep(ctx context.Context, i int, step *spec.Step) (Ste
 		// cmd runner runs the command as local argv too, so it is guarded like
 		// the default runner; only an ssh runner (remote, where a remote shell
 		// may expand it) is exempt.
-		if !step.Run.ShellEnabled() && !isSSHRunner(step.Run.Runner, x.rc.runners) {
-			if names := x.st.Unresolved(step.Run.Command); len(names) > 0 {
-				if envName, isEnv := strings.CutPrefix(names[0], "env:"); isEnv {
-					sr.ErrMsg = fmt.Sprintf(
-						"run.command references ${env:%[1]s}, but the environment variable %[1]s is not set", envName)
-				} else {
-					sr.ErrMsg = fmt.Sprintf(
-						"run.command references ${%[1]s}, but no variable with that name is defined (builtins, matrix vars, store, ready.store, env:) and shell is not enabled, so nothing would expand it; define the variable, set shell: true for shell expansion, or write $${%[1]s} for the literal text",
-						names[0])
+		if !isSSHRunner(step.Run.Runner, x.rc.runners) {
+			if !step.Run.ShellEnabled() {
+				if names := x.st.Unresolved(step.Run.Command); len(names) > 0 {
+					sr.ErrMsg = unresolvedRunRefMsg("run.command", names[0], true)
+					return sr, StatusError, false
 				}
+			}
+			// cwd is passed to cmd.Dir verbatim; no shell ever expands it, so an
+			// unresolved ${name} is always a typo that would make the child fail to
+			// start in a literal "${name}" directory and surface as a misleading
+			// "executable not found". Guard it regardless of shell.
+			if names := x.st.Unresolved(step.Run.Cwd); len(names) > 0 {
+				sr.ErrMsg = unresolvedRunRefMsg("run.cwd", names[0], false)
 				return sr, StatusError, false
 			}
 		}

--- a/internal/fsdelta/fsdelta_test.go
+++ b/internal/fsdelta/fsdelta_test.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"sort"
 	"testing"
+	"time"
 )
 
 func write(t *testing.T, root, rel, content string) {
@@ -170,6 +171,171 @@ func TestDiff_Antisymmetry(t *testing.T) {
 	}
 	if len(fwd.Modified) != 1 || fwd.Modified[0] != "changed" {
 		t.Errorf("Modified = %v, want [changed]", fwd.Modified)
+	}
+}
+
+// TestDiff_RenameIsDeletePlusCreate pins the documented v1 semantics: a
+// content-preserving rename is reported as a delete of the old path and a
+// create of the new one, never as a single move.
+func TestDiff_RenameIsDeletePlusCreate(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	write(t, root, "a.txt", "same-bytes")
+	pre, err := Scan(root)
+	if err != nil {
+		t.Fatalf("pre scan: %v", err)
+	}
+	if err := os.Rename(filepath.Join(root, "a.txt"), filepath.Join(root, "b.txt")); err != nil {
+		t.Fatal(err)
+	}
+	post, err := Scan(root)
+	if err != nil {
+		t.Fatalf("post scan: %v", err)
+	}
+	got := Diff(pre, post)
+	want := Delta{Created: []string{"b.txt"}, Deleted: []string{"a.txt"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("rename Diff() = %+v, want %+v", got, want)
+	}
+}
+
+// TestDiff_DeleteRecreateIdenticalIsNoChange proves the delta is content-based,
+// not timestamp-based: deleting a file and recreating it with identical bytes
+// reports no change, so a step that rewrites a file to the same content does not
+// churn a `changes:` assertion.
+func TestDiff_DeleteRecreateIdenticalIsNoChange(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	write(t, root, "f.txt", "content")
+	pre, err := Scan(root)
+	if err != nil {
+		t.Fatalf("pre scan: %v", err)
+	}
+	if err := os.Remove(filepath.Join(root, "f.txt")); err != nil {
+		t.Fatal(err)
+	}
+	write(t, root, "f.txt", "content")
+	post, err := Scan(root)
+	if err != nil {
+		t.Fatalf("post scan: %v", err)
+	}
+	if d := Diff(pre, post); len(d.Created)+len(d.Modified)+len(d.Deleted) != 0 {
+		t.Errorf("delete+recreate identical Diff() = %+v, want all empty", d)
+	}
+}
+
+// TestScan_EmptyFileAndTruncation covers the zero-byte boundary: an empty file
+// is a tracked create (distinct from a deleted file, which is absent), and
+// truncating a file to empty is a modification.
+func TestScan_EmptyFileAndTruncation(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	write(t, root, "shrink.txt", "not empty yet")
+	pre, err := Scan(root)
+	if err != nil {
+		t.Fatalf("pre scan: %v", err)
+	}
+	write(t, root, "empty.txt", "")
+	write(t, root, "shrink.txt", "")
+	post, err := Scan(root)
+	if err != nil {
+		t.Fatalf("post scan: %v", err)
+	}
+	got := Diff(pre, post)
+	want := Delta{Created: []string{"empty.txt"}, Modified: []string{"shrink.txt"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("empty-file Diff() = %+v, want %+v", got, want)
+	}
+}
+
+// TestDiff_FileReplacedByDirectoryAndReverse covers a name changing kind: a file
+// replaced by a directory of the same name deletes the file and creates the
+// directory's contents, and the reverse deletes the contents and creates the
+// file. Directories themselves are never tracked, only the regular files.
+func TestDiff_FileReplacedByDirectoryAndReverse(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	write(t, root, "foo", "i am a file")
+	pre, err := Scan(root)
+	if err != nil {
+		t.Fatalf("pre scan: %v", err)
+	}
+	if err := os.Remove(filepath.Join(root, "foo")); err != nil {
+		t.Fatal(err)
+	}
+	write(t, root, "foo/bar.txt", "now a dir")
+	post, err := Scan(root)
+	if err != nil {
+		t.Fatalf("post scan: %v", err)
+	}
+	got := Diff(pre, post)
+	want := Delta{Created: []string{"foo/bar.txt"}, Deleted: []string{"foo"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("file->dir Diff() = %+v, want %+v", got, want)
+	}
+	// The reverse must be the mirror image.
+	rev := Diff(post, pre)
+	wantRev := Delta{Created: []string{"foo"}, Deleted: []string{"foo/bar.txt"}}
+	if !reflect.DeepEqual(rev, wantRev) {
+		t.Errorf("dir->file Diff() = %+v, want %+v", rev, wantRev)
+	}
+}
+
+// TestScan_BrokenAndCyclicSymlinksNoCrash proves Scan never follows a symlink
+// into a crash or infinite loop: a dangling link and a self-referential cyclic
+// link are both skipped (only regular files are tracked), leaving the real file.
+func TestScan_BrokenAndCyclicSymlinksNoCrash(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is restricted on Windows")
+	}
+	root := t.TempDir()
+	write(t, root, "real.txt", "data")
+	if err := os.Symlink(filepath.Join(root, "missing-target"), filepath.Join(root, "broken")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(root, "loop"), filepath.Join(root, "loop")); err != nil {
+		t.Fatal(err)
+	}
+	snap, err := Scan(root)
+	if err != nil {
+		t.Fatalf("Scan with broken/cyclic symlinks: %v", err)
+	}
+	if _, ok := snap["real.txt"]; !ok {
+		t.Errorf("regular file should be tracked, snapshot = %v", keys(snap))
+	}
+	for _, link := range []string{"broken", "loop"} {
+		if _, ok := snap[link]; ok {
+			t.Errorf("symlink %q should not be tracked, snapshot = %v", link, keys(snap))
+		}
+	}
+}
+
+// TestDiff_MetadataOnlyChangeNotDetected pins that the delta is purely
+// content-based: a chmod-only or mtime-only change leaves the hash unchanged and
+// is reported nowhere, so `changes:` does not flag a file whose bytes are equal.
+func TestDiff_MetadataOnlyChangeNotDetected(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	write(t, root, "perm.txt", "bytes")
+	write(t, root, "time.txt", "bytes")
+	pre, err := Scan(root)
+	if err != nil {
+		t.Fatalf("pre scan: %v", err)
+	}
+	if err := os.Chmod(filepath.Join(root, "perm.txt"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(filepath.Join(root, "time.txt"), old, old); err != nil {
+		t.Fatal(err)
+	}
+	post, err := Scan(root)
+	if err != nil {
+		t.Fatalf("post scan: %v", err)
+	}
+	if d := Diff(pre, post); len(d.Created)+len(d.Modified)+len(d.Deleted) != 0 {
+		t.Errorf("metadata-only Diff() = %+v, want all empty (content unchanged)", d)
 	}
 }
 

--- a/internal/loader/authoring_test.go
+++ b/internal/loader/authoring_test.go
@@ -179,6 +179,48 @@ scenarios:
 	}
 }
 
+// TestLoadBytes_EmptyMatchingNotMatchesRejected proves that a not_matches pattern
+// that matches the empty string (e.g. "z*") is a load-time validation error:
+// such a pattern matches at position 0 of every input, so not_matches can never
+// pass — the same trap as an empty pattern. The identical pattern under matches
+// is legitimate (it matches everything, which the author may intend) and still
+// loads, and a pattern that requires at least one character (e.g. "z+") loads too.
+func TestLoadBytes_EmptyMatchingNotMatchesRejected(t *testing.T) {
+	t.Parallel()
+	build := func(matcher string) []byte {
+		return []byte(`
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: ok
+    steps:
+      - run: {command: echo hi}
+      - assert:
+          stdout:
+` + matcher + "\n")
+	}
+	t.Run("not_matches empty-matching rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := LoadBytes("sample.atago.yaml", build(`            not_matches: "z*"`))
+		if err == nil || !strings.Contains(err.Error(), "matches the empty string") {
+			t.Fatalf("LoadBytes() error = %v, want an empty-string not_matches error", err)
+		}
+	})
+	t.Run("matches empty-matching still loads", func(t *testing.T) {
+		t.Parallel()
+		if _, err := LoadBytes("sample.atago.yaml", build(`            matches: "z*"`)); err != nil {
+			t.Fatalf("LoadBytes() error = %v, want nil (an empty-matching matches is legitimate)", err)
+		}
+	})
+	t.Run("not_matches requiring a character still loads", func(t *testing.T) {
+		t.Parallel()
+		if _, err := LoadBytes("sample.atago.yaml", build(`            not_matches: "z+"`)); err != nil {
+			t.Fatalf("LoadBytes() error = %v, want nil (z+ needs at least one character)", err)
+		}
+	})
+}
+
 // TestLoadBytes_NegativeJSONLengthRejected proves a negative json/yaml length is
 // a validation error: no array, object, or string has a negative length, so the
 // matcher could never pass and the mistake is caught at load time.

--- a/internal/loader/matrix.go
+++ b/internal/loader/matrix.go
@@ -37,8 +37,97 @@ func validateMatrix(s *spec.Spec) []string {
 				}
 			}
 		}
+		if msg := matrixNameCollapse(sc.Name, sc.Matrix); msg != "" {
+			errs = append(errs, fmt.Sprintf("%s: %s", where, msg))
+		}
 	}
 	return errs
+}
+
+// matrixNameCollapse reports whether a matrix name template that references at
+// least one row variable renders two rows to the same instance name because it
+// omits a variable those rows differ on. It returns a message naming the omitted
+// variable(s), or "" when no such collapse exists.
+//
+// Why: without this the rows are genuinely distinct yet expand to a colliding
+// name, and the downstream duplicate-name check reports only "duplicate scenario
+// name" with no clue that the fix is to reference the missing variable. Rows that
+// are byte-for-byte identical, or a template that references no variable (which
+// auto-disambiguates via a deterministic suffix), are left for that check.
+func matrixNameCollapse(template string, rows []map[string]string) string {
+	byName := map[string][]map[string]string{}
+	for _, row := range rows {
+		referenced := false
+		for k := range row {
+			if strings.Contains(template, "${"+k+"}") {
+				referenced = true
+				break
+			}
+		}
+		if !referenced {
+			// The no-reference path appends a deterministic per-row suffix, so
+			// distinct rows never collapse here; skip it.
+			continue
+		}
+		name := matrixInstanceName(template, row)
+		byName[name] = append(byName[name], row)
+	}
+	for name, group := range byName {
+		if len(group) < 2 {
+			continue
+		}
+		omitted := omittedDistinguishingKeys(template, group)
+		if len(omitted) == 0 {
+			// Rows are identical in every unreferenced key too, i.e. a genuine
+			// duplicate; let the downstream duplicate-name check report it.
+			continue
+		}
+		quoted := make([]string, len(omitted))
+		refs := make([]string, len(omitted))
+		for i, k := range omitted {
+			quoted[i] = fmt.Sprintf("%q", k)
+			refs[i] = "${" + k + "}"
+		}
+		noun := "variable"
+		if len(omitted) > 1 {
+			noun = "variables"
+		}
+		return fmt.Sprintf(
+			"matrix name template %q omits row %s %s, so rows collapse to the same name %q; reference %s in the name to keep them distinct",
+			template, noun, strings.Join(quoted, ", "), name, strings.Join(refs, ", "),
+		)
+	}
+	return ""
+}
+
+// omittedDistinguishingKeys returns the sorted set of keys that the colliding
+// rows differ on but the name template does not reference — the variables the
+// author must add to the name to tell the rows apart.
+func omittedDistinguishingKeys(template string, group []map[string]string) []string {
+	keys := map[string]bool{}
+	for k := range group[0] {
+		keys[k] = true
+	}
+	for _, row := range group[1:] {
+		for k := range row {
+			keys[k] = true
+		}
+	}
+	var omitted []string
+	for k := range keys {
+		if strings.Contains(template, "${"+k+"}") {
+			continue
+		}
+		first := group[0][k]
+		for _, row := range group[1:] {
+			if row[k] != first {
+				omitted = append(omitted, k)
+				break
+			}
+		}
+	}
+	sort.Strings(omitted)
+	return omitted
 }
 
 // expandMatrix replaces every matrix scenario with one concrete scenario per row,

--- a/internal/loader/matrix_test.go
+++ b/internal/loader/matrix_test.go
@@ -92,6 +92,11 @@ func TestLoadBytes_MatrixErrors(t *testing.T) {
 			src:     "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: \"m ${workdir}\"\n    matrix:\n      - { workdir: /tmp/x }\n    steps:\n      - run: {command: echo}",
 			wantMsg: "shadows a built-in variable",
 		},
+		{
+			name:    "template omits a distinguishing variable",
+			src:     "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: \"check ${who}\"\n    matrix:\n      - { who: alice, lang: en }\n      - { who: alice, lang: fr }\n    steps:\n      - run: {command: echo}",
+			wantMsg: "omits row variable \"lang\"",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/loader/validate_assert.go
+++ b/internal/loader/validate_assert.go
@@ -301,8 +301,19 @@ func validateRegexp(add func(string, ...any), where, key, pattern string) {
 		add("%s.%s must not be an empty regexp, which matches everything (matches) or nothing (not_matches); remove it or give a real pattern", where, key)
 		return
 	}
-	if _, err := regexp.Compile(pattern); err != nil {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
 		add("%s.%s %q is not a valid regexp: %v", where, key, pattern, err)
+		return
+	}
+	// A not_matches pattern that matches the empty string (e.g. "z*", "a?",
+	// "(foo)?", "x{0,3}") matches at position 0 of every input, so not_matches
+	// can never pass — the same trap as the empty pattern above. Caught at load
+	// time rather than failing at runtime with a confusing "unexpectedly matched"
+	// hint. An empty-matching pattern under matches is legitimate (it matches
+	// everything, which the author may intend), so this applies to not_matches only.
+	if key == "not_matches" && re.MatchString("") {
+		add("%s.%s %q matches the empty string, so not_matches can never pass; anchor it or require at least one character (e.g. \"z+\")", where, key, pattern)
 	}
 }
 

--- a/internal/record/record.go
+++ b/internal/record/record.go
@@ -5,8 +5,10 @@
 package record
 
 import (
+	"encoding/base64"
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/goccy/go-yaml"
 	"github.com/nao1215/atago/internal/buildinfo"
@@ -166,8 +168,13 @@ func firstLine(stream []byte) string {
 // `contains: ` / `command: ` (producing an invalid document that aborts
 // `atago record`). For a value carrying any control byte, emit an explicit
 // single-line double-quoted scalar that escapes it, so the value round-trips
-// exactly.
+// exactly. A value carrying invalid UTF-8 (binary output, or Latin-1 /
+// Shift-JIS text) cannot survive any string scalar at all — see yamlBinary —
+// so it takes the !!binary path first.
 func yamlScalar(s string) string {
+	if !utf8.ValidString(s) {
+		return yamlBinary(s)
+	}
 	if hasControlByte(s) {
 		return yamlDoubleQuoted(s)
 	}
@@ -176,6 +183,21 @@ func yamlScalar(s string) string {
 		return fmt.Sprintf("%q", s)
 	}
 	return strings.TrimRight(string(out), "\n")
+}
+
+// yamlBinary renders s as a YAML `!!binary` (base64) scalar so a value carrying
+// invalid UTF-8 bytes round-trips byte-for-byte through the loader. No string
+// scalar can do this: a raw invalid byte in a plain, single-, or double-quoted
+// scalar is lossily replaced with U+FFFD (ef bf bd) on reparse, and a `\xNN`
+// double-quoted escape decodes to the Unicode code point U+00NN — re-encoded as
+// two UTF-8 bytes for NN >= 0x80 — not the raw byte. `!!binary` is YAML's
+// canonical arbitrary-byte representation, and go-yaml decodes its base64
+// straight back into the destination string field as the exact original bytes,
+// so the recorded contains anchor still matches the real (raw-byte) stdout on
+// replay. The base64 alphabet ([A-Za-z0-9+/=]) contains nothing that breaks the
+// inline flow or starts a trailing ` # comment`, so it needs no quoting.
+func yamlBinary(s string) string {
+	return "!!binary " + base64.StdEncoding.EncodeToString([]byte(s))
 }
 
 // hasControlByte reports whether s contains a C0 control character (tab,

--- a/internal/record/record_test.go
+++ b/internal/record/record_test.go
@@ -210,6 +210,35 @@ func TestGenerate_ControlBytesRoundTrip(t *testing.T) {
 	}, Options{SuiteName: "demo"}); err != nil {
 		t.Errorf("Generate(multi-line command) failed: %v", err)
 	}
+
+	// Invalid-UTF-8 first line (binary output, or Latin-1 / Shift-JIS text): the
+	// generated contains anchor must reload byte-for-byte identical to the raw
+	// output, or the anchor can never match the real (raw-byte) stdout on replay
+	// and the recorded spec is RED by construction. A raw byte in a plain scalar,
+	// or a \xNN double-quoted escape, is lossily transformed on reparse; only a
+	// !!binary anchor round-trips the exact bytes.
+	rawLine := "caf\xe9 ready"
+	out2, err := Generate(Observation{
+		Command:  "printf-tool",
+		ExitCode: 0,
+		Stdout:   []byte(rawLine + "\n"),
+	}, Options{SuiteName: "demo"})
+	if err != nil {
+		t.Fatalf("Generate(invalid-utf8): %v", err)
+	}
+	s2, err := loader.LoadBytes("g.atago.yaml", out2)
+	if err != nil {
+		t.Fatalf("reload(invalid-utf8): %v\n%s", err, out2)
+	}
+	var got []string
+	for _, st := range s2.Scenarios[0].Steps {
+		if st.Assert != nil && st.Assert.Stdout != nil && st.Assert.Stdout.Contains != nil {
+			got = st.Assert.Stdout.Contains
+		}
+	}
+	if len(got) != 1 || got[0] != rawLine {
+		t.Errorf("invalid-utf8 contains round-trip = %x, want [%x]", got, rawLine)
+	}
 }
 
 // TestGenerate_RecordRunRoundTrip is the metamorphic law for record (#30): a
@@ -351,6 +380,9 @@ func TestYAMLScalar_ExoticControlBytesRoundTrip(t *testing.T) {
 		"mixed\ttab\nnewline\rcr end", // the common control trio
 		"plain punctuation: # * ? &",  // no control bytes → yaml.Marshal path
 		"日本語と\x1bエスケープ",               // multibyte + control byte together
+		"caf\xe9 ready",               // invalid UTF-8 (Latin-1 é): a lone 0x80–0xFF byte
+		"\xff\xfe\x00",                // pure binary: a byte sequence that is not text at all
+		"a\xe9b\x1bc",                 // invalid UTF-8 mixed with a C0 control byte
 	}
 	for _, s := range cases {
 		scalar := yamlScalar(s)

--- a/internal/report/console.go
+++ b/internal/report/console.go
@@ -94,11 +94,12 @@ func writeDetail(b *strings.Builder, color bool, suite string, sc *engine.Scenar
 				continue
 			}
 			// A setup-phase error comes from before any numbered step ran; rendering
-			// it as "step 0 ()" is misleading (issue #19). Use the shared setup label
-			// — the ErrMsg already names the service — so every report format agrees.
+			// it as "step 0 ()" is misleading. Use the phase label — distinguishing a
+			// suite.setup failure from service readiness so neither is mislabeled — so
+			// every report format agrees.
 			var where string
 			if isSetupError(step) {
-				where = setupPhaseLabel
+				where = setupPhaseLabelFor(step)
 			} else {
 				where = fmt.Sprintf("step %d (%s)", step.Index, step.Kind)
 			}

--- a/internal/report/diff.go
+++ b/internal/report/diff.go
@@ -83,11 +83,23 @@ func unifiedDiff(expected, actual, expectedLabel, actualLabel string) string {
 	// The marker describes a side whose last line lacks a trailing newline, judged
 	// per side and independently: when both sides lack it, both are annotated. An
 	// empty side has no last line, so it never carries the marker.
+	surfaced := len(hunks) > 0
 	if expected != "" && !strings.HasSuffix(expected, "\n") {
 		out = append(out, noNewlineMarker+" (expected)")
+		surfaced = true
 	}
 	if actual != "" && !strings.HasSuffix(actual, "\n") {
 		out = append(out, noNewlineMarker+" (actual)")
+		surfaced = true
+	}
+	// A failing comparison must never render a header-only (blank) diff. When
+	// splitDiffLines folded CRLF→LF the visible lines can be identical, yielding
+	// no content hunk, yet the raw strings still differ — the assertion failed
+	// only because one side used CRLF line endings. Surface that explicitly so
+	// the reason is not invisible; the early return above guarantees the raw
+	// strings differ here.
+	if !surfaced {
+		out = append(out, "(only the line endings differ: CRLF vs LF)")
 	}
 	return strings.Join(out, "\n")
 }

--- a/internal/report/diff_test.go
+++ b/internal/report/diff_test.go
@@ -77,21 +77,32 @@ func TestUnifiedDiff_HunkPlacement(t *testing.T) {
 }
 
 // TestUnifiedDiff_CRLFAndTrailingNewline proves CRLF inputs fold (an OS
-// artifact must not diff every line) while a trailing-newline difference is
-// rendered explicitly.
+// artifact must not diff every line) while both a trailing-newline difference
+// and a line-ending-only difference are rendered explicitly. A byte-exact
+// failure caused only by CRLF-vs-LF must never render a blank diff: the folded
+// lines are equal, so there are no content hunks, but the assertion still
+// failed and the reason must be surfaced.
 func TestUnifiedDiff_CRLFAndTrailingNewline(t *testing.T) {
 	t.Parallel()
-	if got := unifiedDiff("a\r\nb\r\n", "a\nb\n", "expected", "actual"); !strings.Contains(got, noNewlineMarker) && got != "" {
-		// CRLF folding makes the contents equal; only the byte-level
-		// difference remains, which the caller treats as equal lines. The
-		// diff is header-only in that case — assert no +/- content lines.
-		for _, l := range strings.Split(got, "\n") {
-			if strings.HasPrefix(l, "-") && !strings.HasPrefix(l, "---") {
-				t.Errorf("CRLF-only difference produced content hunks:\n%s", got)
-			}
+	// CRLF is the only difference: the folded lines are identical, so no
+	// content hunk is produced — but the diff must not be blank and must point
+	// at the line-ending difference.
+	got := unifiedDiff("alpha\nbeta\n", "alpha\r\nbeta\r\n", "expected", "actual")
+	if strings.TrimSpace(got) == "" {
+		t.Fatalf("CRLF-only difference rendered a blank diff")
+	}
+	if !strings.Contains(got, "CRLF") && !strings.Contains(strings.ToLower(got), "line ending") {
+		t.Errorf("CRLF-only difference should point at the line-ending difference:\n%s", got)
+	}
+	// Folding still holds: the content lines must not each diff as changed.
+	for _, l := range strings.Split(got, "\n") {
+		if (strings.HasPrefix(l, "-") && !strings.HasPrefix(l, "---")) ||
+			(strings.HasPrefix(l, "+") && !strings.HasPrefix(l, "+++")) {
+			t.Errorf("CRLF-only difference produced content hunks:\n%s", got)
 		}
 	}
-	got := unifiedDiff("a\nb\n", "a\nb", "expected", "actual")
+
+	got = unifiedDiff("a\nb\n", "a\nb", "expected", "actual")
 	if !strings.Contains(got, noNewlineMarker+" (actual)") {
 		t.Errorf("trailing-newline difference not annotated:\n%s", got)
 	}

--- a/internal/report/format_parity_test.go
+++ b/internal/report/format_parity_test.go
@@ -177,6 +177,53 @@ func TestRender_CrossFormatCountParity(t *testing.T) {
 	})
 }
 
+// TestRender_CrossFormatCountParity_SetupErrored pins the format-cross count
+// invariant for a suite that errored before any scenario ran (all scenarios
+// filtered out, exit 4): junit, tap, and gha must agree on the count. junit
+// synthesizes tests=1/errors=1 and tap a 1..1 plan with one not-ok, so the gha
+// ::notice:: summary must likewise count the synthesized failure (1 errored),
+// not contradict its own ::error:: annotation with an all-zero line.
+func TestRender_CrossFormatCountParity_SetupErrored(t *testing.T) {
+	t.Parallel()
+	res := suiteSetupErrorEmpty()[0]
+
+	t.Run("junit", func(t *testing.T) {
+		t.Parallel()
+		var root junitTestsuites
+		if err := xml.Unmarshal([]byte(render(t, FormatJUnit, res)), &root); err != nil {
+			t.Fatalf("junit invalid: %v", err)
+		}
+		if root.Tests != 1 || root.Errors != 1 {
+			t.Errorf("junit tests=%d errors=%d, want 1/1", root.Tests, root.Errors)
+		}
+	})
+
+	t.Run("tap", func(t *testing.T) {
+		t.Parallel()
+		out := render(t, FormatTAP, res)
+		if !strings.Contains(out, "1..1\n") {
+			t.Errorf("tap plan is not 1..1:\n%s", out)
+		}
+		if n := strings.Count(out, "\nnot ok "); n != 1 {
+			t.Errorf("tap not-ok lines = %d, want 1:\n%s", n, out)
+		}
+	})
+
+	t.Run("gha notice reflects the error, not all-zero", func(t *testing.T) {
+		t.Parallel()
+		out := render(t, FormatGHA, res)
+		if !strings.Contains(out, "::error") {
+			t.Fatalf("gha emitted no ::error:: annotation:\n%s", out)
+		}
+		if strings.Contains(out, "0 scenarios: 0 passed, 0 failed, 0 errored, 0 skipped") {
+			t.Errorf("gha notice is all-zero, contradicting its own ::error:: and junit/tap:\n%s", out)
+		}
+		if !strings.Contains(out, "1 errored") {
+			t.Errorf("gha notice should count the synthesized failure as 1 errored:\n%s", out)
+		}
+	})
+}
+
 // TestRender_HostileCharsStayWellFormed feeds XML/JSON/TAP-hostile bytes through
 // the scenario name and failure detail — angle brackets, ampersands, a CDATA
 // terminator, quotes, an embedded newline, a C0 control byte, and a multibyte

--- a/internal/report/gha.go
+++ b/internal/report/gha.go
@@ -36,10 +36,19 @@ func writeGHA(w io.Writer, results []*engine.SuiteResult) error {
 		// an error annotation, so the Actions UI is never silent for a non-zero
 		// exit that produced no scenario rows.
 		if suiteErroredWithoutScenarios(res) {
-			for _, p := range suiteFailurePoints(res) {
+			pts := suiteFailurePoints(res)
+			for _, p := range pts {
 				fmt.Fprintf(&b, "::error title=%s::%s\n",
 					ghaEscapeProp(res.Suite+" / "+p.name), ghaEscapeData(p.message))
 			}
+			// res.Counts() and len(res.Scenarios) are both zero here (no scenario
+			// rows), so the synthesized points are the suite's only failure rows.
+			// Count them as errored — matching the testcases junit emits and the
+			// not-ok points tap emits for the same run — so the ::notice:: summary
+			// agrees with the ::error:: annotations just written above instead of
+			// reading an all-zero, all-green line.
+			agg.Errored += len(pts)
+			total += len(pts)
 		}
 		c := res.Counts()
 		agg.Passed += c.Passed

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -8,14 +8,16 @@ import (
 	"github.com/nao1215/atago/internal/engine"
 )
 
-// sanitizeControlBytes replaces control characters a machine-readable report
-// cannot carry verbatim with the Unicode replacement rune, matching what the
-// XML encoder already does for junit. A TAP 13 diagnostic is a YAML block and a
-// GitHub Actions annotation is a single line; both reject raw C0/C1 control
-// bytes, so a captured ANSI escape, bell, or DEL byte in a command's output
-// would otherwise make the surrounding document malformed. Tab and newline are
-// structural and kept; invalid UTF-8 is folded to the replacement rune too,
-// since a YAML stream must be valid UTF-8.
+// sanitizeControlBytes replaces control characters a tap/gha report cannot
+// carry verbatim with the Unicode replacement rune. It is stricter than junit:
+// junit feeds raw strings to encoding/xml, which only needs well-formed XML 1.0
+// and so passes DEL (0x7f) and the C1 controls (0x80-0x9f) through unchanged,
+// whereas this helper additionally folds DEL and C1. A TAP 13 diagnostic is a
+// YAML block and a GitHub Actions annotation is a single line; both reject raw
+// C0/C1 control bytes, so a captured ANSI escape, bell, or DEL byte in a
+// command's output would otherwise make the surrounding document malformed. Tab
+// and newline are structural and kept; invalid UTF-8 is folded to the
+// replacement rune too, since a YAML stream must be valid UTF-8.
 func sanitizeControlBytes(s string) string {
 	s = strings.ToValidUTF8(s, "�")
 	return strings.Map(func(r rune) rune {

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -191,6 +191,38 @@ func TestRender_SetupErrorContext_JUnitTAP(t *testing.T) {
 	}
 }
 
+// TestRender_SuiteSetupErrorNotMislabeled is a regression: a suite.setup step
+// failure (the shape engine.go builds — Setup:true, empty Kind, and a message
+// the engine already prefixes with "suite setup failed …") must not be rendered
+// under the "service setup" label, which is for background-service readiness.
+// The label was overloaded across service readiness, suite setup, and workdir
+// creation, so a suite.setup failure printed the misleading "service setup:".
+func TestRender_SuiteSetupErrorNotMislabeled(t *testing.T) {
+	t.Parallel()
+	results := []*engine.SuiteResult{{
+		Suite:  "s1",
+		Status: engine.StatusError,
+		Scenarios: []engine.ScenarioResult{
+			{Name: "svc", Status: engine.StatusError, Steps: []engine.StepResult{
+				{Index: 0, Kind: "", Setup: true, ErrMsg: "suite setup failed at step 2 (run): boom"},
+			}},
+		},
+	}}
+	for _, f := range []Format{FormatConsole, FormatJSON, FormatJUnit, FormatTAP} {
+		var b bytes.Buffer
+		if err := Render(&b, f, results); err != nil {
+			t.Fatalf("%s: %v", f, err)
+		}
+		out := b.String()
+		if strings.Contains(out, "service setup") {
+			t.Errorf("%s mislabeled a suite-setup failure as 'service setup':\n%s", f, out)
+		}
+		if !strings.Contains(out, "suite setup") {
+			t.Errorf("%s dropped the suite-setup attribution:\n%s", f, out)
+		}
+	}
+}
+
 func TestRender_JUnitValidXML(t *testing.T) {
 	t.Parallel()
 	var b bytes.Buffer

--- a/internal/report/step.go
+++ b/internal/report/step.go
@@ -1,6 +1,10 @@
 package report
 
-import "github.com/nao1215/atago/internal/engine"
+import (
+	"strings"
+
+	"github.com/nao1215/atago/internal/engine"
+)
 
 // setupPhaseLabel names the phase of a pre-step execution error — one that
 // happened before any numbered step ran (a service-readiness failure, a
@@ -9,6 +13,12 @@ import "github.com/nao1215/atago/internal/engine"
 // "step 0 ()".
 const setupPhaseLabel = "service setup"
 
+// suiteSetupPhaseLabel names a suite.setup failure specifically, so it is not
+// mislabeled as background-service readiness ("service setup"). The setup phase
+// is otherwise overloaded across service readiness, suite setup, and workdir
+// creation.
+const suiteSetupPhaseLabel = "suite setup"
+
 // isSetupError reports whether a step error belongs to the setup phase. The
 // engine marks these explicitly with Setup; the empty-Kind fallback keeps older
 // result values (and hand-built test fixtures) rendering correctly.
@@ -16,11 +26,29 @@ func isSetupError(step engine.StepResult) bool {
 	return step.Setup || step.Kind == ""
 }
 
+// isSuiteSetupError reports whether a setup-phase error came from the suite.setup
+// block rather than service readiness or workdir creation. The engine names that
+// phase at the front of the message (suiteSetupPhaseLabel), which the generic
+// "service setup" label would otherwise contradict.
+func isSuiteSetupError(step engine.StepResult) bool {
+	return isSetupError(step) && strings.HasPrefix(step.ErrMsg, suiteSetupPhaseLabel)
+}
+
+// setupPhaseLabelFor returns the phase label for a setup-phase error, telling a
+// suite.setup failure apart from a service-readiness / workdir-creation failure
+// so neither is rendered under the other's label.
+func setupPhaseLabelFor(step engine.StepResult) string {
+	if isSuiteSetupError(step) {
+		return suiteSetupPhaseLabel
+	}
+	return setupPhaseLabel
+}
+
 // stepPhase returns the phase label for the machine-readable `step` field: the
 // step kind, or the setup-phase label for a pre-step execution error.
 func stepPhase(step engine.StepResult) string {
 	if isSetupError(step) {
-		return setupPhaseLabel
+		return setupPhaseLabelFor(step)
 	}
 	return string(step.Kind)
 }
@@ -30,7 +58,7 @@ func stepPhase(step engine.StepResult) string {
 // a blank "Error in  step".
 func stepErrorContext(step engine.StepResult) string {
 	if isSetupError(step) {
-		return "during " + setupPhaseLabel
+		return "during " + setupPhaseLabelFor(step)
 	}
 	return "in " + string(step.Kind) + " step"
 }

--- a/internal/report/verbose.go
+++ b/internal/report/verbose.go
@@ -66,7 +66,7 @@ func (v *Verbose) Scenario(res engine.ScenarioResult) {
 func (v *Verbose) writeStep(b *strings.Builder, phase string, sr *engine.StepResult) {
 	label := string(sr.Kind)
 	if sr.Setup {
-		label = setupPhaseLabel
+		label = setupPhaseLabelFor(*sr)
 	}
 	fmt.Fprintf(b, "  [%s%d] %s", phase, sr.Index, label)
 	if sr.Run != nil && sr.Run.Command != "" {

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -73,8 +73,26 @@ func Normalize(data []byte, opt Options) []byte {
 	// snapshot recorded on POSIX matches cmd.exe output on Windows (and the
 	// committed golden never carries CRs). Matches the equals matcher's rule.
 	s = strings.ReplaceAll(s, "\r\n", "\n")
-	s = reCSI.ReplaceAllString(s, "")
-	s = reOSC.ReplaceAllString(s, "")
+	// Folding CRLF can rejoin a multi-line secret whose stored value uses LF: the
+	// first masking pass saw the \r\n form and could not match it, so the raw
+	// credential would otherwise reappear here. Mask once more on the folded text
+	// before any of it can reach the golden.
+	if opt.Secrets != nil {
+		s = string(opt.Secrets([]byte(s)))
+	}
+	// Strip CSI and OSC escapes to a fixed point. Removing a complete OSC
+	// sequence can splice a stray leading ESC onto the bytes that followed it and
+	// form a fresh CSI escape, which a single CSI-then-OSC pass leaves behind —
+	// a raw escape byte then leaks into the golden the CSI rule exists to keep
+	// clean, and Normalize is no longer idempotent. Loop until the text is stable
+	// (each pass only deletes bytes, so this always terminates).
+	for {
+		stripped := reOSC.ReplaceAllString(reCSI.ReplaceAllString(s, ""), "")
+		if stripped == s {
+			break
+		}
+		s = stripped
+	}
 	s = reUUID.ReplaceAllString(s, "<uuid>")
 	s = reTimestamp.ReplaceAllString(s, "<timestamp>")
 	s = rePort.ReplaceAllString(s, "$1:<port>")

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -10,6 +10,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/nao1215/atago/internal/security"
 )
 
 // TestNormalize_Idempotent proves normalizing already-normalized output is a
@@ -30,6 +32,11 @@ func TestNormalize_Idempotent(t *testing.T) {
 		"127.0.0.1:54321", "localhost:8080", "[::1]:22", "0.0.0.0:1",
 		"/tmp/atago-xyz", "plain text ", "\r\n", "\n", "$", "{", "}", "abc",
 		"127.0.0.1:", ":", "-", "T", "Z",
+		// A bare ESC and an incomplete CSI: removing a complete OSC that sits
+		// between them can splice the leftover ESC onto the following bytes and
+		// form a fresh CSI escape, which a single-pass CSI-then-OSC strip would
+		// leave behind. Fold to a fixed point so idempotence still holds.
+		"\x1b", "\x1b[0",
 	}
 	opt := Options{Workdir: "/tmp/atago-xyz"}
 	for iter := range 10000 {
@@ -41,6 +48,50 @@ func TestNormalize_Idempotent(t *testing.T) {
 		if twice := Normalize(once, opt); !bytes.Equal(once, twice) {
 			t.Fatalf("iter %d: Normalize not idempotent\n in:    %q\n once:  %q\n twice: %q", iter, in, once, twice)
 		}
+	}
+}
+
+// TestNormalize_IdempotentAcrossOSCSplice pins the specific splice that the
+// random fuzz above targets: a stray ESC directly before a complete OSC
+// sequence whose removal joins the ESC to the bytes that followed the OSC,
+// forming a valid CSI escape. Stripping CSI before OSC in a single pass leaves
+// that fresh escape in the output, so a second Normalize changes it again and a
+// raw ESC leaks into the golden — exactly what the CSI normalizer exists to
+// prevent. The fixed-point strip must remove it in one Normalize call.
+func TestNormalize_IdempotentAcrossOSCSplice(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"a\x1b\x1b]8;;http://x\x1b\\[31mb",
+		"\x1b\x1b]0;title\x07[m",
+		"link \x1b\x1b]8;;u\x1b\\[31mred\x1b[0m\n",
+	}
+	for _, in := range cases {
+		once := Normalize([]byte(in), Options{})
+		twice := Normalize(once, Options{})
+		if !bytes.Equal(once, twice) {
+			t.Errorf("Normalize not idempotent\n in:    %q\n once:  %q\n twice: %q", in, once, twice)
+		}
+		if bytes.ContainsRune(once, '\x1b') {
+			t.Errorf("Normalize(%q) = %q still contains a raw ESC byte", in, once)
+		}
+	}
+}
+
+// TestNormalize_SecretMaskedAfterCRLFFold proves a declared secret cannot leak
+// into a golden when the captured output uses CRLF line endings. Masking runs on
+// the raw bytes, but the CRLF fold that follows can reconstruct a multi-line
+// secret whose stored value uses LF; without a second masking pass the raw
+// credential lands in the committed golden.
+func TestNormalize_SecretMaskedAfterCRLFFold(t *testing.T) {
+	t.Parallel()
+	m := security.NewMasker([]string{"lineA\nlineB"})
+	opt := Options{Secrets: m.MaskBytes}
+	got := string(Normalize([]byte("lineA\r\nlineB\r\n"), opt))
+	if strings.Contains(got, "lineA\nlineB") {
+		t.Errorf("secret leaked into normalized output: %q", got)
+	}
+	if got != "***\n" {
+		t.Errorf("Normalize masked CRLF output = %q, want %q", got, "***\n")
 	}
 }
 

--- a/internal/spec/walk.go
+++ b/internal/spec/walk.go
@@ -78,7 +78,10 @@ func CollectStepVars(set map[string]bool, step *Step) {
 		CollectVars(set, step.Service.Command, step.Service.Cwd)
 	case StepRun:
 		r := step.Run
-		CollectVars(set, r.Command, r.Cwd, r.Stdin.Inline, r.Stdin.File)
+		// stdout_to/stderr_to are ${name}-expanded by the engine (expandRun), so a
+		// redirect target like `out-${who}.txt` is a real variable use and must be
+		// counted like cwd/stdin — omitting it under-reported it.
+		CollectVars(set, r.Command, r.Cwd, r.Stdin.Inline, r.Stdin.File, r.StdoutTo, r.StderrTo)
 		for _, v := range r.Env {
 			CollectVars(set, v)
 		}

--- a/internal/spec/walk_test.go
+++ b/internal/spec/walk_test.go
@@ -225,9 +225,9 @@ func TestCollectServiceVars_ReadyProbes(t *testing.T) {
 // refactor cannot silently drop them.
 func TestCollectStepVars_KnownFields(t *testing.T) {
 	t.Parallel()
-	run := &Step{Run: &Run{Command: "echo ${cmd}", Cwd: "${cwd}", Env: map[string]string{"T": "${env}"}, Stdin: Stdin{Inline: "${in}"}}}
+	run := &Step{Run: &Run{Command: "echo ${cmd}", Cwd: "${cwd}", Env: map[string]string{"T": "${env}"}, Stdin: Stdin{Inline: "${in}"}, StdoutTo: "${outto}.txt", StderrTo: "${errto}.log"}}
 	got := collectStep(run)
-	for _, want := range []string{"cmd", "cwd", "env", "in"} {
+	for _, want := range []string{"cmd", "cwd", "env", "in", "outto", "errto"} {
 		if !hasVar(got, want) {
 			t.Errorf("run field %q not collected; got %v", want, got)
 		}

--- a/test/e2e/atago/dir.atago.yaml
+++ b/test/e2e/atago/dir.atago.yaml
@@ -34,3 +34,19 @@ scenarios:
           dir:
             path: never-created
             exists: false
+
+  - name: a dangling symlink is a present directory entry (membership uses Lstat)
+    skip: {os: windows}
+    steps:
+      # A broken symlink is still a directory entry the program left behind;
+      # membership must see it via the entry, not by resolving the missing target.
+      - run:
+          shell: true
+          command: mkdir -p linkdir && ln -s /nonexistent-target-xyz linkdir/planted
+      - assert:
+          exit_code: 0
+      - assert:
+          dir:
+            path: linkdir
+            contains: [planted]
+            not_contains: [never-planted]

--- a/test/e2e/atago/matrix.atago.yaml
+++ b/test/e2e/atago/matrix.atago.yaml
@@ -65,3 +65,20 @@ scenarios:
             contains:
               - 'name="row [n=1]"'
               - 'name="row [n=2]"'
+
+  - name: stdout_to expands a matrix variable into the redirect target
+    matrix:
+      - { who: alice }
+      - { who: bob }
+    steps:
+      # The redirect target is a workdir-relative path like the assert path that
+      # reads it, so ${who} must resolve on both sides — a per-row output file.
+      - run:
+          shell: true
+          command: printf hello-${who}
+          stdout_to: out-${who}.txt
+      - assert:
+          exit_code: 0
+          file:
+            path: out-${who}.txt
+            contains: hello-${who}

--- a/test/e2e/atago/rerun.atago.yaml
+++ b/test/e2e/atago/rerun.atago.yaml
@@ -67,3 +67,37 @@ scenarios:
           exit_code: 0
           stderr:
             contains: nothing to rerun
+
+  - name: rerun-failed with a filter preserves the still-failing scenarios it did not run
+    steps:
+      - fixture:
+          file: two.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: two
+            scenarios:
+              - name: red-a
+                steps:
+                  - run: {shell: true, command: "exit 1"}
+                  - assert: {exit_code: 0}
+              - name: red-b
+                steps:
+                  - run: {shell: true, command: "exit 1"}
+                  - assert: {exit_code: 0}
+      # Both scenarios fail, so the ledger records both.
+      - run:
+          command: ${atago} run two.atago.yaml
+      - assert:
+          exit_code: 1
+      # Rerun only red-a via --filter. red-b is excluded from this run but is still
+      # broken, so it must stay in the ledger rather than being silently dropped
+      # (which would greenlight a later plain --rerun-failed).
+      - run:
+          command: ${atago} run --rerun-failed --filter red-a two.atago.yaml
+      - assert:
+          exit_code: 1
+      - assert:
+          file:
+            path: .atago/last-failed.json
+            contains: [red-a, red-b]


### PR DESCRIPTION
## Summary

A bug-hunting sweep across atago's differentiating surfaces — assertions, snapshot normalization, report formats, the run engine, record, and the loader/cli — that fixes verified correctness, security, and UX defects. Every fix lands with a regression test at the layer of the defect, and the most user-visible ones also gain a self-hosted e2e scenario that exercises the binary.

Each defect below was reproduced against the built binary or a focused unit before the fix and re-verified green after.

## Correctness and security

`run` now `${name}`-expands the `stdout_to`/`stderr_to` redirect targets like the assertion paths that read them, so a per-matrix-row or store-keyed filename resolves instead of being written to the literal `out-${who}.txt` while the following assert fails with "no such file".

`dir` `contains`/`not_contains` judged membership by following the symlink, so a dangling symlink was reported absent — a dangerous false pass for a negative assertion. Membership now reflects the directory entry via `Lstat`, matching the recursive and glob paths that already saw it.

`atago record` output containing non-UTF-8 bytes now round-trips: the generated spec re-parsed lossily through the YAML decoder and failed on its first replay. Such lines are emitted as a `!!binary` scalar so `record` then `run` is green.

`snapshot` normalization is idempotent again and no longer leaks secrets. A stray escape spliced by OSC removal left a raw ANSI byte in the golden, and a multi-line secret whose value uses LF reappeared in the golden when the output used CRLF. Escapes are now stripped to a fixed point and secrets are masked after the CRLF fold.

`--rerun-failed` with `--filter`/`--tag`/`--skip-tag` silently dropped the still-failing scenarios it did not run from the ledger, greenlighting a later plain rerun. Those failures are now preserved, the "renamed or removed?" warning is no longer shown for a filter exclusion, and an equivalent absolute/relative spec path now matches the recorded ledger.

`pdf` assertions bound FlateDecode decompression at 64 MiB, so a decompression bomb in the tested CLI's output can no longer exhaust memory (a 407 KB input inflated to ~900 MB before this). PDF hex-string metadata and text are now decoded instead of reported as a missing field.

The GitHub Actions notice summary counts a suite that errored before any scenario ran, matching the junit and tap counts and its own error annotation.

The loader rejects a `not_matches` pattern that also matches the empty string, since it can never pass.

## UX

A byte-exact `file equals` failure that differs only in line endings now renders a note instead of a blank diff.

An unresolved `${var}` in a run step's `cwd` fails with an explained error naming the reference, instead of the misleading "executable not found" the child raised when it could not start in a literal `${var}` directory. Bare `${…}` in `env` values and `stdin` keeps its documented literal passthrough.

Explicit `--help` on `explain`, `doc`, `list`, `manifest`, and `init` prints to stdout, matching `completion` and the top-level help, so the usage text can be piped.

A `suite.setup` failure is labeled `suite setup`, not `service setup`.

A matrix name template that omits a distinguishing row variable now explains the collapse by naming the omitted variable instead of a bare "duplicate scenario name".

A negative `--parallel` is rejected with a config error like `--repeat`/`--retry-failed`, and `--repeat 1` no longer trips the `--retry-failed` mutual-exclusion guard.

## Tests

Every fix has a regression test in its package. New self-hosted e2e scenarios cover symlink membership, `stdout_to` expansion, and rerun ledger preservation. `fsdelta` gains coverage for content-based change classes (rename, delete-recreate, empty file, file/dir replacement, chmod/mtime-only, broken and cyclic symlinks).

`make test`, `make lint`, and `make e2e` pass.

https://claude.ai/code/session_01VkiqasrLZPCeb4vydduqrD
