### PR TITLE
ci(fuzz): mutation-fuzz every shipped target, not four of eight

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,8 +1,7 @@
 name: Fuzz
 
-# The repository ships fuzz targets (internal/loader, internal/store,
-# internal/assert), but the push/PR test workflows only exercise their seed
-# corpus. This job runs real mutation fuzzing on a schedule so the loader, the
+# The repository ships fuzz targets (loader, store, assert, snapshot, record,
+# ptyrun), but the push/PR test workflows only exercise their seed corpus. This job runs real mutation fuzzing on a schedule so the loader, the
 # ${...} expander, and the JSON matcher keep getting adversarial input over
 # time — atago parses untrusted specs and arbitrary program output, so its input
 # surface is exactly where fuzzing pays off. A newly discovered crasher fails the
@@ -34,6 +33,14 @@ jobs:
             target: FuzzCheckJSON
           - pkg: ./internal/assert
             target: FuzzValuesEqual
+          - pkg: ./internal/assert
+            target: FuzzChangesGlob
+          - pkg: ./internal/snapshot
+            target: FuzzNormalize
+          - pkg: ./internal/record
+            target: FuzzGenerateRoundTrip
+          - pkg: ./internal/runner/ptyrun
+            target: FuzzRenderScreen
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
## Summary

Project-review finding: `.github/workflows/fuzz.yml` mutation-fuzzes only 4 of the 8 shipped `Fuzz*` targets; the other four got seed-corpus replay only. The gap is exactly where fuzzing pays: `FuzzChangesGlob` guards the hand-rolled glob/brace matcher that already produced a real bug (PR #199), `FuzzNormalize` chews arbitrary program output, `FuzzGenerateRoundTrip` guards record round-trips, and the new `FuzzRenderScreen` (PR #211) found one crash and two hangs in the vt10x path the moment it ran. The scheduled matrix now lists all eight.

Workflow-file-only PR (merged via git per repo convention — the gh token lacks workflow scope).

https://claude.ai/code/session_01Q2fDa4YigTBuFYCErfjAAP