### PR TITLE
fix(engine): honor teardown security violations, guard leaked refs, atomic snapshot writes, converged retry changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- A network-policy (`permissions.network.allow`) violation raised by a
+  `teardown` step now sets `SecurityViolation` and exits 6, instead of being
+  silently swallowed so a spec that contacted a denied host during cleanup
+  reported a fully green run. Teardown failures still never change the pass/fail
+  verdict — only the security signal is now honored regardless of phase (#248).
+- A store- or matrix-provided value that itself contains a `${...}` reference no
+  longer leaks that reference verbatim into a no-shell command's argv (or into
+  `cwd`). Expansion is single-pass, so such a reference was never expanded; the
+  unresolved-reference guard now catches it after substitution and errors with
+  the leaked reference named instead of running a garbled command (#249).
+- `--update-snapshots` no longer races under `--parallel` when several scenarios
+  share one golden file: snapshot writes are now atomic (temp-file + rename), so
+  identical-content scenarios update the shared golden deterministically instead
+  of failing nondeterministically in a non-atomic remove/create window (#250).
+- A `changes:` assert after a retried (`retry.until`) run step now reflects only
+  the final, converged attempt's workdir delta rather than the cumulative delta
+  of every attempt: the baseline is re-captured before each attempt, so a
+  command with a per-attempt side effect reports the net effect the `until` gate
+  accepted (#251).
+
 ## [0.10.0] - 2026-07-09
 
 ### Added

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -954,7 +954,7 @@ touch a; [ -f b ] && touch c; touch b; [ -f c ]
 ```
 #### Then
 - exit code is `0`
-- the step changed exactly created `a`, `b`, `c`, modified nothing, deleted nothing
+- the step changed exactly created `c`, modified nothing, deleted nothing
 ### Scenario: deleting and recreating a byte-identical file appears in no list (POSIX)
 _skipped on Windows_
 #### Given

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -32,7 +32,7 @@
   - [a generator touches exactly the files it should (POSIX)](#scenario-a-generator-touches-exactly-the-files-it-should-posix)
   - [an unexpected creation breaks the exact contract (POSIX)](#scenario-an-unexpected-creation-breaks-the-exact-contract-posix)
   - [stdout_to counts as created, and modified nothing holds (portable)](#scenario-stdout_to-counts-as-created-and-modified-nothing-holds-portable)
-  - [the delta over a retried step is cumulative across all attempts (POSIX)](#scenario-the-delta-over-a-retried-step-is-cumulative-across-all-attempts-posix)
+  - [the delta over a retried step reflects only the converged attempt (POSIX)](#scenario-the-delta-over-a-retried-step-reflects-only-the-converged-attempt-posix)
   - [deleting and recreating a byte-identical file appears in no list (POSIX)](#scenario-deleting-and-recreating-a-byte-identical-file-appears-in-no-list-posix)
   - [deleting and recreating with different content is modified only (POSIX)](#scenario-deleting-and-recreating-with-different-content-is-modified-only-posix)
   - [stdout_to overwrites a fixture (modified) while stderr_to creates an empty file (POSIX)](#scenario-stdout_to-overwrites-a-fixture-modified-while-stderr_to-creates-an-empty-file-posix)
@@ -946,7 +946,7 @@ echo produced
 - the step changed exactly created `result.txt`, modified nothing, deleted nothing
 #### Generated artifacts
 - `result.txt`
-### Scenario: the delta over a retried step is cumulative across all attempts (POSIX)
+### Scenario: the delta over a retried step reflects only the converged attempt (POSIX)
 _skipped on Windows_
 #### When
 ```shell

--- a/internal/engine/changes_test.go
+++ b/internal/engine/changes_test.go
@@ -124,6 +124,44 @@ scenarios:
 	}
 }
 
+// TestEngine_Changes_RetryReflectsLastAttempt is the regression for #251: a
+// `changes:` assert after a retried run step must pin the delta of the final
+// (converged) attempt, not the cumulative delta of every attempt. Each attempt
+// here creates its own attempt-N file and the until gate accepts once two prior
+// attempts exist; before the fix the delta spanned attempt-0..attempt-2, so an
+// author asking for the converged net effect (attempt-2 only) saw a spurious
+// "unexpected created file attempt-0/attempt-1" failure.
+func TestEngine_Changes_RetryReflectsLastAttempt(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX shell counter to make each retry attempt write its own file")
+	}
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: retry-delta
+scenarios:
+  - name: each attempt writes its own file
+    steps:
+      - run:
+          shell: true
+          command: "n=$(ls attempt-* 2>/dev/null | wc -l); touch attempt-$n; test $n -ge 2"
+          retry:
+            times: 5
+            interval: 5ms
+            until:
+              exit_code: 0
+      - assert:
+          exit_code: 0
+          changes:
+            created:
+              - attempt-2
+`)
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed (changes must reflect the converged last attempt, not the cumulative delta): %+v", res.Status, res.Scenarios[0].Steps)
+	}
+}
+
 // TestEngine_Changes_UnexpectedFileFails proves an unexpected created file
 // fails the assertion (the exhaustive contract) (#70).
 func TestEngine_Changes_UnexpectedFileFails(t *testing.T) {

--- a/internal/engine/changes_test.go
+++ b/internal/engine/changes_test.go
@@ -126,26 +126,28 @@ scenarios:
 
 // TestEngine_Changes_RetryReflectsLastAttempt is the regression for #251: a
 // `changes:` assert after a retried run step must pin the delta of the final
-// (converged) attempt, not the cumulative delta of every attempt. Each attempt
-// here creates its own attempt-N file and the until gate accepts once two prior
-// attempts exist; before the fix the delta spanned attempt-0..attempt-2, so an
-// author asking for the converged net effect (attempt-2 only) saw a spurious
-// "unexpected created file attempt-0/attempt-1" failure.
+// (converged) attempt, not the cumulative delta of every attempt. Here attempt
+// 1 creates a and b but exits 1 (c does not exist yet); attempt 2 finds b
+// present, creates c, and passes. Before the fix the baseline was scanned once
+// before attempt 1, so the delta spanned a, b, and c and an author asking for
+// the converged net effect (c only) saw a spurious "unexpected created file
+// a/b" failure. With the fix the baseline is re-taken before attempt 2, so a
+// and b are inputs and only c is reported.
 func TestEngine_Changes_RetryReflectsLastAttempt(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS == "windows" {
-		t.Skip("uses a POSIX shell counter to make each retry attempt write its own file")
+		t.Skip("uses POSIX shell test/touch to make each retry attempt write its own file")
 	}
 	res := runSpec(t, `
 version: "1"
 suite:
   name: retry-delta
 scenarios:
-  - name: each attempt writes its own file
+  - name: converged attempt delta
     steps:
       - run:
           shell: true
-          command: "n=$(ls attempt-* 2>/dev/null | wc -l); touch attempt-$n; test $n -ge 2"
+          command: 'touch a; [ -f b ] && touch c; touch b; [ -f c ]'
           retry:
             times: 5
             interval: 5ms
@@ -155,7 +157,9 @@ scenarios:
           exit_code: 0
           changes:
             created:
-              - attempt-2
+              - c
+            modified: []
+            deleted: []
 `)
 	if res.Status != StatusPassed {
 		t.Fatalf("status = %s, want passed (changes must reflect the converged last attempt, not the cumulative delta): %+v", res.Status, res.Scenarios[0].Steps)

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -484,6 +484,101 @@ scenarios:
 	}
 }
 
+// TestEngine_StoredRefLeaksIntoArgvErrors is a regression for #249: a stored
+// value that itself contains a ${...} reference, substituted into a no-shell
+// run.command, would survive verbatim into argv because expansion is
+// single-pass. The pre-expansion guard cannot see it (it runs on the raw
+// command, where the outer ${p} IS defined), so the post-expansion guard must
+// catch the leaked reference and error instead of running a garbled command.
+func TestEngine_StoredRefLeaksIntoArgvErrors(t *testing.T) {
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: store-leak
+scenarios:
+  - name: stored ref leaks into argv
+    steps:
+      - run:
+          shell: true
+          command: "printf '%s' '${undefined_var}/x'"
+      - store:
+          name: p
+          from:
+            stdout:
+              trim: true
+      - run:
+          command: "`+catCmd()+` ${p}"
+      - assert:
+          exit_code: 0
+`)
+	if res.Status != StatusError {
+		t.Fatalf("status = %s, want error (leaked ${undefined_var} must not reach argv): %+v", res.Status, res.Scenarios)
+	}
+	msg := res.Scenarios[0].Steps[2].ErrMsg
+	if !strings.Contains(msg, "undefined_var") {
+		t.Errorf("error = %q, want it to name the leaked ${undefined_var}", msg)
+	}
+}
+
+// TestEngine_MatrixRefLeaksIntoArgvErrors is the matrix-row twin of #249: a
+// matrix value carrying a ${...} reference is seeded raw, so substituting it
+// into a no-shell command leaks the inner reference (even one naming a builtin
+// like ${workdir}, which single-pass expansion never re-expands) into argv.
+func TestEngine_MatrixRefLeaksIntoArgvErrors(t *testing.T) {
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: matrix-leak
+scenarios:
+  - name: matrix ref leaks
+    matrix:
+      - { path: "${workdir}/data" }
+    steps:
+      - run:
+          command: "`+catCmd()+` ${path}"
+      - assert:
+          exit_code: 0
+`)
+	if res.Status != StatusError {
+		t.Fatalf("status = %s, want error (leaked ${workdir} must not reach argv): %+v", res.Status, res.Scenarios)
+	}
+	msg := res.Scenarios[0].Steps[0].ErrMsg
+	if !strings.Contains(msg, "workdir") {
+		t.Errorf("error = %q, want it to name the leaked ${workdir}", msg)
+	}
+}
+
+// TestEngine_EscapedRefInArgvIsLiteral guards the #249 fix against a false
+// positive: an author who writes $${name} in a no-shell command (or stores a
+// value that deliberately escapes one) wants the literal text ${name} in argv,
+// not an error. The leak guard must only fire for a reference introduced by a
+// substituted value, never for a deliberate escape.
+func TestEngine_EscapedRefInArgvIsLiteral(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("no-shell run needs a real printf binary; cmd.exe printf is not an exe")
+	}
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: escape-literal
+scenarios:
+  - name: escaped ref stays literal in argv
+    steps:
+      - run:
+          command: "printf %s $${literal_ref}"
+      - assert:
+          exit_code: 0
+          stdout:
+            equals: "${literal_ref}"
+`)
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed (an escaped $${name} is a deliberate literal): %+v", res.Status, res.Scenarios)
+	}
+}
+
 // parityScenarios builds a spec with n scenarios cycling passed/failed/skipped so
 // the parallel scheduler has real mixed outcomes to interleave.
 func parityScenarios(n int) string {

--- a/internal/engine/http.go
+++ b/internal/engine/http.go
@@ -33,7 +33,7 @@ func (e *Engine) runHTTPStep(ctx context.Context, h *spec.HTTP, st *store.Store,
 		r, sv, rerr := e.runHTTP(ctx, h, st, rc, workdir)
 		secViolation = sv
 		return r, rerr
-	})
+	}, nil) // http steps never carry a changes assert, so no per-attempt rebaselining
 	if err != nil {
 		return nil, nil, secViolation, err
 	}

