### PR TITLE
fix(service): key the log-probe rescan off total bytes written, not retained length

### DIFF
--- a/internal/runner/service/service.go
+++ b/internal/runner/service/service.go
@@ -248,14 +248,18 @@ func (p *Proc) waitReady(ctx context.Context, r *spec.Ready, workdir string) (st
 		}
 		// Rescan only when new bytes arrived: the probe polls every 20ms, and
 		// copying + re-matching the whole capture on every idle tick is
-		// O(output²) across a readiness window for a chatty service.
-		lastLen := -1
+		// O(output²) across a readiness window for a chatty service. The
+		// freshness signal must be the MONOTONIC written-byte total, not the
+		// retained length — once a capped buffer reaches max_log_bytes its
+		// length never changes again, and a length-based check would stop
+		// rescanning exactly while the ready line is still streaming in.
+		var lastTotal int64 = -1
 		return "", p.poll(ctx, timeout, func() bool {
-			n := p.out.Len()
-			if n == lastLen {
+			n := p.out.TotalWritten()
+			if n == lastTotal {
 				return false
 			}
-			lastLen = n
+			lastTotal = n
 			return re.MatchString(p.out.String())
 		})
 	default:
@@ -331,12 +335,14 @@ type syncBuffer struct {
 	buf     bytes.Buffer
 	cap     int
 	dropped int64
+	total   int64
 }
 
 func (b *syncBuffer) Write(p []byte) (int, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	n, err := b.buf.Write(p)
+	b.total += int64(n)
 	if b.cap > 0 && b.buf.Len() > b.cap {
 		over := b.buf.Len() - b.cap
 		b.buf.Next(over) // discard the oldest bytes
@@ -354,10 +360,11 @@ func (b *syncBuffer) String() string {
 	return b.buf.String()
 }
 
-// Len reports the retained byte count (without any truncation notice), letting
-// the log probe skip rescans when nothing new arrived.
-func (b *syncBuffer) Len() int {
+// TotalWritten reports the monotonic count of bytes ever written, letting the
+// log probe skip rescans when nothing new arrived. The retained length is
+// useless for that: it stops changing the moment the buffer reaches its cap.
+func (b *syncBuffer) TotalWritten() int64 {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	return b.buf.Len()
+	return b.total
 }

--- a/internal/runner/service/service_test.go
+++ b/internal/runner/service/service_test.go
@@ -660,3 +660,27 @@ func outputOf(p *Proc) string {
 	}
 	return p.Output()
 }
+
+// TestSyncBuffer_TotalWrittenIsMonotonic guards the log-probe freshness signal
+// against the capped-buffer trap that flaked on macOS CI: once the buffer
+// reaches its cap, its retained LENGTH never changes again, so a length-based
+// "did anything new arrive?" check stops rescanning exactly while the ready
+// line is still streaming in. The written-byte total must keep growing.
+func TestSyncBuffer_TotalWrittenIsMonotonic(t *testing.T) {
+	t.Parallel()
+	b := &syncBuffer{cap: 8}
+	var prev int64
+	for i := 0; i < 5; i++ {
+		if _, err := b.Write([]byte("0123456789")); err != nil {
+			t.Fatal(err)
+		}
+		if got := b.TotalWritten(); got <= prev {
+			t.Fatalf("write %d: TotalWritten = %d, want > %d (must grow past the cap)", i, got, prev)
+		} else {
+			prev = got
+		}
+	}
+	if prev != 50 {
+		t.Errorf("TotalWritten = %d, want 50 (every written byte counted)", prev)
+	}
+}


### PR DESCRIPTION
## Summary

Fast-follow fix to #220, caught by its own test flaking on macOS CI (`TestStart_MaxLogBytesCapsOutput`): the ready.log rescan-skip used the buffer's retained **length** as the "did anything new arrive?" signal — but once a capped buffer reaches `max_log_bytes` its length never changes again, so the probe stopped rescanning exactly while the ready line was still streaming in. Slower runners (macOS) let the buffer hit the cap mid-noise and the readiness then timed out deterministically; fast Linux runners masked it by landing the whole burst before the first poll.

The freshness signal is now a **monotonic written-byte total** (`syncBuffer.TotalWritten`), pinned by `TestSyncBuffer_TotalWrittenIsMonotonic` (writes past the cap must keep growing the total).

## Tests

`go test ./internal/runner/service/ -count=3` green (including the previously-flaky cap test), `golangci-lint run` 0 issues.

https://claude.ai/code/session_01Q2fDa4YigTBuFYCErfjAAP