### PR TITLE
feat(website): landing h1, right-ratio social card, favicon, sitemap/robots, search-intent tool titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Website SEO, social, and landing improvements (no tool behavior change): the
+  landing page now leads with a visible `<h1>` tagline above a right-sized logo
+  (with explicit `width`/`height` on the logo and embedded GIFs to eliminate
+  layout shift); every page ships a 1.91:1 (1200x630) social card and a square
+  favicon, both derived at build time from the committed logo, plus a
+  `twitter:card` and `og:image:width`/`height` tags; the sitemap no longer marks
+  the cookbook and real-world pages as priority 0, `robots.txt` advertises the
+  sitemap, and the 44 generated real-world pages get search-intent titles
+  ("Testing <tool> with atago — executable E2E specs") and coverage-based
+  descriptions (#238, #239, #240).
+
 ### Fixed
 
 - A network-policy (`permissions.network.allow`) violation raised by a

--- a/website/assets/css/site.css
+++ b/website/assets/css/site.css
@@ -80,6 +80,32 @@ header nav .sponsor {
   border-radius: 8px;
 }
 
+/* Landing hero: a smaller logo sitting directly above the tagline h1, so the
+   "what is this" headline is the first text a visitor and a crawler see. */
+.hero {
+  text-align: center;
+  margin: 0.5rem 0 1.5rem;
+}
+
+.hero-logo {
+  max-width: min(360px, 90%);
+  height: auto;
+  border-radius: 8px;
+}
+
+.hero h1 {
+  margin: 0.75rem 0 0;
+  font-size: 1.6rem;
+  line-height: 1.25;
+}
+
+/* Embedded doc images (demo/snapshot GIFs) keep their intrinsic ratio while
+   scaling down, so the reserved width/height box never overflows the column. */
+main img {
+  max-width: 100%;
+  height: auto;
+}
+
 main {
   max-width: 56rem;
   margin: 0 auto;

--- a/website/content/_content.gotmpl
+++ b/website/content/_content.gotmpl
@@ -84,7 +84,7 @@
     {{ with (findRE `[0-9]+ suites? · [0-9]+ scenarios?` $md 1) }}{{ $coverage = index . 0 }}{{ end }}
     {{ $pageDesc := printf "Behavior docs for %s, generated from the executable atago specs that run in CI." $name }}
     {{ if $coverage }}
-      {{ $pageDesc = printf "Testing %s with atago: %s of executable E2E specs asserting exit codes, output, and file changes — generated from the specs that run in CI." $name $coverage }}
+      {{ $pageDesc = printf "Testing %s with atago: %s — executable E2E specs asserting exit codes, output, and file changes, generated from the specs that run in CI." $name $coverage }}
     {{ end }}
     {{ $.AddPage (dict
         "path" (printf "real-world/%s" $name)

--- a/website/content/_content.gotmpl
+++ b/website/content/_content.gotmpl
@@ -74,10 +74,24 @@
     {{ $md = replaceRE `!\[([^\]]*)\]\(\.\./\.\./` "![$1](https://raw.githubusercontent.com/nao1215/atago/main/" $md }}
     {{ $md = replaceRE `\]\(\.\./\.\./` (printf "](%s" $gh) $md }}
     {{ $md = replaceRE `\]\(\.\./` (printf "](%sdoc/" $gh) $md }}
+    {{/* Give each tool page a search-intent <title>/description instead of the
+         bare "<tool> · atago" nobody queries. The visible h1 stays the tool
+         name (page.html renders .Title); seoTitle drives the <title>/og:title,
+         and the description leads with the suite/scenario counts pulled from the
+         doc's own Summary line so 44 pages get 44 distinct snippets. */}}
+    {{ $seoTitle := printf "Testing %s with atago — executable E2E specs" $name }}
+    {{ $coverage := "" }}
+    {{ with (findRE `[0-9]+ suites? · [0-9]+ scenarios?` $md 1) }}{{ $coverage = index . 0 }}{{ end }}
+    {{ $pageDesc := printf "Behavior docs for %s, generated from the executable atago specs that run in CI." $name }}
+    {{ if $coverage }}
+      {{ $pageDesc = printf "Testing %s with atago: %s of executable E2E specs asserting exit codes, output, and file changes — generated from the specs that run in CI." $name $coverage }}
+    {{ end }}
     {{ $.AddPage (dict
         "path" (printf "real-world/%s" $name)
         "title" $name
-        "params" (dict "description" (printf "Behavior docs for %s, generated from the executable atago specs that run in CI." $name))
+        "params" (dict
+          "seoTitle" $seoTitle
+          "description" $pageDesc)
         "content" (dict "mediaType" "text/markdown" "value" $md)) }}
   {{ end }}
 {{ end }}

--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -89,6 +89,14 @@ target = "assets/schema/atago.schema.json"
 source = "../doc/img"
 target = "static/img"
 
+# The same images, mounted again as processable assets so the layouts can
+# derive sized variants at build time (a right-ratio social card, a square
+# favicon, and width/height for embedded images to kill layout shift) without
+# committing any extra binary — everything still comes from doc/img.
+[[module.mounts]]
+source = "../doc/img"
+target = "assets/imgsrc"
+
 [[module.mounts]]
 source = "../site/samples"
 target = "static/samples"

--- a/website/layouts/_markup/render-image.html
+++ b/website/layouts/_markup/render-image.html
@@ -1,6 +1,19 @@
 {{- $u := .Destination -}}
-{{- if and (hasPrefix $u "/") (not (hasPrefix $u "//")) -}}
-  {{- $u = relURL (strings.TrimPrefix "/" $u) -}}
+{{- /* Images committed under doc/img are mounted as processable assets too, so
+       resolve one to a resource and emit its intrinsic width/height — the
+       browser then reserves the box before the (often large GIF) loads, so the
+       page does not shift as each image arrives. The resource is published
+       as-is (no re-encoding), so animated GIFs keep animating. */ -}}
+{{- $img := "" -}}
+{{- if hasPrefix $u "/img/" -}}
+  {{- $img = resources.Get (printf "imgsrc/%s" (strings.TrimPrefix "/img/" $u)) -}}
 {{- end -}}
+{{- if $img -}}
+<img src="{{ $img.RelPermalink }}" alt="{{ .Text }}"{{ with .Title }} title="{{ . }}"{{ end }} width="{{ $img.Width }}" height="{{ $img.Height }}" loading="lazy">
+{{- else -}}
+  {{- if and (hasPrefix $u "/") (not (hasPrefix $u "//")) -}}
+    {{- $u = relURL (strings.TrimPrefix "/" $u) -}}
+  {{- end -}}
 <img src="{{ $u }}" alt="{{ .Text }}"{{ with .Title }} title="{{ . }}"{{ end }} loading="lazy">
+{{- end -}}
 {{- /* chomp trailing newline */ -}}

--- a/website/layouts/baseof.html
+++ b/website/layouts/baseof.html
@@ -4,17 +4,36 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 {{- $title := printf "%s · %s" .Title site.Title }}
+{{- with .Params.seoTitle }}{{ $title = . }}{{ end }}
 {{- if .IsHome }}{{ $title = printf "%s — %s" site.Title site.Params.tagline }}{{ end }}
 <title>{{ $title }}</title>
 {{- $desc := or .Params.description site.Params.description }}
 <meta name="description" content="{{ $desc }}">
 <link rel="canonical" href="{{ .Permalink }}">
+{{- /* A right-ratio (1.91:1) social card and a square favicon, both derived at
+       build time from the committed logo: the logo is fit to 1000px wide and
+       padded onto a 1200x630 brand-dark canvas so X/Slack/Discord render a full
+       card instead of cropping the 3:1 source. Falls back to the raw logo if the
+       processable asset is ever unavailable. */ -}}
+{{- $ogImage := absURL "img/atago-logo.jpg" }}{{ $ogW := "2172" }}{{ $ogH := "724" }}{{ $favicon := relURL "img/atago-logo.jpg" }}{{ $faviconType := "image/jpeg" }}
+{{- with resources.Get "imgsrc/atago-logo.jpg" }}
+  {{- $card := (.Resize "1000x q90").Filter (images.Padding 149 100 148 100 "#0d1117") }}
+  {{- $ogImage = $card.Permalink }}{{ $ogW = string $card.Width }}{{ $ogH = string $card.Height }}
+  {{- $icon := ((.Resize "512x").Filter (images.Padding 170 0 171 0 "#0d1117")).Resize "64x64 png" }}
+  {{- $favicon = $icon.RelPermalink }}{{ $faviconType = "image/png" }}
+{{- end }}
 <meta property="og:title" content="{{ $title }}">
 <meta property="og:description" content="{{ $desc }}">
 <meta property="og:type" content="website">
 <meta property="og:url" content="{{ .Permalink }}">
-<meta property="og:image" content="{{ absURL "img/atago-logo.jpg" }}">
-<link rel="icon" href="{{ relURL "img/atago-logo.jpg" }}">
+<meta property="og:image" content="{{ $ogImage }}">
+<meta property="og:image:width" content="{{ $ogW }}">
+<meta property="og:image:height" content="{{ $ogH }}">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{{ $title }}">
+<meta name="twitter:description" content="{{ $desc }}">
+<meta name="twitter:image" content="{{ $ogImage }}">
+<link rel="icon" href="{{ $favicon }}" type="{{ $faviconType }}"{{ if eq $faviconType "image/png" }} sizes="64x64"{{ end }}>
 {{- $css := slice (resources.Get "css/site.css") (resources.Get "css/chroma.css") | resources.Concat "css/bundle.css" | minify | fingerprint }}
 <link rel="stylesheet" href="{{ $css.RelPermalink }}">
 </head>

--- a/website/layouts/home.html
+++ b/website/layouts/home.html
@@ -1,4 +1,12 @@
 {{ define "main" }}
-<p class="logo"><img src="{{ relURL "img/atago-logo.jpg" }}" alt="atago logo" width="400"></p>
+<div class="hero">
+{{- with resources.Get "imgsrc/atago-logo.jpg" }}
+{{- $logo := .Resize "800x q90" }}
+<img class="hero-logo" src="{{ $logo.RelPermalink }}" alt="atago" width="{{ $logo.Width }}" height="{{ $logo.Height }}">
+{{- else }}
+<img class="hero-logo" src="{{ relURL "img/atago-logo.jpg" }}" alt="atago" width="400">
+{{- end }}
+<h1>{{ site.Params.tagline }}</h1>
+</div>
 {{ .Content }}
 {{ end }}

--- a/website/layouts/home.html
+++ b/website/layouts/home.html
@@ -4,7 +4,7 @@
 {{- $logo := .Resize "800x q90" }}
 <img class="hero-logo" src="{{ $logo.RelPermalink }}" alt="atago" width="{{ $logo.Width }}" height="{{ $logo.Height }}">
 {{- else }}
-<img class="hero-logo" src="{{ relURL "img/atago-logo.jpg" }}" alt="atago" width="400">
+<img class="hero-logo" src="{{ relURL "img/atago-logo.jpg" }}" alt="atago" width="400" height="133">
 {{- end }}
 <h1>{{ site.Params.tagline }}</h1>
 </div>

--- a/website/layouts/robots.txt
+++ b/website/layouts/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: {{ "sitemap.xml" | absURL }}

--- a/website/layouts/sitemap.xml
+++ b/website/layouts/sitemap.xml
@@ -1,0 +1,15 @@
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  {{- /* Deliberately omit <priority>: Hugo defaults programmatically-added
+         pages (the cookbook and every real-world page, created via AddPage in
+         content/_content.gotmpl) to priority 0, which told crawlers the site's
+         richest content was the least important. With no priority element the
+         crawler weights every URL equally. */ -}}
+  {{ range .Pages }}
+  <url>
+    <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
+    <lastmod>{{ .Lastmod.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
+    <changefreq>{{ . }}</changefreq>{{ end }}
+  </url>
+  {{ end }}
+</urlset>


### PR DESCRIPTION
## Summary

Presentation-only website improvements (no tool behavior change). Everything is still generated from committed files — no hand-authored binary is added; the social card and favicon are derived from `doc/img/atago-logo.jpg` at build time via Hugo image processing.

### #238 — landing page had no h1 and buried the demo below an oversized logo
- `layouts/home.html` now renders a visible `<h1>` with the tagline directly under a right-sized logo (the 2172x724 source is resized to 800px wide instead of shipping ~5x the displayed pixels).
- Logo and embedded GIFs carry explicit `width`/`height` (the demo/snapshot GIFs are resolved to their committed source via a new mount and the render-image hook emits their intrinsic dimensions), so the page no longer shifts as images load.

### #239 — social cards and crawl signals
- Every page now references a 1.91:1 (1200x630) social card (logo fit onto a brand-dark canvas via `images.Padding`) with `og:image:width`/`og:image:height` and `summary_large_image` `twitter:card`/`twitter:title`/`twitter:description`/`twitter:image` tags.
- A square 64x64 PNG favicon replaces the non-square 3:1 JPEG.
- A custom `layouts/sitemap.xml` omits `<priority>` entirely, so the cookbook and all real-world pages are no longer told to crawlers as priority 0.
- `layouts/robots.txt` now advertises `Sitemap: https://nao1215.github.io/atago/sitemap.xml`.

### #240 — search-intent titles/descriptions for the 44 generated real-world pages
- `content/_content.gotmpl` titles each tool page "Testing <tool> with atago — executable E2E specs" (visible h1 stays the bare tool name) and builds the meta description from the doc's own suite/scenario counts, e.g. "Testing git with atago: 3 suites · 8 scenarios of executable E2E specs asserting exit codes, output, and file changes — generated from the specs that run in CI."

## Verification

`make website` builds clean (6 processed images). Verified in `public/`:
- home `<h1>` present; hero logo 800x267 with width/height; demo.gif width=1180 height=760.
- `og:image` 1200x630 with width/height; `twitter:card` summary_large_image; favicon 64x64 PNG.
- `robots.txt` carries the Sitemap line; `sitemap.xml` has 51 URLs and 0 `<priority>` elements; XML validates.
- `real-world/git/` title and coverage-based description as above.

Closes #238, closes #239, closes #240.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the homepage with a larger, clearer hero section and visible tagline.
  * Improved social sharing previews and favicon rendering for better appearance across platforms.
  * Added a sitemap and robots guidance to help search engines discover site pages.

* **Bug Fixes**
  * Reduced layout shift by sizing embedded images more consistently.
  * Refined page titles and descriptions for better search results and landing-page relevance.
  * Adjusted sitemap visibility signals for a more balanced crawl experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->