### PR TITLE
chore(website): stamp service.max_log_bytes Since column as v0.10.0

### DIFF
--- a/website/data/spec_keys.json
+++ b/website/data/spec_keys.json
@@ -254,7 +254,7 @@
   "service.command": "v0.1.0",
   "service.cwd": "v0.1.0",
   "service.env": "v0.1.0",
-  "service.max_log_bytes": "unreleased",
+  "service.max_log_bytes": "v0.10.0",
   "service.name": "v0.1.0",
   "service.pass_env": "v0.3.0",
   "service.ready": "v0.1.0",


### PR DESCRIPTION
Regenerates `website/data/spec_keys.json` after tagging v0.10.0, so the Reference page's Since column for the new `services[].max_log_bytes` key reads `v0.10.0` instead of `unreleased` (the documented post-release step from website/README.md; `TestSpecSchema_SpecKeysComplete` keeps the file in lockstep with the schema).

https://claude.ai/code/session_01Q2fDa4YigTBuFYCErfjAAP