### PR TITLE
feat(report): name the spec file and surface stderr in failure blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Console failure blocks now say WHERE and WHY without a `--verbose` detour:
+  every `FAILED:` / `ERROR:` / `TEARDOWN FAILED:` header names the spec file
+  that produced it (`FAILED: suite / scenario  (specs/convert.atago.yaml)`),
+  and an `exit_code` failure appends the failing command's captured stderr
+  tail (or its stdout tail when stderr is silent) — the actual error a command
+  printed on its way out, previously visible only under `--verbose`.
 - A hosted documentation website, https://nao1215.github.io/atago/, built
   with Hugo from the committed docs (no content is duplicated: `doc/cookbook.md`,
   `doc/examples.md`, `doc/real-world.md`, and the generated behavior docs under

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 381 scenarios
+74 suites · 383 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -328,11 +328,13 @@
   - [retry polls until the condition becomes true](#scenario-retry-polls-until-the-condition-becomes-true)
   - [retry fails the inner spec when until never holds](#scenario-retry-fails-the-inner-spec-when-until-never-holds)
   - [until with a changes target is a load-time error](#scenario-until-with-a-changes-target-is-a-load-time-error)
-- [atago self-hosting / run](#atago-self-hosting--run) — 6 scenarios
+- [atago self-hosting / run](#atago-self-hosting--run) — 8 scenarios
   - [a passing spec exits zero and reports PASS](#scenario-a-passing-spec-exits-zero-and-reports-pass)
   - [a failing assertion exits one and reports the failure](#scenario-a-failing-assertion-exits-one-and-reports-the-failure)
   - [an exit_code failure surfaces the command's stderr](#scenario-an-exit_code-failure-surfaces-the-commands-stderr)
+  - [an exit_code failure surfaces the command's stderr (windows)](#scenario-an-exit_code-failure-surfaces-the-commands-stderr-windows)
   - [an exit_code failure falls back to stdout when stderr is silent](#scenario-an-exit_code-failure-falls-back-to-stdout-when-stderr-is-silent)
+  - [an exit_code failure falls back to stdout when stderr is silent (windows)](#scenario-an-exit_code-failure-falls-back-to-stdout-when-stderr-is-silent-windows)
   - [a parse error exits with code two](#scenario-a-parse-error-exits-with-code-two)
   - [JSON report is valid JSON with a passed status](#scenario-json-report-is-valid-json-with-a-passed-status)
 - [atago self-hosting / sandbox_home (isolated per-OS home)](#atago-self-hosting--sandbox_home-isolated-per-os-home) — 3 scenarios
@@ -5660,6 +5662,7 @@ ${atago} run failing.atago.yaml
 - exit code is `1`
 - stdout contains `FAILED`, `expected exit code 0`, `(failing.atago.yaml)`
 ### Scenario: an exit_code failure surfaces the command's stderr
+_skipped on Windows_
 #### Given
 - Fixture file `stderr_cause.atago.yaml` is created.
 #### Inputs
@@ -5684,7 +5687,34 @@ ${atago} run stderr_cause.atago.yaml
 #### Then
 - exit code is `1`
 - stdout contains `Stderr:`, `conversion aborted: bad header`
+### Scenario: an exit_code failure surfaces the command's stderr (windows)
+_only on Windows_
+#### Given
+- Fixture file `stderr_cause.atago.yaml` is created.
+#### Inputs
+_Fixture `stderr_cause.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: converter fails loudly
+    steps:
+      - run:
+          shell: true
+          command: "echo conversion aborted: bad header 1>&2 & exit 3"
+      - assert:
+          exit_code: 0
+```
+#### When
+```shell
+${atago} run stderr_cause.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `Stderr:`, `conversion aborted: bad header`
 ### Scenario: an exit_code failure falls back to stdout when stderr is silent
+_skipped on Windows_
 #### Given
 - Fixture file `stdout_cause.atago.yaml` is created.
 #### Inputs
@@ -5699,6 +5729,32 @@ scenarios:
       - run:
           shell: true
           command: "echo wrote 0 of 3 files; exit 3"
+      - assert:
+          exit_code: 0
+```
+#### When
+```shell
+${atago} run stdout_cause.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `Stdout:`, `wrote 0 of 3 files`
+### Scenario: an exit_code failure falls back to stdout when stderr is silent (windows)
+_only on Windows_
+#### Given
+- Fixture file `stdout_cause.atago.yaml` is created.
+#### Inputs
+_Fixture `stdout_cause.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: converter fails on stdout
+    steps:
+      - run:
+          shell: true
+          command: "echo wrote 0 of 3 files & exit 3"
       - assert:
           exit_code: 0
 ```

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 379 scenarios
+74 suites · 381 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -328,9 +328,11 @@
   - [retry polls until the condition becomes true](#scenario-retry-polls-until-the-condition-becomes-true)
   - [retry fails the inner spec when until never holds](#scenario-retry-fails-the-inner-spec-when-until-never-holds)
   - [until with a changes target is a load-time error](#scenario-until-with-a-changes-target-is-a-load-time-error)
-- [atago self-hosting / run](#atago-self-hosting--run) — 4 scenarios
+- [atago self-hosting / run](#atago-self-hosting--run) — 6 scenarios
   - [a passing spec exits zero and reports PASS](#scenario-a-passing-spec-exits-zero-and-reports-pass)
   - [a failing assertion exits one and reports the failure](#scenario-a-failing-assertion-exits-one-and-reports-the-failure)
+  - [an exit_code failure surfaces the command's stderr](#scenario-an-exit_code-failure-surfaces-the-commands-stderr)
+  - [an exit_code failure falls back to stdout when stderr is silent](#scenario-an-exit_code-failure-falls-back-to-stdout-when-stderr-is-silent)
   - [a parse error exits with code two](#scenario-a-parse-error-exits-with-code-two)
   - [JSON report is valid JSON with a passed status](#scenario-json-report-is-valid-json-with-a-passed-status)
 - [atago self-hosting / sandbox_home (isolated per-OS home)](#atago-self-hosting--sandbox_home-isolated-per-os-home) — 3 scenarios
@@ -5656,7 +5658,57 @@ ${atago} run failing.atago.yaml
 ```
 #### Then
 - exit code is `1`
-- stdout contains `FAILED`, `expected exit code 0`
+- stdout contains `FAILED`, `expected exit code 0`, `(failing.atago.yaml)`
+### Scenario: an exit_code failure surfaces the command's stderr
+#### Given
+- Fixture file `stderr_cause.atago.yaml` is created.
+#### Inputs
+_Fixture `stderr_cause.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: converter fails loudly
+    steps:
+      - run:
+          shell: true
+          command: "echo conversion aborted: bad header 1>&2; exit 3"
+      - assert:
+          exit_code: 0
+```
+#### When
+```shell
+${atago} run stderr_cause.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `Stderr:`, `conversion aborted: bad header`
+### Scenario: an exit_code failure falls back to stdout when stderr is silent
+#### Given
+- Fixture file `stdout_cause.atago.yaml` is created.
+#### Inputs
+_Fixture `stdout_cause.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: converter fails on stdout
+    steps:
+      - run:
+          shell: true
+          command: "echo wrote 0 of 3 files; exit 3"
+      - assert:
+          exit_code: 0
+```
+#### When
+```shell
+${atago} run stdout_cause.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `Stdout:`, `wrote 0 of 3 files`
 ### Scenario: a parse error exits with code two
 #### Given
 - Fixture file `broken.atago.yaml` is created.

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -27,7 +27,13 @@ func intList(ns []int) string {
 
 // CheckResult is the structured outcome of one assertion.
 type CheckResult struct {
-	OK       bool
+	OK bool
+	// Target is the assertion target family that produced this result (the
+	// spec.AssertTarget string, e.g. "exit_code", "stdout", "file"). Reports
+	// branch on it structurally — e.g. the console failure block appends the
+	// captured stderr tail only for exit_code failures — instead of sniffing
+	// the human-facing Desc.
+	Target   string
 	Desc     string // human label, e.g. `assert stdout contains "Alice"`
 	Expected string
 	Actual   string
@@ -115,7 +121,9 @@ func CheckAll(a *spec.Assert, res *runner.Result, env Env) []*CheckResult {
 	}
 	out := make([]*CheckResult, 0, len(targets))
 	for _, t := range targets {
-		out = append(out, checkTarget(a, t, res, env))
+		r := checkTarget(a, t, res, env)
+		r.Target = string(t)
+		out = append(out, r)
 	}
 	return out
 }

--- a/internal/report/console.go
+++ b/internal/report/console.go
@@ -2,10 +2,14 @@ package report
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/nao1215/atago/internal/assert"
 	"github.com/nao1215/atago/internal/engine"
+	"github.com/nao1215/atago/internal/runner"
+	"github.com/nao1215/atago/internal/spec"
 )
 
 // writeSummary prints the final tally line. The uppercase status word
@@ -47,17 +51,28 @@ func writeSummary(b *strings.Builder, color bool, c engine.Counts, total int, d 
 }
 
 // writeDetail prints the failure/error block for a scenario, or nothing if it
-// passed or was skipped.
-func writeDetail(b *strings.Builder, color bool, suite string, sc *engine.ScenarioResult) {
+// passed or was skipped. specPath names the spec file in each block header so a
+// multi-file directory run points at the YAML to edit instead of forcing a grep
+// for the scenario name; it is empty in direct API use, which keeps the header
+// in its historical shape.
+func writeDetail(b *strings.Builder, color bool, suite, specPath string, sc *engine.ScenarioResult) {
+	where := specSuffix(specPath)
 	switch sc.Status {
 	case engine.StatusFailed:
 		cmd := lastCommand(sc)
+		var lastRun *runner.Result
 		for _, step := range sc.Steps {
+			// Track the most recent run result BEFORE rendering this step's
+			// checks: a run step's own retry `until` checks assert against that
+			// step's result.
+			if step.Run != nil {
+				lastRun = step.Run
+			}
 			for _, ck := range step.Checks {
 				if ck == nil || ck.OK {
 					continue
 				}
-				fmt.Fprintf(b, "\n%s %s / %s\n", colorize(color, cRed+cBold, "FAILED:"), suite, sc.Name)
+				fmt.Fprintf(b, "\n%s %s / %s%s\n", colorize(color, cRed+cBold, "FAILED:"), suite, sc.Name, where)
 				fmt.Fprintf(b, "\nStep:\n  %s\n", ck.Desc)
 				if cmd != "" {
 					fmt.Fprintf(b, "\nCommand:\n  %s\n", cmd)
@@ -78,6 +93,7 @@ func writeDetail(b *strings.Builder, color bool, suite string, sc *engine.Scenar
 				if ck.Hint != "" {
 					fmt.Fprintf(b, "\nHint:\n  %s\n", ck.Hint)
 				}
+				writeFailureStreams(b, ck, lastRun)
 				// Keep console output compact: reference the durable payloads by path
 				// rather than dumping them inline (#48).
 				if len(ck.ArtifactFiles) > 0 {
@@ -97,14 +113,14 @@ func writeDetail(b *strings.Builder, color bool, suite string, sc *engine.Scenar
 			// it as "step 0 ()" is misleading. Use the phase label — distinguishing a
 			// suite.setup failure from service readiness so neither is mislabeled — so
 			// every report format agrees.
-			var where string
+			var phase string
 			if isSetupError(step) {
-				where = setupPhaseLabelFor(step)
+				phase = setupPhaseLabelFor(step)
 			} else {
-				where = fmt.Sprintf("step %d (%s)", step.Index, step.Kind)
+				phase = fmt.Sprintf("step %d (%s)", step.Index, step.Kind)
 			}
-			fmt.Fprintf(b, "\n%s %s / %s\n  %s: %s\n",
-				colorize(color, cRed+cBold, "ERROR:"), suite, sc.Name, where, step.ErrMsg)
+			fmt.Fprintf(b, "\n%s %s / %s%s\n  %s: %s\n",
+				colorize(color, cRed+cBold, "ERROR:"), suite, sc.Name, where, phase, step.ErrMsg)
 		}
 	}
 	// A failed teardown never flips the verdict — the steps decide that — but
@@ -115,15 +131,15 @@ func writeDetail(b *strings.Builder, color bool, suite string, sc *engine.Scenar
 				if ck == nil || ck.OK {
 					continue
 				}
-				fmt.Fprintf(b, "\n%s %s / %s\n", colorize(color, cYellow+cBold, "TEARDOWN FAILED:"), suite, sc.Name)
+				fmt.Fprintf(b, "\n%s %s / %s%s\n", colorize(color, cYellow+cBold, "TEARDOWN FAILED:"), suite, sc.Name, where)
 				fmt.Fprintf(b, "\nStep:\n  %s\n", ck.Desc)
 				if ck.Hint != "" {
 					fmt.Fprintf(b, "\nHint:\n  %s\n", ck.Hint)
 				}
 			}
 			if step.ErrMsg != "" {
-				fmt.Fprintf(b, "\n%s %s / %s\n  teardown step %d (%s): %s\n",
-					colorize(color, cYellow+cBold, "TEARDOWN FAILED:"), suite, sc.Name, step.Index, step.Kind, step.ErrMsg)
+				fmt.Fprintf(b, "\n%s %s / %s%s\n  teardown step %d (%s): %s\n",
+					colorize(color, cYellow+cBold, "TEARDOWN FAILED:"), suite, sc.Name, where, step.Index, step.Kind, step.ErrMsg)
 			}
 		}
 	}
@@ -227,6 +243,58 @@ func lastCommand(sc *engine.ScenarioResult) string {
 		}
 	}
 	return cmd
+}
+
+// specSuffix renders the spec-file annotation appended to failure headers, or
+// "" when the result carries no path (direct API use).
+func specSuffix(specPath string) string {
+	if specPath == "" {
+		return ""
+	}
+	return fmt.Sprintf("  (%s)", filepath.ToSlash(specPath))
+}
+
+// failureStreamTail bounds how much captured output an exit_code failure block
+// inlines: enough to show the actual error a command printed on its way out,
+// small enough to keep the console report scannable. --verbose still shows
+// everything.
+const failureStreamTail = 10
+
+// writeFailureStreams appends the failing command's captured stderr tail (or
+// stdout tail when stderr is empty) to an exit_code failure block. The WHY of
+// a non-zero exit almost always sits on stderr, and hiding it behind --verbose
+// made the most common first failure a dead end. Stream asserts (stdout,
+// stderr, body, …) already display the stream they matched, so only exit_code
+// failures grow this section. run.Stderr/Stdout arrive already masked by the
+// engine, like every other StepResult field the reports render.
+func writeFailureStreams(b *strings.Builder, ck *assert.CheckResult, run *runner.Result) {
+	if ck.Target != string(spec.AssertExitCode) || run == nil {
+		return
+	}
+	stream, label := run.Stderr, "Stderr"
+	if len(stream) == 0 {
+		stream, label = run.Stdout, "Stdout"
+	}
+	if len(stream) == 0 {
+		return
+	}
+	tail, kept, total := tailLines(stream, failureStreamTail)
+	if kept < total {
+		fmt.Fprintf(b, "\n%s (last %d of %d lines):\n%s\n", label, kept, total, indent(tail))
+		return
+	}
+	fmt.Fprintf(b, "\n%s:\n%s\n", label, indent(tail))
+}
+
+// tailLines returns the last n lines of buf (sans trailing newline), how many
+// lines it kept, and how many the buffer held in total.
+func tailLines(buf []byte, n int) (tail string, kept, total int) {
+	lines := strings.Split(strings.TrimRight(string(buf), "\n"), "\n")
+	total = len(lines)
+	if total > n {
+		lines = lines[total-n:]
+	}
+	return strings.Join(lines, "\n"), len(lines), total
 }
 
 func indent(s string) string {

--- a/internal/report/render.go
+++ b/internal/report/render.go
@@ -73,7 +73,7 @@ func Render(w io.Writer, f Format, results []*engine.SuiteResult, opts ...Option
 		hardFail := false
 		for _, res := range results {
 			for i := range res.Scenarios {
-				writeDetail(&b, color, res.Suite, &res.Scenarios[i])
+				writeDetail(&b, color, res.Suite, res.SpecPath, &res.Scenarios[i])
 			}
 			writeSuiteDetail(&b, color, res)
 			writeRepeatRates(&b, color, res)

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"encoding/xml"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -1088,5 +1089,138 @@ func TestColorize(t *testing.T) {
 	}
 	if got := colorize(true, cRed, "x"); got != cRed+"x"+cReset {
 		t.Errorf("colorized = %q", got)
+	}
+}
+
+// failedExitResults builds one suite whose scenario fails an exit_code assert
+// after a run step that captured output on the given streams. It is the fixture
+// for the failure-context sections (spec path, stderr/stdout tails).
+func failedExitResults(specPath string, stdout, stderr []byte) []*engine.SuiteResult {
+	return []*engine.SuiteResult{{
+		Suite:    "s1",
+		SpecPath: specPath,
+		Status:   engine.StatusFailed,
+		Duration: time.Millisecond,
+		Scenarios: []engine.ScenarioResult{
+			{Name: "f", Status: engine.StatusFailed, Duration: time.Millisecond, Steps: []engine.StepResult{
+				{Index: 0, Kind: "run", Run: &runner.Result{
+					Command: "mytool convert in.txt", ExitCode: 2, Stdout: stdout, Stderr: stderr}},
+				{Index: 1, Kind: "assert", Checks: []*assert.CheckResult{{
+					OK: false, Target: "exit_code", Desc: "assert exit_code is 0",
+					Expected: "exit code 0", Actual: "exit code 2",
+					Hint: "expected exit code 0 but the command exited with 2"}}},
+			}},
+		},
+	}}
+}
+
+// TestConsole_FailureNamesSpecFile: in a directory run the failure block must
+// name the spec file that produced it — with 40+ spec files, "FAILED: suite /
+// scenario" alone forces the user to grep for the scenario name (and duplicate
+// suite names make even that ambiguous). The path is appended to the FAILED /
+// ERROR / TEARDOWN FAILED headers; an empty SpecPath (direct API use) keeps the
+// old header untouched.
+func TestConsole_FailureNamesSpecFile(t *testing.T) {
+	t.Parallel()
+	var b bytes.Buffer
+	if err := Render(&b, FormatConsole, failedExitResults("specs/convert.atago.yaml", nil, []byte("boom\n"))); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(b.String(), "FAILED: s1 / f  (specs/convert.atago.yaml)") {
+		t.Errorf("failure header does not name the spec file:\n%s", b.String())
+	}
+
+	// An errored scenario names the file too.
+	errRes := []*engine.SuiteResult{{
+		Suite: "s1", SpecPath: "specs/convert.atago.yaml", Status: engine.StatusFailed,
+		Scenarios: []engine.ScenarioResult{{Name: "e", Status: engine.StatusError,
+			Steps: []engine.StepResult{{Index: 0, Kind: "run", ErrMsg: "command not found"}}}},
+	}}
+	b.Reset()
+	if err := Render(&b, FormatConsole, errRes); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(b.String(), "ERROR: s1 / e  (specs/convert.atago.yaml)") {
+		t.Errorf("error header does not name the spec file:\n%s", b.String())
+	}
+
+	// No SpecPath -> the header keeps its exact old shape (no stray parens).
+	b.Reset()
+	if err := Render(&b, FormatConsole, failedExitResults("", nil, nil)); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(b.String(), "FAILED: s1 / f\n") || strings.Contains(b.String(), "f  (") {
+		t.Errorf("empty SpecPath must leave the header unchanged:\n%s", b.String())
+	}
+}
+
+// TestConsole_ExitCodeFailureShowsStderr: an exit_code mismatch is the most
+// common first failure a user hits, and the WHY almost always sits on the
+// command's stderr — which the default report never showed, sending users on a
+// --verbose detour. The failure block now prints the captured stderr tail (or
+// the stdout tail when stderr is empty) for exit_code failures only; stream
+// asserts already show the stream they matched against.
+func TestConsole_ExitCodeFailureShowsStderr(t *testing.T) {
+	t.Parallel()
+
+	// stderr present -> Stderr section with the content.
+	var b bytes.Buffer
+	if err := Render(&b, FormatConsole, failedExitResults("", nil, []byte("/bin/sh: 1: Bad substitution\n"))); err != nil {
+		t.Fatal(err)
+	}
+	out := b.String()
+	if !strings.Contains(out, "Stderr:") || !strings.Contains(out, "Bad substitution") {
+		t.Errorf("exit_code failure does not surface stderr:\n%s", out)
+	}
+
+	// stderr empty, stdout present -> Stdout section instead.
+	b.Reset()
+	if err := Render(&b, FormatConsole, failedExitResults("", []byte("wrote 0 files\n"), nil)); err != nil {
+		t.Fatal(err)
+	}
+	out = b.String()
+	if strings.Contains(out, "Stderr:") || !strings.Contains(out, "Stdout:") || !strings.Contains(out, "wrote 0 files") {
+		t.Errorf("exit_code failure with empty stderr does not surface stdout:\n%s", out)
+	}
+
+	// Both empty -> neither section appears.
+	b.Reset()
+	if err := Render(&b, FormatConsole, failedExitResults("", nil, nil)); err != nil {
+		t.Fatal(err)
+	}
+	out = b.String()
+	if strings.Contains(out, "Stderr:") || strings.Contains(out, "Stdout:") {
+		t.Errorf("exit_code failure with no output must not print empty sections:\n%s", out)
+	}
+
+	// A long stderr is tailed, newest lines kept, with an honest header.
+	var long bytes.Buffer
+	for i := 1; i <= 30; i++ {
+		fmt.Fprintf(&long, "line %d\n", i)
+	}
+	b.Reset()
+	if err := Render(&b, FormatConsole, failedExitResults("", nil, long.Bytes())); err != nil {
+		t.Fatal(err)
+	}
+	out = b.String()
+	if !strings.Contains(out, "Stderr (last 10 of 30 lines):") {
+		t.Errorf("long stderr is not labeled as a tail:\n%s", out)
+	}
+	if strings.Contains(out, "line 1\n") || !strings.Contains(out, "line 30") {
+		t.Errorf("stderr tail must keep the newest lines:\n%s", out)
+	}
+
+	// A failing stream assert (not exit_code) does not grow a duplicate
+	// Stderr section — its Actual already shows the stream.
+	streamFail := failedExitResults("", nil, []byte("noise\n"))
+	streamFail[0].Scenarios[0].Steps[1].Checks[0] = &assert.CheckResult{
+		OK: false, Target: "stdout", Desc: `assert stdout contains "x"`,
+		Expected: "x", Actual: "y", Hint: "missing x"}
+	b.Reset()
+	if err := Render(&b, FormatConsole, streamFail); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(b.String(), "Stderr:") {
+		t.Errorf("stream-assert failure must not print the exit_code stderr section:\n%s", b.String())
 	}
 }

--- a/test/e2e/atago/run.atago.yaml
+++ b/test/e2e/atago/run.atago.yaml
@@ -59,7 +59,12 @@ scenarios:
               # points at the YAML to edit without grepping for the scenario.
               - (failing.atago.yaml)
 
+  # The inner command needs "emit a stream, then exit non-zero" in one shell
+  # line, and the separator differs per shell (';' in sh, '&' in cmd.exe), so
+  # the scenario comes in an OS-gated pair.
   - name: an exit_code failure surfaces the command's stderr
+    skip:
+      os: windows
     steps:
       - fixture:
           file: stderr_cause.atago.yaml
@@ -86,7 +91,36 @@ scenarios:
               - "Stderr:"
               - "conversion aborted: bad header"
 
+  - name: an exit_code failure surfaces the command's stderr (windows)
+    only:
+      os: windows
+    steps:
+      - fixture:
+          file: stderr_cause.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: sample
+            scenarios:
+              - name: converter fails loudly
+                steps:
+                  - run:
+                      shell: true
+                      command: "echo conversion aborted: bad header 1>&2 & exit 3"
+                  - assert:
+                      exit_code: 0
+      - run:
+          command: ${atago} run stderr_cause.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "Stderr:"
+              - "conversion aborted: bad header"
+
   - name: an exit_code failure falls back to stdout when stderr is silent
+    skip:
+      os: windows
     steps:
       - fixture:
           file: stdout_cause.atago.yaml
@@ -100,6 +134,33 @@ scenarios:
                   - run:
                       shell: true
                       command: "echo wrote 0 of 3 files; exit 3"
+                  - assert:
+                      exit_code: 0
+      - run:
+          command: ${atago} run stdout_cause.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "Stdout:"
+              - "wrote 0 of 3 files"
+
+  - name: an exit_code failure falls back to stdout when stderr is silent (windows)
+    only:
+      os: windows
+    steps:
+      - fixture:
+          file: stdout_cause.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: sample
+            scenarios:
+              - name: converter fails on stdout
+                steps:
+                  - run:
+                      shell: true
+                      command: "echo wrote 0 of 3 files & exit 3"
                   - assert:
                       exit_code: 0
       - run:

--- a/test/e2e/atago/run.atago.yaml
+++ b/test/e2e/atago/run.atago.yaml
@@ -55,6 +55,61 @@ scenarios:
             contains:
               - FAILED
               - expected exit code 0
+              # The failure header names the spec file, so a multi-file run
+              # points at the YAML to edit without grepping for the scenario.
+              - (failing.atago.yaml)
+
+  - name: an exit_code failure surfaces the command's stderr
+    steps:
+      - fixture:
+          file: stderr_cause.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: sample
+            scenarios:
+              - name: converter fails loudly
+                steps:
+                  - run:
+                      shell: true
+                      command: "echo conversion aborted: bad header 1>&2; exit 3"
+                  - assert:
+                      exit_code: 0
+      - run:
+          command: ${atago} run stderr_cause.atago.yaml
+      - assert:
+          exit_code: 1
+          # The WHY of a non-zero exit sits on stderr; the failure block must
+          # show it instead of hiding it behind --verbose.
+          stdout:
+            contains:
+              - "Stderr:"
+              - "conversion aborted: bad header"
+
+  - name: an exit_code failure falls back to stdout when stderr is silent
+    steps:
+      - fixture:
+          file: stdout_cause.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: sample
+            scenarios:
+              - name: converter fails on stdout
+                steps:
+                  - run:
+                      shell: true
+                      command: "echo wrote 0 of 3 files; exit 3"
+                  - assert:
+                      exit_code: 0
+      - run:
+          command: ${atago} run stdout_cause.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "Stdout:"
+              - "wrote 0 of 3 files"
 
   - name: a parse error exits with code two
     steps:


### PR DESCRIPTION
## Summary

Two console-report improvements from the project review, both TDD (unit tests in `internal/report` first, then self-hosted E2E scenarios):

- **Failure blocks surface the WHY**: an `exit_code` failure now appends the failing command's captured stderr tail (last 10 lines, honest `(last N of M lines)` header when truncated), falling back to the stdout tail when stderr is silent. Previously the real cause (e.g. `/bin/sh: 1: Bad substitution`) was visible only under `--verbose`. Stream asserts are unchanged — they already display the stream they matched. Streams arrive already masked, like every StepResult field the reports render.
- **Failure blocks say WHERE**: every `FAILED:` / `ERROR:` / `TEARDOWN FAILED:` header appends the spec path (`FAILED: suite / scenario  (specs/convert.atago.yaml)`), so a 40-file directory run points at the YAML to edit. An empty SpecPath (direct API use) keeps the historical header shape.

`assert.CheckResult` gains a structural `Target` field (set centrally in `CheckAll`) so the report layer branches on the assertion family instead of sniffing `Desc` strings.

## Tests

- `TestConsole_FailureNamesSpecFile`, `TestConsole_ExitCodeFailureShowsStderr` (written first, red → green)
- Self-hosted E2E: 3 scenarios in `test/e2e/atago/run.atago.yaml` (stderr surfaced, stdout fallback, spec path in header); `make e2e` green (389 scenarios)
- `go test ./...`, `golangci-lint run` (0 issues), `make docs` regenerated `doc/e2e/atago.md`

https://claude.ai/code/session_01Q2fDa4YigTBuFYCErfjAAP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Console failure output now includes the originating spec file path for easier debugging.
  * Exit-code failures now show the relevant command output directly in the console, with a fallback to stdout when stderr is empty.

* **Bug Fixes**
  * Improved failure details so important diagnostics are visible without needing verbose mode.
  * Added clearer teardown and step error labels in console output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->