### PR TITLE
docs: expand cookbook, add website logo/name/Sponsors, trim README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,27 +61,6 @@ The [release page](https://github.com/nao1215/atago/releases) contains prebuilt 
 
 Runs on Linux, macOS, and Windows (CI tests all three).
 
-## Verifying release integrity
-
-Every release ships supply-chain metadata so you can verify what you download:
-
-- Signed checksums: `checksums.txt` is signed with [cosign](https://github.com/sigstore/cosign) (keyless), producing `checksums.txt.sigstore.json`.
-- SBOM: an SPDX Software Bill of Materials is attached to each release archive.
-- Build provenance: SLSA build provenance is attested via GitHub OIDC.
-
-```shell
-cosign verify-blob \
-  --bundle checksums.txt.sigstore.json \
-  --certificate-identity-regexp 'https://github.com/nao1215/atago/\.github/workflows/release\.yml@refs/tags/.*' \
-  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
-  checksums.txt
-sha256sum --check --ignore-missing checksums.txt
-```
-
-```shell
-gh attestation verify atago_<version>_<os>_<arch>.tar.gz --repo nao1215/atago  # .zip on Windows
-```
-
 ## Getting started
 
 ### Start from a real run
@@ -311,7 +290,7 @@ version: "1"
 
 ## Real CLIs tested with atago
 
-These suites run real programs of every shape: the author's Go tools (atago tests itself) and unmodified third-party binaries — git and jq, interactive TUIs (fzf, htop), the python3 REPL, servers driven as scenario services (redis, gitea, grafana, prometheus), cloud and IaC CLIs tested offline (aws-cli, terraform, ecspresso), crypto tools (openssl, age, sops), and document/media pipelines (pandoc, ffmpeg). Most were migrated from ShellSpec. [doc/real-world.md](doc/real-world.md) lists all 40+ with specs and generated behavior docs.
+These suites run real programs of every shape: the author's Go tools (atago tests itself) and unmodified third-party binaries — git and jq, interactive TUIs (fzf, htop), the python3 REPL, servers driven as scenario services (redis, gitea, grafana, prometheus), cloud and IaC CLIs tested offline (aws-cli, terraform, ecspresso), crypto tools (openssl, age, sops), and document/media pipelines (pandoc, ffmpeg). Most were migrated from ShellSpec. [Real CLIs tested with atago](https://nao1215.github.io/atago/real-world/) lists all 40+ with specs and generated behavior docs.
 
 ## The name
 

--- a/doc/RELEASE.md
+++ b/doc/RELEASE.md
@@ -46,7 +46,7 @@ The release workflow then:
 - Check the [Releases page](https://github.com/nao1215/atago/releases) for the
   generated notes and artifacts.
 - Verify a downloaded artifact as described in
-  [Verifying release integrity](../README.md#verifying-release-integrity).
+  [Verifying release integrity](https://nao1215.github.io/atago/install/#verifying-release-integrity).
 
 ## If a release fails
 - Re-run the failed job from the Actions tab once the cause is fixed.

--- a/doc/cookbook.md
+++ b/doc/cookbook.md
@@ -1880,3 +1880,305 @@ clean exit, so capture while the UI is up (`--once` style flags help) rather
 than after quitting.
 
 Full spec: [pty_screen](../examples/pty_screen.atago.yaml)
+
+## Prove a dry run changes nothing
+
+`--dry-run` has exactly one contract: describe what would happen, touch
+nothing. Per-file asserts cannot state the second half ("...and nothing
+else"), but an all-empty `changes:` delta can — the step created, modified,
+and deleted no files at all:
+
+```yaml
+version: "1"
+suite:
+  name: dry run
+
+scenarios:
+  - name: --dry-run reports the plan but touches nothing
+    steps:
+      - fixture:
+          file: notes/draft.txt
+          content: "keep me\n"
+      - run:
+          command: mytool clean --dry-run .
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "would delete notes/draft.txt"
+          # The dry-run contract, stated exhaustively: no file anywhere in the
+          # workdir was created, modified, or deleted.
+          changes:
+            created: []
+            modified: []
+            deleted: []
+```
+
+Full spec: [changes](../examples/changes.atago.yaml)
+
+## Test config precedence
+
+Every layered-config CLI documents "flag beats environment beats file", and
+each layer is usually tested alone — which is exactly how precedence bugs
+hide. Pin each rung against the one below it:
+
+```yaml
+version: "1"
+suite:
+  name: config precedence
+
+scenarios:
+  - name: the config file sets the default
+    steps:
+      - fixture:
+          file: config.toml
+          content: |
+            region = "eu-west-1"
+      - run:
+          command: mytool region --config config.toml
+          # A stray MYTOOL_REGION on the host must not leak into this rung.
+          clear_env: true
+          pass_env: [PATH]
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: eu-west-1
+
+  - name: an environment variable overrides the file
+    steps:
+      - fixture:
+          file: config.toml
+          content: |
+            region = "eu-west-1"
+      - run:
+          command: mytool region --config config.toml
+          clear_env: true
+          pass_env: [PATH]
+          env:
+            MYTOOL_REGION: us-east-2
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: us-east-2
+
+  - name: a flag overrides both
+    steps:
+      - fixture:
+          file: config.toml
+          content: |
+            region = "eu-west-1"
+      - run:
+          command: mytool region --config config.toml --region ap-northeast-1
+          clear_env: true
+          pass_env: [PATH]
+          env:
+            MYTOOL_REGION: us-east-2
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: ap-northeast-1
+```
+
+Full spec: [hermetic_env](../examples/hermetic_env.atago.yaml)
+
+## Abort a destructive command at its confirmation prompt
+
+The "yes" branch of a destructive command gets all the attention; the safety
+branch — answer no, nothing happens — is the one users bet their data on.
+Drive the prompt in a real terminal and pin the delta to empty:
+
+```yaml
+version: "1"
+suite:
+  name: confirmation prompt
+
+scenarios:
+  - name: answering no leaves every file in place
+    steps:
+      - fixture:
+          file: data.db
+          content: "precious\n"
+      - pty:
+          command: mytool purge
+          timeout: 10s
+          session:
+            # [y/N] is a regex character class — escape it.
+            - expect: 'delete 1 file\? \[y/N\]'
+            - send: "n\n"
+      - assert:
+          # Exit-code conventions for an aborted command vary; the files ARE
+          # the contract, so assert those exhaustively instead.
+          changes:
+            created: []
+            modified: []
+            deleted: []
+      - assert:
+          file:
+            path: data.db
+            contains: precious
+```
+
+Full spec: [pty](../examples/pty.atago.yaml)
+
+## Prove color output turns off
+
+Raw ANSI escapes leaking into piped output is a classic CLI bug. Under a
+`run:` step stdout already IS a pipe, so a well-behaved tool should emit no
+color even before you reach for [`NO_COLOR`](https://no-color.org/):
+
+```yaml
+version: "1"
+suite:
+  name: color contract
+
+scenarios:
+  - name: a pipe gets no color by default
+    steps:
+      - run:
+          command: mytool status
+      - assert:
+          exit_code: 0
+          stdout:
+            not_matches: '\x1b\['    # no CSI escape sequence anywhere
+
+  - name: NO_COLOR is honored even where color would be forced
+    steps:
+      - run:
+          command: mytool status --color always
+          env:
+            NO_COLOR: "1"
+      - assert:
+          exit_code: 0
+          stdout:
+            not_matches: '\x1b\['
+```
+
+To test the opposite branch — color IS emitted on a terminal — run the same
+command under `pty:` and assert `matches: '\x1b\['`.
+
+Full spec: [run_and_assert](../examples/run_and_assert.atago.yaml)
+
+## Assert a generated script is executable
+
+A scaffolder that writes hook or build scripts makes two promises: the content
+and the mode bit. A `file:` assert checks one property at a time, so stack two:
+
+```yaml
+version: "1"
+suite:
+  name: executable bit
+
+scenarios:
+  - name: scaffold writes a runnable build script
+    skip:
+      os: windows        # no executable bit to assert there
+    steps:
+      - run:
+          command: mytool scaffold --with-scripts
+      - assert:
+          exit_code: 0
+          file:
+            path: bin/build.sh
+            executable: true
+      - assert:
+          file:
+            path: bin/build.sh
+            contains: "#!/bin/sh"
+```
+
+Full spec: [files_and_fixtures](../examples/files_and_fixtures.atago.yaml)
+
+## Hunt down a flaky scenario
+
+Flakiness survives by hiding behind retries. atago's flake tooling points the
+other way — it surfaces instability instead of absorbing it:
+
+```shell
+atago run --repeat 20 flaky.atago.yaml   # run each scenario 20 times; ONE bad iteration fails the run
+atago run --retry-failed 2 ./specs      # retry failures, but a pass-after-fail is REPORTED as flaky, never hidden
+atago rerun ./specs                     # while bisecting: re-run only what failed last time
+```
+
+The usual culprits, and the recipe that fixes each: sleeping instead of
+polling ([Poll an async result](#poll-an-async-result)), volatile output
+reaching a snapshot ([Pin output with a golden
+file](#pin-output-with-a-golden-file)), host environment leaking in ([Isolate
+the test from the host environment](#isolate-the-test-from-the-host-environment)),
+and unpinned terminal geometry in TUI tests — set `rows:`/`cols:` on the
+`pty:` step so the frame cannot wrap differently between machines.
+
+## Troubleshooting
+
+The failures every new spec hits once, and the fast way out of each.
+
+### "executable file not found", but the command works in your shell
+
+`command:` runs the program directly (argv) — no shell parses the line. Shell
+builtins (`echo`, `cd`, `type`, and `dir` on Windows), pipes, redirects, and
+globs exist only under `shell: true`. If the binary genuinely exists on PATH,
+check whether the scenario cleared its environment: `clear_env: true` drops
+`PATH` too, so re-admit it with `pass_env: [PATH]`.
+
+### atago expands a `${...}` you meant literally
+
+`${name}` is atago's own expansion syntax — stores, matrix parameters,
+`${env:NAME}`, `${workdir}`. To pass a literal `${...}` through to the command
+(a shell variable, a template placeholder), escape it as `$${...}`.
+
+### The command cannot find its input files
+
+Every scenario runs in a fresh, isolated working directory — atago does not
+run your command where you launched atago. Ship each input with a `fixture:`
+step and reference it relatively (or as `${workdir}/...`); do not point at
+files in your repository checkout. See
+[Ship binary test data with fixtures](#ship-binary-test-data-with-fixtures).
+
+### A snapshot passes locally and fails in CI
+
+The built-in normalizers already cover ANSI colors, temp paths, UUIDs,
+timestamps, ports, and CRLF. Anything else that varies per run — build hashes,
+auto-increment IDs, durations — needs a spec-wide `scrub:` rule
+([Pin output with a golden file](#pin-output-with-a-golden-file)). When output
+changed on purpose, `atago snapshot update` re-records and `git diff
+snapshots/` is the review.
+
+### A pty session hangs until its timeout
+
+Three usual causes. A `send:` without a trailing `"\n"` types the text but
+never presses enter. An `expect:` is a Go regex, so a prompt like `[y/N]` is a
+character class until you escape it: `\[y/N\]`. And each `expect` scans only
+the transcript AFTER the previous match — expecting text that appeared earlier
+in the session waits forever for a second occurrence. The session dies at
+`timeout` (default 30s) with the transcript in the failure, so read what the
+terminal actually showed.
+
+### A `screen:` assert sees a blank screen
+
+Most full-screen TUIs use the alternate screen buffer and restore the primary
+screen when they exit cleanly — so after a clean quit there is nothing left to
+assert. Capture the frame while the UI is still displayed: assert before
+sending the quit key, or use a `--once`-style flag that leaves output on the
+primary screen.
+
+### The run exits 2 or 3 before any scenario runs
+
+atago's exit codes separate "your CLI failed the test" from "the test could
+not run": `1` means scenarios failed, `2` means a spec did not load (YAML
+syntax or schema violation — the message points at the offending key), `3`
+means atago itself was misused (unknown flag, or no spec files matched the
+path). On `2`, `atago explain spec.atago.yaml` validates and describes the
+spec without running anything.
+
+### It passes on your machine and fails on a teammate's
+
+Something from the host environment is leaking in — a config file in `$HOME`,
+a locale, an exported variable. Make the scenario hermetic: `clear_env: true`
+with a `pass_env:` allowlist, and `sandbox_home: true` to isolate `$HOME` and
+the per-OS config/cache directories. See
+[Isolate the test from the host environment](#isolate-the-test-from-the-host-environment).
+
+### When all else fails, watch what atago actually did
+
+`atago run --verbose` traces every command, captured stream, and per-assertion
+verdict — for passing scenarios too, which is what you want while authoring.
+`atago explain spec.atago.yaml` describes a spec without running it, and
+`atago list` shows which scenarios and tags a path contains.

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -61,6 +61,13 @@
 | [Check a gRPC dependency after the CLI acts](cookbook.md#check-a-grpc-dependency-after-the-cli-acts) | `grpc:` step, `grpc_status`/`message` asserts |
 | [Verify a generated page in a real browser](cookbook.md#verify-a-generated-page-in-a-real-browser) | `cdp:` actions + `value:` assert |
 | [Lay out specs for a growing suite](cookbook.md#lay-out-specs-for-a-growing-suite) | directory layout, tags, `atago doc`/`list` |
+| [Prove a dry run changes nothing](cookbook.md#prove-a-dry-run-changes-nothing) | all-empty `changes:` delta |
+| [Test config precedence](cookbook.md#test-config-precedence) | flag > env > file, hermetic `clear_env` rungs |
+| [Abort a destructive command at its confirmation prompt](cookbook.md#abort-a-destructive-command-at-its-confirmation-prompt) | `pty:` "no" branch + empty `changes:` |
+| [Prove color output turns off](cookbook.md#prove-color-output-turns-off) | `not_matches:` on ANSI escapes, `NO_COLOR` |
+| [Assert a generated script is executable](cookbook.md#assert-a-generated-script-is-executable) | `file:` `executable:` + `contains:` |
+| [Hunt down a flaky scenario](cookbook.md#hunt-down-a-flaky-scenario) | `--repeat`, `--retry-failed` (flaky is reported), `atago rerun` |
+| [Troubleshooting](cookbook.md#troubleshooting) | the failures every new spec hits once, and the fix for each |
 
 ## By feature
 

--- a/website/assets/css/site.css
+++ b/website/assets/css/site.css
@@ -59,6 +59,27 @@ header nav .brand {
   margin-right: 0.5rem;
 }
 
+header nav .sponsor {
+  color: #bf3989;
+}
+
+@media (prefers-color-scheme: dark) {
+  header nav .sponsor {
+    color: #f778ba;
+  }
+}
+
+/* --- home page logo --- */
+
+.logo {
+  text-align: center;
+}
+
+.logo img {
+  max-width: min(400px, 100%);
+  border-radius: 8px;
+}
+
 main {
   max-width: 56rem;
   margin: 0 auto;

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -40,6 +40,10 @@ The first spec comes from a real run: `atago record -- <command>` executes the t
 
 A `pty:` step runs the command in a real pseudo-terminal — on Windows too (ConPTY) — and drives it with declarative expect/send pairs and named keys, no `expect(1)` scripting. `screen:` asserts the RENDERED frame a user actually sees, after cursor movement and clears are applied, and screen snapshots pin full TUI layouts. TTY-detection branches, wizards, REPLs, htop-style dashboards: all of it is spec-able.
 
+## The name
+
+atago is named after Atago (愛宕), the Japanese deity of fire prevention. The software industry has its own word for a project on fire — 炎上, "going up in flames" — and the name carries a wish: that atago grows into the thing that stops those fires before they spread. It also helps that atago is written in Go, so the name ends in *go*.
+
 ## Where to go
 
 - [Install](/install/) — `go install`, Homebrew, AUR, prebuilt binaries, a GitHub Action.

--- a/website/layouts/baseof.html
+++ b/website/layouts/baseof.html
@@ -26,6 +26,7 @@
 <a{{ if or ($.IsMenuCurrent "main" .) ($.HasMenuCurrent "main" .) }} class="active"{{ end }} href="{{ .URL }}">{{ .Name }}</a>
 {{- end }}
 <a href="https://github.com/nao1215/atago">GitHub</a>
+<a class="sponsor" href="https://github.com/sponsors/nao1215">&#9825; Sponsor</a>
 </nav>
 </header>
 <main>

--- a/website/layouts/home.html
+++ b/website/layouts/home.html
@@ -1,3 +1,4 @@
 {{ define "main" }}
+<p class="logo"><img src="{{ relURL "img/atago-logo.jpg" }}" alt="atago logo" width="400"></p>
 {{ .Content }}
 {{ end }}


### PR DESCRIPTION
## Summary

- **README**: remove the "Verifying release integrity" section (it stays on the website's [Install page](https://nao1215.github.io/atago/install/#verifying-release-integrity), which `doc/RELEASE.md` now links); the "Real CLIs tested with atago" paragraph links to the hosted [/real-world/](https://nao1215.github.io/atago/real-world/) index instead of the raw markdown file.
- **Website**: render the atago logo at the top of the landing page, add a "The name" section (Atago 愛宕, the deity of fire prevention — plus the Go pun), and add a GitHub Sponsors link to the header nav on every page.
- **Cookbook**: six new task recipes — prove a dry run changes nothing, test config precedence, abort a destructive confirmation prompt, prove color output turns off, assert a generated script is executable, hunt down a flaky scenario — plus a new **Troubleshooting** section covering the failures every new spec hits once (direct argv vs `shell: true`, `$${...}` escaping, workdir isolation, CI-only snapshot diffs, pty hangs, blank `screen:` asserts, exit 2/3 semantics, host-env leaks, `--verbose`/`explain`).

## Drift guards

Every new ```yaml block validates through the real loader (`TestCookbook_SnippetsValid`), the by-task index stays in lockstep (`TestExamplesIndex_InLockstep`), and `hugo --gc --minify` builds clean with all new in-page anchors resolving.

## Test plan

- `go test .` (all drift guards) green locally
- Hugo build verified: sponsor link, logo, name section, and cookbook anchors present in `public/`

https://claude.ai/code/session_01Q2fDa4YigTBuFYCErfjAAP