### PR TITLE
fix(pty): defuse vt10x crash and hang on adversarial screen transcripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,19 @@ and this project follows [Semantic Versioning](https://semver.org/).
   these suites on its own initiative — they are not the upstream projects'
   official test suites, and those projects are not affiliated with atago.
 
+### Fixed
+
+- A `screen:` assertion no longer crashes or hangs atago on adversarial
+  terminal output. The vt10x emulator panicked on a negative CSI parameter
+  (`CSI -10 P` reached slice arithmetic in delete/insert-chars) and spun for
+  minutes on an oversized repeat count (`CSI 80111111110 Z` steps one tab stop
+  at a time); both shapes — plus variants that hide behind bytes vt10x's
+  decoder silently skips — are now defused before the transcript reaches the
+  emulator, with a recover backstop so an unknown parser bug fails only the
+  assertion, not the process. Found by the new `FuzzRenderScreen` fuzz target,
+  which asserts the rendered screen's row/column budgets and UTF-8 validity
+  across pathological ANSI input.
+
 ## [0.9.0] - 2026-07-08
 
 A second hardening release. Parallel bug hunters and Go-native fuzzing swept the

--- a/internal/runner/ptyrun/fuzz_test.go
+++ b/internal/runner/ptyrun/fuzz_test.go
@@ -1,0 +1,123 @@
+package ptyrun
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/nao1215/atago/internal/spec"
+)
+
+// FuzzRenderScreen attacks the vt100 screen-rendering path (#27). RenderScreen
+// feeds the ENTIRE raw pty transcript — arbitrary bytes chosen by the program
+// under test — straight into the third-party vt10x escape parser whenever a
+// spec asserts `screen:`. A panic in that parser would crash atago mid-suite,
+// so the fuzzer explores pathological ANSI (huge CSI params, truncated escapes,
+// unterminated OSC, alt-screen toggles, SGR spam, invalid UTF-8, NUL bytes,
+// very long lines, CR/LF mixes) across a range of terminal geometries.
+//
+// Invariants asserted (not just "no panic"), derived from what the code
+// actually guarantees:
+//   - line budget: vt10x.State.String emits exactly `rows` rows, and
+//     RenderScreen only strips trailing blank rows, so the rendered screen
+//     never has MORE than `rows` lines;
+//   - column budget: String emits exactly `cols` runes per row and RenderScreen
+//     only TrimRights each line, so every rendered line is at most `cols` runes
+//     wide (matching TestRenderScreen_TruncatesAtCols);
+//   - valid UTF-8: the emulator drops invalid UTF-8 input bytes before they
+//     reach a cell and back-fills untouched cells with a space, so the returned
+//     screen is always valid UTF-8 even though the transcript need not be.
+func FuzzRenderScreen(f *testing.F) {
+	// Well-formed baselines (mirror screen_test.go).
+	f.Add([]byte("loading...\rdone.     \r\nnext\r\n"), 24, 80)
+	f.Add([]byte("garbage\r\n\x1b[2J\x1b[HMain Menu\r\n> Settings\r\n"), 10, 40)
+
+	// Huge / negative / empty CSI parameters.
+	f.Add([]byte("\x1b[99999999;99999999H"), 24, 80)
+	f.Add([]byte("\x1b[-1;-1Hx"), 24, 80)
+	f.Add([]byte("\x1b[;;;;;;Hx\x1b[999999999999999999999999999999m"), 5, 5)
+	// Regression: a negative DCH/ICH parameter drove vt10x's deleteChars /
+	// insertBlanks into slice-bounds-out-of-range panics (found by this fuzzer);
+	// sanitizeTranscript now discards these malformed sequences.
+	f.Add([]byte("\x1b[-10P"), 76, 28)
+	f.Add([]byte("\x1b[-5@"), 24, 80)
+	f.Add([]byte("abc\x1b[-99Pdef"), 8, 12)
+
+	// Truncated / bare escape sequences at end of stream.
+	f.Add([]byte("text\x1b["), 24, 80)
+	f.Add([]byte("text\x1b]"), 24, 80)
+	f.Add([]byte("text\x1b"), 24, 80)
+	f.Add([]byte("\x1b[38;2;"), 24, 80)
+
+	// OSC without terminator, then more input.
+	f.Add([]byte("\x1b]0;title with no ST or BEL and lots of text after it"), 24, 80)
+	f.Add([]byte("\x1b]0;title\x07visible"), 24, 80)
+
+	// Alternate-screen enter/exit.
+	f.Add([]byte("main\x1b[?1049hALT SCREEN\x1b[?1049lback"), 8, 20)
+	f.Add([]byte("\x1b[?47h\x1b[2Jalt\x1b[?47l"), 8, 20)
+
+	// SGR spam.
+	f.Add([]byte(strings.Repeat("\x1b[1;31;42;4;7m", 500)+"x"), 4, 10)
+
+	// Invalid UTF-8 and lone continuation bytes.
+	f.Add([]byte{0xff, 0xfe, '\n', 0x80, 0x80, 'a'}, 24, 80)
+	f.Add([]byte{0xc3, 0x28, 0xe2, 0x82, '\n'}, 24, 80) // invalid + truncated multibyte
+
+	// NUL bytes.
+	f.Add([]byte("a\x00b\x00c\r\n\x00\x00"), 24, 80)
+
+	// Very long line (forces wrapping) and a tall geometry.
+	f.Add([]byte(strings.Repeat("W", 4096)), 200, 300)
+
+	// CR / LF mixes.
+	f.Add([]byte("a\rb\nc\r\nd\n\re"), 6, 6)
+
+	// Realistic htop-style frame with a menu bar, meters, and a process row.
+	f.Add([]byte("\x1b[2J\x1b[H\x1b[46;30m 1 \x1b[0m[\x1b[42m||||    \x1b[0m 55%]\r\n"+
+		"\x1b[46;30m 2 \x1b[0m[\x1b[41m||||||| \x1b[0m 88%]\r\n"+
+		"  PID USER      CPU% MEM%  Command\r\n"+
+		"\x1b[7m 1234 nao       12.0  3.4  atago run suite.atago.yaml\x1b[0m\r\n"), 24, 80)
+
+	// Degenerate geometries the harness must clamp.
+	f.Add([]byte("clamp me"), 0, 0)
+	f.Add([]byte("clamp me"), -100, -100)
+
+	f.Fuzz(func(t *testing.T, transcript []byte, rows, cols int) {
+		// Explore geometry too, but keep it terminal-shaped: vt10x requires at
+		// least 1x1, and a huge screen just wastes fuzz time, so clamp to a sane
+		// band rather than rejecting the input.
+		rows = clampGeom(rows)
+		cols = clampGeom(cols)
+
+		got := RenderScreen(transcript, &spec.PTY{Rows: rows, Cols: cols})
+
+		if !utf8.ValidString(got) {
+			t.Fatalf("RenderScreen returned invalid UTF-8: %q\ntranscript=%q rows=%d cols=%d", got, transcript, rows, cols)
+		}
+
+		if got == "" {
+			return // an empty screen has zero lines; both budgets hold trivially.
+		}
+		lines := strings.Split(got, "\n")
+		if len(lines) > rows {
+			t.Fatalf("screen has %d lines, exceeds rows=%d\ntranscript=%q cols=%d\nscreen=%q", len(lines), rows, transcript, cols, got)
+		}
+		for i, l := range lines {
+			if n := utf8.RuneCountInString(l); n > cols {
+				t.Fatalf("line %d is %d runes wide, exceeds cols=%d\ntranscript=%q rows=%d\nline=%q", i, n, cols, transcript, rows, l)
+			}
+		}
+	})
+}
+
+// clampGeom keeps a fuzzed terminal dimension in the inclusive band 1..500.
+func clampGeom(v int) int {
+	if v < 1 {
+		return 1
+	}
+	if v > 500 {
+		return 500
+	}
+	return v
+}

