### PR TITLE
feat(website): expand the cookbook to 57 recipes and polish the docs site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,27 @@ and this project follows [Semantic Versioning](https://semver.org/).
   `doc/e2e/` are mounted and turned into pages at build time). Deployed to
   GitHub Pages by `.github/workflows/website.yml` on every push to `main` that
   touches the docs; `make website` / `make website-serve` build it locally.
+- 34 new cookbook recipes (23 → 57), all loader-validated by
+  `TestCookbook_SnippetsValid` and indexed in [doc/examples.md](doc/examples.md):
+  record-first workflows (including `record --pty`), snapshot refresh with
+  `scrub:`, TUI screen-frame snapshots, help/version/completion contracts,
+  environment and secrets handling, REPL and TTY-detection sessions,
+  idempotency and differential oracles, offline API-failure simulation,
+  fixture sources (`from:`/`base64:`/`mode:`/`mtime:`/`symlink:`), binary
+  safety, boundary inputs, db/ssh/grpc/browser peers, matrix release
+  comparison, tags, defaults, and suite layout guidance.
+- A "Write specs with an LLM" website page with a constrained, copy-paste
+  prompt for generating honest atago specs, plus an auto-generated
+  [/llms.txt](https://nao1215.github.io/atago/llms.txt) index for LLM agents.
+- Website polish: per-page "On this page" TOC, hover heading anchors, a copy
+  button on code blocks, active-nav state, card-grid landing links, and zebra
+  tables — plus landing sections spotlighting record, snapshot, and PTY/TUI
+  strengths.
+
+### Changed
+
+- README now links the hosted cookbook and examples index from its Examples
+  section, and points to the documentation site under the tagline.
 
 ## [0.9.0] - 2026-07-08
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 
 atago tests real CLI behavior from plain YAML: commands, files, snapshots, services, and interactive terminals. It runs your actual binary — in any language — and asserts what a user observes. No test code, no shell DSL.
 
+Documentation: **https://nao1215.github.io/atago/**
+
 ![demo](./doc/img/demo.gif)
 
 ```shell
@@ -216,7 +218,7 @@ ssh       run a command on a remote host over SSH (edit host/user first)
 
 ## Examples
 
-Every feature has a commented, runnable spec under [examples/](examples/), tested in CI on Linux, macOS, and Windows. [doc/examples.md](doc/examples.md) indexes them two ways: by task (test a CLI that converts images, drive an interactive prompt, mock an HTTP API) and by feature.
+Every feature has a commented, runnable spec under [examples/](examples/), tested in CI on Linux, macOS, and Windows. The **[cookbook](https://nao1215.github.io/atago/cookbook/)** collects 50+ copyable recipes for common jobs — converting images, driving prompts and TUIs, simulating API failures offline, proving idempotency — and the [examples index](https://nao1215.github.io/atago/examples/) lists every spec by task and by feature.
 
 Selection flags compose with any spec: `--filter NAME` (repeatable, and comma-separated for OR — `--filter a,b` or `--filter a --filter b` runs scenarios whose name contains `a` or `b`), `--tag T`, `--skip-tag T`, `--parallel N`, `--fail-fast`, and `--rerun-failed`. While authoring, `--verbose` traces every command, capture, and assertion verdict — for passing scenarios too.
 

--- a/doc/cookbook.md
+++ b/doc/cookbook.md
@@ -4,6 +4,42 @@ Task-oriented YAML recipes: find what you want to do, copy the spec, replace
 `mytool` with your binary. Each recipe links to a runnable, CI-tested spec
 under [examples/](../examples/) that covers the same feature in full.
 
+## Start from a recorded run
+
+The fastest way to a first spec is not writing one. Run the tool once under
+`record` and atago writes the spec from what it observed:
+
+```shell
+atago record --out convert.atago.yaml -- mytool convert input.txt
+atago run convert.atago.yaml
+```
+
+The generated spec is plain YAML — the same shape as every recipe below — so
+the workflow is: record the happy path, then edit the file to tighten matchers,
+add failure cases, and delete asserts you don't care about:
+
+```yaml
+version: "1"
+suite:
+  name: recorded
+scenarios:
+  - name: mytool convert input.txt
+    steps:
+      - run:
+          command: mytool convert input.txt
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "wrote output.txt"     # recorded verbatim; loosen or tighten
+      - assert:
+          file:
+            path: output.txt
+            exists: true
+```
+
+Interactive tools record too: `atago record --pty -- mytool init` captures one
+hand-driven session and writes a `pty:` step that replays it.
+
 ## Test a CLI that converts images
 
 ```yaml
@@ -729,3 +765,1118 @@ scenarios:
 ```
 
 Full spec: [hermetic_env](../examples/hermetic_env.atago.yaml)
+
+## Pin the help and misuse contract
+
+`--help` and error handling for wrong invocations are user-facing behavior like
+any other — and the cheapest place to catch an accidentally renamed subcommand
+or a usage message that stopped naming the offending flag:
+
+```yaml
+version: "1"
+suite:
+  name: usage contract
+
+scenarios:
+  - name: --help documents every advertised subcommand
+    steps:
+      - run:
+          command: mytool --help
+      - assert:
+          exit_code: 0
+          stdout:
+            contains:
+              - "Usage:"
+              - convert
+              - inspect
+          stderr:
+            empty: true
+
+  - name: an unknown flag fails loudly and names itself
+    steps:
+      - run:
+          command: mytool --no-such-flag
+      - assert:
+          exit_code: 2                  # or `not: 0` if the code is not pinned
+          stderr:
+            contains: --no-such-flag    # the user learns WHAT was wrong
+          stdout:
+            empty: true                 # usage errors do not pollute stdout
+```
+
+Full spec: [run_and_assert](../examples/run_and_assert.atago.yaml)
+
+## Test a CLI that reads environment variables
+
+Set the variable on the step to test the override; use `clear_env` to prove
+the documented default applies when nothing is set — otherwise a value
+exported in your own shell can silently satisfy the test:
+
+```yaml
+version: "1"
+suite:
+  name: env config
+
+scenarios:
+  - name: the environment override wins
+    steps:
+      - run:
+          command: mytool config show
+          env:
+            MYTOOL_PORT: "9090"
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "port: 9090"
+
+  - name: without the variable the documented default applies
+    steps:
+      - run:
+          command: mytool config show
+          clear_env: true       # empty child environment: the default must hold
+          pass_env: [PATH]      # keep only what launching the binary needs
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "port: 8080"
+```
+
+Full spec: [extend_host_env](../examples/extend_host_env.atago.yaml), [hermetic_env](../examples/hermetic_env.atago.yaml)
+
+## Mask secrets in reports and snapshots
+
+Name the variables under `secrets:` and every occurrence of their VALUES
+renders as `***` in output, reports, and snapshots — so a CI token can drive a
+test without ever being committed to a golden file or leaked in a failure log:
+
+```yaml
+version: "1"
+suite:
+  name: secret hygiene
+
+secrets:
+  - API_TOKEN               # env var names; the values get masked everywhere
+
+scenarios:
+  - name: the token drives the run but never appears in output
+    steps:
+      - run:
+          shell: true
+          command: mytool sync --verbose    # verbose mode echoes the token
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "token=***"   # masking replaced the raw value — seeing
+                                    # the placeholder proves it was substituted
+```
+
+## Test a REPL
+
+An `expect` waits for the transcript to match before the next `send` types, so
+the session stays in lockstep with the program — and each `expect` scans only
+past the previous match, so a recurring prompt waits for its NEXT occurrence:
+
+```yaml
+version: "1"
+suite:
+  name: repl
+
+scenarios:
+  - name: the REPL evaluates input and exits cleanly on EOF
+    steps:
+      - pty:
+          command: mytool repl
+          timeout: 20s
+          session:
+            - expect: ">>> "            # the first prompt
+            - send: "1 + 2\n"
+            - expect: "3"
+            - expect: ">>> "            # the NEXT prompt, after the result
+            - send: { key: ctrl-d }     # EOF ends the session
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "3"
+```
+
+Full spec: [pty](../examples/pty.atago.yaml), [pty_portable](../examples/pty_portable.atago.yaml)
+
+## Prove a command is idempotent
+
+Run it twice and pin the second run's workdir delta to nothing. `changes:`
+fields are exhaustive, so empty lists assert "created nothing, modified
+nothing" — a per-file `exists:` check cannot say that:
+
+```yaml
+version: "1"
+suite:
+  name: idempotency
+
+scenarios:
+  - name: running init twice changes nothing the second time
+    steps:
+      - run:
+          command: mytool init --dir out
+      - run:
+          command: mytool init --dir out
+      - assert:
+          exit_code: 0
+          changes:
+            created: []     # the second run created nothing...
+            modified: []    # ...rewrote nothing...
+            deleted: []     # ...and removed nothing
+```
+
+Full spec: [changes](../examples/changes.atago.yaml)
+
+## Compare two implementations of the same command
+
+Capture the reference output with `store:`, then assert the other path
+produces exactly the same bytes — an oracle test for a rewrite, a `--fast`
+flag, or an optimization that must not change behavior:
+
+```yaml
+version: "1"
+suite:
+  name: differential
+
+scenarios:
+  - name: the fast engine matches the classic engine byte for byte
+    steps:
+      - fixture:
+          file: scene.json
+          content: |
+            {"width": 4, "height": 4, "shapes": ["box"]}
+      - run:
+          command: mytool render --engine classic scene.json
+      - store:
+          name: reference
+          from:
+            stdout:
+              trim: true
+      - run:
+          command: mytool render --engine fast scene.json
+      - assert:
+          exit_code: 0
+          stdout:
+            equals: ${reference}
+```
+
+Full spec: [store_and_variables](../examples/store_and_variables.atago.yaml)
+
+## Pin the version and completion contracts
+
+`--version` output is an interface: release tooling greps it, bug reports quote
+it. Pin its shape with a regex, and check the completion script actually
+mentions your subcommands:
+
+```yaml
+version: "1"
+suite:
+  name: version contract
+
+scenarios:
+  - name: --version prints a semver on one line
+    steps:
+      - run:
+          command: mytool --version
+      - assert:
+          exit_code: 0
+          stdout:
+            matches: '^mytool \d+\.\d+\.\d+'
+
+  - name: shell completion covers every subcommand
+    steps:
+      - run:
+          command: mytool completion bash
+      - assert:
+          exit_code: 0
+          stdout:
+            contains:
+              - convert
+              - inspect
+```
+
+Full spec: [run_and_assert](../examples/run_and_assert.atago.yaml)
+
+## Simulate API failures offline
+
+A `mock_servers:` route can answer anything — a 500, a 429, malformed JSON —
+so the error paths of an API-client CLI become deterministic tests instead of
+"hope the staging server is down today":
+
+```yaml
+version: "1"
+suite:
+  name: api failure modes
+
+scenarios:
+  - name: a 500 from the API surfaces as a clean CLI error
+    mock_servers:
+      - name: api
+        routes:
+          - method: GET
+            path: /v1/data
+            status: 500
+            body: internal error
+    steps:
+      - run:
+          command: mytool fetch --endpoint ${api.url}/v1/data
+      - assert:
+          exit_code: 1
+          stderr:
+            contains: "500"      # the CLI reports the upstream status...
+          stdout:
+            empty: true          # ...and writes nothing it would have to undo
+      # The CLI called once — it did not hammer a failing endpoint.
+      - assert:
+          mock:
+            name: api
+            path: /v1/data
+            method: GET
+            count: 1
+```
+
+Full spec: [mock_server](../examples/mock_server.atago.yaml)
+
+## Test a download command offline
+
+Serve the payload from a mock route, let the CLI download it, and compare the
+written file against the same bytes shipped as a fixture:
+
+```yaml
+version: "1"
+suite:
+  name: download
+
+scenarios:
+  - name: fetch writes exactly the served bytes
+    mock_servers:
+      - name: files
+        routes:
+          - method: GET
+            path: /release/tool.bin
+            body: "binary-payload-v1"
+    steps:
+      - fixture:
+          file: expected.bin
+          content: "binary-payload-v1"
+      - run:
+          command: mytool fetch ${files.url}/release/tool.bin --out tool.bin
+      - assert:
+          exit_code: 0
+          file:
+            path: tool.bin
+            equals_file: expected.bin   # byte-for-byte, no normalization
+```
+
+Full spec: [mock_server](../examples/mock_server.atago.yaml)
+
+## Verify server state after the CLI acts
+
+When the CLI's job is to change a server (deploy, publish, upload), assert the
+server afterwards — an `http:` step queries it directly, as an observer:
+
+```yaml
+version: "1"
+suite:
+  name: server side effects
+
+runners:
+  api:
+    type: http
+    base_url: http://127.0.0.1:8080
+
+scenarios:
+  - name: publish makes the article visible over HTTP
+    services:
+      - name: server
+        command: mytool serve --port 8080
+        ready:
+          file: server.pid
+          timeout: 10s
+    steps:
+      - fixture:
+          file: draft.md
+          content: "# Hello"
+      - run:
+          command: mytool publish draft.md
+      - assert:
+          exit_code: 0
+      - http:
+          runner: api
+          method: GET
+          path: /articles/hello
+      - assert:
+          status: 200
+          header:
+            name: Content-Type
+            contains: text/html
+          body:
+            json:
+              path: "$.title"
+              equals: Hello
+```
+
+Full spec: [services](../examples/services.atago.yaml), [http](../examples/http.atago.yaml)
+
+## Send output streams to files
+
+For output too large or too binary to inline, redirect each stream to a file
+and use file assertions — the same matchers, applied at rest:
+
+```yaml
+version: "1"
+suite:
+  name: stream redirects
+
+scenarios:
+  - name: the export lands in the file, diagnostics stay on stderr
+    steps:
+      - run:
+          command: mytool export --all
+          stdout_to: export.csv
+          stderr_to: warnings.log
+      - assert:
+          exit_code: 0
+          file:
+            path: export.csv
+            contains: "id,name,role"
+      - assert:
+          file:
+            path: warnings.log
+            contains: "skipped 2 archived records"
+```
+
+Full spec: [shell_and_redirect](../examples/shell_and_redirect.atago.yaml)
+
+## Ship binary test data with fixtures
+
+`content:` carries text; `base64:` carries exact bytes; `from:` copies a real
+file committed next to the spec; `mode:` pins permissions. Pick by what the
+input is, not by what is easiest to paste:
+
+```yaml
+version: "1"
+suite:
+  name: fixture sources
+
+scenarios:
+  - name: a real sample file drives the parser
+    steps:
+      - fixture:
+          file: sample.dat
+          from: testdata/sample.dat     # committed beside the spec
+      - fixture:
+          file: header.bin
+          base64: iVBORw0KGgo=          # exact bytes, safe for any content
+      - fixture:
+          file: run.sh
+          content: "#!/bin/sh\necho ok\n"
+          mode: "0755"                  # executable fixture
+      - run:
+          command: mytool inspect sample.dat
+      - assert:
+          exit_code: 0
+```
+
+Full spec: [files_and_fixtures](../examples/files_and_fixtures.atago.yaml)
+
+## Test how the CLI treats symlinks
+
+A `symlink:` fixture creates the link inside the isolated workdir, so
+follow/no-follow behavior is testable without touching the host filesystem:
+
+```yaml
+version: "1"
+suite:
+  name: symlinks
+
+scenarios:
+  - name: the scanner follows links to files but reports the link path
+    skip:
+      os: windows      # symlink creation needs privileges on Windows
+    steps:
+      - fixture:
+          file: real.txt
+          content: "payload"
+      - fixture:
+          file: link.txt
+          symlink: real.txt
+      - run:
+          command: mytool scan link.txt
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: link.txt      # reported under the name it was given
+```
+
+Full spec: [files_and_fixtures](../examples/files_and_fixtures.atago.yaml)
+
+## Test freshness logic with fixture timestamps
+
+`mtime:` backdates a fixture, so "rebuild only what changed" logic has a
+deterministic stale file to react to — no `sleep`, no clock games:
+
+```yaml
+version: "1"
+suite:
+  name: freshness
+
+scenarios:
+  - name: a stale output is rebuilt, a fresh one is left alone
+    steps:
+      - fixture:
+          file: src/page.md
+          content: "# v2"
+      - fixture:
+          file: out/page.html
+          content: "<h1>v1</h1>"
+          mtime: "2020-01-01T00:00:00Z"   # older than the source
+      - run:
+          command: mytool build
+      - assert:
+          exit_code: 0
+          changes:
+            modified:
+              - out/page.html     # rebuilt — and nothing else was touched
+            created: []
+            deleted: []
+```
+
+Full spec: [files_and_fixtures](../examples/files_and_fixtures.atago.yaml), [changes](../examples/changes.atago.yaml)
+
+## Prove the tool is binary-safe
+
+Feed exact bytes on stdin, capture stdout to a file, and compare against the
+expected bytes — any CRLF mangling, encoding pass, or stray log line breaks
+the equality:
+
+```yaml
+version: "1"
+suite:
+  name: binary safety
+
+scenarios:
+  - name: pass-through preserves every byte
+    steps:
+      - fixture:
+          file: expected.bin
+          base64: AAEC/wDerg==
+      - run:
+          command: mytool passthrough
+          stdin:
+            base64: AAEC/wDerg==
+          stdout_to: got.bin
+      - assert:
+          exit_code: 0
+          file:
+            path: got.bin
+            equals_file: expected.bin
+```
+
+Full spec: [stdin](../examples/stdin.atago.yaml), [files_and_fixtures](../examples/files_and_fixtures.atago.yaml)
+
+## Test the empty-input boundary
+
+Empty file, empty stdin: the classic crash sites. Decide what the contract IS
+(error? empty output? default?), then pin it:
+
+```yaml
+version: "1"
+suite:
+  name: empty inputs
+
+scenarios:
+  - name: an empty file is a clean no-op, not a crash
+    steps:
+      - fixture:
+          file: empty.csv
+          content: ""
+      - run:
+          command: mytool convert empty.csv out.json
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "0 records"
+          file:
+            path: out.json
+            contains: "[]"
+
+  - name: empty stdin fails with a pointer to --help
+    steps:
+      - run:
+          command: mytool convert
+          stdin: ""
+      - assert:
+          exit_code: 2
+          stderr:
+            contains: "no input"
+```
+
+Full spec: [stdin](../examples/stdin.atago.yaml)
+
+## Prove multibyte text survives
+
+Round-trip text that breaks naive byte handling — CJK, emoji, combining marks —
+and require exact equality, not just "contains":
+
+```yaml
+version: "1"
+suite:
+  name: multibyte
+
+scenarios:
+  - name: unicode passes through unchanged
+    steps:
+      - run:
+          command: mytool echo
+          stdin: "café 😀 日本語\n"
+      - assert:
+          exit_code: 0
+          stdout:
+            equals: "café 😀 日本語\n"
+```
+
+Full spec: [stdin](../examples/stdin.atago.yaml)
+
+## Test TTY detection
+
+Many CLIs render progress bars on a terminal but plain lines when piped. Both
+branches are contracts; `pty:` runs the real-terminal one, `run:` the piped one:
+
+```yaml
+version: "1"
+suite:
+  name: tty detection
+
+scenarios:
+  - name: a terminal gets the interactive rendering
+    steps:
+      - pty:
+          command: mytool export --all
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "%"          # the progress indicator drew
+
+  - name: a pipe gets plain machine-readable lines
+    steps:
+      - run:
+          command: mytool export --all
+      - assert:
+          exit_code: 0
+          stdout:
+            not_matches: "[%\\r]"  # no progress art in piped output
+```
+
+Full spec: [pty](../examples/pty.atago.yaml)
+
+## Inspect an archive the CLI produced
+
+No archive assertion exists (yet) — list the archive with a real tool and
+assert on the listing, which pins the member paths:
+
+```yaml
+version: "1"
+suite:
+  name: archives
+
+scenarios:
+  - name: the bundle contains exactly the advertised layout
+    skip:
+      os: windows     # relies on tar being on PATH
+    steps:
+      - run:
+          command: mytool bundle --out dist.tar.gz
+      - assert:
+          exit_code: 0
+      - run:
+          shell: true
+          command: tar -tzf dist.tar.gz
+      - assert:
+          exit_code: 0
+          stdout:
+            contains:
+              - dist/bin/mytool
+              - dist/LICENSE
+            not_contains:
+              - .git
+```
+
+Full spec: [shell_and_redirect](../examples/shell_and_redirect.atago.yaml)
+
+## Test the unreadable-input failure mode
+
+A `mode: "0000"` fixture is a file the CLI cannot open — the permission-denied
+path becomes reproducible instead of needing a root-owned file on the host:
+
+```yaml
+version: "1"
+suite:
+  name: permission errors
+
+scenarios:
+  - name: an unreadable input names the file and fails cleanly
+    skip:
+      os: windows       # POSIX permission semantics
+    steps:
+      - fixture:
+          file: locked.txt
+          content: "cannot read me"
+          mode: "0000"
+      - run:
+          command: mytool convert locked.txt out.txt
+      - assert:
+          exit_code: 2
+          stderr:
+            contains: locked.txt
+          file:
+            path: out.txt
+            exists: false
+```
+
+Full spec: [files_and_fixtures](../examples/files_and_fixtures.atago.yaml)
+
+## Run the command from a subdirectory
+
+Config discovery, path resolution, and "am I inside a project?" checks all
+depend on the working directory. `cwd:` runs the step from a subdirectory of
+the isolated workdir:
+
+```yaml
+version: "1"
+suite:
+  name: working directory
+
+scenarios:
+  - name: the tool finds the project root from a nested directory
+    steps:
+      - fixture:
+          file: mytool.yaml
+          content: "name: demo"
+      - fixture:
+          file: src/deep/keep.txt
+          content: ""
+      - run:
+          command: mytool status
+          cwd: src/deep
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "project: demo"   # found the root two levels up
+```
+
+Full spec: [run_and_assert](../examples/run_and_assert.atago.yaml)
+
+## Write one spec that runs on all three OSes
+
+Prefer direct argv commands (no shell) so quoting is identical everywhere; use
+`shell: true` only for shell builtins, and gate genuinely POSIX-only scenarios
+instead of letting them fail on Windows:
+
+```yaml
+version: "1"
+suite:
+  name: portable
+
+scenarios:
+  - name: the core contract holds everywhere
+    steps:
+      # Direct execution: no /bin/sh vs cmd.exe quoting differences exist.
+      - run:
+          command: mytool convert input.txt
+      - assert:
+          exit_code: 0
+          # contains/matches don't care about \n vs \r\n line endings within
+          # a line; avoid asserting exact multi-line blocks with equals here.
+          stdout:
+            contains: "wrote output.txt"
+
+  - name: the POSIX-only part is gated, not broken
+    skip:
+      os: windows
+    steps:
+      - run:
+          shell: true
+          command: 'test -x output.txt || echo not executable'
+      - assert:
+          stdout:
+            contains: not executable
+```
+
+Full spec: [pty_portable](../examples/pty_portable.atago.yaml), [select_skip_only](../examples/select_skip_only.atago.yaml)
+
+## Compare releases of your CLI with a matrix
+
+A matrix variable can be the command itself — run the same contract against
+two installed versions to catch behavior drift before shipping:
+
+```yaml
+version: "1"
+suite:
+  name: release comparison
+
+scenarios:
+  - name: "the convert contract holds in ${bin}"
+    matrix:
+      - bin: mytool-v1
+      - bin: mytool-v2
+    steps:
+      - fixture:
+          file: input.txt
+          content: "hello"
+      - run:
+          command: ${bin} convert input.txt
+      - assert:
+          exit_code: 0
+          file:
+            path: output.txt
+            contains: HELLO
+```
+
+Full spec: [matrix](../examples/matrix.atago.yaml)
+
+## Tag scenarios and run a slice in CI
+
+Tags split one suite into fast/slow, smoke/full, or per-feature slices —
+selection happens at run time, so the spec files stay together:
+
+```yaml
+version: "1"
+suite:
+  name: tagged suite
+
+scenarios:
+  - name: version prints instantly
+    tags: [smoke, fast]
+    steps:
+      - run:
+          command: mytool --version
+      - assert:
+          exit_code: 0
+
+  - name: a full export takes a while
+    tags: [slow]
+    steps:
+      - run:
+          command: mytool export --all
+      - assert:
+          exit_code: 0
+```
+
+```shell
+atago run --tag smoke ./specs        # PR gate: the fast slice
+atago run --skip-tag slow ./specs    # everything except the expensive ones
+atago run --ci ./specs               # nightly: the whole suite
+```
+
+Full spec: [select_skip_only](../examples/select_skip_only.atago.yaml)
+
+## Set defaults once for the whole suite
+
+`defaults:` applies a setting to every step or scenario, so specs stop
+repeating `shell: true` or a shared environment variable line by line:
+
+```yaml
+version: "1"
+suite:
+  name: suite defaults
+
+defaults:
+  run:
+    shell: true            # every run step goes through the shell
+  scenario:
+    env:
+      MYTOOL_NO_COLOR: "1" # every scenario gets deterministic plain output
+
+scenarios:
+  - name: steps inherit both defaults
+    steps:
+      - run:
+          command: echo plain and shelled
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: plain and shelled
+```
+
+Full spec: [defaults](../examples/defaults.atago.yaml)
+
+## Assert a database migration's schema
+
+Run the migration, then query the schema catalog with a `db` runner — the
+bundled SQLite needs no server, and the `rows:` assertion reads the result:
+
+```yaml
+version: "1"
+suite:
+  name: migrations
+
+runners:
+  store:
+    type: db
+    dsn: sqlite:${workdir}/app.db
+
+scenarios:
+  - name: migrate creates the promised tables
+    steps:
+      - run:
+          command: mytool migrate --db app.db
+      - assert:
+          exit_code: 0
+      - query:
+          runner: store
+          sql: "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+      - assert:
+          rows:
+            json:
+              - { path: "$[0].name", equals: jobs }
+              - { path: "$[1].name", equals: users }
+```
+
+Full spec: [db](../examples/db.atago.yaml)
+
+## Run the CLI on a remote host over SSH
+
+An `ssh` runner executes run steps on another machine — for a CLI whose job is
+provisioning or deployment, the remote is where the observable behavior lives:
+
+```yaml
+version: "1"
+suite:
+  name: remote
+
+runners:
+  box:
+    type: ssh
+    host: staging.example.com
+    user: deploy
+    key_file: ~/.ssh/id_ed25519
+    known_hosts: ~/.ssh/known_hosts
+
+scenarios:
+  - name: deploy leaves the service running on the box
+    steps:
+      - run:
+          command: mytool deploy --target staging
+      - assert:
+          exit_code: 0
+      - run:
+          runner: box
+          command: systemctl is-active myservice
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: active
+```
+
+Full spec: [ssh](../examples/ssh.atago.yaml)
+
+## Check a gRPC dependency after the CLI acts
+
+A `grpc:` step calls a method through server reflection — use it to observe
+the state your CLI was supposed to change:
+
+```yaml
+version: "1"
+suite:
+  name: grpc side effects
+
+runners:
+  registry:
+    type: grpc
+    target: localhost:50051
+
+scenarios:
+  - name: register makes the entry queryable over gRPC
+    steps:
+      - run:
+          command: mytool register --name demo
+      - assert:
+          exit_code: 0
+      - grpc:
+          runner: registry
+          method: registry.v1.Registry/Get
+          json:
+            name: demo
+      - assert:
+          grpc_status: 0
+      - assert:
+          message:
+            json:
+              path: "$.entry.name"
+              equals: demo
+```
+
+Full spec: [grpc](../examples/grpc.atago.yaml)
+
+## Verify a generated page in a real browser
+
+A `cdp:` step drives headless Chrome — when the CLI generates or serves HTML,
+assert what a browser actually renders, not just what the bytes contain:
+
+```yaml
+version: "1"
+suite:
+  name: browser verification
+
+runners:
+  web:
+    type: browser
+
+scenarios:
+  - name: the built site renders its title
+    services:
+      - name: server
+        command: mytool serve --dir site --port 8080
+        ready:
+          file: server.pid
+          timeout: 10s
+    steps:
+      - run:
+          command: mytool build --out site
+      - assert:
+          exit_code: 0
+      - cdp:
+          runner: web
+          actions:
+            - navigate: http://127.0.0.1:8080/
+            - wait_visible: h1
+            - text: h1
+      - assert:
+          value:
+            contains: Welcome
+```
+
+Full spec: [browser](../examples/browser.atago.yaml)
+
+## Lay out specs for a growing suite
+
+One file per contract area, a shared directory per product, tags for cost.
+`atago run` takes directories, so CI never lists files:
+
+```text
+specs/
+  cli/
+    usage.atago.yaml        # help, version, misuse exit codes
+    convert.atago.yaml      # the core command, happy + failure paths
+    config.atago.yaml       # env vars, config files, defaults
+  server/
+    serve.atago.yaml        # services: + http asserts
+    publish.atago.yaml      # side effects observed over HTTP
+  interactive/
+    wizard.atago.yaml       # pty: sessions
+```
+
+```shell
+atago run ./specs                 # everything
+atago run ./specs/cli             # one area
+atago run --tag smoke ./specs     # one cost slice
+atago list ./specs                # what exists, without running it
+```
+
+A spec file is also documentation: `atago doc --out docs/specs.md ./specs`
+renders every scenario, fixture, and expectation as Markdown — this cookbook's
+sibling [real-world docs](real-world.md) are generated exactly that way.
+
+## Record an interactive session instead of scripting it
+
+You don't hand-write expect/send choreography either. `record --pty` runs the
+tool in a real terminal, you drive it once by hand, and the keystrokes become a
+replayable `pty:` step — a password prompt turns into an `${env:...}`
+placeholder instead of a recorded secret:
+
+```shell
+atago record --pty --out wizard.atago.yaml -- mytool init
+```
+
+```yaml
+version: "1"
+suite:
+  name: recorded wizard
+scenarios:
+  - name: mytool init
+    steps:
+      - pty:
+          command: mytool init
+          session:
+            - expect: "Project name:"
+            - send: "demo\n"
+            - expect: "Password:"
+            - send: "${env:MYTOOL_PASSWORD}\n"   # record masked this for you
+            - expect: "created demo/"
+      - assert:
+          exit_code: 0
+```
+
+Recording works on Linux, macOS, and Windows (ConPTY). Trim the session to the
+exchanges that matter — fewer expects means less brittleness.
+
+## Refresh snapshots when output legitimately changes
+
+A golden file is only as good as its update workflow. When a change is
+intentional, one command re-records every snapshot the spec owns; volatile
+details (temp paths, UUIDs, timestamps, ports, ANSI colors) are normalized at
+compare time, so refreshed goldens stay stable across machines:
+
+```yaml
+version: "1"
+suite:
+  name: golden workflow
+
+scrub:
+  - {pattern: 'build [0-9a-f]{8}', placeholder: 'build <HASH>'}  # your own volatiles
+
+scenarios:
+  - name: the report matches its golden
+    steps:
+      - run:
+          command: mytool report
+      - assert:
+          exit_code: 0
+          stdout:
+            snapshot: snapshots/report.txt
+```
+
+```shell
+atago run report.atago.yaml                     # fails with a colorized diff
+atago snapshot update report.atago.yaml         # accept the new output
+git diff snapshots/                             # review exactly what changed
+```
+
+The failure diff and the `git diff` after updating are the same review — a
+snapshot turns "is this output right?" into a code-review question.
+
+## Pin the final TUI frame with a screen snapshot
+
+`stdout` of a pty step is the full transcript — every redraw, every spinner
+frame. `screen:` asserts the RENDERED terminal instead: what a user actually
+sees after cursor movement and clears are applied. Snapshot it like any text:
+
+```yaml
+version: "1"
+suite:
+  name: tui frame
+
+scenarios:
+  - name: the dashboard's final frame is stable
+    steps:
+      - pty:
+          command: mytool dashboard --once
+          rows: 24
+          cols: 80          # pin the geometry, or the frame wraps differently
+      - assert:
+          screen:
+            line: 1
+            contains: "MYTOOL DASHBOARD"
+      - assert:
+          screen:
+            snapshot: snapshots/dashboard_screen.txt
+```
+
+One caveat: a TUI on the alternate screen buffer restores the primary screen at
+clean exit, so capture while the UI is up (`--once` style flags help) rather
+than after quitting.
+
+Full spec: [pty_screen](../examples/pty_screen.atago.yaml)

--- a/doc/cookbook.md
+++ b/doc/cookbook.md
@@ -1111,7 +1111,7 @@ scenarios:
           status: 200
           header:
             name: Content-Type
-            contains: text/html
+            contains: application/json
           body:
             json:
               path: "$.title"

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -4,6 +4,7 @@
 
 | You want to | Uses |
 |-------------|------|
+| [Start from a recorded run](cookbook.md#start-from-a-recorded-run) | `atago record`, then edit the generated spec |
 | [Test a CLI that converts images](cookbook.md#test-a-cli-that-converts-images) | `image:` format/dimension/similarity asserts |
 | [Test a CLI that generates a PDF](cookbook.md#test-a-cli-that-generates-a-pdf) | `pdf:` page/metadata/text asserts |
 | [Test a CLI that generates files](cookbook.md#test-a-cli-that-generates-files) | `file:`/`dir:` asserts, byte-exact `equals_file` |
@@ -27,6 +28,39 @@
 | [Run the same scenario over many inputs](cookbook.md#run-the-same-scenario-over-many-inputs) | `matrix:` expansion |
 | [Capture a value in one step and reuse it](cookbook.md#capture-a-value-in-one-step-and-reuse-it) | `store:` + `${name}` |
 | [Isolate the test from the host environment](cookbook.md#isolate-the-test-from-the-host-environment) | `clear_env`, `pass_env`, `sandbox_home` |
+| [Pin the help and misuse contract](cookbook.md#pin-the-help-and-misuse-contract) | `--help` content, unknown-flag exit code and stderr |
+| [Test a CLI that reads environment variables](cookbook.md#test-a-cli-that-reads-environment-variables) | step `env:`, `clear_env` to prove the default |
+| [Mask secrets in reports and snapshots](cookbook.md#mask-secrets-in-reports-and-snapshots) | `secrets:` masking as `***` |
+| [Test a REPL](cookbook.md#test-a-repl) | `pty:` prompt-gated expect/send, EOF via `ctrl-d` |
+| [Prove a command is idempotent](cookbook.md#prove-a-command-is-idempotent) | second-run `changes:` pinned to empty |
+| [Compare two implementations of the same command](cookbook.md#compare-two-implementations-of-the-same-command) | `store:` + `equals: ${reference}` oracle |
+| [Record an interactive session instead of scripting it](cookbook.md#record-an-interactive-session-instead-of-scripting-it) | `atago record --pty`, secrets become `${env:...}` |
+| [Refresh snapshots when output legitimately changes](cookbook.md#refresh-snapshots-when-output-legitimately-changes) | `atago snapshot update`, `scrub:`, git-reviewable goldens |
+| [Pin the final TUI frame with a screen snapshot](cookbook.md#pin-the-final-tui-frame-with-a-screen-snapshot) | `screen:` line/contains asserts and snapshots, `rows:`/`cols:` |
+| [Pin the version and completion contracts](cookbook.md#pin-the-version-and-completion-contracts) | `matches:` on `--version`, completion output |
+| [Simulate API failures offline](cookbook.md#simulate-api-failures-offline) | `mock_servers:` error routes, `mock:` call counting |
+| [Test a download command offline](cookbook.md#test-a-download-command-offline) | mock route body, `equals_file` byte compare |
+| [Verify server state after the CLI acts](cookbook.md#verify-server-state-after-the-cli-acts) | `services:` + observer `http:` step, `status`/`header`/`body` |
+| [Send output streams to files](cookbook.md#send-output-streams-to-files) | `stdout_to:`/`stderr_to:` + file asserts |
+| [Ship binary test data with fixtures](cookbook.md#ship-binary-test-data-with-fixtures) | fixture `from:`/`base64:`/`mode:` |
+| [Test how the CLI treats symlinks](cookbook.md#test-how-the-cli-treats-symlinks) | fixture `symlink:` |
+| [Test freshness logic with fixture timestamps](cookbook.md#test-freshness-logic-with-fixture-timestamps) | fixture `mtime:` + `changes:` delta |
+| [Prove the tool is binary-safe](cookbook.md#prove-the-tool-is-binary-safe) | `stdin: {base64:}`, `stdout_to:`, `equals_file` |
+| [Test the empty-input boundary](cookbook.md#test-the-empty-input-boundary) | empty fixtures and `stdin: ""` |
+| [Prove multibyte text survives](cookbook.md#prove-multibyte-text-survives) | exact `equals:` on unicode round-trips |
+| [Test TTY detection](cookbook.md#test-tty-detection) | the same command under `pty:` and `run:` |
+| [Inspect an archive the CLI produced](cookbook.md#inspect-an-archive-the-cli-produced) | listing via a real tool + `contains`/`not_contains` |
+| [Test the unreadable-input failure mode](cookbook.md#test-the-unreadable-input-failure-mode) | fixture `mode: "0000"` |
+| [Run the command from a subdirectory](cookbook.md#run-the-command-from-a-subdirectory) | `cwd:` inside the workdir |
+| [Write one spec that runs on all three OSes](cookbook.md#write-one-spec-that-runs-on-all-three-oses) | direct argv commands, `skip: {os:}` gates |
+| [Compare releases of your CLI with a matrix](cookbook.md#compare-releases-of-your-cli-with-a-matrix) | `matrix:` over the command itself |
+| [Tag scenarios and run a slice in CI](cookbook.md#tag-scenarios-and-run-a-slice-in-ci) | `tags:` + `--tag`/`--skip-tag` |
+| [Set defaults once for the whole suite](cookbook.md#set-defaults-once-for-the-whole-suite) | `defaults:` for run steps and scenario env |
+| [Assert a database migration's schema](cookbook.md#assert-a-database-migrations-schema) | db runner, catalog `query:` + `rows:` |
+| [Run the CLI on a remote host over SSH](cookbook.md#run-the-cli-on-a-remote-host-over-ssh) | `ssh` runner as the observation point |
+| [Check a gRPC dependency after the CLI acts](cookbook.md#check-a-grpc-dependency-after-the-cli-acts) | `grpc:` step, `grpc_status`/`message` asserts |
+| [Verify a generated page in a real browser](cookbook.md#verify-a-generated-page-in-a-real-browser) | `cdp:` actions + `value:` assert |
+| [Lay out specs for a growing suite](cookbook.md#lay-out-specs-for-a-growing-suite) | directory layout, tags, `atago doc`/`list` |
 
 ## By feature
 

--- a/website/README.md
+++ b/website/README.md
@@ -16,8 +16,10 @@ repository-relative links to site pages or GitHub:
 | `doc/e2e/<tool>.md` | `/real-world/<tool>/` |
 | `doc/img/`, `site/samples/` | served as static files |
 
-Only the landing page and the Install / Getting started / CI / Reference pages
-under `content/` are authored here; their prose is adapted from README.md.
+Only the landing page and the Install / Getting started / CI / Reference /
+LLM pages under `content/` are authored here; their prose is adapted from
+README.md. `/llms.txt` (a plain-text page index for LLM agents) is generated
+by `layouts/home.llms.txt` via the custom `llms` output format.
 
 ```shell
 make website        # build into website/public (requires hugo)

--- a/website/assets/css/site.css
+++ b/website/assets/css/site.css
@@ -169,3 +169,108 @@ hr {
   border-top: 1px solid var(--border);
   margin: 2rem 0;
 }
+
+/* --- navigation state --- */
+
+header nav a.active {
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 0.35em;
+}
+
+/* --- heading anchors: visible on hover --- */
+
+.hlink {
+  text-decoration: none;
+  opacity: 0;
+  font-weight: 400;
+  transition: opacity 0.1s;
+}
+
+h1:hover .hlink, h2:hover .hlink, h3:hover .hlink, h4:hover .hlink {
+  opacity: 0.7;
+}
+
+/* --- "On this page" box --- */
+
+details.toc {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.5rem 1rem;
+  margin: 1rem 0;
+  font-size: 0.95rem;
+}
+
+details.toc summary {
+  cursor: pointer;
+  color: var(--muted);
+}
+
+details.toc ul {
+  margin: 0.5rem 0;
+  padding-left: 1.25rem;
+}
+
+details.toc a {
+  text-decoration: none;
+}
+
+details.toc a:hover {
+  text-decoration: underline;
+}
+
+/* --- copy button on code blocks --- */
+
+pre {
+  position: relative;
+}
+
+pre .copy {
+  position: absolute;
+  top: 0.4rem;
+  right: 0.4rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--muted);
+  font: 0.75rem ui-monospace, monospace;
+  padding: 0.15rem 0.5rem;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.1s;
+}
+
+pre:hover .copy {
+  opacity: 1;
+}
+
+pre .copy:hover {
+  color: var(--fg);
+}
+
+/* --- subtle zebra striping for wide tables --- */
+
+tbody tr:nth-child(even) {
+  background: var(--code-bg);
+}
+
+/* --- landing: "Where to go" as a card grid --- */
+
+#where-to-go + ul {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(21rem, 1fr));
+  gap: 0.75rem;
+}
+
+#where-to-go + ul li {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  margin: 0;
+}
+
+#where-to-go + ul li a:first-child {
+  font-weight: 600;
+}

