### PR TITLE
chore(release): stamp CHANGELOG for v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-07-09
+
 ### Added
 
 - Console failure blocks now say WHERE and WHY without a `--verbose` detour:


### PR DESCRIPTION
## Summary

Stamps the Unreleased section as **v0.10.0** (2026-07-09). Minor bump: the release adds the `services[].max_log_bytes` spec key plus the hosted documentation website, failure-report context (spec path + stderr tail), positioned union-shape loader errors, selector-aware no-match UX with `--ci` hard-failing empty selections, ssh step-timeout parity, mock request-log artifacts, vt10x crash/hang hardening with a new fuzz target, and the schema/struct parity drift guards — everything merged in PRs #209–#224.

After merge: `git tag v0.10.0 && git push origin v0.10.0` (GoReleaser handles artifacts/signing/SBOM/cask), then `website/data/spec_keys.json` gets regenerated so the new key's Since column reads v0.10.0 instead of unreleased.

https://claude.ai/code/session_01Q2fDa4YigTBuFYCErfjAAP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new release entry header for version `0.10.0` in the changelog.
  * Organized the changelog to include the upcoming release section directly under the unreleased heading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->