### PR TITLE
feat(website): add hosted documentation website built with Hugo

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,0 +1,71 @@
+name: Website
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "website/**"
+      - "doc/**"
+      - "site/samples/**"
+      - ".github/workflows/website.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "website/**"
+      - "doc/**"
+      - "site/samples/**"
+      - ".github/workflows/website.yml"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    env:
+      HUGO_VERSION: 0.164.0
+      HUGO_SHA256: d9c8b17285ea4ec004d9f814273ea910f2051ce02c284993fd1f91ba455ae50d
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install Hugo
+        run: |
+          curl -fsSL -o "${RUNNER_TEMP}/hugo.tar.gz" \
+            "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_linux-amd64.tar.gz"
+          echo "${HUGO_SHA256}  ${RUNNER_TEMP}/hugo.tar.gz" | sha256sum --check -
+          tar -C "${RUNNER_TEMP}" -xzf "${RUNNER_TEMP}/hugo.tar.gz" hugo
+          sudo mv "${RUNNER_TEMP}/hugo" /usr/local/bin/hugo
+          hugo version
+
+      - name: Build website
+        run: make website
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        with:
+          path: website/public
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,8 @@ go.work.sum
 
 # `atago run --rerun-failed` state (records the previous run's failing scenarios)
 .atago/
+
+# Hugo build artifacts for the hosted website (`make website`)
+/website/public/
+/website/resources/
+/website/.hugo_build.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- A hosted documentation website, https://nao1215.github.io/atago/, built
+  with Hugo from the committed docs (no content is duplicated: `doc/cookbook.md`,
+  `doc/examples.md`, `doc/real-world.md`, and the generated behavior docs under
+  `doc/e2e/` are mounted and turned into pages at build time). Deployed to
+  GitHub Pages by `.github/workflows/website.yml` on every push to `main` that
+  touches the docs; `make website` / `make website-serve` build it locally.
+
 ## [0.9.0] - 2026-07-08
 
 A second hardening release. Parallel bug hunters and Go-native fuzzing swept the

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test coverage clean vet fmt lint tools release-smoke e2e thirdparty dogfood dogfood-iso8583tool dogfood-jose dogfood-career dogfood-gup dogfood-mimixbox dogfood-mobilepkg demo docs site help
+.PHONY: build test coverage clean vet fmt lint tools release-smoke e2e thirdparty dogfood dogfood-iso8583tool dogfood-jose dogfood-career dogfood-gup dogfood-mimixbox dogfood-mobilepkg demo docs site website website-serve help
 
 APP         = atago
 VERSION     = $(shell git describe --tags --always --dirty 2>/dev/null)
@@ -144,6 +144,12 @@ docs: ## Regenerate the committed behavior docs under doc/e2e/ from the specs
 
 site: ## Regenerate the browsable docs site under site/ (drift-guarded by TestSite_InSync)
 	env UPDATE_SITE=1 $(GO) test -run TestSite_InSync .
+
+website: ## Build the hosted documentation website into website/public (requires hugo on PATH)
+	cd website && hugo --gc --minify
+
+website-serve: ## Serve the website locally with live reload (requires hugo on PATH)
+	cd website && hugo server
 
 demo: ## Regenerate the README GIFs with vhs (requires vhs on PATH)
 	env CGO_ENABLED=0 $(GO_BUILD) $(GO_LDFLAGS) -o ./dist/$(APP) .

--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,31 @@
+# website/
+
+The hosted documentation website, https://nao1215.github.io/atago/, built with
+Hugo and deployed by `.github/workflows/website.yml` on every push to `main`
+that touches `website/`, `doc/`, or `site/samples/`.
+
+The committed docs stay the single source of truth. Hugo mounts them read-only
+(`hugo.toml`) and `content/_content.gotmpl` turns them into pages, rewriting
+repository-relative links to site pages or GitHub:
+
+| Source | Page |
+|--------|------|
+| `doc/cookbook.md` | `/cookbook/` |
+| `doc/examples.md` | `/examples/` |
+| `doc/real-world.md` | `/real-world/` |
+| `doc/e2e/<tool>.md` | `/real-world/<tool>/` |
+| `doc/img/`, `site/samples/` | served as static files |
+
+Only the landing page and the Install / Getting started / CI / Reference pages
+under `content/` are authored here; their prose is adapted from README.md.
+
+```shell
+make website        # build into website/public (requires hugo)
+make website-serve  # live-reload server for local editing
+```
+
+There is no theme dependency: `layouts/` and `assets/css/` are the whole
+design. `assets/css/chroma.css` is generated (`hugo gen chromastyles`, github
+style light + github-dark wrapped in a dark-mode media query); regenerate it
+only when changing the highlight style. `site/` (the repo-local Markdown index)
+is unrelated to this directory and stays drift-guarded by `TestSite_InSync`.

--- a/website/assets/css/chroma.css
+++ b/website/assets/css/chroma.css
@@ -1,0 +1,159 @@
+/* Generated using: hugo gen chromastyles --style=github */
+
+/* Background */ .bg { background-color:#f7f7f7; }
+/* PreWrapper */ .chroma { background-color:#f7f7f7;-webkit-text-size-adjust:none; }
+/* Error */ .chroma .err { color:#f6f8fa;background-color:#82071e }
+/* LineLink */ .chroma .lnlinks { outline:none;text-decoration:none;color:inherit }
+/* LineTableTD */ .chroma .lntd { vertical-align:top;padding:0;margin:0;border:0; }
+/* LineTable */ .chroma .lntable { border-spacing:0;padding:0;margin:0;border:0; }
+/* LineHighlight */ .chroma .hl { background-color:#dedede }
+/* LineNumbersTable */ .chroma .lnt { white-space:pre;-webkit-user-select:none;user-select:none;margin-right:0.4em;padding:0 0.4em 0 0.4em;color:#7f7f7f }
+/* LineNumbers */ .chroma .ln { white-space:pre;-webkit-user-select:none;user-select:none;margin-right:0.4em;padding:0 0.4em 0 0.4em;color:#7f7f7f }
+/* Line */ .chroma .line { display:flex; }
+/* Keyword */ .chroma .k { color:#cf222e }
+/* KeywordConstant */ .chroma .kc { color:#cf222e }
+/* KeywordDeclaration */ .chroma .kd { color:#cf222e }
+/* KeywordNamespace */ .chroma .kn { color:#cf222e }
+/* KeywordPseudo */ .chroma .kp { color:#cf222e }
+/* KeywordReserved */ .chroma .kr { color:#cf222e }
+/* KeywordType */ .chroma .kt { color:#cf222e }
+/* NameAttribute */ .chroma .na { color:#1f2328 }
+/* NameClass */ .chroma .nc { color:#1f2328 }
+/* NameConstant */ .chroma .no { color:#0550ae }
+/* NameDecorator */ .chroma .nd { color:#0550ae }
+/* NameEntity */ .chroma .ni { color:#6639ba }
+/* NameLabel */ .chroma .nl { color:#900;font-weight:bold }
+/* NameNamespace */ .chroma .nn { color:#24292e }
+/* NameOther */ .chroma .nx { color:#1f2328 }
+/* NameTag */ .chroma .nt { color:#0550ae }
+/* NameBuiltin */ .chroma .nb { color:#6639ba }
+/* NameBuiltinPseudo */ .chroma .bp { color:#6a737d }
+/* NameVariable */ .chroma .nv { color:#953800 }
+/* NameVariableClass */ .chroma .vc { color:#953800 }
+/* NameVariableGlobal */ .chroma .vg { color:#953800 }
+/* NameVariableInstance */ .chroma .vi { color:#953800 }
+/* NameVariableMagic */ .chroma .vm { color:#953800 }
+/* NameFunction */ .chroma .nf { color:#6639ba }
+/* NameFunctionMagic */ .chroma .fm { color:#6639ba }
+/* LiteralString */ .chroma .s { color:#0a3069 }
+/* LiteralStringAffix */ .chroma .sa { color:#0a3069 }
+/* LiteralStringBacktick */ .chroma .sb { color:#0a3069 }
+/* LiteralStringChar */ .chroma .sc { color:#0a3069 }
+/* LiteralStringDelimiter */ .chroma .dl { color:#0a3069 }
+/* LiteralStringDoc */ .chroma .sd { color:#0a3069 }
+/* LiteralStringDouble */ .chroma .s2 { color:#0a3069 }
+/* LiteralStringEscape */ .chroma .se { color:#0a3069 }
+/* LiteralStringHeredoc */ .chroma .sh { color:#0a3069 }
+/* LiteralStringInterpol */ .chroma .si { color:#0a3069 }
+/* LiteralStringOther */ .chroma .sx { color:#0a3069 }
+/* LiteralStringRegex */ .chroma .sr { color:#0a3069 }
+/* LiteralStringSingle */ .chroma .s1 { color:#0a3069 }
+/* LiteralStringSymbol */ .chroma .ss { color:#032f62 }
+/* LiteralNumber */ .chroma .m { color:#0550ae }
+/* LiteralNumberBin */ .chroma .mb { color:#0550ae }
+/* LiteralNumberFloat */ .chroma .mf { color:#0550ae }
+/* LiteralNumberHex */ .chroma .mh { color:#0550ae }
+/* LiteralNumberInteger */ .chroma .mi { color:#0550ae }
+/* LiteralNumberIntegerLong */ .chroma .il { color:#0550ae }
+/* LiteralNumberOct */ .chroma .mo { color:#0550ae }
+/* Operator */ .chroma .o { color:#0550ae }
+/* OperatorWord */ .chroma .ow { color:#0550ae }
+/* OperatorReserved */ .chroma .or { color:#0550ae }
+/* Punctuation */ .chroma .p { color:#1f2328 }
+/* Comment */ .chroma .c { color:#57606a }
+/* CommentHashbang */ .chroma .ch { color:#57606a }
+/* CommentMultiline */ .chroma .cm { color:#57606a }
+/* CommentSingle */ .chroma .c1 { color:#57606a }
+/* CommentSpecial */ .chroma .cs { color:#57606a }
+/* CommentPreproc */ .chroma .cp { color:#57606a }
+/* CommentPreprocFile */ .chroma .cpf { color:#57606a }
+/* GenericDeleted */ .chroma .gd { color:#82071e;background-color:#ffebe9 }
+/* GenericEmph */ .chroma .ge { color:#1f2328 }
+/* GenericInserted */ .chroma .gi { color:#116329;background-color:#dafbe1 }
+/* GenericOutput */ .chroma .go { color:#1f2328 }
+/* GenericUnderline */ .chroma .gl { text-decoration:underline }
+/* TextWhitespace */ .chroma .w { color:#fff }
+
+@media (prefers-color-scheme: dark) {
+  /* Generated using: hugo gen chromastyles --style=github-dark */
+  
+  /* Background */ .bg { color:#e6edf3;background-color:#0d1117; }
+  /* PreWrapper */ .chroma { color:#e6edf3;background-color:#0d1117;-webkit-text-size-adjust:none; }
+  /* Error */ .chroma .err { color:#f85149 }
+  /* LineLink */ .chroma .lnlinks { outline:none;text-decoration:none;color:inherit }
+  /* LineTableTD */ .chroma .lntd { vertical-align:top;padding:0;margin:0;border:0; }
+  /* LineTable */ .chroma .lntable { border-spacing:0;padding:0;margin:0;border:0; }
+  /* LineHighlight */ .chroma .hl { background-color:#6e7681 }
+  /* LineNumbersTable */ .chroma .lnt { white-space:pre;-webkit-user-select:none;user-select:none;margin-right:0.4em;padding:0 0.4em 0 0.4em;color:#737679 }
+  /* LineNumbers */ .chroma .ln { white-space:pre;-webkit-user-select:none;user-select:none;margin-right:0.4em;padding:0 0.4em 0 0.4em;color:#6e7681 }
+  /* Line */ .chroma .line { display:flex; }
+  /* Keyword */ .chroma .k { color:#ff7b72 }
+  /* KeywordConstant */ .chroma .kc { color:#79c0ff }
+  /* KeywordDeclaration */ .chroma .kd { color:#ff7b72 }
+  /* KeywordNamespace */ .chroma .kn { color:#ff7b72 }
+  /* KeywordPseudo */ .chroma .kp { color:#79c0ff }
+  /* KeywordReserved */ .chroma .kr { color:#ff7b72 }
+  /* KeywordType */ .chroma .kt { color:#ff7b72 }
+  /* NameClass */ .chroma .nc { color:#f0883e;font-weight:bold }
+  /* NameConstant */ .chroma .no { color:#79c0ff;font-weight:bold }
+  /* NameDecorator */ .chroma .nd { color:#d2a8ff;font-weight:bold }
+  /* NameEntity */ .chroma .ni { color:#ffa657 }
+  /* NameException */ .chroma .ne { color:#f0883e;font-weight:bold }
+  /* NameLabel */ .chroma .nl { color:#79c0ff;font-weight:bold }
+  /* NameNamespace */ .chroma .nn { color:#ff7b72 }
+  /* NameOther */ .chroma .nx { color:#e6edf3 }
+  /* NameProperty */ .chroma .py { color:#79c0ff }
+  /* NameTag */ .chroma .nt { color:#7ee787 }
+  /* NameVariable */ .chroma .nv { color:#79c0ff }
+  /* NameVariableClass */ .chroma .vc { color:#79c0ff }
+  /* NameVariableGlobal */ .chroma .vg { color:#79c0ff }
+  /* NameVariableInstance */ .chroma .vi { color:#79c0ff }
+  /* NameVariableMagic */ .chroma .vm { color:#79c0ff }
+  /* NameFunction */ .chroma .nf { color:#d2a8ff;font-weight:bold }
+  /* NameFunctionMagic */ .chroma .fm { color:#d2a8ff;font-weight:bold }
+  /* Literal */ .chroma .l { color:#a5d6ff }
+  /* LiteralDate */ .chroma .ld { color:#79c0ff }
+  /* LiteralString */ .chroma .s { color:#a5d6ff }
+  /* LiteralStringAffix */ .chroma .sa { color:#79c0ff }
+  /* LiteralStringBacktick */ .chroma .sb { color:#a5d6ff }
+  /* LiteralStringChar */ .chroma .sc { color:#a5d6ff }
+  /* LiteralStringDelimiter */ .chroma .dl { color:#79c0ff }
+  /* LiteralStringDoc */ .chroma .sd { color:#a5d6ff }
+  /* LiteralStringDouble */ .chroma .s2 { color:#a5d6ff }
+  /* LiteralStringEscape */ .chroma .se { color:#79c0ff }
+  /* LiteralStringHeredoc */ .chroma .sh { color:#79c0ff }
+  /* LiteralStringInterpol */ .chroma .si { color:#a5d6ff }
+  /* LiteralStringOther */ .chroma .sx { color:#a5d6ff }
+  /* LiteralStringRegex */ .chroma .sr { color:#79c0ff }
+  /* LiteralStringSingle */ .chroma .s1 { color:#a5d6ff }
+  /* LiteralStringSymbol */ .chroma .ss { color:#a5d6ff }
+  /* LiteralNumber */ .chroma .m { color:#a5d6ff }
+  /* LiteralNumberBin */ .chroma .mb { color:#a5d6ff }
+  /* LiteralNumberFloat */ .chroma .mf { color:#a5d6ff }
+  /* LiteralNumberHex */ .chroma .mh { color:#a5d6ff }
+  /* LiteralNumberInteger */ .chroma .mi { color:#a5d6ff }
+  /* LiteralNumberIntegerLong */ .chroma .il { color:#a5d6ff }
+  /* LiteralNumberOct */ .chroma .mo { color:#a5d6ff }
+  /* Operator */ .chroma .o { color:#ff7b72;font-weight:bold }
+  /* OperatorWord */ .chroma .ow { color:#ff7b72;font-weight:bold }
+  /* OperatorReserved */ .chroma .or { color:#ff7b72;font-weight:bold }
+  /* Comment */ .chroma .c { color:#8b949e;font-style:italic }
+  /* CommentHashbang */ .chroma .ch { color:#8b949e;font-style:italic }
+  /* CommentMultiline */ .chroma .cm { color:#8b949e;font-style:italic }
+  /* CommentSingle */ .chroma .c1 { color:#8b949e;font-style:italic }
+  /* CommentSpecial */ .chroma .cs { color:#8b949e;font-weight:bold;font-style:italic }
+  /* CommentPreproc */ .chroma .cp { color:#8b949e;font-weight:bold;font-style:italic }
+  /* CommentPreprocFile */ .chroma .cpf { color:#8b949e;font-weight:bold;font-style:italic }
+  /* GenericDeleted */ .chroma .gd { color:#ffa198;background-color:#490202 }
+  /* GenericEmph */ .chroma .ge { font-style:italic }
+  /* GenericError */ .chroma .gr { color:#ffa198 }
+  /* GenericHeading */ .chroma .gh { color:#79c0ff;font-weight:bold }
+  /* GenericInserted */ .chroma .gi { color:#56d364;background-color:#0f5323 }
+  /* GenericOutput */ .chroma .go { color:#8b949e }
+  /* GenericPrompt */ .chroma .gp { color:#8b949e }
+  /* GenericStrong */ .chroma .gs { font-weight:bold }
+  /* GenericSubheading */ .chroma .gu { color:#79c0ff }
+  /* GenericTraceback */ .chroma .gt { color:#ff7b72 }
+  /* GenericUnderline */ .chroma .gl { text-decoration:underline }
+  /* TextWhitespace */ .chroma .w { color:#6e7681 }
+}

--- a/website/assets/css/site.css
+++ b/website/assets/css/site.css
@@ -1,0 +1,171 @@
+:root {
+  --bg: #ffffff;
+  --fg: #1f2328;
+  --muted: #59636e;
+  --link: #0757ba;
+  --border: #d1d9e0;
+  --code-bg: #f6f8fa;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0d1117;
+    --fg: #e6edf3;
+    --muted: #9198a1;
+    --link: #58a6ff;
+    --border: #30363d;
+    --code-bg: #161b22;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  font-size: 1.0625rem;
+  line-height: 1.6;
+}
+
+header {
+  border-bottom: 1px solid var(--border);
+}
+
+header nav {
+  max-width: 56rem;
+  margin: 0 auto;
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 1rem;
+  align-items: baseline;
+}
+
+header nav a {
+  color: var(--fg);
+  text-decoration: none;
+}
+
+header nav a:hover {
+  text-decoration: underline;
+}
+
+header nav .brand {
+  font-weight: 700;
+  margin-right: 0.5rem;
+}
+
+main {
+  max-width: 56rem;
+  margin: 0 auto;
+  padding: 1.5rem 1rem 3rem;
+}
+
+footer {
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 0.875rem;
+}
+
+footer p {
+  max-width: 56rem;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+footer a {
+  color: var(--muted);
+}
+
+h1, h2, h3, h4 {
+  line-height: 1.25;
+  margin: 1.75em 0 0.5em;
+}
+
+h1 {
+  margin-top: 0.5em;
+  font-size: 1.75rem;
+}
+
+h2 {
+  font-size: 1.35rem;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0.25rem;
+}
+
+h3 {
+  font-size: 1.1rem;
+}
+
+a {
+  color: var(--link);
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+code, pre {
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: 0.875em;
+}
+
+code {
+  background: var(--code-bg);
+  border-radius: 4px;
+  padding: 0.15em 0.35em;
+}
+
+pre {
+  background: var(--code-bg);
+  border-radius: 6px;
+  padding: 0.9rem 1rem;
+  overflow-x: auto;
+  line-height: 1.5;
+}
+
+pre code {
+  background: none;
+  padding: 0;
+  font-size: 1em;
+}
+
+.highlight pre {
+  background: var(--code-bg) !important;
+}
+
+table {
+  display: block;
+  overflow-x: auto;
+  border-collapse: collapse;
+  margin: 1rem 0;
+}
+
+th, td {
+  border: 1px solid var(--border);
+  padding: 0.4rem 0.7rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+th {
+  background: var(--code-bg);
+}
+
+blockquote {
+  margin: 1rem 0;
+  padding: 0 1rem;
+  color: var(--muted);
+  border-left: 3px solid var(--border);
+}
+
+hr {
+  border: 0;
+  border-top: 1px solid var(--border);
+  margin: 2rem 0;
+}

--- a/website/content/_content.gotmpl
+++ b/website/content/_content.gotmpl
@@ -1,0 +1,71 @@
+{{/* Build pages from docs committed in this repository (mounted under
+     assets/). The committed files stay the single source of truth; this
+     template only strips the H1 (the layout renders the title) and rewrites
+     repository-relative links to site pages or GitHub. */}}
+
+{{ $gh := "https://github.com/nao1215/atago/blob/main/" }}
+
+{{/* doc/cookbook.md -> /cookbook/ */}}
+{{ with resources.Get "doc/cookbook.md" }}
+  {{ $md := .Content }}
+  {{ $md = replaceRE `\A# Cookbook\n` "" $md }}
+  {{ $md = replaceRE `\]\(examples\.md(#[^)]*)?\)` "](/examples/$1)" $md }}
+  {{ $md = replaceRE `\]\(real-world\.md(#[^)]*)?\)` "](/real-world/$1)" $md }}
+  {{ $md = replaceRE `\]\(e2e/([A-Za-z0-9._-]+)\.md(#[^)]*)?\)` "](/real-world/$1/$2)" $md }}
+  {{ $md = replaceRE `\]\(\.\./` (printf "](%s" $gh) $md }}
+  {{ $.AddPage (dict
+      "path" "cookbook"
+      "title" "Cookbook"
+      "params" (dict "description" "Copyable atago specs for common jobs: converting files, driving prompts and TUIs, mocking HTTP APIs, pinning output trees, and more.")
+      "content" (dict "mediaType" "text/markdown" "value" $md)) }}
+{{ end }}
+
+{{/* doc/examples.md -> /examples/ */}}
+{{ with resources.Get "doc/examples.md" }}
+  {{ $md := .Content }}
+  {{ $md = replaceRE `\A# Examples\n` "" $md }}
+  {{ $md = replaceRE `\]\(cookbook\.md(#[^)]*)?\)` "](/cookbook/$1)" $md }}
+  {{ $md = replaceRE `\]\(real-world\.md(#[^)]*)?\)` "](/real-world/$1)" $md }}
+  {{ $md = replaceRE `\]\(e2e/([A-Za-z0-9._-]+)\.md(#[^)]*)?\)` "](/real-world/$1/$2)" $md }}
+  {{ $md = replaceRE `\]\(\.\./` (printf "](%s" $gh) $md }}
+  {{ $.AddPage (dict
+      "path" "examples"
+      "title" "Examples"
+      "params" (dict "description" "Every atago feature has a commented, runnable spec, tested in CI on Linux, macOS, and Windows — indexed by task and by feature.")
+      "content" (dict "mediaType" "text/markdown" "value" $md)) }}
+{{ end }}
+
+{{/* doc/real-world.md -> /real-world/ (section index) */}}
+{{ with resources.Get "doc/real-world.md" }}
+  {{ $md := .Content }}
+  {{ $md = replaceRE `\A# Real CLIs tested with atago\n` "" $md }}
+  {{ $md = replaceRE `\]\(e2e/([A-Za-z0-9._-]+)\.md(#[^)]*)?\)` "](/real-world/$1/$2)" $md }}
+  {{ $md = replaceRE `\]\(e2e/\)` "](/real-world/)" $md }}
+  {{ $md = replaceRE `\]\(\.\./` (printf "](%s" $gh) $md }}
+  {{ $.AddPage (dict
+      "path" "real-world"
+      "kind" "section"
+      "title" "Real CLIs tested with atago"
+      "params" (dict "description" "40+ real programs run their E2E suites on atago: git, jq, fzf, htop, redis, terraform, ffmpeg, and more — each with executable specs and generated behavior docs.")
+      "content" (dict "mediaType" "text/markdown" "value" $md)) }}
+{{ end }}
+
+{{/* doc/e2e/<tool>.md -> /real-world/<tool>/ */}}
+{{ range resources.Match "e2e/*.md" }}
+  {{ $name := path.BaseName .Name }}
+  {{ if ne $name "README" }}
+    {{ $md := .Content }}
+    {{ $md = replaceRE `\A# atago Behavior Specs\n` "" $md }}
+    {{ $md = replaceRE `\]\(\.\./real-world\.md(#[^)]*)?\)` "](/real-world/$1)" $md }}
+    {{ $md = replaceRE `\]\(([A-Za-z0-9._-]+)\.md(#[^)]*)?\)` "](/real-world/$1/$2)" $md }}
+    {{/* embedded images need the raw file, not the GitHub blob page */}}
+    {{ $md = replaceRE `!\[([^\]]*)\]\(\.\./\.\./` "![$1](https://raw.githubusercontent.com/nao1215/atago/main/" $md }}
+    {{ $md = replaceRE `\]\(\.\./\.\./` (printf "](%s" $gh) $md }}
+    {{ $md = replaceRE `\]\(\.\./` (printf "](%sdoc/" $gh) $md }}
+    {{ $.AddPage (dict
+        "path" (printf "real-world/%s" $name)
+        "title" $name
+        "params" (dict "description" (printf "Behavior docs for %s, generated from the executable atago specs that run in CI." $name))
+        "content" (dict "mediaType" "text/markdown" "value" $md)) }}
+  {{ end }}
+{{ end }}

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -1,0 +1,39 @@
+---
+title: atago
+---
+
+atago tests real CLI behavior from plain YAML: commands, files, snapshots, services, and interactive terminals. It runs your actual binary — in any language — and asserts what a user observes. No test code, no shell DSL.
+
+![atago running a spec suite](/img/demo.gif)
+
+```shell
+atago record --out mytool.atago.yaml -- mytool convert input.txt  # turn a real run into a spec
+atago run mytool.atago.yaml                                       # replay it as a test
+atago run --report junit specs/                                   # or run a whole suite in CI
+```
+
+## Why atago?
+
+Pick the tool that owns your layer:
+
+| You are testing | Use |
+|-----------------|-----|
+| An HTTP/gRPC API server — scenario-based API testing | [runn](https://github.com/k1LoW/runn) |
+| A whole platform — integration suites across HTTP, gRPC, Kafka, databases, and more | [venom](https://github.com/ovh/venom) |
+| Shell functions and scripts — BDD-style unit tests | [ShellSpec](https://shellspec.info/) |
+| Bash scripts — TAP-style tests | [Bats](https://github.com/bats-core/bats-core) |
+| A CLI product — exit codes, output, generated files, snapshots, interactive prompts and TUIs | atago |
+
+If the server or the platform is the system under test, use runn or venom. atago points the other way: the CLI is the product, and HTTP, database, SSH, gRPC, browser, and mock servers appear only as peers your CLI talks to.
+
+## Where to go
+
+- [Install](/install/) — `go install`, Homebrew, AUR, prebuilt binaries, a GitHub Action.
+- [Getting started](/getting-started/) — record a real run, read the spec it wrote, keep it as a test.
+- [Cookbook](/cookbook/) — copyable specs for common jobs, from image conversion to graceful shutdown.
+- [Examples](/examples/) — every feature has a commented, runnable spec, tested in CI on Linux, macOS, and Windows.
+- [Use it in CI](/ci/) — report formats, retries, flake detection, artifacts, secret masking.
+- [Reference](/reference/) — subcommands, selection flags, exit codes, editor schema.
+- [Real CLIs tested with atago](/real-world/) — 40+ programs from jq to terraform to htop, each with executable specs and generated behavior docs.
+
+Everything on this site comes from files committed in the [repository](https://github.com/nao1215/atago). The behavior docs are regenerated from executable specs, and drift tests fail the build when docs and specs disagree — if an example is on this site, it runs.

--- a/website/content/ci.md
+++ b/website/content/ci.md
@@ -1,0 +1,45 @@
+---
+title: Use it in CI
+description: Run atago suites in CI with JUnit/JSON/TAP/GitHub reports, loud retries for flaky scenarios, repeat-based flake detection, kept artifacts, and secret masking.
+---
+
+Real E2E suites flake (timing, ports, external tools). `--retry-failed N` re-runs failed scenarios in a fresh workdir and reports recovered ones as flaky — green for the exit code, but loud in every report format; silent retries are explicitly a non-goal. `--repeat N` does the opposite job: run each scenario N times to detect flakiness before it reaches CI.
+
+```shell
+atago run --ci --retry-failed 2 ./specs          # keep CI green, report instability loudly
+atago run --repeat 20 --filter "race prone" ./specs   # flake detection
+```
+
+[setup-atago](https://github.com/nao1215/setup-atago) installs a released binary:
+
+```yaml
+name: behavior-specs
+on: [push, pull_request]
+jobs:
+  atago:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: nao1215/setup-atago@v0
+      - run: atago run --ci --report gha ./specs
+```
+
+- `--report json|junit|gha|tap` picks the report format; the JSON shape is stable and versioned ([sample JSON](/samples/report.json), [JUnit](/samples/report.junit.xml), [TAP](/samples/report.tap)).
+- `--ci` enables deterministic, color-free output.
+- `--artifacts-dir DIR` persists the exact payloads a failed assertion compared, so a failure stays reviewable after the job ends.
+- Environment variable names listed under `secrets:` are masked as `***` in all reports and snapshots.
+
+## Review specs without running them
+
+`explain` describes what a spec does, `doc` generates Markdown (with fixtures, expected payloads, and golden files inlined), `manifest` emits a stable JSON summary for tooling, and `list` shows scenarios, tags, and artifacts. All of them load and validate the spec first — exit code 2 on a schema error — so any of them doubles as a lint step in CI:
+
+![atago explain and doc rendering a spec](/img/review.gif)
+
+```shell
+atago explain spec.atago.yaml
+atago doc --out docs/specs.md ./specs
+atago manifest ./specs
+atago list ./specs
+```
+
+The [real-world pages](/real-world/) on this site are `atago doc` output, committed and drift-tested.

--- a/website/content/getting-started.md
+++ b/website/content/getting-started.md
@@ -1,0 +1,140 @@
+---
+title: Getting started
+description: Record a real run of your CLI, read the spec atago wrote, and keep it as a test — then assert on files, snapshots, interactive prompts, and server peers.
+---
+
+## Start from a real run
+
+You don't write the first spec — your tool does. `atago record -- <command>` runs it once and generates a spec from what it observed (exit code, output, created files):
+
+```shell
+$ atago record --out mytool.atago.yaml -- mytool convert input.txt
+recorded: exit 0, 2 stdout line(s), 1 file(s) created
+wrote mytool.atago.yaml
+$ atago run mytool.atago.yaml
+.
+
+PASSED  1 scenario: 1 passed, 0 failed, 0 errored, 0 skipped (12ms)
+```
+
+Interactive tools record too: `atago record --pty -- <command>` runs it in a real terminal, lets you drive one session by hand, and writes a `pty:` step that replays your keystrokes as expect/send pairs. It works on Linux, macOS, and Windows (a ConPTY); on POSIX a password prompt becomes an `${env:...}` placeholder automatically, while on Windows — where a ConPTY exposes no echo state — you convert a secret send to `${env:...}` by hand. A `--pty` session is bounded by `--timeout` (default 30s): if the program never exits, atago kills it, writes whatever was captured, and fails instead of hanging forever:
+
+```shell
+$ atago record --pty --out wizard.atago.yaml -- mytool init
+```
+
+Prefer a blank template? `atago init` scaffolds one. Either way, the shape is always the same: declare a command, run it, assert on what it produced.
+
+## 1. Check exit code, stdout, and stderr
+
+```yaml
+version: "1"
+suite:
+  name: example
+scenarios:
+  - name: echo greets the world
+    steps:
+      - run:
+          shell: true            # portable: echo is a shell builtin on Windows
+          command: echo "hello atago"
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: atago
+          stderr:
+            empty: true
+```
+
+`atago run` accepts spec files and directories (searched recursively for `*.atago.yaml`; the `*.atago.yml` spelling is accepted too). Each scenario runs in its own temporary directory, and progress streams as a dot per scenario (`.` pass, `F` fail, `E` error, `s` skip):
+
+```shell
+$ atago run ./specs
+...............................................
+
+PASSED  47 scenarios: 47 passed, 0 failed, 0 errored, 0 skipped (1.2s)
+```
+
+Scenarios run concurrently by default (`--parallel N`, defaulting to your CPU count; set `--parallel 1` to serialize). Workdirs are isolated, but the host network is shared — so if two scenarios each start a background `service:`, give them distinct ports, or one scenario's requests can reach the other's server.
+
+When a check fails, atago prints exactly what was expected and what happened; multi-line mismatches render a colorized unified diff:
+
+```text
+FAILED: demo / greeting matches its golden
+
+Step:
+  assert stdout snapshot
+
+Diff (-expected +actual):
+  --- snapshot (golden)
+  +++ actual
+  @@ -1,3 +1,3 @@
+   hello
+  -WORLD
+  +world
+   bye
+
+Hint:
+  stdout did not match snapshot "snaps/greeting.txt" (update with --update-snapshots if intended)
+```
+
+## 2. Check generated files and snapshots
+
+`fixture:` writes input files into the isolated workdir; `file:`/`dir:` assertions check what the command produced, and `snapshot:` pins output to a committed golden file (volatile details like temp paths, UUIDs, and timestamps are normalized). A fixture's source is one of `content:` (inline text), `base64:` (inline bytes), `from:` (copy an existing file), or `symlink:` (link to a target):
+
+```yaml
+scenarios:
+  - name: the generator writes the expected files
+    steps:
+      - run:
+          command: mytool generate --out site
+      - assert:
+          file:
+            path: site/index.html
+            contains:
+              - "<html"
+      - assert:
+          stdout:
+            snapshot: snapshots/generate.txt   # record/refresh with `atago snapshot update`
+```
+
+See [files_and_fixtures](https://github.com/nao1215/atago/blob/main/examples/files_and_fixtures.atago.yaml), [snapshot](https://github.com/nao1215/atago/blob/main/examples/snapshot.atago.yaml), and [dir_tree](https://github.com/nao1215/atago/blob/main/examples/dir_tree.atago.yaml) for whole-tree golden manifests.
+
+## 3. Drive interactive prompts and TUIs
+
+A `pty` step runs the command in a real pseudo-terminal and drives it with a declarative expect/send session — wizards, REPLs, and TTY-detection branches, no `expect(1)` scripting:
+
+```yaml
+scenarios:
+  - name: the init wizard completes
+    steps:
+      - pty:
+          command: mytool init
+          session:
+            - expect: "Project name:"
+            - send: "demo\n"
+            - expect: "created demo/"
+      - assert:
+          exit_code: 0
+```
+
+Named keys (`send: {key: enter}`) and asserts on the RENDERED terminal screen cover full TUIs — see [pty](https://github.com/nao1215/atago/blob/main/examples/pty.atago.yaml), [pty_screen](https://github.com/nao1215/atago/blob/main/examples/pty_screen.atago.yaml), and the cross-platform [pty_portable](https://github.com/nao1215/atago/blob/main/examples/pty_portable.atago.yaml). `pty` steps and `atago record --pty` run on Linux, macOS, and Windows (where they drive a ConPTY pseudo-console); only `signal:` stays POSIX-only.
+
+## When your CLI talks to a server
+
+The same YAML also drives HTTP, database, SSH, gRPC, headless-browser, and offline mock-server peers — as dependencies of the CLI under test. `atago init --template <name>` scaffolds each:
+
+```shell
+$ atago init --list-templates
+browser   drive a headless Chrome; assert page content (needs Chrome on PATH)
+cli       run a command; assert exit code/stdout/stderr (runs as-is)
+db        run SQL; assert on rows via bundled SQLite (runs as-is)
+grpc      call a unary gRPC method via server reflection (edit target first)
+http      call an HTTP API; assert status and JSON body (edit base_url first)
+mock      stub an HTTP API offline and assert what the client sent (needs curl on PATH)
+services  test against a background server: readiness, retry, teardown (runs as-is)
+ssh       run a command on a remote host over SSH (edit host/user first)
+```
+
+## Next
+
+The [cookbook](/cookbook/) has a copyable spec for most jobs, the [examples](/examples/) index covers every feature, and [Use it in CI](/ci/) wires a suite into GitHub Actions.

--- a/website/content/install.md
+++ b/website/content/install.md
@@ -1,0 +1,47 @@
+---
+title: Install
+description: Install atago with go install, Homebrew, the AUR, prebuilt binaries for Linux/macOS/Windows, or the setup-atago GitHub Action — and verify what you download.
+---
+
+```shell
+go install github.com/nao1215/atago@latest
+```
+
+On macOS, Homebrew works too:
+
+```shell
+brew install --cask nao1215/tap/atago
+```
+
+On Arch Linux, install the [`atago-bin`](https://aur.archlinux.org/packages/atago-bin) package from the AUR:
+
+```shell
+yay -S atago-bin   # or: paru -S atago-bin
+```
+
+The [release page](https://github.com/nao1215/atago/releases) contains prebuilt binary archives for Linux, macOS, and Windows (amd64/arm64; `.tar.gz`, or `.zip` on Windows), plus `.deb`, `.rpm`, and `.apk` packages for Linux. Requires Go 1.26 or later when building from source.
+
+Runs on Linux, macOS, and Windows (CI tests all three).
+
+In GitHub Actions, [setup-atago](https://github.com/nao1215/setup-atago) installs a released binary — see [Use it in CI](/ci/).
+
+## Verifying release integrity
+
+Every release ships supply-chain metadata so you can verify what you download:
+
+- Signed checksums: `checksums.txt` is signed with [cosign](https://github.com/sigstore/cosign) (keyless), producing `checksums.txt.sigstore.json`.
+- SBOM: an SPDX Software Bill of Materials is attached to each release archive.
+- Build provenance: SLSA build provenance is attested via GitHub OIDC.
+
+```shell
+cosign verify-blob \
+  --bundle checksums.txt.sigstore.json \
+  --certificate-identity-regexp 'https://github.com/nao1215/atago/\.github/workflows/release\.yml@refs/tags/.*' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  checksums.txt
+sha256sum --check --ignore-missing checksums.txt
+```
+
+```shell
+gh attestation verify atago_<version>_<os>_<arch>.tar.gz --repo nao1215/atago  # .zip on Windows
+```

--- a/website/content/reference.md
+++ b/website/content/reference.md
@@ -1,0 +1,71 @@
+---
+title: Reference
+description: atago subcommands, scenario selection flags, snapshot updating and scrub rules, the JSON Schema for editors, shell completion, and the exit code contract.
+---
+
+## Subcommands
+
+| Command | Does |
+|---------|------|
+| `atago run` | run specs and report results |
+| `atago record` | run a command once and write a spec from what it observed (`--pty` for interactive sessions) |
+| `atago init` | scaffold a spec (`--template` for http, db, grpc, ssh, browser, mock, services) |
+| `atago snapshot update` | record or refresh golden files |
+| `atago explain` | describe what a spec does without running it |
+| `atago doc` | generate Markdown from specs, with fixtures and golden files inlined |
+| `atago manifest` | emit a stable JSON summary of specs for tooling |
+| `atago list` | show scenarios, tags, and artifacts |
+| `atago rerun` | re-run the scenarios that failed last time |
+| `atago completion` | print a shell completion script |
+
+`explain`, `doc`, `manifest`, and `list` all load and validate the spec first — exit code 2 on a schema error — so any of them doubles as a lint step in CI.
+
+## Selecting scenarios
+
+Selection flags compose with any spec: `--filter NAME` (repeatable, and comma-separated for OR — `--filter a,b` or `--filter a --filter b` runs scenarios whose name contains `a` or `b`), `--tag T`, `--skip-tag T`, `--parallel N`, `--fail-fast`, and `--rerun-failed`. While authoring, `--verbose` traces every command, capture, and assertion verdict — for passing scenarios too.
+
+## Snapshot testing
+
+`snapshot` matchers compare output against committed golden files; ANSI colors, temp paths, UUIDs, timestamps, ports, and CRLF are normalized so snapshots stay stable across machines. Record or refresh them with:
+
+```shell
+atago snapshot update spec.atago.yaml
+```
+
+For volatile patterns the built-ins do not cover — auto-increment IDs, request identifiers, epoch times — declare spec-wide `scrub:` rules that rewrite each regex match to a placeholder before the compare (applied after `secrets:` masking):
+
+```yaml
+scrub:
+  - {pattern: 'id=\d+', placeholder: 'id=<ID>'}
+```
+
+See the [scrub example](https://github.com/nao1215/atago/blob/main/examples/scrub.atago.yaml).
+
+## Editor support (JSON Schema)
+
+A JSON Schema lives at [schema/atago.schema.json](https://github.com/nao1215/atago/blob/main/schema/atago.schema.json). With the YAML language server you get completion and validation as you type — step types, every matcher, and the `${workdir}` / `${env:NAME}` / `${name}` / `$${...}` expansion rules. `atago init` and `atago record` already emit this header as the first line of every generated spec, so scaffolded specs get completion out of the box. To add it to an existing spec, use the absolute URL (it resolves in any project, unlike a repo-relative path):
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nao1215/atago/main/schema/atago.schema.json
+version: "1"
+```
+
+The report and manifest outputs have schemas too: [report.schema.json](https://github.com/nao1215/atago/blob/main/schema/report.schema.json) and [manifest.schema.json](https://github.com/nao1215/atago/blob/main/schema/manifest.schema.json).
+
+## Shell completion
+
+`atago completion <bash|zsh|fish|powershell>` prints a completion script for your shell.
+
+## Exit codes
+
+| Code | Meaning                   |
+|------|---------------------------|
+| `0`  | all scenarios passed      |
+| `1`  | one or more failed        |
+| `2`  | spec error (YAML syntax or schema/semantic validation) |
+| `3`  | CLI-invocation error (unknown subcommand, bad flag, or no matching spec files) |
+| `4`  | execution error           |
+| `5`  | internal error            |
+| `6`  | security policy violation |
+
+`Ctrl-C`/`SIGTERM` stops the run cleanly: in-flight processes, services, and sessions are torn down, partial results are reported, and the run exits `4`.

--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -1,0 +1,91 @@
+# Configuration for the hosted documentation website (GitHub Pages).
+# Content comes from the repository itself: committed docs under doc/ are
+# mounted read-only and turned into pages by content/_content.gotmpl, so the
+# repository files stay the single source of truth.
+baseURL = "https://nao1215.github.io/atago/"
+locale = "en"
+title = "atago"
+disableKinds = ["taxonomy", "term", "rss"]
+enableRobotsTXT = true
+timeZone = "UTC"
+
+[params]
+tagline = "black-box E2E testing for CLIs, from plain YAML"
+description = "atago tests real CLI behavior from plain YAML: exit codes, output, generated files, snapshots, services, and interactive terminals (PTY/TUI)."
+
+[markup.highlight]
+noClasses = false
+
+[[menus.main]]
+name = "Install"
+pageRef = "/install"
+weight = 10
+
+[[menus.main]]
+name = "Getting started"
+pageRef = "/getting-started"
+weight = 20
+
+[[menus.main]]
+name = "Cookbook"
+pageRef = "/cookbook"
+weight = 30
+
+[[menus.main]]
+name = "Examples"
+pageRef = "/examples"
+weight = 40
+
+[[menus.main]]
+name = "CI"
+pageRef = "/ci"
+weight = 50
+
+[[menus.main]]
+name = "Reference"
+pageRef = "/reference"
+weight = 60
+
+[[menus.main]]
+name = "Real-world CLIs"
+pageRef = "/real-world"
+weight = 70
+
+[module]
+[[module.mounts]]
+source = "content"
+target = "content"
+
+[[module.mounts]]
+source = "layouts"
+target = "layouts"
+
+[[module.mounts]]
+source = "assets"
+target = "assets"
+
+# Repository docs, mounted so pages can be generated from the committed files.
+[[module.mounts]]
+source = "../doc/e2e"
+target = "assets/e2e"
+
+[[module.mounts]]
+source = "../doc/cookbook.md"
+target = "assets/doc/cookbook.md"
+
+[[module.mounts]]
+source = "../doc/examples.md"
+target = "assets/doc/examples.md"
+
+[[module.mounts]]
+source = "../doc/real-world.md"
+target = "assets/doc/real-world.md"
+
+# Images and deterministic sample artifacts served as-is.
+[[module.mounts]]
+source = "../doc/img"
+target = "static/img"
+
+[[module.mounts]]
+source = "../site/samples"
+target = "static/samples"

--- a/website/layouts/404.html
+++ b/website/layouts/404.html
@@ -1,0 +1,6 @@
+{{ define "main" }}
+<article>
+<h1>Page not found</h1>
+<p>No page lives at this address. Start from the <a href="{{ site.Home.RelPermalink }}">front page</a>.</p>
+</article>
+{{ end }}

--- a/website/layouts/_markup/render-image.html
+++ b/website/layouts/_markup/render-image.html
@@ -1,0 +1,6 @@
+{{- $u := .Destination -}}
+{{- if and (hasPrefix $u "/") (not (hasPrefix $u "//")) -}}
+  {{- $u = relURL (strings.TrimPrefix "/" $u) -}}
+{{- end -}}
+<img src="{{ $u }}" alt="{{ .Text }}"{{ with .Title }} title="{{ . }}"{{ end }} loading="lazy">
+{{- /* chomp trailing newline */ -}}

--- a/website/layouts/_markup/render-link.html
+++ b/website/layouts/_markup/render-link.html
@@ -1,0 +1,9 @@
+{{- /* Site-absolute destinations ("/cookbook/") are prefixed with the base
+     path so pages work under https://<host>/atago/. Everything else —
+     external URLs, fragments, page-relative paths — passes through. */ -}}
+{{- $u := .Destination -}}
+{{- if and (hasPrefix $u "/") (not (hasPrefix $u "//")) -}}
+  {{- $u = relURL (strings.TrimPrefix "/" $u) -}}
+{{- end -}}
+<a href="{{ $u }}"{{ with .Title }} title="{{ . }}"{{ end }}>{{ .Text }}</a>
+{{- /* chomp trailing newline */ -}}

--- a/website/layouts/baseof.html
+++ b/website/layouts/baseof.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+{{- $title := printf "%s · %s" .Title site.Title }}
+{{- if .IsHome }}{{ $title = printf "%s — %s" site.Title site.Params.tagline }}{{ end }}
+<title>{{ $title }}</title>
+{{- $desc := or .Params.description site.Params.description }}
+<meta name="description" content="{{ $desc }}">
+<link rel="canonical" href="{{ .Permalink }}">
+<meta property="og:title" content="{{ $title }}">
+<meta property="og:description" content="{{ $desc }}">
+<meta property="og:type" content="website">
+<meta property="og:url" content="{{ .Permalink }}">
+<meta property="og:image" content="{{ absURL "img/atago-logo.jpg" }}">
+<link rel="icon" href="{{ relURL "img/atago-logo.jpg" }}">
+{{- $css := slice (resources.Get "css/site.css") (resources.Get "css/chroma.css") | resources.Concat "css/bundle.css" | minify | fingerprint }}
+<link rel="stylesheet" href="{{ $css.RelPermalink }}">
+</head>
+<body>
+<header>
+<nav>
+<a class="brand" href="{{ site.Home.RelPermalink }}">atago</a>
+{{- range site.Menus.main }}
+<a href="{{ .URL }}">{{ .Name }}</a>
+{{- end }}
+<a href="https://github.com/nao1215/atago">GitHub</a>
+</nav>
+</header>
+<main>
+{{ block "main" . }}{{ end }}
+</main>
+<footer>
+<p>MIT licensed · <a href="https://github.com/nao1215/atago">nao1215/atago</a> · every page on this site is generated from files committed in the repository.</p>
+</footer>
+</body>
+</html>

--- a/website/layouts/home.html
+++ b/website/layouts/home.html
@@ -1,0 +1,3 @@
+{{ define "main" }}
+{{ .Content }}
+{{ end }}

--- a/website/layouts/page.html
+++ b/website/layouts/page.html
@@ -1,0 +1,6 @@
+{{ define "main" }}
+<article>
+<h1>{{ .Title }}</h1>
+{{ .Content }}
+</article>
+{{ end }}

--- a/website/layouts/section.html
+++ b/website/layouts/section.html
@@ -1,0 +1,6 @@
+{{ define "main" }}
+<article>
+<h1>{{ .Title }}</h1>
+{{ .Content }}
+</article>
+{{ end }}


### PR DESCRIPTION
## Summary

Adds a hosted documentation website at https://nao1215.github.io/atago/, built with Hugo and deployed to GitHub Pages on every push to `main` that touches the docs. The main goal is to put the repository's strongest documentation asset — the 45 generated behavior docs under `doc/e2e/` — on individually linkable, searchable pages instead of leaving them buried in the repo tree.

## Changes

- `website/hugo.toml` — Hugo configuration; mounts `doc/e2e/`, `doc/cookbook.md`, `doc/examples.md`, `doc/real-world.md`, `doc/img/`, and `site/samples/` read-only so the committed files stay the single source of truth.
- `website/content/_content.gotmpl` — content adapter that turns the mounted docs into pages (`/cookbook/`, `/examples/`, `/real-world/`, `/real-world/<tool>/`), rewriting repository-relative links to site pages or GitHub and embedded images to raw URLs.
- `website/content/*.md` — the landing page plus Install / Getting started / CI / Reference pages; prose adapted from README.md.
- `website/layouts/`, `website/assets/css/` — a dependency-free minimal theme (no external theme, no JavaScript): system fonts, light/dark via `prefers-color-scheme`, Chroma syntax-highlight styles generated by `hugo gen chromastyles`.
- `.github/workflows/website.yml` — builds with a checksum-pinned Hugo and deploys via `actions/deploy-pages` (SHA-pinned like the other workflows); PRs that touch the docs build the site as a check without deploying.
- `Makefile` — `make website` / `make website-serve` targets; `.gitignore` — Hugo build artifacts; `CHANGELOG.md` — Unreleased entry.

## Design Decisions

- No content duplication: the cookbook, example index, real-world index, and behavior docs are mounted and transformed at build time, so the existing drift tests (`TestDocs_E2EDocsInSync`, `TestSite_InSync`) keep guarding the single source and the site can never disagree with the repo.
- A hand-rolled minimal theme instead of a third-party Hugo theme: no submodule/module dependency to keep updated, full control over the output, and the site stays readable rather than decorated.
- Link rewriting lives in the content adapter (specific regex rules per source file) plus a small render hook that prefixes site-absolute hrefs with the base path, so pages work under the `/atago/` project-pages subpath.
- The repo-local `site/` index is untouched and unrelated; this directory only serves browsers, `site/` keeps serving GitHub-rendered navigation.

## Limitations

- The landing/Install/Getting started/CI/Reference prose is adapted from README.md by hand, so future README edits will not propagate automatically to those five pages.
- No client-side search; the real-world index page and browser find-in-page cover the current 50-page size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a hosted documentation website with navigation, syntax highlighting, dark mode support, and improved link/image handling.
  * Added local build and preview commands for the site, plus automated publishing to GitHub Pages.

* **Documentation**
  * Expanded guides for installation, getting started, CI usage, reference commands, and project examples.
  * Added a site README and updated release notes with website usage details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->