--- a/website/content/_content.gotmpl
+++ b/website/content/_content.gotmpl
@@ -16,7 +16,9 @@
   {{ $.AddPage (dict
       "path" "cookbook"
       "title" "Cookbook"
-      "params" (dict "description" "Copyable atago specs for common jobs: converting files, driving prompts and TUIs, mocking HTTP APIs, pinning output trees, and more.")
+      "params" (dict
+        "description" "50+ copyable atago specs for common jobs: converting files, driving prompts and TUIs, simulating API failures, pinning output trees, and more."
+        "toc" true)
       "content" (dict "mediaType" "text/markdown" "value" $md)) }}
 {{ end }}
 

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -26,14 +26,29 @@ Pick the tool that owns your layer:
 
 If the server or the platform is the system under test, use runn or venom. atago points the other way: the CLI is the product, and HTTP, database, SSH, gRPC, browser, and mock servers appear only as peers your CLI talks to.
 
+## Record, don't write
+
+The first spec comes from a real run: `atago record -- <command>` executes the tool once and writes a spec from what it observed — exit code, output, created files. Interactive tools record too: `record --pty` runs in a real terminal, you drive one session by hand, and the keystrokes become a replayable expect/send script, with password prompts masked into `${env:...}` placeholders automatically. Then you edit YAML, not write it from scratch.
+
+## Snapshots built for CLI output
+
+![snapshot testing: failure diff and one-command update](/img/snapshot.gif)
+
+`snapshot:` pins output to a committed golden file. ANSI colors, temp paths, UUIDs, timestamps, ports, and CRLF are normalized so goldens stay stable across machines; your own volatile patterns get spec-wide `scrub:` rules. A failure renders a colorized unified diff, and `atago snapshot update` re-records everything intentionally changed — the review is just `git diff snapshots/`.
+
+## Real terminals, not faked pipes
+
+A `pty:` step runs the command in a real pseudo-terminal — on Windows too (ConPTY) — and drives it with declarative expect/send pairs and named keys, no `expect(1)` scripting. `screen:` asserts the RENDERED frame a user actually sees, after cursor movement and clears are applied, and screen snapshots pin full TUI layouts. TTY-detection branches, wizards, REPLs, htop-style dashboards: all of it is spec-able.
+
 ## Where to go
 
 - [Install](/install/) — `go install`, Homebrew, AUR, prebuilt binaries, a GitHub Action.
 - [Getting started](/getting-started/) — record a real run, read the spec it wrote, keep it as a test.