--- a/internal/engine/http_test.go
+++ b/internal/engine/http_test.go
@@ -156,6 +156,56 @@ scenarios:
 	}
 }
 
+// TestEngine_HTTPNetworkPolicyViolationInTeardown proves a network-policy
+// breach raised by a teardown step still sets SecurityViolation (and thus
+// exits 6), even though a teardown failure never changes the scenario verdict
+// (#248). Before the fix runTeardown discarded execStep's secViolation return,
+// so a denied host contacted only during cleanup reported a fully green run.
+func TestEngine_HTTPNetworkPolicyViolationInTeardown(t *testing.T) {
+	t.Parallel()
+	srv := loginServer(t)
+	src := fmt.Sprintf(`
+version: "1"
+suite:
+  name: api
+permissions:
+  network:
+    allow:
+      - api.allowed.example
+runners:
+  api:
+    type: http
+    base_url: %s
+scenarios:
+  - name: denied host only in teardown
+    steps:
+      - run: {shell: true, command: echo ok}
+      - assert: {exit_code: 0}
+    teardown:
+      - http:
+          runner: api
+          method: GET
+          path: /me
+`, srv.URL)
+
+	res := runSpec(t, src)
+	// The body passed; the teardown contract keeps the scenario verdict passed.
+	if res.Status != StatusPassed {
+		t.Errorf("status = %s, want passed (teardown failures do not change the verdict)", res.Status)
+	}
+	// But the egress-policy breach in teardown must still be recorded.
+	if !res.SecurityViolation {
+		t.Error("SecurityViolation = false, want true (denied host contacted in teardown)")
+	}
+	td := res.Scenarios[0].Teardown
+	if len(td) != 1 {
+		t.Fatalf("recorded %d teardown steps, want 1", len(td))
+	}
+	if !strings.Contains(td[0].ErrMsg, "network policy denies") {
+		t.Errorf("teardown err = %q, want network policy denial", td[0].ErrMsg)
+	}
+}
+
 func TestEngine_HTTPUnknownRunner(t *testing.T) {
 	t.Parallel()
 	src := `

--- a/internal/engine/mask_test.go
+++ b/internal/engine/mask_test.go
@@ -62,6 +62,62 @@ scenarios:
 	}
 }
 
+// TestEngine_UpdateSnapshotsSharedGoldenParallel is the regression for #250:
+// several matrix rows that assert against the SAME snapshot path, updated under
+// the default parallelism, must update the shared golden deterministically when
+// every row produces byte-identical output. Before the atomic-write fix the
+// concurrent snapshot.Update calls raced in WriteFileNoFollow's non-atomic
+// remove/create window and the update failed ~80% of the time with a confusing
+// filesystem-race error.
+func TestEngine_UpdateSnapshotsSharedGoldenParallel(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "s.atago.yaml")
+	src := `
+version: "1"
+suite:
+  name: snap-race
+scenarios:
+  - name: row ${v}
+    matrix:
+      - { v: "a" }
+      - { v: "b" }
+      - { v: "c" }
+      - { v: "d" }
+      - { v: "e" }
+      - { v: "f" }
+      - { v: "g" }
+      - { v: "h" }
+    steps:
+      - run: { shell: true, command: echo same }
+      - assert:
+          stdout:
+            snapshot: snaps/race.txt
+`
+	if err := os.WriteFile(specPath, []byte(src), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s, err := loader.LoadBytes(specPath, []byte(src))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	eng := New()
+	eng.UpdateSnapshots = true
+	eng.Parallel = 8
+	res := eng.Run(context.Background(), s, specPath)
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed (identical-content rows must update a shared golden without racing): %+v", res.Status, res.Scenarios)
+	}
+	golden, err := os.ReadFile(filepath.Join(dir, "snaps", "race.txt"))
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if strings.TrimSpace(string(golden)) != "same" {
+		t.Errorf("golden = %q, want %q", golden, "same")
+	}
+}
+
 // Regression for issue #12: a failed service-readiness probe embeds the service's
 // raw output in its error; a secret in that output must be masked before it
 // reaches the report.

--- a/internal/engine/polluntil.go
+++ b/internal/engine/polluntil.go
@@ -19,13 +19,20 @@ import (
 // fails the step if they never all passed. Keeping one loop means a future
 // change to retry semantics (jitter, max-elapsed, ctx-err reporting) cannot
 // silently apply to one step kind and not the other.
-func pollUntil(ctx context.Context, retry *spec.Retry, st *store.Store, env assert.Env, exec func(context.Context) (*runner.Result, error)) (*runner.Result, []*assert.CheckResult, error) {
+func pollUntil(ctx context.Context, retry *spec.Retry, st *store.Store, env assert.Env, exec func(context.Context) (*runner.Result, error), beforeAttempt func()) (*runner.Result, []*assert.CheckResult, error) {
 	interval, _ := time.ParseDuration(retry.Interval) // validated at load time
 	until := expandAssert(st, retry.Until)
 
 	var last *runner.Result
 	var checks []*assert.CheckResult
 	for attempt := 1; attempt <= retry.Times; attempt++ {
+		// beforeAttempt re-captures the caller's `changes:` baseline just before
+		// each attempt, so a following changes assert measures only the final
+		// (converged) attempt's workdir delta rather than the sum of every
+		// attempt's per-run side effects (#251).
+		if beforeAttempt != nil {
+			beforeAttempt()
+		}
 		r, err := exec(ctx)
 		if err != nil {
 			return nil, nil, err

--- a/internal/engine/stepexec.go
+++ b/internal/engine/stepexec.go
@@ -34,11 +34,28 @@ func unresolvedRunRefMsg(field, name string, shellExpandable bool) string {
 		field, name, name)
 }
 
+// leakedRunRefMsg explains a run field whose value, after substitution, still
+// contains a ${name} reference that leaked in from a store/matrix value.
+// Expansion is single-pass, so a reference carried by a substituted value is
+// never re-expanded and would reach argv (or cwd) verbatim. field names the
+// spec field ("run.command"/"run.cwd") and name the leaked reference.
+func leakedRunRefMsg(field, name string) string {
+	return fmt.Sprintf(
+		"%s expands to text that still contains ${%s}: a store or matrix value used here itself contains a ${%s} reference, and variable expansion is single-pass, so that inner reference is left verbatim and would leak into the command rather than being expanded. Reference ${%s} directly in the field instead of storing a value that contains it",
+		field, name, name, name)
+}
+
 // execStep runs one step and returns its result, its status contribution
 // (passed/failed/error), and whether it breached the security policy. It is
 // shared by the Steps loop and the Teardown loop; only the caller decides
 // whether the contribution affects the scenario's verdict.
-func (x *scenarioRun) execStep(ctx context.Context, i int, step *spec.Step) (StepResult, Status, bool) {
+//
+// beforeAttempt, when non-nil, is invoked immediately before each execution
+// attempt of a retried run step. runSteps uses it to re-capture the `changes:`
+// baseline before every attempt, so the recorded delta reflects only the final
+// (converged) attempt rather than the cumulative delta of all attempts (#251).
+// It is nil for the teardown path and for every non-run step kind.
+func (x *scenarioRun) execStep(ctx context.Context, i int, step *spec.Step, beforeAttempt func()) (StepResult, Status, bool) {
 	sr := StepResult{Index: i, Kind: step.Kind()}
 	status := StatusPassed
 	secViolation := false
@@ -86,9 +103,25 @@ func (x *scenarioRun) execStep(ctx context.Context, i int, step *spec.Step) (Ste
 				sr.ErrMsg = unresolvedRunRefMsg("run.cwd", names[0], false)
 				return sr, StatusError, false
 			}
+			// The guards above run on the raw fields, where the outer ${p}/${path}
+			// IS defined. But a store/matrix value can itself contain a ${...}
+			// reference, and expansion is single-pass — so substituting such a value
+			// leaves an unexpanded reference that leaks verbatim into a no-shell argv
+			// (or into cwd, which no shell ever expands). Catch that leaked reference
+			// here instead of running a garbled command (#249).
+			if !step.Run.ShellEnabled() {
+				if _, leaked := x.st.ExpandDetectingLeaks(step.Run.Command); len(leaked) > 0 {
+					sr.ErrMsg = leakedRunRefMsg("run.command", leaked[0])
+					return sr, StatusError, false
+				}
+			}
+			if _, leaked := x.st.ExpandDetectingLeaks(step.Run.Cwd); len(leaked) > 0 {
+				sr.ErrMsg = leakedRunRefMsg("run.cwd", leaked[0])
+				return sr, StatusError, false
+			}
 		}
 		run := mergeScenarioEnv(x.scEnv, expandRun(x.st, step.Run), x.st)
-		r, untilChecks, err := x.e.runStep(ctx, run, x.st, x.workdir, x.specDir, x.rc, x.sshConns)
+		r, untilChecks, err := x.e.runStep(ctx, run, x.st, x.workdir, x.specDir, x.rc, x.sshConns, beforeAttempt)
 		if err != nil {
 			sr.ErrMsg = err.Error()
 			return sr, StatusError, isPolicyViolation(err)
@@ -225,11 +258,18 @@ func (x *scenarioRun) runSteps(ctx context.Context, leadingFixtures int) {
 		// (stdout_to/stderr_to) land after the baseline and count as created.
 		var preScan fsdelta.Snapshot
 		scanChanges := measurableForChanges(step.Kind()) && changesFollows(x.sc.Steps, i)
+		// rescan re-captures the baseline. For a retried run step it is invoked
+		// before every attempt (via execStep → runStep → pollUntil), so the delta
+		// below reflects only the final, converged attempt rather than the sum of
+		// every attempt's writes (#251). The pre-loop scan here still covers pty
+		// steps and the no-retry path.
+		var rescan func()
 		if scanChanges {
-			preScan, _ = fsdelta.Scan(x.workdir)
+			rescan = func() { preScan, _ = fsdelta.Scan(x.workdir) }
+			rescan()
 		}
 
-		sr, status, secViolation := x.execStep(ctx, i, step)
+		sr, status, secViolation := x.execStep(ctx, i, step, rescan)
 		if scanChanges && x.current != nil {
 			post, _ := fsdelta.Scan(x.workdir)
 			delta := fsdelta.Diff(preScan, post)
@@ -271,7 +311,15 @@ func (x *scenarioRun) runTeardown(ctx context.Context) {
 			defer cancel()
 		}
 		for i := range x.sc.Teardown {
-			sr, _, _ := x.execStep(tctx, i, &x.sc.Teardown[i])
+			sr, _, secViolation := x.execStep(tctx, i, &x.sc.Teardown[i], nil) // teardown never carries a changes assert
+			// A teardown failure never changes the scenario verdict — the behavior
+			// under test was decided by the steps above. But a security-policy
+			// breach (e.g. a denied network host contacted during cleanup) is not a
+			// verdict question: it must still set SecurityViolation so the run does
+			// not report green after a declared egress rule was violated (#248).
+			if secViolation {
+				x.out.SecurityViolation = true
+			}
 			sr.ErrMsg = x.masker.Mask(sr.ErrMsg)
 			x.out.Teardown = append(x.out.Teardown, sr)
 		}
@@ -291,7 +339,7 @@ func isSSHRunner(name string, runners map[string]spec.Runner) bool {
 // configured), and an execution error. With retry, the command is re-run until
 // until passes or the attempt budget is spent; the last attempt's result is what
 // later steps observe.
-func (e *Engine) runStep(ctx context.Context, run *spec.Run, st *store.Store, workdir, specDir string, rc runConfig, sshConns map[string]*sshrunner.Runner) (*runner.Result, []*assert.CheckResult, error) {
+func (e *Engine) runStep(ctx context.Context, run *spec.Run, st *store.Store, workdir, specDir string, rc runConfig, sshConns map[string]*sshrunner.Runner, beforeAttempt func()) (*runner.Result, []*assert.CheckResult, error) {
 	// A run step naming an ssh runner executes remotely; otherwise it
 	// runs locally via the cmd runner. The runner is resolved once (not per
 	// retry attempt) so the timeout precedence below sees the pristine authored
@@ -355,11 +403,16 @@ func (e *Engine) runStep(ctx context.Context, run *spec.Run, st *store.Store, wo
 	}
 
 	if run.Retry == nil {
+		// No retry: the caller's single pre-step `changes:` baseline already
+		// covers this one execution, so no per-attempt rebaselining is needed.
+		if beforeAttempt != nil {
+			beforeAttempt()
+		}
 		r, err := exec(ctx)
 		return r, nil, err
 	}
 	env := assert.Env{Workdir: workdir, SpecDir: specDir, UpdateSnapshots: e.UpdateSnapshots, Secrets: rc.masker.MaskBytes, Scrub: rc.scrubber.Apply}
-	return pollUntil(ctx, run.Retry, st, env, exec)
+	return pollUntil(ctx, run.Retry, st, env, exec, beforeAttempt)
 }
 
 // measurableForChanges reports whether a step kind produces a workdir delta a

--- a/internal/engine/suite.go
+++ b/internal/engine/suite.go
@@ -116,7 +116,7 @@ func (e *Engine) runSuiteSteps(ctx context.Context, steps []spec.Step, rt *suite
 			}
 		case spec.StepRun:
 			run := mergeScenarioEnv(rt.env, expandRun(rt.st, step.Run), rt.st)
-			r, untilChecks, err := e.runStep(ctx, run, rt.st, rt.dir, rc.specDir, rc, rt.sshConns)
+			r, untilChecks, err := e.runStep(ctx, run, rt.st, rt.dir, rc.specDir, rc, rt.sshConns, nil) // suite setup/teardown steps carry no changes assert
 			if err != nil {
 				sr.ErrMsg = err.Error()
 				failed = true

--- a/internal/security/path.go
+++ b/internal/security/path.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 )
 
 // A user-declared path in a spec (a file assertion target, a store source, a
@@ -61,6 +62,16 @@ func ReadFileNoFollow(path string) ([]byte, error) {
 	return os.ReadFile(path) //nolint:gosec // path is containment-checked by the caller and Lstat-guarded against a leaf symlink
 }
 
+// writeLocks serializes WriteFileNoFollow calls that target the same path.
+// Several parallel scenarios can share one golden file (e.g. matrix rows with an
+// identical snapshot under --update-snapshots); without serialization their
+// writes race in the filesystem — a non-atomic remove/create window on POSIX, or
+// a MoveFileEx sharing violation between concurrent renames on Windows. Keying
+// the lock on the destination path lets writes to different files still proceed
+// concurrently. Entries are never deleted: the count is bounded by the distinct
+// output paths a run touches, and each holds only a mutex pointer (#250).
+var writeLocks sync.Map // dest path -> *sync.Mutex
+
 // WriteFileNoFollow writes data to dest without following a symlink planted at
 // dest. Lexical containment proves dest is inside its root, but the untrusted
 // program under test may have created a link there pointing outside the root;
@@ -70,13 +81,19 @@ func ReadFileNoFollow(path string) ([]byte, error) {
 // The payload is written to a fresh temp file (created O_EXCL, so a planted link
 // is never written through) in dest's own directory and then atomically renamed
 // over dest. os.Rename replaces the destination name without following a link
-// that may sit there, and the rename is a single filesystem operation — so
-// concurrent writers targeting one path (e.g. several parallel scenarios sharing
-// one golden under --update-snapshots) can never observe a torn file or race in
-// a Lstat→Remove→create window; identical-content writers all succeed and the
-// last rename wins (#250). This is portable — unlike O_NOFOLLOW, which is not
+// that may sit there, and the rename is a single filesystem operation, so a
+// reader never observes a torn file. Concurrent writers targeting the same path
+// are additionally serialized on a per-path lock (see writeLocks) so identical
+// writes all succeed and the last one wins deterministically on every OS,
+// instead of colliding in the create window (POSIX) or a rename sharing
+// violation (Windows) (#250). This is portable — unlike O_NOFOLLOW, which is not
 // available on all platforms.
 func WriteFileNoFollow(dest string, data []byte, perm os.FileMode) error {
+	muAny, _ := writeLocks.LoadOrStore(dest, &sync.Mutex{})
+	mu := muAny.(*sync.Mutex) //nolint:errcheck // only *sync.Mutex is ever stored
+	mu.Lock()
+	defer mu.Unlock()
+
 	if fi, err := os.Lstat(dest); err == nil && fi.Mode()&os.ModeSymlink != 0 {
 		return fmt.Errorf("refusing to write through the existing symlink %q (it escapes the scenario root)", dest)
 	}

--- a/internal/security/path.go
+++ b/internal/security/path.go
@@ -65,29 +65,43 @@ func ReadFileNoFollow(path string) ([]byte, error) {
 // dest. Lexical containment proves dest is inside its root, but the untrusted
 // program under test may have created a link there pointing outside the root;
 // following it on write would escape containment and clobber a host file (TOCTOU,
-// issue #16). An existing symlink is rejected outright; an existing regular file
-// is removed and re-created with O_EXCL so a link planted in the race is never
-// written through (O_EXCL fails atomically on any existing path). This is
-// portable — unlike O_NOFOLLOW, which is not available on all platforms.
+// issue #16). An existing symlink is rejected outright.
+//
+// The payload is written to a fresh temp file (created O_EXCL, so a planted link
+// is never written through) in dest's own directory and then atomically renamed
+// over dest. os.Rename replaces the destination name without following a link
+// that may sit there, and the rename is a single filesystem operation — so
+// concurrent writers targeting one path (e.g. several parallel scenarios sharing
+// one golden under --update-snapshots) can never observe a torn file or race in
+// a Lstat→Remove→create window; identical-content writers all succeed and the
+// last rename wins (#250). This is portable — unlike O_NOFOLLOW, which is not
+// available on all platforms.
 func WriteFileNoFollow(dest string, data []byte, perm os.FileMode) error {
-	if fi, err := os.Lstat(dest); err == nil {
-		if fi.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("refusing to write through the existing symlink %q (it escapes the scenario root)", dest)
-		}
-		if err := os.Remove(dest); err != nil {
-			return err
-		}
+	if fi, err := os.Lstat(dest); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to write through the existing symlink %q (it escapes the scenario root)", dest)
 	}
-	f, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_EXCL, perm) //nolint:gosec // dest is containment-checked by the caller; O_EXCL guards against a planted link
+	// Create the temp file in dest's directory so the rename stays on one
+	// filesystem (a cross-device rename is not atomic and errors). CreateTemp's
+	// name is unique per call, so concurrent writers never collide on the temp.
+	tmp, err := os.CreateTemp(filepath.Dir(dest), "."+filepath.Base(dest)+".tmp-*")
 	if err != nil {
 		return err
 	}
-	_, werr := f.Write(data)
-	cerr := f.Close()
-	if werr != nil {
-		return werr
+	tmpName := tmp.Name()
+	// Best-effort cleanup: harmless if the rename already consumed the temp.
+	defer func() { _ = os.Remove(tmpName) }()
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		return err
 	}
-	return cerr
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, dest)
 }
 
 // WithinRoot reports whether resolved lies inside root (root itself counts).

--- a/internal/security/path_test.go
+++ b/internal/security/path_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -158,6 +159,48 @@ func TestWriteFileNoFollow(t *testing.T) {
 	}
 	if got, _ := os.ReadFile(victim); string(got) != "original" {
 		t.Errorf("host file was modified through the symlink: %q", got)
+	}
+}
+
+// TestWriteFileNoFollow_ConcurrentIdenticalContent is the regression for #250:
+// several parallel scenarios that share one golden file call WriteFileNoFollow
+// on the same path with byte-identical content (e.g. matrix rows producing the
+// same output under --update-snapshots). The old non-atomic
+// Lstat→Remove→OpenFile(O_EXCL) sequence raced — one goroutine's Remove hit the
+// file another had already removed (ENOENT), or its O_EXCL open hit a file
+// another had just created — so an update failed nondeterministically even
+// though every writer produced the same bytes. An atomic write must let every
+// concurrent identical write succeed and leave the expected content behind.
+func TestWriteFileNoFollow_ConcurrentIdenticalContent(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	dest := filepath.Join(root, "shared.golden")
+	content := []byte("same output from every row\n")
+
+	const writers = 16
+	var wg sync.WaitGroup
+	errs := make([]error, writers)
+	start := make(chan struct{})
+	for i := range writers {
+		wg.Go(func() {
+			<-start // release all goroutines at once to maximize contention
+			errs[i] = WriteFileNoFollow(dest, content, 0o600)
+		})
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("writer %d: WriteFileNoFollow errored on identical concurrent write: %v", i, err)
+		}
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("final content = %q, want %q", got, content)
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -82,6 +82,48 @@ func (s *Store) Expand(in string) string {
 	})
 }
 
+// ExpandDetectingLeaks expands in like Expand, and additionally reports the
+// names of any ${...} references that a *substituted value* carries into the
+// output. Expansion is deliberately single-pass (see Expand): a reference that
+// a store/matrix value contains is never re-examined, so it survives verbatim
+// into the result — and, for a no-shell run.command, into argv, where nothing
+// will ever expand it. Reporting these lets the run guard refuse the garbled
+// command instead of leaking the literal text (#249).
+//
+// Only references introduced by a substituted value are reported. A reference
+// the author wrote directly in in is not (an unresolved one is already the
+// pre-expansion guard's job, and a resolved one expands normally), and an
+// escaped $${name} — in the input or inside a substituted value — is a
+// deliberate literal, never a leak.
+func (s *Store) ExpandDetectingLeaks(in string) (string, []string) {
+	if s == nil || !varRef.MatchString(in) {
+		return in, nil
+	}
+	var leaked []string
+	out := varRef.ReplaceAllStringFunc(in, func(m string) string {
+		sub := varRef.FindStringSubmatch(m)
+		escaped, name := sub[1], sub[2]
+		if escaped != "" {
+			return "${" + name + "}"
+		}
+		v, ok := s.resolve(name)
+		if !ok {
+			return m // authored unresolved reference: pre-expansion guard's domain
+		}
+		// The substituted value is inserted verbatim (single-pass); any live
+		// reference it carries will never be expanded and would leak into argv.
+		// An escaped $${x} inside the value is a deliberate literal, so skip it.
+		for _, vm := range varRef.FindAllStringSubmatch(v, -1) {
+			if vm[1] != "" {
+				continue
+			}
+			leaked = append(leaked, vm[2])
+		}
+		return v
+	})
+	return out, leaked
+}
+
 // Escape rewrites text so that Expand returns it verbatim: it prefixes an extra
 // `$` onto exactly the references Expand acts on — a live `${name}` becomes the
 // literal `$${name}`, and an already-escaped `$${name}` becomes `$$${name}` —

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -46,6 +46,51 @@ func TestExpand(t *testing.T) {
 	}
 }
 
+// TestExpandDetectingLeaks proves the leak detector (#249) reports exactly the
+// ${...} references a substituted value introduces — never one the author wrote
+// directly, and never an escaped literal. Single-pass expansion never re-visits
+// a substituted value, so any live reference it carries survives verbatim into
+// the output; the no-shell argv guard uses this to refuse a garbled command.
+func TestExpandDetectingLeaks(t *testing.T) {
+	t.Parallel()
+	s := New()
+	s.Set("p", "${undefined_var}/x") // a stored value carrying an unresolved ref
+	s.Set("q", "${workdir}/data")    // a value carrying a builtin-looking ref
+	s.Set("plain", "value")          // a value with no reference
+	s.Set("esc", "$${keep}")         // a value with a deliberately escaped ref
+	s.Set("workdir", "/tmp/wd")      // workdir IS defined, but single-pass never re-expands it
+
+	tests := []struct {
+		name, in, wantOut string
+		wantLeaked        []string
+	}{
+		{"stored unresolved ref leaks", "cat ${p}", "cat ${undefined_var}/x", []string{"undefined_var"}},
+		{"stored builtin ref leaks (never re-expanded)", "cat ${q}", "cat ${workdir}/data", []string{"workdir"}},
+		{"plain value does not leak", "echo ${plain}", "echo value", nil},
+		{"escaped ref in a value is not a leak", "echo ${esc}", "echo $${keep}", nil},
+		{"authored unresolved ref is not a leak", "echo ${direct}", "echo ${direct}", nil},
+		{"authored escape is not a leak", "echo $${lit}", "echo ${lit}", nil},
+		{"no references at all", "echo hi", "echo hi", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, leaked := s.ExpandDetectingLeaks(tt.in)
+			if out != tt.wantOut {
+				t.Errorf("out = %q, want %q", out, tt.wantOut)
+			}
+			if len(leaked) != len(tt.wantLeaked) {
+				t.Fatalf("leaked = %v, want %v", leaked, tt.wantLeaked)
+			}
+			for i := range leaked {
+				if leaked[i] != tt.wantLeaked[i] {
+					t.Errorf("leaked[%d] = %q, want %q", i, leaked[i], tt.wantLeaked[i])
+				}
+			}
+		})
+	}
+}
+
 // TestExpand_EnvRefs proves ${env:NAME} resolves from the host environment:
 // set variables expand (including set-but-empty), unset ones stay verbatim so
 // they surface as failures, $${env:NAME} stays literal, and env names never

--- a/test/e2e/atago/changes.atago.yaml
+++ b/test/e2e/atago/changes.atago.yaml
@@ -93,11 +93,13 @@ scenarios:
     skip:
       os: windows
     steps:
-      # Pinned semantic: with retry, atago pre-scans ONCE before attempt 1 and
-      # post-scans ONCE after the LAST attempt — so the changes delta is the
-      # cumulative footprint of every attempt, not just the winning one. This
-      # command fails on attempt 1 (c does not exist yet) and passes on attempt
-      # 2, and a, b, c are all created along the way.
+      # Pinned semantic (#251): with retry, atago re-scans the workdir baseline
+      # before EVERY attempt, so the changes delta reflects only the final,
+      # converged attempt — the state the until gate accepted — not the
+      # cumulative footprint of every attempt. This command fails on attempt 1
+      # (c does not exist yet) and passes on attempt 2. On attempt 2, a and b
+      # already exist from attempt 1 (so they are baseline, not changes), and the
+      # only new file the winning attempt creates is c.
       - run:
           shell: true
           command: 'touch a; [ -f b ] && touch c; touch b; [ -f c ]'
@@ -110,8 +112,6 @@ scenarios:
           exit_code: 0
           changes:
             created:
-              - a
-              - b
               - c
             modified: []
             deleted: []

--- a/test/e2e/atago/changes.atago.yaml
+++ b/test/e2e/atago/changes.atago.yaml
@@ -89,7 +89,7 @@ scenarios:
             modified: []
             deleted: []
 
-  - name: the delta over a retried step is cumulative across all attempts (POSIX)
+  - name: the delta over a retried step reflects only the converged attempt (POSIX)
     skip:
       os: windows
     steps:


### PR DESCRIPTION
## Summary

Fixes four correctness bugs found in the post-v0.10.0 project review, each with a failing-test-first (TDD) regression:

- **#248 — teardown security violations are swallowed.** A `permissions.network.allow` breach raised by a `teardown` step exited 0 and never set `SecurityViolation`, so a spec that contacted a denied host during cleanup reported a fully green run. `runTeardown` now captures `execStep`'s `secViolation` return and sets `out.SecurityViolation` (→ exit 6). Teardown failures still never change the pass/fail verdict — only the security signal is honored regardless of phase.
- **#249 — a substituted `${...}` leaks into no-shell argv.** A store/matrix value that itself contains a `${...}` reference was substituted into a no-shell `run.command` (or `cwd`) and, because expansion is single-pass, the inner reference survived verbatim into argv. The pre-expansion guard could not see it (the outer `${p}`/`${path}` *is* defined). A new `store.ExpandDetectingLeaks` reports references introduced by a substituted value (but never an authored escape `$${name}`), and the run guard errors with the leaked reference named.
- **#250 — `--update-snapshots` races under `--parallel` on a shared golden.** Concurrent `snapshot.Update` calls raced in `WriteFileNoFollow`'s non-atomic Lstat→Remove→O_EXCL window when several scenarios shared one golden path. Writes are now atomic (temp-file + `os.Rename`), so identical-content scenarios update deterministically. The existing-symlink refusal (#16 TOCTOU protection) is preserved, and `rename` never follows a link planted at the target.
- **#251 — `changes:` after a retried run accumulates every attempt's delta.** The workdir baseline was scanned once before all `retry.until` attempts, so a command with a per-attempt side effect showed N files rather than the converged net effect. The baseline is now re-captured before each attempt (via a `beforeAttempt` hook threaded to `pollUntil`), so the delta reflects only the final, accepted attempt.

## Tests

- `store`: `TestExpandDetectingLeaks` (leak-vs-escape table).
- `security`: `TestWriteFileNoFollow_ConcurrentIdenticalContent` (16-goroutine race, fails ~100% pre-fix).
- `engine`: teardown policy violation, stored/matrix ref leak + escaped-literal control, shared-golden parallel update, retry-reflects-last-attempt.
- Updated the `test/e2e/atago/changes.atago.yaml` retry scenario (which had codified the old cumulative behavior) to the converged-attempt semantics and regenerated `doc/e2e/atago.md`.

All packages pass with `-race`; `golangci-lint` clean.

Closes #248, #249, #250, #251.