--- a/internal/runner/ptyrun/screen.go
+++ b/internal/runner/ptyrun/screen.go
@@ -1,7 +1,9 @@
 package ptyrun
 
 import (
+	"bytes"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/hinshun/vt10x"
 	"github.com/nao1215/atago/internal/spec"
@@ -22,7 +24,7 @@ func RenderScreen(transcript []byte, p *spec.PTY) string {
 		cols = p.Cols
 	}
 	term := vt10x.New(vt10x.WithSize(cols, rows))
-	_, _ = term.Write(transcript)
+	writeTranscript(term, sanitizeTranscript(transcript))
 
 	lines := strings.Split(term.String(), "\n")
 	for i, l := range lines {
@@ -35,4 +37,205 @@ func RenderScreen(transcript []byte, p *spec.PTY) string {
 		end--
 	}
 	return strings.Join(lines[:end], "\n")
+}
+
+// writeTranscript feeds the transcript to the emulator, containing panics
+// from vt10x's escape parser. The transcript is arbitrary bytes chosen by the
+// program under test, and unmaintained vt10x runs strconv.Atoi over CSI
+// parameters and feeds the result straight into slice arithmetic — a crash
+// there must not take down the whole atago process mid-suite. The known-bad
+// shapes are defused up front by sanitizeTranscript, which preserves the rest
+// of the frame; this recover is the backstop for whatever shape the fuzzer has
+// not met yet. On panic the screen state built so far still renders — vt10x
+// mutates cells as it parses and releases its lock via defer during unwind —
+// so the assertion compares against everything drawn before the malformed
+// sequence.
+func writeTranscript(term vt10x.Terminal, transcript []byte) {
+	defer func() { _ = recover() }()
+	_, _ = term.Write(transcript)
+}
+
+// maxCSIParamDigits bounds a CSI numeric parameter before the transcript
+// reaches vt10x: any digit run longer than this is clamped to all-nines.
+// Legitimate parameters never get near it — rows/cols top out at 4 digits and
+// SGR components at 3 — but several vt10x handlers loop PARAM times (CBT/CHT
+// tab stepping, scroll counts), so an adversarial "CSI 80111111110 Z" would
+// otherwise spin the emulator for minutes. 9999 iterations are instant.
+const maxCSIParamDigits = 4
+
+// sanitizeTranscript defuses the transcript shapes that crash or hang vt10x's
+// parser, mirroring exactly what its Write loop and state machine will see:
+//
+//   - Write silently DROPS lone invalid-UTF-8 bytes without touching parser
+//     state, and handleControlCodes makes NUL/ENQ/XON/XOFF/DEL (and friends)
+//     transparent to an escape in progress — so "ESC \x00 [" still opens a
+//     CSI sequence and the scanner must look through those bytes too.
+//   - csiEscape.put runs strconv.Atoi over each ';'-separated parameter, so a
+//     '-' (not a valid ECMA-48 parameter byte; a conformant terminal ignores
+//     the sequence) yields a NEGATIVE count that panics the slice arithmetic
+//     in deleteChars (CSI P / DCH) and insertBlanks (CSI @ / ICH). Sequences
+//     carrying one are dropped wholesale, as are sequences whose parameters
+//     contain non-ASCII runes (vt10x would truncate those to their low byte).
+//   - Loop-per-count handlers (CBT, CHT, scrolls) execute an absurd repeat
+//     count one step at a time, hanging the run for minutes; digit runs longer
+//     than maxCSIParamDigits are clamped to all-nines.
+//   - ESC inside a CSI restarts escape parsing and CAN/SUB reset the parameter
+//     buffer without leaving CSI state; the scan follows both so its notion of
+//     "the parameters vt10x will Atoi" never drifts from the real parser.
+//
+// Clean sequences — including OSC runs and truncated trailing escapes — pass
+// through byte-for-byte.
+func sanitizeTranscript(b []byte) []byte {
+	if bytes.IndexByte(b, 0x1b) < 0 {
+		return b // no ESC: nothing can start a CSI sequence.
+	}
+	out := make([]byte, 0, len(b))
+	i := 0
+scan:
+	for i < len(b) {
+		if b[i] != 0x1b {
+			out = append(out, b[i])
+			i++
+			continue
+		}
+		// ESC: find the rune that decides the escape kind, looking through the
+		// bytes vt10x's Write/handleControlCodes make transparent.
+		j := i + 1
+		for j < len(b) {
+			r, sz := utf8.DecodeRune(b[j:])
+			switch {
+			case r == utf8.RuneError && sz == 1:
+				j++ // invalid byte: dropped by Write before the parser sees it.
+				continue
+			case r == 0x1b:
+				// A second ESC restarts escape parsing: the first is inert.
+				out = append(out, b[i:j]...)
+				i = j
+				continue scan
+			case r < 0x20 || r == 0x7f:
+				j += sz // control code: handled out-of-band, escape state kept.
+				continue
+			}
+			break
+		}
+		if j >= len(b) || b[j] != '[' {
+			// Not a CSI (or a truncated trailing ESC): copy the ESC and rescan
+			// from the next byte, so non-CSI escapes pass through untouched.
+			out = append(out, b[i])
+			i++
+			continue
+		}
+		// CSI body: scan effective runes until the final byte (0x40..0x7E),
+		// tracking exactly the parameter bytes vt10x will accumulate.
+		body := make([]byte, 0, 16)
+		var controls []byte // side-effect control codes seen inside the sequence
+		hasMinus, hasWideRune := false, false
+		finalByte := byte(0)
+		k := j + 1
+		for k < len(b) {
+			r, sz := utf8.DecodeRune(b[k:])
+			if r == utf8.RuneError && sz == 1 {
+				k++ // transparent to vt10x's parser, transparent to the scan.
+				continue
+			}
+			if r == 0x1b {
+				// ESC restarts escape parsing: the sequence so far can never
+				// dispatch, so drop its parameter bytes — copying them verbatim
+				// would leave an OPEN CSI in the output if the aborting escape
+				// later gets dropped as malformed, and then ordinary text (say a
+				// final-range 'Z') would finalize the stale parameters into a
+				// quadrillion-step CBT (found by FuzzRenderScreen). Only the
+				// embedded control codes vt10x already executed are kept.
+				out = append(out, controls...)
+				i = k
+				continue scan
+			}
+			if r == 0x18 || r == 0x1a {
+				// CAN/SUB reset the parameter buffer but STAY in CSI state.
+				body = body[:0]
+				hasMinus, hasWideRune = false, false
+				k += sz
+				continue
+			}
+			if r < 0x20 || r == 0x7f {
+				// Other control codes are transparent to the CSI state but DO
+				// execute (tab, CR, LF move the cursor mid-sequence); remember
+				// them so a dropped sequence still replays its side effects.
+				controls = append(controls, byte(r&0x7f)) // r < 0x20 or == 0x7f here
+				k += sz
+				continue
+			}
+			if r > 0x7e {
+				// vt10x truncates the rune to its low byte — nonsense that can
+				// even finalize the sequence. Mirror the boundary, drop later.
+				hasWideRune = true
+				if low := byte(r & 0xff); low >= 0x40 && low <= 0x7e {
+					finalByte = low
+					k += sz
+					break
+				}
+				k += sz
+				continue
+			}
+			c := byte(r)
+			if c >= 0x40 && c <= 0x7e {
+				finalByte = c
+				k += sz
+				break
+			}
+			if c == '-' {
+				hasMinus = true
+			}
+			body = append(body, c)
+			k += sz
+		}
+		switch {
+		case finalByte == 0:
+			// Truncated trailing CSI: it can never dispatch, copy verbatim.
+			out = append(out, b[i:k]...)
+		case hasMinus || hasWideRune:
+			// Malformed parameters: a conformant terminal ignores the whole
+			// sequence, so drop it — replaying only the control codes it
+			// carried — and keep the surrounding frame intact.
+			out = append(out, controls...)
+		case len(clampDigitRuns(body)) != len(body):
+			// An oversized repeat count: replay embedded control codes, then
+			// re-emit the sequence with the digit runs clamped.
+			out = append(out, controls...)
+			out = append(out, 0x1b, '[')
+			out = append(out, clampDigitRuns(body)...)
+			out = append(out, finalByte)
+		default:
+			// Clean sequence: byte-for-byte, side-effect bytes included.
+			out = append(out, b[i:k]...)
+		}
+		i = k
+	}
+	return out
+}
+
+// clampDigitRuns rewrites every digit run longer than maxCSIParamDigits to
+// all-nines of that width, bounding the work a loop-per-count CSI handler can
+// be asked to do while leaving every legitimate parameter untouched.
+func clampDigitRuns(body []byte) []byte {
+	out := make([]byte, 0, len(body))
+	for i := 0; i < len(body); {
+		c := body[i]
+		if c < '0' || c > '9' {
+			out = append(out, c)
+			i++
+			continue
+		}
+		j := i
+		for j < len(body) && body[j] >= '0' && body[j] <= '9' {
+			j++
+		}
+		if j-i > maxCSIParamDigits {
+			out = append(out, bytes.Repeat([]byte{'9'}, maxCSIParamDigits)...)
+		} else {
+			out = append(out, body[i:j]...)
+		}
+		i = j
+	}
+	return out
 }

--- a/internal/runner/ptyrun/screen_test.go
+++ b/internal/runner/ptyrun/screen_test.go
@@ -3,6 +3,7 @@ package ptyrun
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nao1215/atago/internal/spec"
 )
