### PR TITLE
fix(cli): preserve recorded failures a run did not execute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- The last-failed ledger now preserves a recorded failure the run did not
+  execute, so a green run of an unrelated spec (or one whose `--filter`/`--tag`
+  excludes the failing scenario) no longer clears it and lets the next
+  `--rerun-failed` exit 0 while the failure is still real. A fully-green run of
+  the same specs still clears the ledger; only scenarios that actually ran are
+  re-decided. This is the rule the narrowed `--rerun-failed` path already used,
+  now applied to every run.
 - Secret masking now collects declared `secrets:` values from every
   env-bearing location — suite.env, defaults.scenario.env, pty steps, suite
   setup/teardown, and scenario teardown — not just run-step, scenario, and

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1421,7 +1421,8 @@ func TestRunCmd_SaveStateWriteErrorWarns(t *testing.T) {
 	dir := t.TempDir()
 	writeSpec(t, dir, "fail.atago.yaml", failingSpec)
 	withWorkdir(t, dir, func() {
-		// Block .atago dir creation with a file of the same name.
+		// Block the .atago state dir with a file of the same name, so the ledger can
+		// be neither read nor written.
 		if err := os.WriteFile(rerunStateDir, []byte("x"), 0o600); err != nil {
 			t.Fatal(err)
 		}
@@ -1429,8 +1430,11 @@ func TestRunCmd_SaveStateWriteErrorWarns(t *testing.T) {
 		if got := Main([]string{"run", "fail.atago.yaml"}, &out, &errb); got != ExitFailures {
 			t.Fatalf("exit = %d, want %d (the run's own verdict, stderr=%s)", got, ExitFailures, errb.String())
 		}
-		if !strings.Contains(errb.String(), "could not update") {
-			t.Errorf("stderr = %q, want a best-effort save warning", errb.String())
+		// A ledger persistence problem is a best-effort warning naming the state
+		// file, never a fatal error — whether it surfaces as a read or a write
+		// failure. The run's own verdict stands above.
+		if !strings.Contains(errb.String(), rerunStatePath()) {
+			t.Errorf("stderr = %q, want a best-effort ledger warning naming %s", errb.String(), rerunStatePath())
 		}
 	})
 }

--- a/internal/cli/features_test.go
+++ b/internal/cli/features_test.go
@@ -472,17 +472,60 @@ func TestRerunFailed_NothingRecorded(t *testing.T) {
 func TestRerunFailed_GreenRunClearsState(t *testing.T) {
 	dir := t.TempDir()
 	withWorkdir(t, dir, func() {
-		// Seed a state file, then a fully-green run should remove it.
-		if err := saveRerunState([]failedEntry{{SpecPath: "x.atago.yaml", Scenario: "old"}}); err != nil {
-			t.Fatal(err)
-		}
-		writeSpec(t, dir, "ok.atago.yaml", passingSpec)
+		// A spec that fails, records its failure, then is fixed and re-run green:
+		// re-running THE SAME spec re-decides its scenario and clears the ledger.
+		writeSpec(t, dir, "s.atago.yaml", singleFailSpec("s", false))
 		var out, errb bytes.Buffer
-		if got := Main([]string{"run", "ok.atago.yaml"}, &out, &errb); got != ExitOK {
-			t.Fatalf("exit = %d (stderr=%s)", got, errb.String())
+		if got := Main([]string{"run", "s.atago.yaml"}, &out, &errb); got != ExitFailures {
+			t.Fatalf("failing run exit = %d, want %d (stderr=%s)", got, ExitFailures, errb.String())
+		}
+		writeSpec(t, dir, "s.atago.yaml", singleFailSpec("s", true))
+		out.Reset()
+		errb.Reset()
+		if got := Main([]string{"run", "s.atago.yaml"}, &out, &errb); got != ExitOK {
+			t.Fatalf("fixed run exit = %d (stderr=%s)", got, errb.String())
 		}
 		if _, err := os.Stat(rerunStatePath()); !os.IsNotExist(err) {
-			t.Errorf("green run did not clear rerun state file (err=%v)", err)
+			t.Errorf("re-running the fixed spec did not clear the rerun state file (err=%v)", err)
+		}
+	})
+}
+
+// TestRun_UnrelatedGreenRunPreservesRecordedFailures is a regression: a green run
+// that does not execute a recorded failure — running an unrelated spec, or a
+// --filter that excludes the failing scenario — must not clear that failure from
+// the ledger. Overwriting the ledger with only what ran forgot still-failing work
+// and let the next --rerun-failed exit 0 while the failure was still real. The
+// preserve rule the narrowed-rerun path always used now applies to every run.
+func TestRun_UnrelatedGreenRunPreservesRecordedFailures(t *testing.T) {
+	dir := t.TempDir()
+	writeSpec(t, dir, "fail.atago.yaml", singleFailSpec("f", false))
+	writeSpec(t, dir, "ok.atago.yaml", passingSpec)
+
+	withWorkdir(t, dir, func() {
+		var out, errb bytes.Buffer
+		// Record f_fail.
+		if got := Main([]string{"run", "fail.atago.yaml"}, &out, &errb); got != ExitFailures {
+			t.Fatalf("first run exit = %d, want %d (stderr=%s)", got, ExitFailures, errb.String())
+		}
+		// Run an unrelated green spec: it must not touch fail.atago.yaml's record.
+		out.Reset()
+		errb.Reset()
+		if got := Main([]string{"run", "ok.atago.yaml"}, &out, &errb); got != ExitOK {
+			t.Fatalf("unrelated green run exit = %d (stderr=%s)", got, errb.String())
+		}
+		st, err := loadRerunState()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(st.Failed) != 1 || st.Failed[0].Scenario != "f_fail" {
+			t.Fatalf("ledger = %+v, want f_fail preserved after an unrelated green run", st.Failed)
+		}
+		// The still-real failure is therefore still caught by --rerun-failed.
+		out.Reset()
+		errb.Reset()
+		if got := Main([]string{"run", "--rerun-failed", "."}, &out, &errb); got != ExitFailures {
+			t.Fatalf("--rerun-failed exit = %d, want %d (the preserved failure must still be caught); stderr=%s", got, ExitFailures, errb.String())
 		}
 	})
 }
@@ -706,6 +749,50 @@ func TestRerunFailed_AbsolutePathMatchesRelativeLedger(t *testing.T) {
 		abs := filepath.Join(dir, "s.atago.yaml")
 		if got := Main([]string{"run", "--rerun-failed", abs}, &out, &errb); got != ExitFailures {
 			t.Fatalf("absolute-path rerun exit = %d, want %d (recorded failure was not selected); stderr=%s", got, ExitFailures, errb.String())
+		}
+	})
+}
+
+// TestRun_FilteredGreenRunPreservesExcludedFailure proves a plain run whose
+// --filter excludes a recorded failing scenario does not clear that failure, the
+// same way a narrowed --rerun-failed preserves it. Only scenarios that actually
+// ran are re-decided.
+func TestRun_FilteredGreenRunPreservesExcludedFailure(t *testing.T) {
+	dir := t.TempDir()
+	writeSpec(t, dir, "m.atago.yaml", twoFailingSpec)
+
+	withWorkdir(t, dir, func() {
+		var out, errb bytes.Buffer
+		// Record alpha_fail and beta_fail.
+		if got := Main([]string{"run", "m.atago.yaml"}, &out, &errb); got != ExitFailures {
+			t.Fatalf("first run exit = %d, want %d (stderr=%s)", got, ExitFailures, errb.String())
+		}
+		// Fix alpha, then run with a --filter that only touches alpha: beta_fail was
+		// not re-run and is still broken, so it must survive.
+		writeSpec(t, dir, "m.atago.yaml", `version: "1"
+suite:
+  name: multi
+scenarios:
+  - name: alpha_fail
+    steps:
+      - run: {shell: true, command: "exit 0"}
+      - assert: {exit_code: 0}
+  - name: beta_fail
+    steps:
+      - run: {shell: true, command: "exit 1"}
+      - assert: {exit_code: 0}
+`)
+		out.Reset()
+		errb.Reset()
+		if got := Main([]string{"run", "--filter", "alpha_fail", "m.atago.yaml"}, &out, &errb); got != ExitOK {
+			t.Fatalf("filtered run exit = %d (stderr=%s)", got, errb.String())
+		}
+		st, err := loadRerunState()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(st.Failed) != 1 || st.Failed[0].Scenario != "beta_fail" {
+			t.Errorf("ledger = %+v, want only beta_fail (alpha re-verified green, beta preserved)", st.Failed)
 		}
 	})
 }

--- a/internal/cli/rerun.go
+++ b/internal/cli/rerun.go
@@ -201,6 +201,32 @@ func intersectPaths(paths, keep []string) []string {
 	return out
 }
 
+// canonicalScenarioID is engine.ScenarioID with the spec path canonicalized, so
+// a recorded failure matches an executed scenario whether their paths are spelled
+// relative or absolute (or reach the same file through a symlinked temp dir).
+// Comparing raw ScenarioID strings would miss equivalent-but-differently-spelled
+// paths and let a preserved failure be dropped or double-counted.
+func canonicalScenarioID(specPath, scenario string) string {
+	return engine.ScenarioID(absClean(specPath), scenario)
+}
+
+// dedupeEntries removes duplicate (spec_path, scenario) entries, keeping
+// first-seen order, so a failure preserved from the prior ledger and the same
+// failure freshly recorded this run never both land in the file.
+func dedupeEntries(in []failedEntry) []failedEntry {
+	seen := make(map[string]bool, len(in))
+	var out []failedEntry
+	for _, e := range in {
+		k := e.SpecPath + "\x00" + e.Scenario
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		out = append(out, e)
+	}
+	return out
+}
+
 // collectFailures extracts the failing scenario identities from a set of suite
 // results and their spec paths, in a deterministic order.
 func collectFailures(results []*engine.SuiteResult) []failedEntry {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -129,18 +129,6 @@ func runCmd(label string, args []string, stdout, stderr io.Writer) int {
 	// identity selector so only the recorded scenarios execute. With nothing
 	// recorded there is nothing to rerun, which is reported and treated as success.
 	//
-	// rerunPreserved holds recorded failures this rerun did NOT execute, which must
-	// be carried back into the saved ledger below. A rerun skips a recorded failure
-	// two ways: its spec is outside this run's targets (a narrowed
-	// `--rerun-failed a.atago.yaml` when b.atago.yaml also had recorded failures),
-	// or an active --filter/--tag/--skip-tag excludes it. Either way the scenario
-	// was not re-verified and is still failing, so overwriting the ledger with only
-	// what ran would forget still-failing work and could greenlight the loop. It is
-	// computed after the run from what actually executed, which covers both cases
-	// uniformly (tag exclusion cannot be predicted from the ledger, which stores
-	// only names). recordedFailures carries the loaded ledger to that computation.
-	var rerunPreserved []failedEntry
-	var recordedFailures []failedEntry
 	if *rerunFailed {
 		state, lerr := loadRerunState()
 		if lerr != nil {
@@ -168,7 +156,6 @@ func runCmd(label string, args []string, stdout, stderr io.Writer) int {
 			fmt.Fprintln(stderr, label+": no previously failed scenarios under the given targets")
 			return ExitOK
 		}
-		recordedFailures = state.Failed
 		eng.Select = sel
 	}
 
@@ -234,24 +221,6 @@ func runCmd(label string, args []string, stdout, stderr io.Writer) int {
 	for _, r := range results {
 		ranScenarios += len(r.Scenarios)
 	}
-	// Carry back recorded failures this rerun did not execute (spec outside the
-	// targets, or excluded by an active --filter/--tag/--skip-tag). They were not
-	// re-verified and are still failing, so they stay in the ledger; only scenarios
-	// that actually ran are re-decided below (recorded again if still failing,
-	// dropped if fixed).
-	if *rerunFailed {
-		executed := make(map[string]bool)
-		for _, r := range results {
-			for _, sc := range r.Scenarios {
-				executed[engine.ScenarioID(r.SpecPath, sc.Name)] = true
-			}
-		}
-		for _, e := range recordedFailures {
-			if !executed[engine.ScenarioID(e.SpecPath, e.Scenario)] {
-				rerunPreserved = append(rerunPreserved, e)
-			}
-		}
-	}
 	// A --rerun-failed run that matched NOTHING verified nothing, yet the recorded
 	// failures are still real: greenlighting it and clearing the state would
 	// silently forget still-failing work. Warn loudly, keep the state, and do not
@@ -269,25 +238,48 @@ func runCmd(label string, args []string, stdout, stderr io.Writer) int {
 		exit = worseExit(exit, ExitConfig)
 	}
 
-	// Record this run's failing scenarios for a later `--rerun-failed` (#64). The
-	// state reflects exactly the scenarios that ran: failures are recorded and a
-	// fully-green run clears the file. It is only rewritten when at least one suite
-	// loaded, so a run where every spec failed to parse leaves prior state intact;
-	// and a --rerun-failed that matched no scenario must NOT clear the file, or the
-	// still-failing work it could not map would be forgotten. A narrowed
-	// --rerun-failed carries back the recorded failures for specs outside its
-	// target (rerunPreserved), which it did not re-verify, so a partial rerun
-	// cannot silently drop still-failing work elsewhere in the ledger. Writing is
-	// best-effort — a read-only checkout must not fail the run — so a write error
-	// is a warning, not a fatal exit.
+	// Update the last-failed ledger for a later `--rerun-failed` (#64). The ledger
+	// reflects what this run decided about the scenarios it EXECUTED — a failure is
+	// recorded, a pass is cleared — while PRESERVING every recorded failure the run
+	// did not execute. A run that touches only a subset of scenarios (a narrowed
+	// --rerun-failed, a --filter/--tag/--skip-tag selection, or simply running a
+	// different or smaller set of specs) must not drop still-failing work elsewhere:
+	// overwriting the ledger with only what ran would forget it and could greenlight
+	// a later --rerun-failed while real failures remain. So a fully-green run of the
+	// SAME specs clears the file, but a green run of an unrelated spec keeps the
+	// other spec's recorded failures. The ledger is left untouched when no suite
+	// loaded (prior state stays intact) and when a --rerun-failed matched nothing
+	// (its unmapped failures must survive). Writing is best-effort — a read-only
+	// checkout must not fail the run — so a write error is a warning, not a fatal
+	// exit.
 	if len(results) > 0 && !rerunMatchedNothing {
-		// Store portable (cwd-relative) spec paths so the ledger survives a project
-		// move. A --rerun-failed absolutizes paths in memory to match across
-		// spellings; persisting that absolute form would break the next rerun after
-		// the directory moves.
-		entries := portableEntries(append(collectFailures(results), rerunPreserved...))
-		if err := saveRerunState(entries); err != nil {
-			fmt.Fprintf(stderr, label+": could not update %s: %v\n", rerunStatePath(), err)
+		prior, perr := loadRerunState()
+		if perr != nil {
+			// A corrupt or future-version ledger: do not overwrite it and destroy
+			// recorded failures we cannot read. (--rerun-failed already exited above on
+			// this same error, so this only guards a plain run.)
+			fmt.Fprintf(stderr, label+": cannot read %s; leaving it untouched: %v\n", rerunStatePath(), perr)
+		} else {
+			executed := make(map[string]bool, ranScenarios)
+			for _, r := range results {
+				for _, sc := range r.Scenarios {
+					executed[canonicalScenarioID(r.SpecPath, sc.Name)] = true
+				}
+			}
+			var preserved []failedEntry
+			for _, e := range prior.Failed {
+				if !executed[canonicalScenarioID(e.SpecPath, e.Scenario)] {
+					preserved = append(preserved, e)
+				}
+			}
+			// Store portable (cwd-relative) spec paths so the ledger survives a project
+			// move. A --rerun-failed absolutizes paths in memory to match across
+			// spellings; persisting that absolute form would break the next rerun after
+			// the directory moves.
+			entries := dedupeEntries(portableEntries(append(collectFailures(results), preserved...)))
+			if err := saveRerunState(entries); err != nil {
+				fmt.Fprintf(stderr, label+": could not update %s: %v\n", rerunStatePath(), err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Follow-up to #199. During review of that PR, this ledger behavior was flagged as "by design" because a test asserted it; on a second look the test encoded a bug.

## The bug

The `--rerun-failed` ledger (`.atago/last-failed.json`) records the scenarios that failed so a later `--rerun-failed` can re-run only those. A plain run rewrote the ledger from only the scenarios it executed, so a green run that did not execute a recorded failure silently dropped it:

```
atago run fail.atago.yaml       # records fail.atago.yaml / s_fail
atago run ok.atago.yaml         # unrelated green spec — ledger is now WIPED
atago run --rerun-failed .      # "no previously failed scenarios recorded", exit 0
```

`s_fail` is still broken, but the red-green loop lost it. The same happens when a `--filter`/`--tag` excludes the failing scenario.

## Why it is a bug, not a design choice

The narrowed `--rerun-failed` path already guards against exactly this — it carries back failures it did not run, with a comment stating that overwriting the ledger with only what ran "would forget still-failing work and could greenlight the loop". That reasoning applies to every run, not just a rerun. The plain-run path was the inconsistent one.

## The fix

Load the prior ledger, re-decide only the scenarios that actually executed (record a failure, clear a pass), and preserve every recorded failure the run did not execute. A fully-green run of the same specs still clears the ledger, so the loop-completion case is unchanged. Paths are compared canonically (a relative and an absolute spelling of the same spec match) and stored portably (the ledger survives a project move).

## Tests

`TestRerunFailed_GreenRunClearsState` asserted that an unrelated green run clears the ledger — it encoded the bug. It is rewritten to assert the correct same-spec-clears semantics. New regression tests cover the unrelated-spec case (`TestRun_UnrelatedGreenRunPreservesRecordedFailures`) and the filtered-run case (`TestRun_FilteredGreenRunPreservesExcludedFailure`). `make test`, `make lint`, and `make e2e` (387 self-hosted scenarios) pass.
