### PR TITLE
fix(cli): selector-aware no-match note, and fail empty selections under --ci

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,19 @@ and this project follows [Semantic Versioning](https://semver.org/).
   `/real-world/` now state explicitly that the atago project wrote and runs
   these suites on its own initiative — they are not the upstream projects'
   official test suites, and those projects are not affiliated with atago.
+- Under `--ci`, a `--filter`/`--tag`/`--skip-tag` selection that matches no
+  scenario now fails the run (exit 3, `ExitConfig`) instead of exiting 0 with
+  `PASSED 0 scenarios`, so a typo'd selector can no longer silently disable an
+  entire suite in a pipeline. Without `--ci` the same case stays a warning that
+  exits 0, leaving interactive workflows untouched.
+
+### Fixed
+
+- The "no scenarios matched" warning is now selector-aware. `--tag`/`--skip-tag`
+  say tags match exactly and point at `atago list`, while `--filter` keeps the
+  case-sensitive-substring note. Previously every empty selection was blamed on a
+  "case-sensitive substring", which is wrong for tags (they match by equality via
+  `==`) and sent users fixing the wrong thing.
 
 ## [0.9.0] - 2026-07-08
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ ssh       run a command on a remote host over SSH (edit host/user first)
 
 Every feature has a commented, runnable spec under [examples/](examples/), tested in CI on Linux, macOS, and Windows. The **[cookbook](https://nao1215.github.io/atago/cookbook/)** collects 50+ copyable recipes for common jobs — converting images, driving prompts and TUIs, simulating API failures offline, proving idempotency — and indexes every spec by task and by feature.
 
-Selection flags compose with any spec: `--filter NAME` (repeatable, and comma-separated for OR — `--filter a,b` or `--filter a --filter b` runs scenarios whose name contains `a` or `b`), `--tag T`, `--skip-tag T`, `--parallel N`, `--fail-fast`, and `--rerun-failed`. While authoring, `--verbose` traces every command, capture, and assertion verdict — for passing scenarios too.
+Selection flags compose with any spec: `--filter NAME` (repeatable, and comma-separated for OR — `--filter a,b` or `--filter a --filter b` runs scenarios whose name contains `a` or `b`), `--tag T` and `--skip-tag T` (tags match exactly, not by substring — `atago list` shows the available tags), `--parallel N`, `--fail-fast`, and `--rerun-failed`. While authoring, `--verbose` traces every command, capture, and assertion verdict — for passing scenarios too.
 
 ## Use it in CI
 
@@ -225,7 +225,7 @@ jobs:
 ```
 
 - `--report json|junit|gha|tap` picks the report format; the JSON shape is stable and versioned.
-- `--ci` enables deterministic, color-free output.
+- `--ci` enables deterministic, color-free output. It also turns an empty selection into a hard error: a `--filter`/`--tag`/`--skip-tag` that matches no scenario fails the run (exit 3) instead of passing an empty suite, so a typo cannot silently disable your specs. Without `--ci` the same case is a warning that still exits 0.
 - `--artifacts-dir DIR` persists the exact payloads a failed assertion compared, so a failure stays reviewable after the job ends.
 - Environment variable names listed under `secrets:` are masked as `***` in all reports and snapshots.
 

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 379 scenarios
+74 suites · 381 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -41,14 +41,16 @@
   - [a stray file outside the doublestar prefix breaks the exact contract (POSIX)](#scenario-a-stray-file-outside-the-doublestar-prefix-breaks-the-exact-contract-posix)
   - [a doublestar glob matches a nested redirect target (portable)](#scenario-a-doublestar-glob-matches-a-nested-redirect-target-portable)
   - [a doublestar prefix covers both redirect streams (portable)](#scenario-a-doublestar-prefix-covers-both-redirect-streams-portable)
-- [atago self-hosting / CLI scenario selection](#atago-self-hosting--cli-scenario-selection) — 7 scenarios
+- [atago self-hosting / CLI scenario selection](#atago-self-hosting--cli-scenario-selection) — 9 scenarios
   - [filter selects by a name substring](#scenario-filter-selects-by-a-name-substring)
   - [filter is OR across a comma-separated list](#scenario-filter-is-or-across-a-comma-separated-list)
   - [tag selects scenarios carrying the tag](#scenario-tag-selects-scenarios-carrying-the-tag)
   - [a repeated tag flag is OR](#scenario-a-repeated-tag-flag-is-or)
   - [skip-tag removes scenarios carrying the tag](#scenario-skip-tag-removes-scenarios-carrying-the-tag)
   - [tag and skip-tag compose as selected minus skipped](#scenario-tag-and-skip-tag-compose-as-selected-minus-skipped)
-  - [a filter that matches nothing selects an empty set and still exits zero](#scenario-a-filter-that-matches-nothing-selects-an-empty-set-and-still-exits-zero)
+  - [an empty filter selection fails under --ci with a substring hint](#scenario-an-empty-filter-selection-fails-under---ci-with-a-substring-hint)
+  - [an empty tag selection fails under --ci and names the exact-tag rule](#scenario-an-empty-tag-selection-fails-under---ci-and-names-the-exact-tag-rule)
+  - [without --ci an empty selection only warns and still exits zero](#scenario-without---ci-an-empty-selection-only-warns-and-still-exits-zero)
 - [atago self-hosting / completion](#atago-self-hosting--completion) — 5 scenarios
   - [bash completion emits a recognizable script](#scenario-bash-completion-emits-a-recognizable-script)
   - [zsh completion emits a compdef script](#scenario-zsh-completion-emits-a-compdef-script)
@@ -1227,7 +1229,7 @@ ${atago} run --ci --report json --tag fast --skip-tag slow inner.atago.yaml
 - exit code is `0`
 - stdout at `$.suites[0].scenarios` has length 1
 - stdout contains `"alpha"`
-### Scenario: a filter that matches nothing selects an empty set and still exits zero
+### Scenario: an empty filter selection fails under --ci with a substring hint
 #### Given
 - Fixture file `inner.atago.yaml` is created.
 #### Inputs
@@ -1251,8 +1253,62 @@ scenarios:
 ${atago} run --ci --report json --filter no_such_name inner.atago.yaml
 ```
 #### Then
+- exit code is `3`
+- stdout at `$.suites[0].scenarios` has length 0
+- stderr contains `no scenarios matched`, `--filter "no_such_name"`, `case-sensitive substring`
+### Scenario: an empty tag selection fails under --ci and names the exact-tag rule
+#### Given
+- Fixture file `inner.atago.yaml` is created.
+#### Inputs
+_Fixture `inner.atago.yaml`:_
+```text
+version: "1"
+suite: {name: inner}
+scenarios:
+  - name: alpha
+    tags: [fast]
+    steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+  - name: beta
+    tags: [slow]
+    steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+  - name: gamma
+    tags: [fast, slow]
+    steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+```
+#### When
+```shell
+${atago} run --ci --report json --tag no_such_tag inner.atago.yaml
+```
+#### Then
+- exit code is `3`
+- stderr contains `no scenarios matched`, `--tag "no_such_tag"`, `match tags exactly`, `atago list`
+### Scenario: without --ci an empty selection only warns and still exits zero
+#### Given
+- Fixture file `inner.atago.yaml` is created.
+#### Inputs
+_Fixture `inner.atago.yaml`:_
+```text
+version: "1"
+suite: {name: inner}
+scenarios:
+  - name: alpha
+    tags: [fast]
+    steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+  - name: beta
+    tags: [slow]
+    steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+  - name: gamma
+    tags: [fast, slow]
+    steps: [{run: {shell: true, command: "exit 0"}}, {assert: {exit_code: 0}}]
+```
+#### When
+```shell
+${atago} run --report json --filter no_such_name inner.atago.yaml
+```
+#### Then
 - exit code is `0`
 - stdout at `$.suites[0].scenarios` has length 0
+- stderr contains `warning: no scenarios matched`
 ## atago self-hosting / completion
 Source: `test/e2e/atago/completion.atago.yaml`
 ### Scenario: bash completion emits a recognizable script

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -183,6 +183,11 @@ func TestRunCmd_SelectionMatchesNothingWarns(t *testing.T) {
 	if !strings.Contains(errb.String(), `no scenarios matched --filter "no-such-name"`) {
 		t.Errorf("stderr = %q, want a no-match warning", errb.String())
 	}
+	// --filter matches by substring, so keep that note (only --tag/--skip-tag
+	// match exactly).
+	if !strings.Contains(errb.String(), "case-sensitive substring") {
+		t.Errorf("stderr = %q, want the --filter case-sensitive-substring note", errb.String())
+	}
 	// A matching selection stays quiet.
 	errb.Reset()
 	out.Reset()
@@ -1477,7 +1482,10 @@ func TestSubcommands_DefaultTargetIsDot(t *testing.T) {
 
 // TestRunCmd_TagSelectionNoMatchWarns proves a --tag/--skip-tag that selects
 // nothing still exits 0 but warns loudly, mentioning the exact selector — a
-// typo in CI must not greenlight in silence.
+// typo in CI must not greenlight in silence. The note must be selector-aware:
+// tags match EXACTLY (engine.hasAnyTag uses ==), so the warning must say so and
+// point at `atago list`, never repeat the --filter "case-sensitive substring"
+// note (which would send users fixing the wrong thing).
 func TestRunCmd_TagSelectionNoMatchWarns(t *testing.T) {
 	dir := t.TempDir()
 	p := writeSpec(t, dir, "ok.atago.yaml", passingSpec)
@@ -1486,8 +1494,18 @@ func TestRunCmd_TagSelectionNoMatchWarns(t *testing.T) {
 		if got := Main([]string{"run", "--tag", "no-such-tag", p}, &out, &errb); got != ExitOK {
 			t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitOK, errb.String())
 		}
-		if !strings.Contains(errb.String(), `--tag "no-such-tag"`) {
-			t.Errorf("stderr = %q, want a --tag no-match warning", errb.String())
+		s := errb.String()
+		if !strings.Contains(s, `--tag "no-such-tag"`) {
+			t.Errorf("stderr = %q, want a --tag no-match warning", s)
+		}
+		if !strings.Contains(s, "match tags exactly") {
+			t.Errorf("stderr = %q, want it to say tags match exactly", s)
+		}
+		if !strings.Contains(s, "atago list") {
+			t.Errorf("stderr = %q, want it to suggest `atago list`", s)
+		}
+		if strings.Contains(s, "case-sensitive substring") {
+			t.Errorf("stderr = %q, must not use the --filter substring note for a tag", s)
 		}
 	})
 	t.Run("skip-tag", func(t *testing.T) {
@@ -1510,8 +1528,87 @@ scenarios:
 		if got := Main([]string{"run", "--skip-tag", "slow", tp}, &out, &errb); got != ExitOK {
 			t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitOK, errb.String())
 		}
-		if !strings.Contains(errb.String(), `--skip-tag "slow"`) {
-			t.Errorf("stderr = %q, want a --skip-tag no-match warning", errb.String())
+		s := errb.String()
+		if !strings.Contains(s, `--skip-tag "slow"`) {
+			t.Errorf("stderr = %q, want a --skip-tag no-match warning", s)
+		}
+		if !strings.Contains(s, "match tags exactly") {
+			t.Errorf("stderr = %q, want it to say tags match exactly", s)
+		}
+		if strings.Contains(s, "case-sensitive substring") {
+			t.Errorf("stderr = %q, must not use the --filter substring note for a skip-tag", s)
+		}
+	})
+}
+
+// TestRunCmd_CIEmptySelectionFails proves that under --ci an empty selection is
+// a hard configuration error (exit 3), not a silent green PASSED-0: a typo'd
+// --tag/--filter/--skip-tag in a pipeline would otherwise disable the whole
+// suite forever. Without --ci the run keeps warning and exiting 0 so interactive
+// workflows are untouched. A selector that DOES match keeps exiting 0 even under
+// --ci — only the empty case fails.
+func TestRunCmd_CIEmptySelectionFails(t *testing.T) {
+	dir := t.TempDir()
+	p := writeSpec(t, dir, "ok.atago.yaml", passingSpec)
+
+	t.Run("tag empty under --ci fails", func(t *testing.T) {
+		var out, errb bytes.Buffer
+		if got := Main([]string{"run", "--ci", "--tag", "no-such-tag", p}, &out, &errb); got != ExitConfig {
+			t.Fatalf("exit = %d, want %d (ExitConfig) (stderr=%s)", got, ExitConfig, errb.String())
+		}
+		s := errb.String()
+		if !strings.Contains(s, "no scenarios matched") || !strings.Contains(s, `--tag "no-such-tag"`) {
+			t.Errorf("stderr = %q, want the CI empty-selection error naming --tag", s)
+		}
+		if !strings.Contains(s, "match tags exactly") {
+			t.Errorf("stderr = %q, want the exact-tag note", s)
+		}
+		if !strings.Contains(s, "atago list") {
+			t.Errorf("stderr = %q, want a hint on how to list scenarios", s)
+		}
+	})
+
+	t.Run("filter empty under --ci fails", func(t *testing.T) {
+		var out, errb bytes.Buffer
+		if got := Main([]string{"run", "--ci", "--filter", "no-such-name", p}, &out, &errb); got != ExitConfig {
+			t.Fatalf("exit = %d, want %d (ExitConfig) (stderr=%s)", got, ExitConfig, errb.String())
+		}
+		s := errb.String()
+		if !strings.Contains(s, "no scenarios matched") || !strings.Contains(s, `--filter "no-such-name"`) {
+			t.Errorf("stderr = %q, want the CI empty-selection error naming --filter", s)
+		}
+		if !strings.Contains(s, "case-sensitive substring") {
+			t.Errorf("stderr = %q, want the --filter substring note", s)
+		}
+	})
+
+	t.Run("no --ci keeps warning and exits 0", func(t *testing.T) {
+		var out, errb bytes.Buffer
+		if got := Main([]string{"run", "--tag", "no-such-tag", p}, &out, &errb); got != ExitOK {
+			t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitOK, errb.String())
+		}
+		if !strings.Contains(errb.String(), "warning: no scenarios matched") {
+			t.Errorf("stderr = %q, want a warning (not an error) without --ci", errb.String())
+		}
+	})
+
+	t.Run("--ci with a matching selector still passes", func(t *testing.T) {
+		var out, errb bytes.Buffer
+		if got := Main([]string{"run", "--ci", "--filter", "exit 0", p}, &out, &errb); got != ExitOK {
+			t.Fatalf("exit = %d, want %d (a matching selection must not fail) (stderr=%s)", got, ExitOK, errb.String())
+		}
+		if strings.Contains(errb.String(), "no scenarios matched") {
+			t.Errorf("stderr = %q, want no empty-selection message for a matching filter", errb.String())
+		}
+	})
+
+	t.Run("--ci with no selector runs normally", func(t *testing.T) {
+		var out, errb bytes.Buffer
+		if got := Main([]string{"run", "--ci", p}, &out, &errb); got != ExitOK {
+			t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitOK, errb.String())
+		}
+		if strings.Contains(errb.String(), "no scenarios matched") {
+			t.Errorf("stderr = %q, want no empty-selection message with no selector", errb.String())
 		}
 	})
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1535,6 +1535,9 @@ scenarios:
 		if !strings.Contains(s, "match tags exactly") {
 			t.Errorf("stderr = %q, want it to say tags match exactly", s)
 		}
+		if !strings.Contains(s, "atago list") {
+			t.Errorf("stderr = %q, want it to suggest `atago list`", s)
+		}
 		if strings.Contains(s, "case-sensitive substring") {
 			t.Errorf("stderr = %q, must not use the --filter substring note for a skip-tag", s)
 		}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -37,9 +37,9 @@ func runCmd(label string, args []string, stdout, stderr io.Writer) int {
 	var filter csvFlag
 	fs.Var(&filter, "filter", "run only scenarios whose name contains any of these comma-separated substrings (repeatable; OR semantics like --tag)")
 	var tag csvFlag
-	fs.Var(&tag, "tag", "run only scenarios with any of these tags (comma-separated and repeatable; OR semantics)")
+	fs.Var(&tag, "tag", "run only scenarios with any of these tags, matched exactly (comma-separated and repeatable; OR semantics)")
 	var skipTag csvFlag
-	fs.Var(&skipTag, "skip-tag", "skip scenarios with any of these tags (comma-separated and repeatable)")
+	fs.Var(&skipTag, "skip-tag", "skip scenarios with any of these tags, matched exactly (comma-separated and repeatable)")
 	artifactsDir := fs.String("artifacts-dir", "", "write deterministic failure artifacts (actual/expected payloads) under DIR for review tooling")
 	rerunFailed := fs.Bool("rerun-failed", false, "run only the scenarios that failed on the previous run (recorded in .atago/last-failed.json)")
 	repeat := fs.Int("repeat", 0, "run each selected scenario N times to surface flakiness; any failing iteration fails the run")
@@ -294,14 +294,20 @@ func runCmd(label string, args []string, stdout, stderr io.Writer) int {
 		return exit
 	}
 
-	// A selection that matches nothing still exits 0 (nothing ran, nothing
-	// failed), but stay loud about it: a typo'd --filter/--tag in CI would
-	// otherwise greenlight silently.
-	if len(filter) > 0 || len(tag) > 0 || len(skipTag) > 0 {
+	// A selection that matches nothing: interactively this still exits 0 (nothing
+	// ran, nothing failed) but stays loud; under --ci it is a hard config error so
+	// a typo'd --filter/--tag/--skip-tag cannot silently disable the whole suite in
+	// a pipeline forever.
+	if selectionActive {
 		total := 0
 		for _, r := range results {
 			total += len(r.Scenarios)
 		}
+		// total == 0 here can only mean the selectors excluded every scenario, never
+		// that the specs were empty: the loader rejects a spec with no scenarios, and
+		// a selected-but-skipped scenario (os gate, skip step) still appears in
+		// res.Scenarios. So this is precisely the "selectors filtered everything"
+		// case the task must fail on, not "the specs had nothing to run".
 		if total == 0 && ctx.Err() == nil {
 			var sel []string
 			if len(filter) > 0 {
@@ -313,7 +319,22 @@ func runCmd(label string, args []string, stdout, stderr io.Writer) int {
 			if len(skipTag) > 0 {
 				sel = append(sel, fmt.Sprintf("--skip-tag %q", strings.Join(skipTag, ",")))
 			}
-			fmt.Fprintf(stderr, label+": warning: no scenarios matched %s (name matching is a case-sensitive substring)\n", strings.Join(sel, " "))
+			tagActive := len(tag) > 0 || len(skipTag) > 0
+			// The note is selector-aware: --filter matches names by case-sensitive
+			// substring, but --tag/--skip-tag compare tags for EXACT equality
+			// (engine.hasAnyTag uses ==). A single "substring" note for tags would send
+			// users fixing the wrong thing, so name each selector's real rule.
+			note := selectorNoMatchNote(len(filter) > 0, tagActive)
+			if *ci {
+				fmt.Fprintf(stderr, label+": no scenarios matched %s under --ci; refusing to exit 0 (an empty selection would silently disable the suite). %s. Run `atago list` to see available scenarios and tags.\n", strings.Join(sel, " "), note)
+				exit = worseExit(exit, ExitConfig)
+			} else {
+				hint := note
+				if tagActive {
+					hint += "; run `atago list` to see the available tags"
+				}
+				fmt.Fprintf(stderr, label+": warning: no scenarios matched %s (%s)\n", strings.Join(sel, " "), hint)
+			}
 		}
 	}
 
@@ -540,6 +561,21 @@ func exitForSuite(res *engine.SuiteResult) int {
 	default:
 		return ExitInternal
 	}
+}
+
+// selectorNoMatchNote explains, per active selector, why a selection came up
+// empty. --filter matches scenario NAMES by case-sensitive substring, whereas
+// --tag/--skip-tag compare TAGS for exact equality (engine.hasAnyTag uses ==);
+// conflating the two rules would point users at the wrong fix.
+func selectorNoMatchNote(filterActive, tagActive bool) string {
+	var parts []string
+	if filterActive {
+		parts = append(parts, "--filter matches scenario names by case-sensitive substring")
+	}
+	if tagActive {
+		parts = append(parts, "--tag/--skip-tag match tags exactly")
+	}
+	return strings.Join(parts, "; ")
 }
 
 // worseExit returns the more severe of two exit codes, preferring failure codes

--- a/test/e2e/atago/cli_selection.atago.yaml
+++ b/test/e2e/atago/cli_selection.atago.yaml
@@ -111,13 +111,46 @@ scenarios:
             contains: '"alpha"'
             not_contains: '"gamma"'
 
-  - name: a filter that matches nothing selects an empty set and still exits zero
+  - name: an empty filter selection fails under --ci with a substring hint
     steps:
       - fixture: {file: inner.atago.yaml, content: *inner}
+      # Under --ci an empty selection is a hard config error (exit 3): a typo'd
+      # --filter must not silently disable the whole suite. The json report still
+      # renders (0 selected), but the exit code and stderr flag the mistake.
       - run: {command: "${atago} run --ci --report json --filter no_such_name inner.atago.yaml"}
+      - assert:
+          exit_code: 3
+          stdout:
+            json:
+              - path: "$.suites[0].scenarios"
+                length: 0
+      - assert:
+          stderr:
+            contains: ['no scenarios matched', '--filter "no_such_name"', 'case-sensitive substring']
+
+  - name: an empty tag selection fails under --ci and names the exact-tag rule
+    steps:
+      - fixture: {file: inner.atago.yaml, content: *inner}
+      # Tags match EXACTLY, so the note must say so and point at `atago list`,
+      # never repeat the --filter substring wording.
+      - run: {command: "${atago} run --ci --report json --tag no_such_tag inner.atago.yaml"}
+      - assert:
+          exit_code: 3
+      - assert:
+          stderr:
+            contains: ['no scenarios matched', '--tag "no_such_tag"', 'match tags exactly', 'atago list']
+            not_contains: 'case-sensitive substring'
+
+  - name: without --ci an empty selection only warns and still exits zero
+    steps:
+      - fixture: {file: inner.atago.yaml, content: *inner}
+      - run: {command: "${atago} run --report json --filter no_such_name inner.atago.yaml"}
       - assert:
           exit_code: 0
           stdout:
             json:
               - path: "$.suites[0].scenarios"
                 length: 0
+      - assert:
+          stderr:
+            contains: 'warning: no scenarios matched'

--- a/website/content/ci.md
+++ b/website/content/ci.md
@@ -26,7 +26,7 @@ jobs:
 ```
 
 - `--report json|junit|gha|tap` picks the report format; the JSON shape is stable and versioned ([sample JSON](/samples/report.json), [JUnit](/samples/report.junit.xml), [TAP](/samples/report.tap)).
-- `--ci` enables deterministic, color-free output.
+- `--ci` enables deterministic, color-free output. It also turns an empty selection into a hard error: a `--filter`/`--tag`/`--skip-tag` that matches no scenario fails the run (exit 3) instead of passing an empty suite, so a typo cannot silently disable your specs. Without `--ci` the same case is a warning that still exits 0.
 - `--artifacts-dir DIR` persists the exact payloads a failed assertion compared, so a failure stays reviewable after the job ends.
 - Environment variable names listed under `secrets:` are masked as `***` in all reports and snapshots.
 

--- a/website/content/reference.md
+++ b/website/content/reference.md
@@ -23,7 +23,7 @@ description: atago subcommands, scenario selection flags, snapshot updating and 
 
 ## Selecting scenarios
 
-Selection flags compose with any spec: `--filter NAME` (repeatable, and comma-separated for OR — `--filter a,b` or `--filter a --filter b` runs scenarios whose name contains `a` or `b`), `--tag T`, `--skip-tag T`, `--parallel N`, `--fail-fast`, and `--rerun-failed`. While authoring, `--verbose` traces every command, capture, and assertion verdict — for passing scenarios too.
+Selection flags compose with any spec: `--filter NAME` (repeatable, and comma-separated for OR — `--filter a,b` or `--filter a --filter b` runs scenarios whose name contains `a` or `b`), `--tag T` and `--skip-tag T` (tags match exactly, not by substring — `atago list` shows the available tags), `--parallel N`, `--fail-fast`, and `--rerun-failed`. While authoring, `--verbose` traces every command, capture, and assertion verdict — for passing scenarios too. Under `--ci`, a selection that matches no scenario fails the run (exit 3) rather than passing an empty suite.
 
 ## Snapshot testing
 


### PR DESCRIPTION
## Summary

Two selector-UX fixes from the project review (TDD: unit test first, then self-hosted E2E):

- **Selector-aware no-match note**: the warning hardcoded "name matching is a case-sensitive substring" for every selector, but that rule only applies to `--filter` — `--tag`/`--skip-tag` match tags **exactly** (`engine.hasAnyTag` uses `==`). A user debugging a tag mismatch was pointed at the wrong fix. The note now names each active selector's real rule, and tag users are pointed at `atago list`.
- **`--ci` refuses an empty selection**: `atago run --ci --tag typo ./specs` used to exit 0 with `PASSED 0 scenarios`, silently disabling the suite in CI forever. Under `--ci` it is now a hard config error (exit 3) naming the selectors that matched nothing. Without `--ci` the behavior is unchanged (warning + exit 0). The empty-selection case is precise: the loader rejects scenario-less specs and OS-gated scenarios still appear as skipped, so `total == 0` can only mean the selectors filtered everything.

Flag help texts, README, and the website's CI/Reference pages document the new semantics; CHANGELOG updated.

## Tests

- `TestRunCmd_CIEmptySelectionFails` (unit, red first)
- Self-hosted E2E: 3 scenarios in `test/e2e/atago/cli_selection.atago.yaml` — `--ci` + filter fails with the substring note, `--ci` + tag fails naming the exact-tag rule (and must NOT say substring), no-`--ci` warns and exits 0
- `go test ./...`, `make e2e` (389 scenarios), `golangci-lint run` 0 issues, hugo build OK, `make docs` regenerated

https://claude.ai/code/session_01Q2fDa4YigTBuFYCErfjAAP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty scenario selections now fail under `--ci` instead of exiting successfully.
  * No-match warnings now clearly distinguish between filter substring matching and exact tag matching.
  * Tag-related messages now point to the tag list for easier discovery.

* **Documentation**
  * Updated CLI, CI, and reference docs to reflect exact tag matching and empty-selection behavior.
  * Expanded scenario-selection examples and expected results in end-to-end documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->