@@ -48,6 +49,91 @@ func TestRenderScreen_TrailingNormalization(t *testing.T) {
 	got := RenderScreen([]byte("only line   \r\n"), &spec.PTY{Rows: 24, Cols: 80})
 	if got != "only line" {
 		t.Errorf("screen = %q, want %q (trailing spaces and blank rows stripped)", got, "only line")
+	}
+}
+
+// TestRenderScreen_NegativeCSIParamDoesNotCrash guards the fix for the crash
+// FuzzRenderScreen found: a negative CSI DCH ("\x1b[-10P") or ICH ("\x1b[-5@")
+// parameter drove vt10x's deleteChars/insertBlanks into a slice-bounds panic.
+// A real terminal treats "-" as an invalid parameter byte and ignores the whole
+// sequence; RenderScreen now drops it, so the surrounding text still renders.
+func TestRenderScreen_NegativeCSIParamDoesNotCrash(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name       string
+		transcript string
+	}{
+		{"DCH", "before\x1b[-10Pafter"},
+		{"ICH", "before\x1b[-5@after"},
+		{"large negative DCH", "x\x1b[-99999999Py"},
+	} {
+		got := RenderScreen([]byte(tc.transcript), &spec.PTY{Rows: 5, Cols: 40})
+		if !strings.Contains(got, "before") && !strings.Contains(got, "x") {
+			t.Errorf("%s: screen = %q, want the surrounding text preserved", tc.name, got)
+		}
+	}
+}
+
+// TestRenderScreen_PanicContainment guards the recover backstop: vt10x's
+// parser re-enters CSI across an invalid-rune run, so "ESC \xf3 [ -1 P"
+// reaches deleteChars with a negative parameter even though the byte-level
+// pre-filter sees no ESC-'[' pair (found by FuzzRenderScreen). The emulator's
+// panic must stay contained — the process survives and everything drawn before
+// the malformed sequence still renders.
+func TestRenderScreen_PanicContainment(t *testing.T) {
+	t.Parallel()
+	got := RenderScreen([]byte("drawn\r\n\x1b\xf3[-1P"), &spec.PTY{Rows: 5, Cols: 40})
+	if !strings.Contains(got, "drawn") {
+		t.Errorf("screen = %q, want the pre-panic content preserved", got)
+	}
+}
+
+// TestRenderScreen_DroppedSequenceStaysStateNeutral guards the second bug
+// FuzzRenderScreen found: dropping a malformed CSI must not re-open the
+// unterminated CSI before it. In the raw stream the second ESC aborts the
+// first sequence's 16-digit parameter buffer; a naive sanitizer that copies
+// the aborted prefix verbatim but deletes the aborting sequence leaves that
+// buffer OPEN in its output, and the ordinary text 'Z' that follows becomes
+// the final byte of a quadrillion-step CBT — hanging the emulator for hours.
+func TestRenderScreen_DroppedSequenceStaysStateNeutral(t *testing.T) {
+	t.Parallel()
+	got := RenderScreen([]byte("00\x1b[2\x89\xd40000000000000\x8300\x1b[2\x89\xd4\x82tZ"), &spec.PTY{Rows: 1, Cols: 140})
+	if !strings.Contains(got, "Z") {
+		t.Errorf("screen = %q, want the trailing text rendered", got)
+	}
+}
+
+// TestRenderScreen_HugeRepeatCountIsClamped guards the hang FuzzRenderScreen
+// found: vt10x executes CBT/CHT one tab stop at a time, so an adversarial
+// "CSI 80111111110 Z" spins for minutes. The sanitizer clamps oversized digit
+// runs, keeping the sequence's effect while bounding its cost.
+func TestRenderScreen_HugeRepeatCountIsClamped(t *testing.T) {
+	t.Parallel()
+	done := make(chan string, 1)
+	go func() {
+		done <- RenderScreen([]byte("x\x1b[80111111110Zy"), &spec.PTY{Rows: 5, Cols: 40})
+	}()
+	select {
+	case got := <-done:
+		// The clamped CBT legitimately tabs the cursor back to column 0, so
+		// 'y' overwrites 'x' — exactly what a real terminal shows. The point
+		// is completing at all, with the trailing text rendered.
+		if !strings.Contains(got, "y") {
+			t.Errorf("screen = %q, want the trailing text rendered", got)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("RenderScreen still hangs on a huge CSI repeat count")
+	}
+}
+
+// TestRenderScreen_KeepsValidCSI proves the negative-param guard leaves
+// well-formed CSI sequences (and their effects) untouched.
+func TestRenderScreen_KeepsValidCSI(t *testing.T) {
+	t.Parallel()
+	// A normal SGR-colored line plus a positive DCH must still render.
+	got := RenderScreen([]byte("\x1b[31mred\x1b[0m\r\n"), &spec.PTY{Rows: 5, Cols: 20})
+	if got != "red" {
+		t.Errorf("screen = %q, want %q", got, "red")
 	}
 }
 

--- a/internal/runner/ptyrun/testdata/fuzz/FuzzRenderScreen/1735bcc2fc524aa5
+++ b/internal/runner/ptyrun/testdata/fuzz/FuzzRenderScreen/1735bcc2fc524aa5
@@ -1,0 +1,4 @@
+go test fuzz v1
+[]byte("\x1b[1000000028Z")
+int(-61)
+int(55)

--- a/internal/runner/ptyrun/testdata/fuzz/FuzzRenderScreen/18f77f152f52ee0d
+++ b/internal/runner/ptyrun/testdata/fuzz/FuzzRenderScreen/18f77f152f52ee0d
@@ -1,0 +1,4 @@
+go test fuzz v1
+[]byte("\x1b\x00[92270000000000I0000A")
+int(60)
+int(67)

--- a/internal/runner/ptyrun/testdata/fuzz/FuzzRenderScreen/660d6c57c52c4a02
+++ b/internal/runner/ptyrun/testdata/fuzz/FuzzRenderScreen/660d6c57c52c4a02
@@ -1,0 +1,4 @@
+go test fuzz v1
+[]byte("\x1b[80111111110Z")
+int(62)
+int(-22)

--- a/internal/runner/ptyrun/testdata/fuzz/FuzzRenderScreen/97818cd8df3e0453
+++ b/internal/runner/ptyrun/testdata/fuzz/FuzzRenderScreen/97818cd8df3e0453
@@ -1,0 +1,4 @@
+go test fuzz v1
+[]byte("\x1b\xf3[-1P")
+int(54)
+int(51)

--- a/internal/runner/ptyrun/testdata/fuzz/FuzzRenderScreen/c7f871ddf292cdba
+++ b/internal/runner/ptyrun/testdata/fuzz/FuzzRenderScreen/c7f871ddf292cdba
@@ -1,0 +1,4 @@
+go test fuzz v1
+[]byte("00\x1b[2\x89\xd40000000000000\x8300\x1b[2\x89ԂtZ")
+int(-122)
+int(140)

--- a/internal/runner/ptyrun/testdata/fuzz/FuzzRenderScreen/e6f8ddefdf4720f4
+++ b/internal/runner/ptyrun/testdata/fuzz/FuzzRenderScreen/e6f8ddefdf4720f4
@@ -1,0 +1,4 @@
+go test fuzz v1
+[]byte("\x1b[-10P")
+int(76)
+int(28)


### PR DESCRIPTION
## Summary

`RenderScreen` feeds the raw pty transcript — arbitrary bytes chosen by the program under test — straight into the unmaintained vt10x emulator whenever a spec asserts `screen:`. Fuzzing found two ways that takes down the whole atago process:

- **Panic**: a negative CSI parameter (`CSI -10 P` / `CSI -5 @`) reaches `strconv.Atoi` and then slice arithmetic in vt10x's `deleteChars`/`insertBlanks` → `slice bounds out of range`. `'-'` is not a valid ECMA-48 parameter byte; a conformant terminal ignores the sequence.
- **Hang**: an oversized repeat count (`CSI 80111111110 Z`) makes CBT/CHT step one tab stop at a time — minutes of CPU per assertion.

Both shapes also hide behind bytes vt10x's decoder **silently skips** (lone invalid UTF-8 bytes, NUL and other transparent control codes), so `ESC \xf3 [` and `ESC \x00 [` still open a CSI. The fix is a sanitizer that mirrors vt10x's decode loop exactly (invalid-byte skipping, control-code transparency, ESC-restart, CAN/SUB buffer reset, low-byte truncation of wide runes) and:

- drops sequences with negative or non-ASCII parameters, replaying their embedded control codes so the parser state stays neutral — a dropped sequence must not re-open the unterminated CSI before it (a third hang the fuzzer found in an earlier version of this patch),
- clamps digit runs longer than 4 to `9999` (legit params never exceed 4 digits; 9999 loop steps are instant),
- passes every clean sequence through byte-for-byte,
- and keeps a `recover` backstop in `writeTranscript` so an unknown vt10x bug fails the assertion, not the process.

## Tests

- New `FuzzRenderScreen` target with pathological ANSI seeds; asserts row/column budgets and UTF-8 validity, not just no-panic. 3-minute local run: 44M execs, clean.
- All three fuzz-found crashers committed as regression seeds under `testdata/fuzz/`, plus named unit tests for each bug shape (negative param, state-neutral drop, clamped repeat count).
- `go test ./...` green, `golangci-lint run` 0 issues.

Note: adding `FuzzRenderScreen` to the scheduled fuzz.yml matrix is a separate PR (workflow-file scope).

https://claude.ai/code/session_01Q2fDa4YigTBuFYCErfjAAP