### PR TITLE
refactor: consolidate duration validation, retry loops, and rerun ledger logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,11 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- `retry.interval` now rejects negative durations at load time like every
+  other duration field (a negative interval silently behaved as "no wait").
+  All duration validation shares one helper, so bounds and wording can no
+  longer drift between fields.
+
 - A step-level `timeout:` on an ssh run step was parsed, validated — and
   silently ignored: the loader whitelists it "because it is honored remotely",
   but the engine only ever applied the runner-level timeout captured at dial.

--- a/internal/cli/rerun.go
+++ b/internal/cli/rerun.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -242,4 +243,82 @@ func collectFailures(results []*engine.SuiteResult) []failedEntry {
 		}
 	}
 	return failed
+}
+
+// applyRerunSelection narrows a --rerun-failed run to the scenarios the ledger
+// recorded as failing: it absolutizes the recorded spec paths AND the run
+// targets so a spec matches regardless of how its path is spelled between the
+// recording run and the rerun (relative vs absolute) — without this, a rerun
+// addressed by an equivalent-but-different spelling finds "nothing" and
+// silently greenlights while the failures are still real. It intersects the
+// recorded spec paths with the collected targets so the usual path semantics
+// still apply, and installs an identity selector so only the recorded
+// scenarios execute. done reports that the run should end immediately with
+// exitNow: an unreadable ledger is a config error, and nothing-to-rerun is
+// reported and treated as success.
+func applyRerunSelection(label string, stderr io.Writer, paths []string, eng *engine.Engine) (narrowed []string, exitNow int, done bool) {
+	state, lerr := loadRerunState()
+	if lerr != nil {
+		fmt.Fprintf(stderr, label+": cannot read %s: %v\n", rerunStatePath(), lerr)
+		return nil, ExitConfig, true
+	}
+	for i := range state.Failed {
+		state.Failed[i].SpecPath = absClean(state.Failed[i].SpecPath)
+	}
+	for i := range paths {
+		paths[i] = absClean(paths[i])
+	}
+	sel := state.selectSet()
+	if len(sel) == 0 {
+		fmt.Fprintln(stderr, label+": no previously failed scenarios recorded; nothing to rerun")
+		return nil, ExitOK, true
+	}
+	paths = intersectPaths(paths, state.specPaths())
+	if len(paths) == 0 {
+		fmt.Fprintln(stderr, label+": no previously failed scenarios under the given targets")
+		return nil, ExitOK, true
+	}
+	eng.Select = sel
+	return paths, 0, false
+}
+
+// updateRerunLedger persists the last-failed ledger after a run. The ledger
+// reflects what this run decided about the scenarios it EXECUTED — a failure is
+// recorded, a pass is cleared — while PRESERVING every recorded failure the run
+// did not execute. A run that touches only a subset of scenarios (a narrowed
+// --rerun-failed, a --filter/--tag/--skip-tag selection, or simply running a
+// different or smaller set of specs) must not drop still-failing work elsewhere:
+// overwriting the ledger with only what ran would forget it and could greenlight
+// a later --rerun-failed while real failures remain. So a fully-green run of the
+// SAME specs clears the file, but a green run of an unrelated spec keeps the
+// other spec's recorded failures. Entries are stored with portable
+// (cwd-relative) spec paths so the ledger survives a project move — a
+// --rerun-failed absolutizes paths in memory to match across spellings, and
+// persisting that absolute form would break the next rerun after the directory
+// moves. Writing is best-effort — a read-only checkout must not fail the run —
+// so a write error is a warning, not a fatal exit; an UNREADABLE ledger is
+// never overwritten, so recorded failures a newer atago wrote survive a plain
+// run by an older one.
+func updateRerunLedger(label string, stderr io.Writer, results []*engine.SuiteResult, ranScenarios int) {
+	prior, perr := loadRerunState()
+	if perr != nil {
+		fmt.Fprintf(stderr, label+": cannot read %s; leaving it untouched: %v\n", rerunStatePath(), perr)
+		return
+	}
+	executed := make(map[string]bool, ranScenarios)
+	for _, r := range results {
+		for _, sc := range r.Scenarios {
+			executed[canonicalScenarioID(r.SpecPath, sc.Name)] = true
+		}
+	}
+	var preserved []failedEntry
+	for _, e := range prior.Failed {
+		if !executed[canonicalScenarioID(e.SpecPath, e.Scenario)] {
+			preserved = append(preserved, e)
+		}
+	}
+	entries := dedupeEntries(portableEntries(append(collectFailures(results), preserved...)))
+	if err := saveRerunState(entries); err != nil {
+		fmt.Fprintf(stderr, label+": could not update %s: %v\n", rerunStatePath(), err)
+	}
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -124,39 +124,14 @@ func runCmd(label string, args []string, stdout, stderr io.Writer) int {
 	}
 
 	// --rerun-failed restricts this run to the scenarios recorded as failing on
-	// the previous run (#64). It intersects the recorded spec paths with the
-	// collected targets so the usual path semantics still apply, and installs an
-	// identity selector so only the recorded scenarios execute. With nothing
-	// recorded there is nothing to rerun, which is reported and treated as success.
-	//
+	// the previous run (#64); the selection and canonicalization invariants live
+	// with the ledger primitives in rerun.go.
 	if *rerunFailed {
-		state, lerr := loadRerunState()
-		if lerr != nil {
-			fmt.Fprintf(stderr, label+": cannot read %s: %v\n", rerunStatePath(), lerr)
-			return ExitConfig
+		narrowed, exitNow, done := applyRerunSelection(label, stderr, paths, eng)
+		if done {
+			return exitNow
 		}
-		// Absolutize the recorded spec paths and the run targets so a spec matches
-		// regardless of how its path is spelled between the recording run and the
-		// rerun (relative vs absolute). Without this, a rerun addressed by an
-		// equivalent-but-different spelling finds "nothing" and silently greenlights
-		// while the failures are still real.
-		for i := range state.Failed {
-			state.Failed[i].SpecPath = absClean(state.Failed[i].SpecPath)
-		}
-		for i := range paths {
-			paths[i] = absClean(paths[i])
-		}
-		sel := state.selectSet()
-		if len(sel) == 0 {
-			fmt.Fprintln(stderr, label+": no previously failed scenarios recorded; nothing to rerun")
-			return ExitOK
-		}
-		paths = intersectPaths(paths, state.specPaths())
-		if len(paths) == 0 {
-			fmt.Fprintln(stderr, label+": no previously failed scenarios under the given targets")
-			return ExitOK
-		}
-		eng.Select = sel
+		paths = narrowed
 	}
 
 	// In console mode, stream a live dot per scenario as it finishes, so a run
@@ -238,49 +213,13 @@ func runCmd(label string, args []string, stdout, stderr io.Writer) int {
 		exit = worseExit(exit, ExitConfig)
 	}
 
-	// Update the last-failed ledger for a later `--rerun-failed` (#64). The ledger
-	// reflects what this run decided about the scenarios it EXECUTED — a failure is
-	// recorded, a pass is cleared — while PRESERVING every recorded failure the run
-	// did not execute. A run that touches only a subset of scenarios (a narrowed
-	// --rerun-failed, a --filter/--tag/--skip-tag selection, or simply running a
-	// different or smaller set of specs) must not drop still-failing work elsewhere:
-	// overwriting the ledger with only what ran would forget it and could greenlight
-	// a later --rerun-failed while real failures remain. So a fully-green run of the
-	// SAME specs clears the file, but a green run of an unrelated spec keeps the
-	// other spec's recorded failures. The ledger is left untouched when no suite
-	// loaded (prior state stays intact) and when a --rerun-failed matched nothing
-	// (its unmapped failures must survive). Writing is best-effort — a read-only
-	// checkout must not fail the run — so a write error is a warning, not a fatal
-	// exit.
+	// Update the last-failed ledger for a later `--rerun-failed` (#64); the
+	// preservation invariants live with the ledger primitives in rerun.go. The
+	// ledger is left untouched when no suite loaded (prior state stays intact)
+	// and when a --rerun-failed matched nothing (its unmapped failures must
+	// survive).
 	if len(results) > 0 && !rerunMatchedNothing {
-		prior, perr := loadRerunState()
-		if perr != nil {
-			// A corrupt or future-version ledger: do not overwrite it and destroy
-			// recorded failures we cannot read. (--rerun-failed already exited above on
-			// this same error, so this only guards a plain run.)
-			fmt.Fprintf(stderr, label+": cannot read %s; leaving it untouched: %v\n", rerunStatePath(), perr)
-		} else {
-			executed := make(map[string]bool, ranScenarios)
-			for _, r := range results {
-				for _, sc := range r.Scenarios {
-					executed[canonicalScenarioID(r.SpecPath, sc.Name)] = true
-				}
-			}
-			var preserved []failedEntry
-			for _, e := range prior.Failed {
-				if !executed[canonicalScenarioID(e.SpecPath, e.Scenario)] {
-					preserved = append(preserved, e)
-				}
-			}
-			// Store portable (cwd-relative) spec paths so the ledger survives a project
-			// move. A --rerun-failed absolutizes paths in memory to match across
-			// spellings; persisting that absolute form would break the next rerun after
-			// the directory moves.
-			entries := dedupeEntries(portableEntries(append(collectFailures(results), preserved...)))
-			if err := saveRerunState(entries); err != nil {
-				fmt.Fprintf(stderr, label+": could not update %s: %v\n", rerunStatePath(), err)
-			}
-		}
+		updateRerunLedger(label, stderr, results, ranScenarios)
 	}
 
 	// Every spec failed to load, or an interrupt skipped every suite before it

--- a/internal/engine/http.go
+++ b/internal/engine/http.go
@@ -25,33 +25,17 @@ func (e *Engine) runHTTPStep(ctx context.Context, h *spec.HTTP, st *store.Store,
 		r, secViolation, err := e.runHTTP(ctx, h, st, rc, workdir)
 		return r, nil, secViolation, err
 	}
-
-	interval, _ := time.ParseDuration(h.Retry.Interval) // validated at load time
-	until := expandAssert(st, h.Retry.Until)
+	// The policy-violation flag only matters alongside an error, so the shared
+	// poll loop carries it inside the closure.
+	secViolation := false
 	env := assert.Env{Workdir: workdir, SpecDir: specDir, UpdateSnapshots: e.UpdateSnapshots, Secrets: rc.masker.MaskBytes, Scrub: rc.scrubber.Apply}
-
-	var last *runner.Result
-	var checks []*assert.CheckResult
-	for attempt := 1; attempt <= h.Retry.Times; attempt++ {
-		r, secViolation, err := e.runHTTP(ctx, h, st, rc, workdir)
-		if err != nil {
-			// Transport and policy errors abort the poll like a run step's exec
-			// error: retry exists for "the server answered, but not what we want
-			// yet", not for a broken target.
-			return nil, nil, secViolation, err
-		}
-		last = r
-		checks = assert.CheckAll(until, r, env)
-		if assert.AllOK(checks) {
-			break
-		}
-		if attempt < h.Retry.Times && interval > 0 {
-			select {
-			case <-ctx.Done():
-				return last, checks, false, nil
-			case <-time.After(interval):
-			}
-		}
+	last, checks, err := pollUntil(ctx, h.Retry, st, env, func(ctx context.Context) (*runner.Result, error) {
+		r, sv, rerr := e.runHTTP(ctx, h, st, rc, workdir)
+		secViolation = sv
+		return r, rerr
+	})
+	if err != nil {
+		return nil, nil, secViolation, err
 	}
 	return last, checks, false, nil
 }

--- a/internal/engine/polluntil.go
+++ b/internal/engine/polluntil.go
@@ -1,0 +1,47 @@
+package engine
+
+import (
+	"context"
+	"time"
+
+	"github.com/nao1215/atago/internal/assert"
+	"github.com/nao1215/atago/internal/runner"
+	"github.com/nao1215/atago/internal/spec"
+	"github.com/nao1215/atago/internal/store"
+)
+
+// pollUntil is the single retry/until loop shared by run and http steps: it
+// executes exec up to retry.Times, evaluating retry.Until against each result,
+// and stops early when every check passes, the context ends, or exec errors
+// (retry exists for "the target answered, but not what we want yet", not for a
+// broken target — an exec error aborts the poll). It returns the last result
+// and the last until-checks; the caller records the checks like assertions and
+// fails the step if they never all passed. Keeping one loop means a future
+// change to retry semantics (jitter, max-elapsed, ctx-err reporting) cannot
+// silently apply to one step kind and not the other.
+func pollUntil(ctx context.Context, retry *spec.Retry, st *store.Store, env assert.Env, exec func(context.Context) (*runner.Result, error)) (*runner.Result, []*assert.CheckResult, error) {
+	interval, _ := time.ParseDuration(retry.Interval) // validated at load time
+	until := expandAssert(st, retry.Until)
+
+	var last *runner.Result
+	var checks []*assert.CheckResult
+	for attempt := 1; attempt <= retry.Times; attempt++ {
+		r, err := exec(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+		last = r
+		checks = assert.CheckAll(until, r, env)
+		if assert.AllOK(checks) {
+			break
+		}
+		if attempt < retry.Times && interval > 0 {
+			select {
+			case <-ctx.Done():
+				return last, checks, nil
+			case <-time.After(interval):
+			}
+		}
+	}
+	return last, checks, nil
+}

--- a/internal/engine/stepexec.go
+++ b/internal/engine/stepexec.go
@@ -358,32 +358,8 @@ func (e *Engine) runStep(ctx context.Context, run *spec.Run, st *store.Store, wo
 		r, err := exec(ctx)
 		return r, nil, err
 	}
-
-	interval, _ := time.ParseDuration(run.Retry.Interval) // validated at load time
-	until := expandAssert(st, run.Retry.Until)
 	env := assert.Env{Workdir: workdir, SpecDir: specDir, UpdateSnapshots: e.UpdateSnapshots, Secrets: rc.masker.MaskBytes, Scrub: rc.scrubber.Apply}
-
-	var last *runner.Result
-	var checks []*assert.CheckResult
-	for attempt := 1; attempt <= run.Retry.Times; attempt++ {
-		r, err := exec(ctx)
-		if err != nil {
-			return nil, nil, err
-		}
-		last = r
-		checks = assert.CheckAll(until, r, env)
-		if assert.AllOK(checks) {
-			break
-		}
-		if attempt < run.Retry.Times && interval > 0 {
-			select {
-			case <-ctx.Done():
-				return last, checks, nil
-			case <-time.After(interval):
-			}
-		}
-	}
-	return last, checks, nil
+	return pollUntil(ctx, run.Retry, st, env, exec)
 }
 
 // measurableForChanges reports whether a step kind produces a workdir delta a

--- a/internal/engine/suite.go
+++ b/internal/engine/suite.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/nao1215/atago/internal/assert"
 	"github.com/nao1215/atago/internal/fixture"
@@ -232,7 +231,3 @@ func (e *Engine) runSuiteTeardown(ctx context.Context, s *spec.Spec, rt *suiteRu
 	out, _ := e.runSuiteSteps(tctx, s.Suite.Teardown, rt, rc, false)
 	return out
 }
-
-// suiteTimeNow is a seam kept trivial on purpose; suite phases reuse the
-// scenario duration accounting via time.Since at the call sites.
-var _ = time.Now

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -617,6 +617,12 @@ func TestLoadBytes_Errors(t *testing.T) {
 			wantMsg:  "name is required",
 		},
 		{
+			name:     "retry interval must not be negative",
+			src:      "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps:\n      - run:\n          command: echo\n          retry: {times: 3, interval: -1s, until: {exit_code: 0}}",
+			wantKind: KindValidation,
+			wantMsg:  "retry.interval must not be negative",
+		},
+		{
 			name:     "service max_log_bytes must be positive",
 			src:      "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    services:\n      - {name: s, command: sleep 1, max_log_bytes: -1}\n    steps:\n      - run: {command: echo}",
 			wantKind: KindValidation,

--- a/internal/loader/validate.go
+++ b/internal/loader/validate.go
@@ -197,13 +197,7 @@ func validateDefaults(add func(string, ...any), d *spec.Defaults) {
 		if !r.Stdin.IsZero() {
 			add("defaults.run.stdin is not supported (stdin is per-step input data, like command)")
 		}
-		if r.Timeout != "" {
-			if d, err := time.ParseDuration(r.Timeout); err != nil {
-				add("defaults.run.timeout %q is not a valid duration (e.g. \"30s\")", r.Timeout)
-			} else if d < 0 {
-				add("defaults.run.timeout must not be negative (got %q); a wall-clock bound is never below zero", r.Timeout)
-			}
-		}
+		nonNegativeDuration(add, "defaults.run.timeout", r.Timeout, "30s")
 		validateHermeticEnv(add, "defaults.run", r.ClearEnv, r.PassEnv)
 	}
 	if sv := d.Service; sv != nil {
@@ -407,5 +401,42 @@ func measurableStep(k spec.StepKind) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+// nonNegativeDuration validates a wall-clock duration field that may be zero
+// (zero usually means "disabled" or "no wait") in one place, so the accepted
+// bounds and the failure wording cannot drift between the many duration keys —
+// they already had: retry.interval accepted negatives that every timeout field
+// rejected. key is the fully-qualified field ("scenario X.steps[0].run.timeout"),
+// example the hint value shown for an unparsable string.
+func nonNegativeDuration(add func(string, ...any), key, val, example string) {
+	if val == "" {
+		return
+	}
+	d, err := time.ParseDuration(val)
+	if err != nil {
+		add("%s %q is not a valid duration (e.g. %q)", key, val, example)
+		return
+	}
+	if d < 0 {
+		add("%s must not be negative (got %q); a wall-clock bound is never below zero", key, val)
+	}
+}
+
+// positiveDuration validates a duration knob whose zero value is meaningless
+// because omitting the key already selects a documented default; def names
+// that default in the failure message.
+func positiveDuration(add func(string, ...any), key, val, example, def string) {
+	if val == "" {
+		return
+	}
+	d, err := time.ParseDuration(val)
+	if err != nil {
+		add("%s %q is not a valid duration (e.g. %q)", key, val, example)
+		return
+	}
+	if d <= 0 {
+		add("%s must be positive (got %q); omit it for the %s default", key, val, def)
 	}
 }

--- a/internal/loader/validate_pty.go
+++ b/internal/loader/validate_pty.go
@@ -3,7 +3,6 @@ package loader
 import (
 	"fmt"
 	"regexp"
-	"time"
 
 	"github.com/nao1215/atago/internal/spec"
 )
@@ -15,15 +14,7 @@ func validatePTY(add func(string, ...any), where string, p *spec.PTY) {
 	if p.Command == "" {
 		add("%s.pty.command is required", where)
 	}
-	if p.Timeout != "" {
-		d, err := time.ParseDuration(p.Timeout)
-		switch {
-		case err != nil:
-			add("%s.pty.timeout %q is not a valid duration (e.g. \"30s\")", where, p.Timeout)
-		case d <= 0:
-			add("%s.pty.timeout must be positive (got %q); omit it for the 30s default", where, p.Timeout)
-		}
-	}
+	positiveDuration(add, where+".pty.timeout", p.Timeout, "30s", "30s")
 	validateHermeticEnv(add, where+".pty", p.ClearEnv, p.PassEnv)
 	// A pty size is a uint16 on the wire; reject values the terminal cannot
 	// represent instead of silently truncating.

--- a/internal/loader/validate_run.go
+++ b/internal/loader/validate_run.go
@@ -2,7 +2,6 @@ package loader
 
 import (
 	"encoding/base64"
-	"time"
 
 	"github.com/nao1215/atago/internal/spec"
 )
@@ -15,13 +14,7 @@ import (
 // only difference was those two additions).
 func validateRunStep(add func(string, ...any), where string, r *spec.Run, runners map[string]spec.Runner, full bool) {
 	validateRunnerRef(add, where, "run", r.Runner, runners)
-	if r.Timeout != "" {
-		if d, err := time.ParseDuration(r.Timeout); err != nil {
-			add("%s.run.timeout %q is not a valid duration (e.g. \"30s\")", where, r.Timeout)
-		} else if d < 0 {
-			add("%s.run.timeout must not be negative (got %q); a wall-clock bound is never below zero", where, r.Timeout)
-		}
-	}
+	nonNegativeDuration(add, where+".run.timeout", r.Timeout, "30s")
 	if r.Command == "" {
 		add("%s.run.command is required", where)
 	} else if full && !r.ShellEnabled() && !runnerIsSSH(r.Runner, runners) {
@@ -208,11 +201,7 @@ func validateRetry(add func(string, ...any), where string, r *spec.Retry) {
 	if r.Times < 1 {
 		add("%s.retry.times must be >= 1 (got %d)", where, r.Times)
 	}
-	if r.Interval != "" {
-		if _, err := time.ParseDuration(r.Interval); err != nil {
-			add("%s.retry.interval %q is not a valid duration", where, r.Interval)
-		}
-	}
+	nonNegativeDuration(add, where+".retry.interval", r.Interval, "500ms")
 	if r.Until == nil {
 		add("%s.retry.until is required", where)
 		return

--- a/internal/loader/validate_runner.go
+++ b/internal/loader/validate_runner.go
@@ -2,7 +2,6 @@ package loader
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/nao1215/atago/internal/runner/db"
 	"github.com/nao1215/atago/internal/spec"
@@ -47,13 +46,7 @@ func validateRunners(add func(string, ...any), runners map[string]spec.Runner) {
 		}
 		// timeout is common to every runner type; catch a malformed value here
 		// instead of when the first step opens the connection.
-		if r.Timeout != "" {
-			if d, err := time.ParseDuration(r.Timeout); err != nil {
-				add("%s.timeout %q is not a valid duration (e.g. \"30s\")", where, r.Timeout)
-			} else if d < 0 {
-				add("%s.timeout must not be negative (got %q); a wall-clock bound is never below zero", where, r.Timeout)
-			}
-		}
+		nonNegativeDuration(add, where+".timeout", r.Timeout, "30s")
 		validateRunnerFields(add, where, &r)
 	}
 }

--- a/internal/loader/validate_service.go
+++ b/internal/loader/validate_service.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	"time"
 
 	"github.com/nao1215/atago/internal/spec"
 )
@@ -50,17 +49,8 @@ func validateReady(add func(string, ...any), where string, r *spec.Ready) {
 	if r.Store != "" && r.File == "" {
 		add("%s.ready.store requires file (the file whose content is captured)", where)
 	}
-	for _, d := range []struct {
-		key, val string
-	}{{"timeout", r.Timeout}, {"delay", r.Delay}} {
-		if d.val != "" {
-			if dur, err := time.ParseDuration(d.val); err != nil {
-				add("%s.ready.%s %q is not a valid duration", where, d.key, d.val)
-			} else if dur < 0 {
-				add("%s.ready.%s must not be negative (got %q); a wall-clock bound is never below zero", where, d.key, d.val)
-			}
-		}
-	}
+	nonNegativeDuration(add, where+".ready.timeout", r.Timeout, "5s")
+	nonNegativeDuration(add, where+".ready.delay", r.Delay, "500ms")
 	if r.Log != "" {
 		if _, err := regexp.Compile(r.Log); err != nil {
 			add("%s.ready.log %q is not a valid regexp: %v", where, r.Log, err)
@@ -118,12 +108,6 @@ func validateMockRoutes(add func(string, ...any), where string, routes []spec.Mo
 		if rt.Status != 0 && (rt.Status < 100 || rt.Status > 599) {
 			add("%s.status %d is not a valid HTTP status", rw, rt.Status)
 		}
-		if rt.Delay != "" {
-			if d, err := time.ParseDuration(rt.Delay); err != nil {
-				add("%s.delay %q is not a valid duration (e.g. \"500ms\")", rw, rt.Delay)
-			} else if d < 0 {
-				add("%s.delay must not be negative (got %q); a wall-clock bound is never below zero", rw, rt.Delay)
-			}
-		}
+		nonNegativeDuration(add, rw+".delay", rt.Delay, "500ms")
 	}
 }

--- a/internal/loader/validate_signal.go
+++ b/internal/loader/validate_signal.go
@@ -4,7 +4,6 @@ import (
 	"maps"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/nao1215/atago/internal/spec"
 )
@@ -29,13 +28,7 @@ func validateSignal(add func(string, ...any), where string, sg *spec.Signal, ser
 	case !spec.ValidSignalName(sg.Signal):
 		add("%s.signal.signal %q is not an accepted signal (TERM, INT, HUP, USR1, USR2, or KILL, with an optional SIG prefix)", where, sg.Signal)
 	}
-	if sg.Wait != nil && sg.Wait.Timeout != "" {
-		d, err := time.ParseDuration(sg.Wait.Timeout)
-		switch {
-		case err != nil:
-			add("%s.signal.wait.timeout %q is not a valid duration (e.g. \"5s\")", where, sg.Wait.Timeout)
-		case d <= 0:
-			add("%s.signal.wait.timeout must be positive (got %q); omit it for the 5s default", where, sg.Wait.Timeout)
-		}
+	if sg.Wait != nil {
+		positiveDuration(add, where+".signal.wait.timeout", sg.Wait.Timeout, "5s", "5s")
 	}
 }

--- a/internal/runner/ptyrun/ptyrun_unix.go
+++ b/internal/runner/ptyrun/ptyrun_unix.go
@@ -36,7 +36,7 @@ func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runne
 	}
 	cmd.Dir = workdir
 	if p.Cwd != "" {
-		cmd.Dir = resolveCwd(workdir, p.Cwd)
+		cmd.Dir = runnercmd.ResolveDir(workdir, p.Cwd)
 	}
 	cmd.Env = env
 	// A fresh process group so cleanup kills the whole tree, mirroring the cmd

--- a/internal/runner/ptyrun/ptyrun_unix_test.go
+++ b/internal/runner/ptyrun/ptyrun_unix_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	runnercmd "github.com/nao1215/atago/internal/runner/cmd"
 	"github.com/nao1215/atago/internal/spec"
 )
 
@@ -54,8 +55,8 @@ func TestResolveCwd(t *testing.T) {
 		{"/abs", "/abs"},
 	}
 	for _, c := range cases {
-		if got := resolveCwd(wd, c.cwd); got != c.want {
-			t.Errorf("resolveCwd(%q, %q) = %q, want %q", wd, c.cwd, got, c.want)
+		if got := runnercmd.ResolveDir(wd, c.cwd); got != c.want {
+			t.Errorf("ResolveDir(%q, %q) = %q, want %q", wd, c.cwd, got, c.want)
 		}
 	}
 }

--- a/internal/runner/ptyrun/ptyrun_windows.go
+++ b/internal/runner/ptyrun/ptyrun_windows.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	runnercmd "github.com/nao1215/atago/internal/runner/cmd"
 	"os/exec"
 	"strconv"
 
@@ -32,7 +33,7 @@ func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runne
 
 	dir := workdir
 	if p.Cwd != "" {
-		dir = resolveCwd(workdir, p.Cwd)
+		dir = runnercmd.ResolveDir(workdir, p.Cwd)
 	}
 
 	rows, cols := defaultRows, defaultCols

--- a/internal/runner/ptyrun/session.go
+++ b/internal/runner/ptyrun/session.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"path/filepath"
 	"sync"
 	"time"
 
@@ -233,17 +232,4 @@ func driveSession(ctx context.Context, p *spec.PTY, proc ptyProcess) (*runner.Re
 		}
 		return abort(nil)
 	}
-}
-
-// resolveCwd resolves a step cwd against the scenario workdir like the cmd
-// runner does: an absolute path is used verbatim, a relative path nests inside
-// the workdir, and an empty cwd stays at the workdir.
-func resolveCwd(workdir, cwd string) string {
-	if cwd == "" {
-		return workdir
-	}
-	if filepath.IsAbs(cwd) {
-		return cwd
-	}
-	return filepath.Join(workdir, cwd)
 }


### PR DESCRIPTION
## Summary

Five maintainability findings from the project review. Pure consolidation — behavior unchanged except one drift fix, called out below and CHANGELOG'd:

- **Duration validation (9 copy-pasted sites, already drifted)**: `nonNegativeDuration`/`positiveDuration` helpers now own the bounds and failure wording. The drift they close: **`retry.interval` accepted negative durations** that every timeout field rejects (a negative interval silently behaved as "no wait") — now rejected at load time, TDD'd (`retry interval must not be negative` loader case). The two deliberate outliers keep their richer wording: `suite.timeout` (its `use \"0\" to disable` hint) and `duration:` asserts ("a measured duration" phrasing).
- **Retry/until loop duplicated verbatim** between run steps (`stepexec.go`) and http steps (`http.go`): extracted to `pollUntil` with the abort-on-exec-error contract documented once. The http policy-violation flag rides the closure.
- **`runCmd`'s rerun-ledger blocks** (selection narrowing + failure-preserving persistence — the CLI's subtlest invariants) moved to `applyRerunSelection`/`updateRerunLedger` in `rerun.go`, next to all their primitives, with their invariant comments; `runCmd` shrinks accordingly. The just-merged #221 ledger test pins the moved behavior.
- **`ptyrun.resolveCwd`** was a private duplicate of `cmd.ResolveDir` (its own comment said "like the cmd runner does"); deleted, call sites use the exported helper.
- **Dead `var _ = time.Now` seam anchor** in `engine/suite.go` removed with its misleading comment and now-unused import.

## Verification

`go test ./...` green (loader message assertions, rerun ledger tests, retry E2E all pass), `make e2e` (393 scenarios), `golangci-lint run` 0 issues.

https://claude.ai/code/session_01Q2fDa4YigTBuFYCErfjAAP