### PR TITLE
fix(engine): honor ssh step timeouts, guard shell env refs, preserve mock request logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@ and this project follows [Semantic Versioning](https://semver.org/).
   make schema-validating editors reject valid specs) — or a schema change
   without regenerating `spec_keys.json` — can no longer ship silently.
 
+- Failing scenarios now preserve each mock server's recorded requests as a
+  durable artifact next to the service logs (`--artifacts-dir`), so the
+  sharpest evidence a mock scenario has — the typo'd client path that 404'd —
+  survives the CI job. Green runs and mocks that recorded nothing write no
+  file, exactly like service logs.
+
 ### Changed
 
 - README now links the hosted cookbook from its Examples section and points to
@@ -70,6 +76,19 @@ and this project follows [Semantic Versioning](https://semver.org/).
   exits 0, leaving interactive workflows untouched.
 
 ### Fixed
+
+- A step-level `timeout:` on an ssh run step was parsed, validated — and
+  silently ignored: the loader whitelists it "because it is honored remotely",
+  but the engine only ever applied the runner-level timeout captured at dial.
+  The step timeout now bounds the remote command (taking precedence over the
+  runner-level value), and an ssh timeout of either level is an observable
+  `TimedOut` result naming its source — matching how the cmd runner reports
+  local timeouts — instead of a hard scenario error.
+- An unset `${env:NAME}` in a `shell: true` run command now fails with the
+  same explained error as the shell-less path ("the environment variable NAME
+  is not set") instead of reaching the shell, where POSIX sh dies with a
+  cryptic "Bad substitution" and cmd.exe forwards the literal text. A bare
+  unresolved `${name}` is still left for the shell, which CAN expand it.
 
 - The "no scenarios matched" warning is now selector-aware. `--tag`/`--skip-tag`
   say tags match exactly and point at `atago list`, while `--filter` keeps the

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ jobs:
 
 - `--report json|junit|gha|tap` picks the report format; the JSON shape is stable and versioned.
 - `--ci` enables deterministic, color-free output. It also turns an empty selection into a hard error: a `--filter`/`--tag`/`--skip-tag` that matches no scenario fails the run (exit 3) instead of passing an empty suite, so a typo cannot silently disable your specs. Without `--ci` the same case is a warning that still exits 0.
-- `--artifacts-dir DIR` persists the exact payloads a failed assertion compared, so a failure stays reviewable after the job ends.
+- `--artifacts-dir DIR` persists the exact payloads a failed assertion compared — plus, for a failed scenario, its background services' logs and each mock server's recorded requests — so a failure stays reviewable after the job ends.
 - Environment variable names listed under `secrets:` are masked as `***` in all reports and snapshots.
 
 ## Review specs without running them

--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -104,3 +104,10 @@ func FailurePath(specPath, scenario string, scenarioIdx, stepIdx int, kind, role
 func ServiceLogPath(specPath, scenario string, scenarioIdx int, serviceName string) string {
 	return path.Join(SuiteToken(specPath), ScenarioToken(scenario, scenarioIdx), "service-"+Slug(serviceName)+".log")
 }
+
+// MockLogPath composes the relative path for a mock server's preserved request
+// log: <suite-token>/<scenario-token>/mock-<name>.log. The mock- prefix keeps
+// it distinct from a service log even when a mock and a service share a name.
+func MockLogPath(specPath, scenario string, scenarioIdx int, mockName string) string {
+	return path.Join(SuiteToken(specPath), ScenarioToken(scenario, scenarioIdx), "mock-"+Slug(mockName)+".log")
+}

--- a/internal/artifact/artifact_test.go
+++ b/internal/artifact/artifact_test.go
@@ -60,6 +60,20 @@ func TestFailurePathStableAndUnique(t *testing.T) {
 	}
 }
 
+// TestMockLogPath_DistinctFromServiceLog proves a mock server's request log
+// never collides with a service log even when both share a declared name.
+func TestMockLogPath_DistinctFromServiceLog(t *testing.T) {
+	t.Parallel()
+	m := MockLogPath("test/e2e/atago/mock.atago.yaml", "client posts", 0, "api")
+	if !strings.HasSuffix(m, "mock-api.log") {
+		t.Errorf("MockLogPath = %q", m)
+	}
+	s := ServiceLogPath("test/e2e/atago/mock.atago.yaml", "client posts", 0, "api")
+	if m == s {
+		t.Errorf("mock and service logs for the same name collided: %q", m)
+	}
+}
+
 func TestServiceLogPathStableAndUnique(t *testing.T) {
 	t.Parallel()
 	p := ServiceLogPath("test/e2e/atago/services.atago.yaml", "peer talks", 0, "api server")

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -229,6 +229,51 @@ scenarios:
 	}
 }
 
+// TestEngine_UnsetEnvRefErrorsUnderShell closes the shell:true gap in the
+// unresolved-reference guard: ${env:NAME} is atago-only syntax that NO shell
+// can expand — POSIX sh dies with a cryptic "Bad substitution", cmd.exe passes
+// the literal through — so an unset ${env:NAME} must error with the same
+// explained message as the shell-less path instead of falling through to the
+// shell. A bare unresolved ${name} stays exempt: a shell CAN expand that, and
+// the second scenario proves it still reaches the shell untouched.
+func TestEngine_UnsetEnvRefErrorsUnderShell(t *testing.T) {
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: s
+scenarios:
+  - name: unset env ref errors even with a shell
+    steps:
+      - run: {shell: true, command: "echo [${env:ATAGO_TEST_DEFINITELY_UNSET}]"}
+`)
+	if res.Status != StatusError {
+		t.Fatalf("status = %s, want error (no shell can expand ${env:...}): %+v", res.Status, res.Scenarios)
+	}
+	if msg := res.Scenarios[0].Steps[0].ErrMsg; !strings.Contains(msg, "environment variable ATAGO_TEST_DEFINITELY_UNSET is not set") {
+		t.Errorf("ErrMsg = %q, want it to name the unset environment variable", msg)
+	}
+
+	if runtime.GOOS == "windows" {
+		return // the control below uses POSIX parameter expansion
+	}
+	res = runSpec(t, `
+version: "1"
+suite:
+  name: s
+scenarios:
+  - name: a bare unresolved ref is still left for the shell
+    steps:
+      - run: {shell: true, command: "echo ${ATAGO_UNDEFINED_SHELLVAR:-shell-fallback}"}
+      - assert:
+          exit_code: 0
+          stdout: {contains: shell-fallback}
+`)
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed (bare ${name} must stay shell-expandable): %+v", res.Status, res.Scenarios)
+	}
+}
+
 // TestEngine_TeardownAlwaysRuns proves the teardown contract: teardown steps
 // run after a pass, after an assertion failure, and after an execution error;
 // they share the scenario store (a store-captured value flows into cleanup);

--- a/internal/engine/mask.go
+++ b/internal/engine/mask.go
@@ -7,6 +7,7 @@ import (
 	"github.com/nao1215/atago/internal/artifact"
 	"github.com/nao1215/atago/internal/assert"
 	"github.com/nao1215/atago/internal/runner"
+	mockrunner "github.com/nao1215/atago/internal/runner/mock"
 	servicerunner "github.com/nao1215/atago/internal/runner/service"
 	"github.com/nao1215/atago/internal/scrub"
 	"github.com/nao1215/atago/internal/security"
@@ -144,6 +145,37 @@ func (e *Engine) writeServiceLogs(out *ScenarioResult, m *security.Masker, procs
 			continue
 		}
 		out.ServiceLogs = append(out.ServiceLogs, ServiceLog{Name: proc.Name(), Path: p})
+	}
+}
+
+// writeMockLogs preserves each mock server's recorded requests as a durable
+// artifact when a scenario fails, honoring RequestLog's contract ("the durable
+// artifact written next to service logs when a scenario fails"). The request
+// log is often the sharpest failure evidence a mock scenario has — a typo'd
+// client path shows up as a recorded 404. Failure-gated and artifacts-dir-gated
+// like service logs; a mock that recorded no request writes nothing.
+func (e *Engine) writeMockLogs(out *ScenarioResult, m *security.Masker, mocks []*mockrunner.Server, specPath, scenario string, scenarioIdx int) {
+	if e.Artifacts == nil {
+		return
+	}
+	for _, srv := range mocks {
+		if srv == nil {
+			continue
+		}
+		name := srv.Name() + " (mock requests)"
+		if serviceLogged(out, name) {
+			continue
+		}
+		log := srv.RequestLog()
+		if log == "" {
+			continue // no recorded request -> no artifact
+		}
+		rel := artifact.MockLogPath(specPath, scenario, scenarioIdx, srv.Name())
+		p, err := e.Artifacts.Write(rel, m.MaskBytes([]byte(log)))
+		if err != nil {
+			continue
+		}
+		out.ServiceLogs = append(out.ServiceLogs, ServiceLog{Name: name, Path: p})
 	}
 }
 

--- a/internal/engine/scenario.go
+++ b/internal/engine/scenario.go
@@ -110,6 +110,7 @@ func (e *Engine) runScenario(ctx context.Context, scenarioIdx int, sc *spec.Scen
 	// gated), keeping logs opt-in rather than mandatory noise.
 	if x.out.Status == StatusFailed || x.out.Status == StatusError {
 		x.e.writeServiceLogs(&x.out, x.masker, x.services, x.rc.specPath, x.sc.Name, x.idx)
+		x.e.writeMockLogs(&x.out, x.masker, x.mocks, x.rc.specPath, x.sc.Name, x.idx)
 	}
 
 	x.out.Duration = time.Since(x.start)

--- a/internal/engine/service_artifacts_test.go
+++ b/internal/engine/service_artifacts_test.go
@@ -208,3 +208,106 @@ scenarios:
 		t.Errorf("green run should write no service log, got %+v", logs)
 	}
 }
+
+// TestEngine_MockRequestLogPreservedOnFailure closes the gap RequestLog's doc
+// comment promised away: it billed itself as "the durable artifact written next
+// to service logs when a scenario fails", but nothing ever called it — a failed
+// scenario preserved the service's stdout while discarding the requests the
+// mock observed, which is exactly the evidence (a typo'd path 404ing) the
+// artifact dir exists to keep. On failure each mock server with at least one
+// recorded request now writes its request log next to the service logs.
+func TestEngine_MockRequestLogPreservedOnFailure(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	res := runSpecWithArtifacts(t, "mock.atago.yaml", `
+version: "1"
+suite:
+  name: s
+runners:
+  api:
+    type: http
+    base_url: ${api.url}
+scenarios:
+  - name: the client hits a typo'd path
+    mock_servers:
+      - name: api
+        routes:
+          - method: GET
+            path: /v1/ping
+            status: 200
+            body: pong
+    steps:
+      - http:
+          runner: api
+          method: GET
+          path: /v1/pingg
+      - assert:
+          status: 200
+`, root)
+	if res.Status != StatusFailed {
+		t.Fatalf("status = %s, want failed: %+v", res.Status, res.Scenarios)
+	}
+	sl := serviceLog(t, res, "api (mock requests)")
+	data, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(sl.Path)))
+	if err != nil {
+		t.Fatalf("read mock request log: %v", err)
+	}
+	if !strings.Contains(string(data), "GET /v1/pingg -> 404") {
+		t.Errorf("mock request log = %q, want the 404'd typo'd request", data)
+	}
+}
+
+// TestEngine_MockRequestLogSkippedWhenGreenOrSilent pins the two no-artifact
+// cases: a passing scenario writes nothing (failure-gated like service logs),
+// and a failing scenario whose mock recorded no request writes no empty file.
+func TestEngine_MockRequestLogSkippedWhenGreenOrSilent(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	res := runSpecWithArtifacts(t, "mock.atago.yaml", `
+version: "1"
+suite:
+  name: s
+runners:
+  api:
+    type: http
+    base_url: ${api.url}
+scenarios:
+  - name: green round trip
+    mock_servers:
+      - name: api
+        routes:
+          - method: GET
+            path: /v1/ping
+            status: 200
+            body: pong
+    steps:
+      - http:
+          runner: api
+          method: GET
+          path: /v1/ping
+      - assert:
+          status: 200
+  - name: failing but the mock saw nothing
+    mock_servers:
+      - name: quiet
+        routes:
+          - method: GET
+            path: /v1/ping
+            status: 200
+            body: pong
+    steps:
+      - run: {shell: true, command: "exit 7"}
+      - assert:
+          exit_code: 0
+`, root)
+	if res.Scenarios[0].Status != StatusPassed || res.Scenarios[1].Status != StatusFailed {
+		t.Fatalf("statuses = %s/%s, want passed/failed", res.Scenarios[0].Status, res.Scenarios[1].Status)
+	}
+	for i := range res.Scenarios {
+		for _, sl := range res.Scenarios[i].ServiceLogs {
+			if strings.Contains(sl.Name, "mock requests") {
+				t.Errorf("scenario %d unexpectedly recorded a mock request log: %+v", i, sl)
+			}
+		}
+	}
+}

--- a/internal/engine/ssh_test.go
+++ b/internal/engine/ssh_test.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	sshd "github.com/gliderlabs/ssh"
 
@@ -37,6 +38,14 @@ func sshTestServer(t *testing.T) string {
 		case "fail":
 			_, _ = io.WriteString(s.Stderr(), "boom\n")
 			_ = s.Exit(2)
+		case "sleep":
+			d, _ := time.ParseDuration(cmd[1])
+			select {
+			case <-time.After(d):
+				_ = s.Exit(0)
+			case <-s.Context().Done():
+				return
+			}
 		default:
 			_, _ = io.WriteString(s.Stderr(), "unknown command\n")
 			_ = s.Exit(127)
@@ -100,6 +109,94 @@ scenarios:
 	res := runSpec(t, src)
 	if res.Status != StatusPassed {
 		t.Fatalf("status = %s, want passed: %+v", res.Status, res.Scenarios[0].Steps)
+	}
+}
+
+// TestEngine_SSHStepTimeoutHonored closes the silent no-op the loader comment
+// promised away: validateSSHRunFields whitelists `timeout` on an ssh run step
+// "because it is honored remotely", but the engine only ever applied the
+// RUNNER-level timeout captured at dial — a step-level `timeout:` was parsed,
+// validated, and ignored. It must bound the remote command, and — mirroring the
+// cmd runner (#17) — a fired timeout is an OBSERVABLE TimedOut result naming
+// its source, not a hard scenario error.
+func TestEngine_SSHStepTimeoutHonored(t *testing.T) {
+	t.Parallel()
+	addr := sshTestServer(t)
+	src := fmt.Sprintf(`
+version: "1"
+suite:
+  name: ssh
+runners:
+  box:
+    type: ssh
+    host: %s
+    user: tester
+    password: secret
+    insecure_host_key: true
+scenarios:
+  - name: a step timeout bounds the remote command
+    steps:
+      - run:
+          runner: box
+          command: sleep 10s
+          timeout: 300ms
+      - assert:
+          exit_code: {not: 0}
+`, addr)
+	res := runSpec(t, src)
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed (a timeout is an observable result the assert inspects): %+v", res.Status, res.Scenarios[0].Steps)
+	}
+	run := res.Scenarios[0].Steps[0].Run
+	if run == nil || !run.TimedOut {
+		t.Fatalf("step result = %+v, want TimedOut", run)
+	}
+	if run.TimeoutSource != "run.timeout" {
+		t.Errorf("TimeoutSource = %q, want %q so the failure hint names the knob", run.TimeoutSource, "run.timeout")
+	}
+	if run.Duration >= 5*time.Second {
+		t.Errorf("Duration = %s, want the 300ms step timeout to have cut the 10s sleep", run.Duration)
+	}
+}
+
+// TestEngine_SSHRunnerTimeoutIsObservable pins the parity half: a RUNNER-level
+// ssh timeout that fires mid-command also produces a TimedOut result (source
+// "runner.timeout"), matching how the cmd runner reports local timeouts,
+// instead of the previous hard "ssh command timed out" scenario error.
+func TestEngine_SSHRunnerTimeoutIsObservable(t *testing.T) {
+	t.Parallel()
+	addr := sshTestServer(t)
+	src := fmt.Sprintf(`
+version: "1"
+suite:
+  name: ssh
+runners:
+  box:
+    type: ssh
+    host: %s
+    user: tester
+    password: secret
+    insecure_host_key: true
+    timeout: 300ms
+scenarios:
+  - name: the runner timeout bounds every remote command
+    steps:
+      - run:
+          runner: box
+          command: sleep 10s
+      - assert:
+          exit_code: {not: 0}
+`, addr)
+	res := runSpec(t, src)
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed: %+v", res.Status, res.Scenarios[0].Steps)
+	}
+	run := res.Scenarios[0].Steps[0].Run
+	if run == nil || !run.TimedOut {
+		t.Fatalf("step result = %+v, want TimedOut", run)
+	}
+	if run.TimeoutSource != "runner.timeout" {
+		t.Errorf("TimeoutSource = %q, want %q", run.TimeoutSource, "runner.timeout")
 	}
 }
 

--- a/internal/engine/stepexec.go
+++ b/internal/engine/stepexec.go
@@ -64,6 +64,19 @@ func (x *scenarioRun) execStep(ctx context.Context, i int, step *spec.Step) (Ste
 					sr.ErrMsg = unresolvedRunRefMsg("run.command", names[0], true)
 					return sr, StatusError, false
 				}
+			} else {
+				// A shell can expand a bare ${name}, so those pass through — but
+				// ${env:NAME} is atago-only syntax NO shell understands: POSIX sh
+				// dies with a cryptic "Bad substitution" and cmd.exe forwards the
+				// literal text. An unset ${env:NAME} under shell: true is the same
+				// authoring error as without a shell; fail it with the same
+				// explained message instead of handing it to the shell.
+				for _, name := range x.st.Unresolved(step.Run.Command) {
+					if strings.HasPrefix(name, "env:") {
+						sr.ErrMsg = unresolvedRunRefMsg("run.command", name, true)
+						return sr, StatusError, false
+					}
+				}
 			}
 			// cwd is passed to cmd.Dir verbatim; no shell ever expands it, so an
 			// unresolved ${name} is always a typo that would make the child fail to
@@ -309,9 +322,12 @@ func (e *Engine) runStep(ctx context.Context, run *spec.Run, st *store.Store, wo
 	if !remote {
 		// Resolve the effective timeout across all five levels (#17) and
 		// remember which level supplied it so a timeout kill can name the knob
-		// in its hint. Remote (ssh) runs are bounded by the ssh runner's own
-		// connection timeout instead.
+		// in its hint. Remote (ssh) runs apply only the step's own explicit
+		// timeout below — the other levels shape local execution, and the ssh
+		// runner's dial-time timeout already bounds every remote command.
 		run.Timeout, run.TimeoutSource = resolveTimeout(run.Timeout, runnerTimeout, rc.defaultsRunTimeout, rc.suiteTimeout)
+	} else if run.Timeout != "" {
+		run.TimeoutSource = "run.timeout"
 	}
 	exec := func(ctx context.Context) (*runner.Result, error) {
 		if remote {
@@ -319,7 +335,21 @@ func (e *Engine) runStep(ctx context.Context, run *spec.Run, st *store.Store, wo
 			if err != nil {
 				return nil, err
 			}
-			return conn.Run(ctx, run.Command)
+			// The loader whitelists `timeout` on ssh run steps because it is
+			// honored remotely — so honor it: the step's own timeout arrives at
+			// the runner as a context deadline and takes precedence over the
+			// runner-level timeout applied inside conn.Run.
+			if run.Timeout != "" {
+				d, _ := time.ParseDuration(run.Timeout) // validated at load time
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, d)
+				defer cancel()
+			}
+			r, err := conn.Run(ctx, run.Command)
+			if r != nil && r.TimedOut && r.TimeoutSource == "" {
+				r.TimeoutSource = run.TimeoutSource
+			}
+			return r, err
 		}
 		return e.cmd.Run(ctx, run, workdir)
 	}

--- a/internal/runner/ssh/ssh.go
+++ b/internal/runner/ssh/ssh.go
@@ -87,6 +87,18 @@ func (r *Runner) Run(ctx context.Context, command string) (*runner.Result, error
 	}
 	defer func() { _ = sess.Close() }()
 
+	// A caller-supplied deadline (the engine applies the step's own
+	// run.timeout that way) takes precedence; without one, the runner-level
+	// timeout captured at dial bounds the command. Track which level armed the
+	// deadline so a fired timeout can name its knob, mirroring the cmd runner.
+	timeoutSource := ""
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline && r.timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, r.timeout)
+		defer cancel()
+		timeoutSource = "runner.timeout"
+	}
+
 	var stdout, stderr strings.Builder
 	sess.Stdout = &stdout
 	sess.Stderr = &stderr
@@ -96,23 +108,33 @@ func (r *Runner) Run(ctx context.Context, command string) (*runner.Result, error
 	go func() { done <- sess.Run(command) }()
 
 	var runErr error
-	if r.timeout > 0 {
+	select {
+	case <-ctx.Done():
+		_ = sess.Signal(ssh.SIGKILL)
+		_ = sess.Close()
+		// Wait (bounded) for the session goroutine so the output builders are
+		// quiescent before they are read — a remote that ignores the kill must
+		// not turn into a data race or a hang here.
 		select {
-		case <-ctx.Done():
-			_ = sess.Signal(ssh.SIGKILL)
-			return nil, ctx.Err()
-		case <-time.After(r.timeout):
-			_ = sess.Signal(ssh.SIGKILL)
-			return nil, fmt.Errorf("ssh command timed out after %s", r.timeout)
-		case runErr = <-done:
+		case <-done:
+		case <-time.After(2 * time.Second):
 		}
-	} else {
-		select {
-		case <-ctx.Done():
-			_ = sess.Signal(ssh.SIGKILL)
-			return nil, ctx.Err()
-		case runErr = <-done:
+		// A fired deadline is an OBSERVABLE outcome assertions can inspect —
+		// TimedOut with the captured output so far — matching the cmd runner
+		// (#17). Only a cancellation (Ctrl-C / suite teardown) is an error.
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return &runner.Result{
+				Command:       command,
+				Stdout:        []byte(stdout.String()),
+				Stderr:        []byte(stderr.String()),
+				Duration:      time.Since(start),
+				ExitCode:      -1,
+				TimedOut:      true,
+				TimeoutSource: timeoutSource,
+			}, nil
 		}
+		return nil, ctx.Err()
+	case runErr = <-done:
 	}
 	elapsed := time.Since(start)
 

--- a/internal/runner/ssh/ssh.go
+++ b/internal/runner/ssh/ssh.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"golang.org/x/crypto/ssh"
@@ -99,7 +100,7 @@ func (r *Runner) Run(ctx context.Context, command string) (*runner.Result, error
 		timeoutSource = "runner.timeout"
 	}
 
-	var stdout, stderr strings.Builder
+	var stdout, stderr lockedBuilder
 	sess.Stdout = &stdout
 	sess.Stderr = &stderr
 
@@ -112,9 +113,10 @@ func (r *Runner) Run(ctx context.Context, command string) (*runner.Result, error
 	case <-ctx.Done():
 		_ = sess.Signal(ssh.SIGKILL)
 		_ = sess.Close()
-		// Wait (bounded) for the session goroutine so the output builders are
-		// quiescent before they are read — a remote that ignores the kill must
-		// not turn into a data race or a hang here.
+		// Wait (bounded) for the session goroutine so the captured output is
+		// as complete as possible; the builders are lock-guarded, so even a
+		// remote that ignores the kill and keeps streaming past the grace
+		// window cannot turn the read below into a data race.
 		select {
 		case <-done:
 		case <-time.After(2 * time.Second):
@@ -154,6 +156,26 @@ func (r *Runner) Run(ctx context.Context, command string) (*runner.Result, error
 		return nil, fmt.Errorf("ssh run %q: %w", command, runErr)
 	}
 	return res, nil
+}
+
+// lockedBuilder is a strings.Builder safe for the session goroutine to write
+// while the timeout path reads: a killed remote may ignore the signal and keep
+// streaming past the bounded grace wait, so the read must not race the write.
+type lockedBuilder struct {
+	mu sync.Mutex
+	b  strings.Builder
+}
+
+func (w *lockedBuilder) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.b.Write(p)
+}
+
+func (w *lockedBuilder) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.b.String()
 }
 
 func authMethods(cfg Config) ([]ssh.AuthMethod, error) {

--- a/website/content/ci.md
+++ b/website/content/ci.md
@@ -27,7 +27,7 @@ jobs:
 
 - `--report json|junit|gha|tap` picks the report format; the JSON shape is stable and versioned ([sample JSON](/samples/report.json), [JUnit](/samples/report.junit.xml), [TAP](/samples/report.tap)).
 - `--ci` enables deterministic, color-free output. It also turns an empty selection into a hard error: a `--filter`/`--tag`/`--skip-tag` that matches no scenario fails the run (exit 3) instead of passing an empty suite, so a typo cannot silently disable your specs. Without `--ci` the same case is a warning that still exits 0.
-- `--artifacts-dir DIR` persists the exact payloads a failed assertion compared, so a failure stays reviewable after the job ends.
+- `--artifacts-dir DIR` persists the exact payloads a failed assertion compared — plus, for a failed scenario, its background services' logs and each mock server's recorded requests — so a failure stays reviewable after the job ends.
 - Environment variable names listed under `secrets:` are masked as `***` in all reports and snapshots.
 
 ## Review specs without running them


### PR DESCRIPTION
## Summary

Three engine-correctness findings from the project review, each implemented TDD (failing test first):

### 1. `timeout:` on an ssh run step was silently ignored
`validateSSHRunFields` whitelists `timeout` on ssh steps with the comment *"timeout and retry are honored remotely"* — but the engine resolved timeouts only for local runs; the remote path was bounded solely by the runner-level timeout captured at dial. Now:
- the step's own `timeout:` reaches the ssh runner as a context deadline and **takes precedence** over the runner-level value;
- a fired timeout at either level returns an **observable `TimedOut` result** (`exit -1`, `TimeoutSource: run.timeout|runner.timeout`, captured output attached) exactly like the cmd runner (#17), instead of the previous hard `ssh command timed out` scenario error;
- the kill path waits (bounded 2s) for the session goroutine so reading the output builders is race-free (verified with `-race`).

### 2. Unset `${env:NAME}` under `shell: true` produced "Bad substitution"
The unresolved-reference guard exempted all of a shell-enabled command on the theory a shell might expand it — but `${env:...}` is atago-only syntax **no** shell understands. It now fails with the same explained message as the shell-less path; bare `${name}` is still left for the shell (control test proves POSIX `${X:-fallback}` keeps working). This trap was amplified by `atago init` and the README both using `shell: true` in their first examples.

### 3. `mock.Server.RequestLog` was dead code promising an unshipped artifact
Its doc comment called it "the durable artifact written next to service logs when a scenario fails" — no caller existed. Failing scenarios now preserve each mock's recorded requests as `mock-<name>.log` under `--artifacts-dir`, next to service logs (the recorded 404 for a typo'd client path is exactly the evidence you want after CI). Green runs / silent mocks write nothing; names render as `api (mock requests)` in the existing Service logs report section.

README + website CI page now mention service logs and mock requests under `--artifacts-dir`; CHANGELOG updated.

## Tests

- `TestEngine_SSHStepTimeoutHonored`, `TestEngine_SSHRunnerTimeoutIsObservable` (in-process sshd gains a `sleep` command), race-clean
- `TestEngine_UnsetEnvRefErrorsUnderShell` (+ shell-expandability control)
- `TestEngine_MockRequestLogPreservedOnFailure`, `TestEngine_MockRequestLogSkippedWhenGreenOrSilent`, `TestMockLogPath_DistinctFromServiceLog`
- `go test ./...`, `make e2e` (391 scenarios), `golangci-lint run` 0 issues, hugo build OK

https://claude.ai/code/session_01Q2fDa4YigTBuFYCErfjAAP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Failed scenarios now preserve mock server request logs as durable artifacts alongside service logs.
  * Artifact documentation now reflects the expanded failure evidence saved for later review.

* **Bug Fixes**
  * SSH step timeouts are now honored and reported with clearer timeout source details.
  * Unset environment references under shell execution now fail with a clearer error message.
  * SSH timeout handling now returns consistent timeout results instead of unexpected command errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->