### PR TITLE
fix(loader): position union-shape errors at the offending value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,13 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Union-shape spec errors (`exit_code`, `stdin`, pty `send`, `json`/`yaml`
+  check lists) now carry the same `[line:col]` annotation, source excerpt, and
+  caret a typo'd key gets, pointing at the offending value. Previously they
+  were bare messages — in a 300-line spec with a dozen `exit_code` asserts,
+  "exit_code must be an integer … got \"zero\"" named neither scenario, step,
+  nor line.
+
 - A step-level `timeout:` on an ssh run step was parsed, validated — and
   silently ignored: the loader whitelists it "because it is honored remotely",
   but the engine only ever applied the runner-level timeout captured at dial.

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 386 scenarios
+74 suites · 387 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -216,7 +216,7 @@
 - [atago self-hosting / list](#atago-self-hosting--list) — 2 scenarios
   - [list surfaces suites, scenarios, tags, and gates](#scenario-list-surfaces-suites-scenarios-tags-and-gates)
   - [list --json is a stable machine contract](#scenario-list---json-is-a-stable-machine-contract)
-- [atago self-hosting / loader rejects malformed specs](#atago-self-hosting--loader-rejects-malformed-specs) — 14 scenarios
+- [atago self-hosting / loader rejects malformed specs](#atago-self-hosting--loader-rejects-malformed-specs) — 15 scenarios
   - [an empty scenario list is rejected](#scenario-an-empty-scenario-list-is-rejected)
   - [a wrong version string is rejected](#scenario-a-wrong-version-string-is-rejected)
   - [an unknown top-level field is rejected with its position](#scenario-an-unknown-top-level-field-is-rejected-with-its-position)
@@ -231,6 +231,7 @@
   - [a fixture with two content sources is rejected](#scenario-a-fixture-with-two-content-sources-is-rejected)
   - [an absolute changes glob is rejected as not workdir-relative](#scenario-an-absolute-changes-glob-is-rejected-as-not-workdir-relative)
   - [the inline stdin form is a scalar, not a mapping key](#scenario-the-inline-stdin-form-is-a-scalar-not-a-mapping-key)
+  - [a wrong-typed exit_code is rejected with its position and excerpt](#scenario-a-wrong-typed-exit_code-is-rejected-with-its-position-and-excerpt)
 - [atago self-hosting / manifest](#atago-self-hosting--manifest) — 2 scenarios
   - [manifest emits a stable JSON summary without running the spec](#scenario-manifest-emits-a-stable-json-summary-without-running-the-spec)
   - [manifest does not execute the spec's commands](#scenario-manifest-does-not-execute-the-specs-commands)
@@ -3949,6 +3950,28 @@ ${atago} run bad.atago.yaml
 #### Then
 - exit code is `2`
 - stderr contains `unknown key "inline"`
+### Scenario: a wrong-typed exit_code is rejected with its position and excerpt
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps:
+      - run: {command: echo}
+      - assert:
+          exit_code: zero
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `[8:22]`, `exit_code must be an integer`, `exit_code: zero`
 ## atago self-hosting / manifest
 Source: `test/e2e/atago/manifest.atago.yaml`
 ### Scenario: manifest emits a stable JSON summary without running the spec

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -1211,3 +1211,107 @@ func TestBugHunt_FileAndJSONExtras(t *testing.T) {
 		})
 	}
 }
+
+// TestLoadBytes_UnionErrorsCarryPosition guards the location quality of the
+// hand-decoded union nodes (exit_code, stdin, pty send, json checks). Their
+// custom unmarshalers used to return bare fmt.Errorf messages, so in a 300-line
+// spec with a dozen exit_code asserts the error named neither scenario, step,
+// nor line — a hunt, while a typo'd KEY got a [line:col], source excerpt, and
+// caret. Every union-shape error must now carry the same [line:col] annotation
+// pointing at the offending value, plus the source excerpt.
+func TestLoadBytes_UnionErrorsCarryPosition(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		src     string
+		wantMsg string // the human explanation, unchanged
+		wantPos string // the exact [line:col] of the offending value
+		excerpt string // a fragment of the offending source line
+	}{
+		{
+			name: "exit_code wrong type",
+			src: `version: "1"
+suite:
+  name: x
+scenarios:
+  - name: a
+    steps:
+      - run: {command: echo}
+      - assert:
+          exit_code: zero
+`,
+			wantMsg: "exit_code must be an integer",
+			wantPos: "[9:22]",
+			excerpt: "exit_code: zero",
+		},
+		{
+			name: "stdin wrong shape",
+			src: `version: "1"
+suite:
+  name: x
+scenarios:
+  - name: a
+    steps:
+      - run:
+          command: cat
+          stdin: [1, 2]
+`,
+			wantMsg: "stdin must be a string, {file: path}, or {base64: data}",
+			wantPos: "[9:18]",
+			excerpt: "stdin: [1, 2]",
+		},
+		{
+			name: "pty send unknown key",
+			src: `version: "1"
+suite:
+  name: x
+scenarios:
+  - name: a
+    steps:
+      - pty:
+          command: cat
+          session:
+            - send: {keyy: enter}
+`,
+			wantMsg: `send: unknown key "keyy"`,
+			wantPos: "[10:21]",
+			excerpt: "keyy: enter",
+		},
+		{
+			name: "json empty check list",
+			src: `version: "1"
+suite:
+  name: x
+scenarios:
+  - name: a
+    steps:
+      - run: {command: echo}
+      - assert:
+          stdout:
+            json: []
+`,
+			wantMsg: "a json/yaml matcher list must have at least one check",
+			wantPos: "[10:19]",
+			excerpt: "json: []",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := LoadBytes("t.atago.yaml", []byte(tc.src))
+			if err == nil {
+				t.Fatal("LoadBytes accepted the malformed union value")
+			}
+			msg := err.Error()
+			if !strings.Contains(msg, tc.wantMsg) {
+				t.Errorf("error = %q, want the explanation %q", msg, tc.wantMsg)
+			}
+			if !strings.Contains(msg, tc.wantPos) {
+				t.Errorf("error = %q, want the position %q pointing at the offending value", msg, tc.wantPos)
+			}
+			if !strings.Contains(msg, tc.excerpt) {
+				t.Errorf("error = %q, want a source excerpt containing %q", msg, tc.excerpt)
+			}
+		})
+	}
+}

--- a/internal/spec/assert.go
+++ b/internal/spec/assert.go
@@ -1,11 +1,12 @@
 package spec
 
 import (
+	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/goccy/go-yaml"
+	"github.com/goccy/go-yaml/ast"
 )
 
 // Assert checks externally observable behavior. Exactly one target family is set.
@@ -231,23 +232,15 @@ type ExitCode struct {
 }
 
 // UnmarshalYAML decodes exit_code as a scalar int, a {not: int} map, or an
-// {in: [int, ...]} map. Anything else gets a purpose-built error: the generic
-// decoder message ("string was used where mapping is expected", positioned at
-// the sub-node) reads like an internal failure, and a spec author needs to
-// know the accepted shapes.
-func (e *ExitCode) UnmarshalYAML(b []byte) error {
-	if n, err := strconv.Atoi(trimYAMLScalar(string(b))); err == nil {
-		e.Equals = &n
-		return nil
-	}
-	// A YAML-quoted integer (exit_code: "0" / '2') is still an integer to the
-	// author, but the raw-bytes Atoi above sees the surrounding quotes and fails.
-	// A plain int decode unquotes it, so a quoted scalar is accepted instead of
-	// falling through to the misleading "must be an integer … got \"0\"" error.
-	// Mapping/sequence forms ({not:…}, {in:[…]}) fail this decode and fall
-	// through to the shape-specific handling below.
+// {in: [int, ...]} map. It takes the AST node (not raw bytes) so a wrong shape
+// gets a purpose-built error POSITIONED at the offending value — the loader's
+// formatter then renders the same [line:col] + source excerpt a typo'd key
+// gets, instead of a message the author must hunt for across the spec. A
+// quoted integer (exit_code: "0") is still an integer to the author; the plain
+// int decode unquotes it.
+func (e *ExitCode) UnmarshalYAML(node ast.Node) error {
 	var n int
-	if err := yaml.Unmarshal(b, &n); err == nil {
+	if err := yaml.NodeToValue(node, &n); err == nil {
 		e.Equals = &n
 		return nil
 	}
@@ -258,9 +251,18 @@ func (e *ExitCode) UnmarshalYAML(b []byte) error {
 	// Decode strictly so an unknown key (a typo like {not: 0, bogus: 5}) is
 	// rejected here too. A custom unmarshaler bypasses the loader's document-wide
 	// yaml.Strict(), so without this the mapping form silently drops misspelled
-	// fields — the same reason PTYSend and Stdin reject unknown keys.
-	if err := yaml.UnmarshalWithOptions(b, &m, yaml.Strict()); err != nil {
-		return fmt.Errorf("exit_code must be an integer (exit_code: 0), a negation (exit_code: {not: 0}), or a set (exit_code: {in: [0, 2]}), got %q", strings.TrimSpace(string(b)))
+	// fields — the same reason PTYSend and Stdin reject unknown keys. A strict
+	// unknown-field error already carries its own position and did-you-mean, so
+	// it passes through untouched.
+	if err := yaml.NodeToValue(node, &m, yaml.Strict()); err != nil {
+		var unknown *yaml.UnknownFieldError
+		if errors.As(err, &unknown) {
+			return err
+		}
+		return &yaml.SyntaxError{
+			Message: fmt.Sprintf("exit_code must be an integer (exit_code: 0), a negation (exit_code: {not: 0}), or a set (exit_code: {in: [0, 2]}), got %q", strings.TrimSpace(node.String())),
+			Token:   node.GetToken(),
+		}
 	}
 	e.Not = m.Not
 	e.In = m.In
@@ -397,27 +399,27 @@ type JSONAssert struct {
 type JSONChecks []JSONAssert
 
 // UnmarshalYAML accepts a single mapping or a sequence of mappings, rejecting an
-// empty sequence. It probes the node's shape, then decodes strictly so an
-// unknown key inside a check (a typo like `equalss:`) is still rejected — a
-// custom unmarshaler otherwise bypasses the loader's document-wide yaml.Strict().
-func (c *JSONChecks) UnmarshalYAML(b []byte) error {
-	var probe any
-	if err := yaml.Unmarshal(b, &probe); err != nil {
-		return err
-	}
-	if _, isSeq := probe.([]any); isSeq {
+// empty sequence. It decodes from the AST node (not re-tokenized bytes) so
+// every error — a strict unknown-key rejection inside a check, or the
+// empty-list message — carries the ORIGINAL document's [line:col] instead of a
+// position relative to a detached snippet.
+func (c *JSONChecks) UnmarshalYAML(node ast.Node) error {
+	if _, isSeq := node.(*ast.SequenceNode); isSeq {
 		var many []JSONAssert
-		if err := yaml.UnmarshalWithOptions(b, &many, yaml.Strict()); err != nil {
+		if err := yaml.NodeToValue(node, &many, yaml.Strict()); err != nil {
 			return err
 		}
 		if len(many) == 0 {
-			return fmt.Errorf("a json/yaml matcher list must have at least one check")
+			return &yaml.SyntaxError{
+				Message: "a json/yaml matcher list must have at least one check",
+				Token:   node.GetToken(),
+			}
 		}
 		*c = JSONChecks(many)
 		return nil
 	}
 	var one JSONAssert
-	if err := yaml.UnmarshalWithOptions(b, &one, yaml.Strict()); err != nil {
+	if err := yaml.NodeToValue(node, &one, yaml.Strict()); err != nil {
 		return err
 	}
 	*c = JSONChecks{one}
@@ -462,17 +464,4 @@ type StoreFrom struct {
 	Rows    *StreamAssert `yaml:"rows,omitempty"`
 	Message *StreamAssert `yaml:"message,omitempty"`
 	Value   *StreamAssert `yaml:"value,omitempty"`
-}
-
-// trimYAMLScalar strips surrounding whitespace/newlines from a raw scalar node.
-func trimYAMLScalar(s string) string {
-	start := 0
-	end := len(s)
-	for start < end && (s[start] == ' ' || s[start] == '\n' || s[start] == '\t' || s[start] == '\r') {
-		start++
-	}
-	for end > start && (s[end-1] == ' ' || s[end-1] == '\n' || s[end-1] == '\t' || s[end-1] == '\r') {
-		end--
-	}
-	return s[start:end]
 }

--- a/internal/spec/pty.go
+++ b/internal/spec/pty.go
@@ -3,6 +3,9 @@ package spec
 import (
 	"fmt"
 	"strings"
+
+	"github.com/goccy/go-yaml"
+	"github.com/goccy/go-yaml/ast"
 )
 
 // ClearEnvEnabled reports whether the pty step opts into a cleared environment (#16).
@@ -71,29 +74,33 @@ func SendText(s string) *PTYSend { return &PTYSend{Text: &s} }
 
 // UnmarshalYAML decodes send as a scalar string or a {key: name} mapping,
 // rejecting unknown mapping keys (a custom unmarshaler bypasses the loader's
-// strict decode).
-func (p *PTYSend) UnmarshalYAML(unmarshal func(any) error) error {
+// strict decode). It decodes from the AST node so every shape error carries
+// the offending value's [line:col] for the loader's excerpt formatter.
+func (p *PTYSend) UnmarshalYAML(node ast.Node) error {
+	fail := func(format string, args ...any) error {
+		return &yaml.SyntaxError{Message: fmt.Sprintf(format, args...), Token: node.GetToken()}
+	}
 	var one string
-	if err := unmarshal(&one); err == nil {
+	if err := yaml.NodeToValue(node, &one); err == nil {
 		p.Text = &one
 		return nil
 	}
 	var raw map[string]any
-	if err := unmarshal(&raw); err != nil {
-		return fmt.Errorf("send must be a string or {key: <name>} (e.g. {key: enter})")
+	if err := yaml.NodeToValue(node, &raw); err != nil {
+		return fail("send must be a string or {key: <name>} (e.g. {key: enter})")
 	}
 	for k, v := range raw {
 		if k != "key" {
-			return fmt.Errorf("send: unknown key %q (accepted: key)", k)
+			return fail("send: unknown key %q (accepted: key)", k)
 		}
 		str, ok := v.(string)
 		if !ok {
-			return fmt.Errorf("send.key must be a string")
+			return fail("send.key must be a string")
 		}
 		p.Key = strings.ToLower(strings.TrimSpace(str))
 	}
 	if p.Key == "" {
-		return fmt.Errorf("send: {key: <name>} requires a key name (e.g. enter, tab, ctrl-c)")
+		return fail("send: {key: <name>} requires a key name (e.g. enter, tab, ctrl-c)")
 	}
 	return nil
 }

--- a/internal/spec/stdin.go
+++ b/internal/spec/stdin.go
@@ -1,6 +1,11 @@
 package spec
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/goccy/go-yaml"
+	"github.com/goccy/go-yaml/ast"
+)
 
 // Stdin is a run step's standard-input source (#18). It accepts either the
 // historical scalar string (inline text) or a mapping with exactly one of
@@ -31,25 +36,29 @@ func (s Stdin) IsZero() bool {
 func (s Stdin) IsMapping() bool { return s.mapped }
 
 // UnmarshalYAML decodes stdin as a scalar string or a {file}/{base64} mapping.
-// It uses the interface-based decoder so escapes like "\x1b" in the inline
-// form are resolved by goccy's parser, matching the historical behavior.
-// Unknown mapping keys are rejected here (a custom unmarshaler bypasses the
-// loader's strict-decode), with the accepted shapes spelled out.
-func (s *Stdin) UnmarshalYAML(unmarshal func(any) error) error {
+// It decodes from the AST node so escapes like "\x1b" in the inline form stay
+// resolved by goccy's parser AND every shape error carries the offending
+// value's [line:col] for the loader's excerpt-and-caret formatter. Unknown
+// mapping keys are rejected here (a custom unmarshaler bypasses the loader's
+// strict-decode), with the accepted shapes spelled out.
+func (s *Stdin) UnmarshalYAML(node ast.Node) error {
+	fail := func(format string, args ...any) error {
+		return &yaml.SyntaxError{Message: fmt.Sprintf(format, args...), Token: node.GetToken()}
+	}
 	var one string
-	if err := unmarshal(&one); err == nil {
+	if err := yaml.NodeToValue(node, &one); err == nil {
 		s.Inline = one
 		return nil
 	}
 	var raw map[string]any
-	if err := unmarshal(&raw); err != nil {
-		return fmt.Errorf("stdin must be a string, {file: path}, or {base64: data}")
+	if err := yaml.NodeToValue(node, &raw); err != nil {
+		return fail("stdin must be a string, {file: path}, or {base64: data}")
 	}
 	s.mapped = true
 	for k, v := range raw {
 		str, ok := v.(string)
 		if !ok {
-			return fmt.Errorf("stdin.%s must be a string", k)
+			return fail("stdin.%s must be a string", k)
 		}
 		switch k {
 		case "file":
@@ -57,7 +66,7 @@ func (s *Stdin) UnmarshalYAML(unmarshal func(any) error) error {
 		case "base64":
 			s.Base64 = str
 		default:
-			return fmt.Errorf("stdin: unknown key %q (accepted: file, base64)", k)
+			return fail("stdin: unknown key %q (accepted: file, base64)", k)
 		}
 	}
 	return nil

--- a/internal/spec/step_test.go
+++ b/internal/spec/step_test.go
@@ -233,18 +233,3 @@ func TestExitCode_UnmarshalYAML(t *testing.T) {
 		}
 	})
 }
-
-func TestTrimYAMLScalar(t *testing.T) {
-	t.Parallel()
-	cases := map[string]string{
-		"  7\n":    "7",
-		"\t\r\n9 ": "9",
-		"plain":    "plain",
-		"   ":      "",
-	}
-	for in, want := range cases {
-		if got := trimYAMLScalar(in); got != want {
-			t.Errorf("trimYAMLScalar(%q) = %q, want %q", in, got, want)
-		}
-	}
-}

--- a/test/e2e/atago/loader_errors.atago.yaml
+++ b/test/e2e/atago/loader_errors.atago.yaml
@@ -217,3 +217,28 @@ scenarios:
       - assert:
           exit_code: 2
           stderr: {contains: 'unknown key "inline"'}
+
+  - name: a wrong-typed exit_code is rejected with its position and excerpt
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios:
+              - name: a
+                steps:
+                  - run: {command: echo}
+                  - assert:
+                      exit_code: zero
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          # The union-shape error is positioned like a typo'd key: [line:col]
+          # pointing at the offending value, plus the source excerpt — not a
+          # bare message the author must hunt for across the spec.
+          stderr:
+            contains:
+              - "[8:22]"
+              - "exit_code must be an integer"
+              - "exit_code: zero"


### PR DESCRIPTION
## Summary

Last UX finding from the project review: the loader's error location quality was wildly inconsistent. A typo'd key gets `[13:13]` + source excerpt + caret + did-you-mean; a wrong-typed union value (`exit_code: zero`) got a bare message naming neither scenario, step, nor line.

The four hand-decoded union nodes (`exit_code`, `stdin`, pty `send`, `json`/`yaml` check lists) now implement goccy's `NodeUnmarshaler` instead of the bytes/interface forms:

- shape errors are returned as `yaml.SyntaxError` carrying the node's token, so the existing `formatYAMLError` path renders them exactly like a typo'd key:

```
bad.atago.yaml: [14:22] exit_code must be an integer (exit_code: 0), a negation (exit_code: {not: 0}), or a set (exit_code: {in: [0, 2]}), got "zero"
  11 |     steps:
  12 |       - run: {command: echo hi}
  13 |       - assert:
> 14 |           exit_code: zero
                            ^
```

- decoding from the AST node keeps positions anchored to the **original document**, which also fixes the json-check strict sub-decode errors that previously reported positions relative to a detached snippet;
- strict unknown-field errors inside the mapping forms (`{not: 0, bogus: 5}`) pass through untouched with their own position and did-you-mean hint;
- escape resolution for inline `stdin`/`send` strings is unchanged (`NodeToValue` decodes through the same parser), and marshal round-trips are untouched.

Out of scope, noted from the review: semantic validation errors (durations etc.) already carry the full `scenario "NAME".steps[i]` path; giving them line numbers needs Source-lookup plumbing through the validators and is left for a future pass.

## Tests

- `TestLoadBytes_UnionErrorsCarryPosition` (red first): all four unions assert exact `[line:col]`, message, and excerpt
- Self-hosted E2E scenario in `loader_errors.atago.yaml` pinning the positioned exit_code error end-to-end
- `go test ./...`, `make e2e` (395 scenarios), `make docs`, `golangci-lint run` 0 issues

https://claude.ai/code/session_01Q2fDa4YigTBuFYCErfjAAP