-- [Cookbook](/cookbook/) — copyable specs for common jobs, from image conversion to graceful shutdown.
+- [Cookbook](/cookbook/) — 50+ copyable recipes, from image conversion to API-failure simulation to TUI frames.
 - [Examples](/examples/) — every feature has a commented, runnable spec, tested in CI on Linux, macOS, and Windows.
 - [Use it in CI](/ci/) — report formats, retries, flake detection, artifacts, secret masking.
 - [Reference](/reference/) — subcommands, selection flags, exit codes, editor schema.
+- [Write specs with an LLM](/llm/) — a ready-made prompt that keeps generated specs honest.
 - [Real CLIs tested with atago](/real-world/) — 40+ programs from jq to terraform to htop, each with executable specs and generated behavior docs.
 
 Everything on this site comes from files committed in the [repository](https://github.com/nao1215/atago). The behavior docs are regenerated from executable specs, and drift tests fail the build when docs and specs disagree — if an example is on this site, it runs.

--- a/website/content/ci.md
+++ b/website/content/ci.md
@@ -1,4 +1,5 @@
 ---
+toc: true
 title: Use it in CI
 description: Run atago suites in CI with JUnit/JSON/TAP/GitHub reports, loud retries for flaky scenarios, repeat-based flake detection, kept artifacts, and secret masking.
 ---

--- a/website/content/getting-started.md
+++ b/website/content/getting-started.md
@@ -1,4 +1,5 @@
 ---
+toc: true
 title: Getting started
 description: Record a real run of your CLI, read the spec atago wrote, and keep it as a test — then assert on files, snapshots, interactive prompts, and server peers.
 ---

--- a/website/content/llm.md
+++ b/website/content/llm.md
@@ -1,0 +1,96 @@
+---
+title: Write specs with an LLM
+description: A ready-made prompt that makes an LLM generate honest atago specs — black-box, plain YAML, deterministic assertions, no invented features.
+---
+
+Spec YAML is a good target for an LLM: the format is small, the assertions are
+declarative, and `atago run` validates the result mechanically (exit code 2
+means the spec is malformed, not your CLI). What a model needs is constraints —
+otherwise it invents features, mocks internals, or asserts fragile details.
+
+Paste this prompt into your assistant, then replace the last paragraph with a
+description of the behavior you want tested:
+
+```text
+You are helping me write atago specs.
+
+atago is a black-box E2E testing tool for CLI products. It tests real CLI
+behavior from plain YAML by running the actual binary and asserting what a
+user observes: exit codes, stdout, stderr, generated files, snapshots,
+services, and interactive terminals.
+
+Your job is to generate practical atago YAML specs for the CLI behavior I
+describe.
+
+Rules:
+
+* Treat the CLI itself as the product under test.
+* Prefer black-box tests over unit-test-like assumptions.
+* Run the actual command behavior conceptually; do not mock the CLI internals.
+* Do not write Go, Python, Bash test code, or a shell-based DSL unless I
+  explicitly ask for it.
+* Use plain atago YAML.
+* Keep each test focused on one observable behavior.
+* Assert user-visible results: exit code, stdout, stderr, files, snapshots,
+  or TUI/PTY behavior.
+* Include setup/fixtures only when needed.
+* Prefer deterministic assertions.
+* Avoid fragile assertions such as full paths, timestamps, random IDs,
+  network-dependent output, or OS-specific text unless they are the behavior
+  being tested.
+* For cross-platform CLIs, avoid assumptions that only work on Linux unless I
+  explicitly target Linux.
+* When output may change, use snapshots only if they make the test easier to
+  review.
+* If the command generates files, assert both file existence and relevant
+  file content.
+* If stderr matters, assert it separately from stdout.
+* If the CLI is interactive, use atago's PTY/TUI style instead of pretending
+  it is a normal stdout-only command.
+* If the behavior requires a database, HTTP server, mock server, or service,
+  model it as an external peer used by the CLI, not as the main system under
+  test.
+
+Before writing the final spec:
+
+1. Identify the CLI command being tested.
+2. Identify the observable behavior.
+3. Decide the minimum necessary fixture/setup.
+4. Decide which assertions are stable.
+5. Then output the atago YAML.
+
+Output format:
+
+* First, briefly explain the test intent.
+* Then provide the YAML spec in a fenced yaml block.
+* After the YAML, mention any assumptions or parts I should adjust.
+* Do not over-explain basic YAML.
+* Do not invent unsupported atago features. If unsure, say what needs to be
+  checked in the atago reference.
+
+The CLI behavior I want to test is:
+
+[Describe the command, inputs, expected output, generated files, error cases,
+or interactive behavior here.]
+```
+
+## Give the model ground truth
+
+The prompt tells the model not to invent features; ground truth lets it check
+instead of guess. Attach or link these when your assistant can read them:
+
+- The [JSON Schema](https://raw.githubusercontent.com/nao1215/atago/main/schema/atago.schema.json) — every step type and matcher, machine-readable.
+- The [cookbook](/cookbook/) — 50+ validated recipes; the closest one is a better starting point than a blank page.
+- This site's [/llms.txt](/llms.txt) — a plain-text index of every page here, for agents that fetch docs themselves.
+
+## Validate what comes back
+
+Never trust a generated spec until atago has loaded it:
+
+```shell
+atago explain generated.atago.yaml   # exit 2 = malformed spec, with the reason
+atago run generated.atago.yaml       # the actual test
+```
+
+`explain`, `doc`, `list`, and `manifest` all validate before doing anything,
+so any of them doubles as a lint step for machine-written YAML.

--- a/website/content/reference.md
+++ b/website/content/reference.md
@@ -1,4 +1,5 @@
 ---
+toc: true
 title: Reference
 description: atago subcommands, scenario selection flags, snapshot updating and scrub rules, the JSON Schema for editors, shell completion, and the exit code contract.
 ---

--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -16,6 +16,19 @@ description = "atago tests real CLI behavior from plain YAML: exit codes, output
 [markup.highlight]
 noClasses = false
 
+[markup.tableOfContents]
+startLevel = 2
+endLevel = 3
+
+# /llms.txt: a plain-text index of every page, for LLM agents that fetch docs.
+[outputFormats.llms]
+mediaType = "text/plain"
+baseName = "llms"
+isPlainText = true
+
+[outputs]
+home = ["html", "llms"]
+
 [[menus.main]]
 name = "Install"
 pageRef = "/install"
@@ -45,6 +58,11 @@ weight = 50
 name = "Reference"
 pageRef = "/reference"
 weight = 60
+
+[[menus.main]]
+name = "LLM"
+pageRef = "/llm"
+weight = 65
 
 [[menus.main]]
 name = "Real-world CLIs"

--- a/website/layouts/_markup/render-heading.html
+++ b/website/layouts/_markup/render-heading.html
@@ -1,0 +1,1 @@
+<h{{ .Level }} id="{{ .Anchor | safeURL }}">{{ .Text }}{{ if ge .Level 2 }} <a class="hlink" href="#{{ .Anchor | safeURL }}" aria-label="Link to this section">#</a>{{ end }}</h{{ .Level }}>

--- a/website/layouts/baseof.html
+++ b/website/layouts/baseof.html
@@ -35,20 +35,25 @@
 <p>MIT licensed · <a href="https://github.com/nao1215/atago">nao1215/atago</a> · every page on this site is generated from files committed in the repository.</p>
 </footer>
 <script>
-document.querySelectorAll("pre").forEach(function (pre) {
-  var b = document.createElement("button");
-  b.type = "button";
-  b.className = "copy";
-  b.textContent = "copy";
-  b.addEventListener("click", function () {
-    var code = pre.querySelector("code");
-    navigator.clipboard.writeText(code ? code.innerText : pre.innerText).then(function () {
-      b.textContent = "copied";
-      setTimeout(function () { b.textContent = "copy"; }, 1200);
+if (navigator.clipboard && window.isSecureContext) {
+  document.querySelectorAll("pre").forEach(function (pre) {
+    var b = document.createElement("button");
+    b.type = "button";
+    b.className = "copy";
+    b.textContent = "copy";
+    b.addEventListener("click", function () {
+      var code = pre.querySelector("code");
+      navigator.clipboard.writeText(code ? code.innerText : pre.innerText).then(function () {
+        b.textContent = "copied";
+      }, function () {
+        b.textContent = "failed";
+      }).then(function () {
+        setTimeout(function () { b.textContent = "copy"; }, 1200);
+      });
     });
+    pre.appendChild(b);
   });
-  pre.appendChild(b);
-});
+}
 </script>
 </body>
 </html>

--- a/website/layouts/baseof.html
+++ b/website/layouts/baseof.html
@@ -23,7 +23,7 @@
 <nav>
 <a class="brand" href="{{ site.Home.RelPermalink }}">atago</a>
 {{- range site.Menus.main }}
-<a href="{{ .URL }}">{{ .Name }}</a>
+<a{{ if or ($.IsMenuCurrent "main" .) ($.HasMenuCurrent "main" .) }} class="active"{{ end }} href="{{ .URL }}">{{ .Name }}</a>
 {{- end }}
 <a href="https://github.com/nao1215/atago">GitHub</a>
 </nav>
@@ -34,5 +34,21 @@
 <footer>
 <p>MIT licensed · <a href="https://github.com/nao1215/atago">nao1215/atago</a> · every page on this site is generated from files committed in the repository.</p>
 </footer>
+<script>
+document.querySelectorAll("pre").forEach(function (pre) {
+  var b = document.createElement("button");
+  b.type = "button";
+  b.className = "copy";
+  b.textContent = "copy";
+  b.addEventListener("click", function () {
+    var code = pre.querySelector("code");
+    navigator.clipboard.writeText(code ? code.innerText : pre.innerText).then(function () {
+      b.textContent = "copied";
+      setTimeout(function () { b.textContent = "copy"; }, 1200);
+    });
+  });
+  pre.appendChild(b);
+});
+</script>
 </body>
 </html>

--- a/website/layouts/home.llms.txt
+++ b/website/layouts/home.llms.txt
@@ -1,0 +1,21 @@
+# atago
+
+> {{ site.Params.description }}
+
+Docs: {{ site.Home.Permalink }}
+Source: https://github.com/nao1215/atago
+Spec JSON Schema: https://raw.githubusercontent.com/nao1215/atago/main/schema/atago.schema.json
+
+Every page below is generated from files committed in the repository; the
+real-world pages are behavior docs regenerated from executable specs that run
+in CI.
+
+## Docs
+{{ range site.RegularPages.ByTitle }}
+- [{{ .Title }}]({{ .Permalink }}): {{ or .Params.description .Summary | plainify | chomp }}
+{{- end }}
+
+## Sections
+{{ range site.Sections }}
+- [{{ .Title }}]({{ .Permalink }}): {{ or .Params.description "" | plainify | chomp }}
+{{- end }}

--- a/website/layouts/page.html
+++ b/website/layouts/page.html
@@ -1,6 +1,12 @@
 {{ define "main" }}
 <article>
 <h1>{{ .Title }}</h1>
+{{ if .Params.toc }}
+<details class="toc">
+<summary>On this page</summary>
+{{ .TableOfContents }}
+</details>
+{{ end }}
 {{ .Content }}
 </article>
 {{ end }}


### PR DESCRIPTION
## Summary

Expands the cookbook from 23 to 57 loader-validated recipes so a user facing a concrete testing job ("how do I test a REPL / a download command / idempotency?") finds a copyable spec instead of reverse-engineering one, and gives the hosted site restrained visual polish plus two LLM-oriented additions: a "Write specs with an LLM" prompt page and an auto-generated `/llms.txt` index. README's Examples section now points at the hosted cookbook.

## Changes

- `doc/cookbook.md` — 34 new recipes, each ending in a link to a runnable example: record-first workflows (including `record --pty` with automatic secret placeholders), snapshot refresh with `scrub:` and the git-review workflow, TUI screen-frame snapshots, help/version/completion contracts, environment variables and secrets masking, REPL and TTY-detection sessions, idempotency via empty `changes:`, differential oracles with `store:`, offline API-failure simulation and downloads against `mock_servers:`, fixture sources (`from:`/`base64:`/`mode:`/`mtime:`/`symlink:`), binary safety, empty-input and multibyte boundaries, archive inspection, unreadable-input failure via `mode: "0000"`, `cwd:`, three-OS portability, matrix release comparison, tags, `defaults:`, db-migration/ssh/grpc/browser peers, and suite layout guidance.
- `doc/examples.md` — by-task index rows for every new recipe (`TestExamplesIndex_InLockstep` enforces the two-way mapping; `TestCookbook_SnippetsValid` loads every YAML block through the real loader — both green locally along with the full root test package).
- `website/content/llm.md` — a constrained copy-paste prompt for generating honest atago specs with any LLM, plus ground-truth links (schema, cookbook, `/llms.txt`) and a validate-what-comes-back section.
- `website/layouts/home.llms.txt` + `hugo.toml` — `/llms.txt` generated from the page tree via a custom output format.
- Website polish, all dependency-free: collapsible "On this page" TOC (cookbook/getting-started/CI/reference), hover heading anchors via a render hook, a copy button on code blocks (the one piece of vanilla JS), active-nav state, the landing "Where to go" list as a CSS-only card grid, and subtle zebra striping on tables.
- `website/content/_index.md` — landing sections spotlighting the three differentiators: record-first, CLI-tuned snapshots, and real PTY/TUI testing (with the snapshot GIF).
- `README.md` — Examples section links the hosted cookbook and examples index; the tagline links the documentation site.

## Design Decisions

- Recipes use the placeholder `mytool`, so they validate through the loader without executing — the same contract the existing 23 recipes follow; runnable coverage stays in `examples/`, which each recipe links to.
- The LLM prompt page ships the prompt as one fenced text block so it is a single copy action, and pairs it with machine-readable ground truth instead of prose explanations.
- Polish stays CSS-first; the copy button is the only JavaScript on the site and degrades to nothing without it.

## Limitations

- Recipes are validated, not executed, so a behavioral (as opposed to schema) drift in a recipe would not be caught by CI — mitigated by linking each recipe to a CI-run example covering the same feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Write specs with an LLM” page and a plain-text `/llms.txt` home index.
  * Expanded the cookbook with 50+ runnable recipes and more task-based examples.
* **Documentation**
  * Updated the README and docs links to point to the hosted documentation and examples pages.
* **Style**
  * Improved the website experience with table-of-contents support, active navigation highlighting, heading anchors, code-copy buttons, and layout/card polish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->