### PR TITLE
feat(website): lazy copy buttons, content-visibility, and an accessibility pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project follows [Semantic Versioning](https://semver.org/).
   sitemap, and the 44 generated real-world pages get search-intent titles
   ("Testing <tool> with atago — executable E2E specs") and coverage-based
   descriptions (#238, #239, #240).
+- Website performance and accessibility (no tool behavior change): the heavy
+  real-world pages skip off-screen layout via `content-visibility` on code
+  blocks and tables, and copy buttons are now created lazily as blocks scroll
+  into view (instead of building ~1,900 buttons at load); a skip-to-content link,
+  keyboard/touch-visible copy buttons with `:focus-visible` outlines, and real
+  `<table>` semantics (horizontal scroll moved to a wrapper so screen readers
+  keep announcing the Reference tables) round out an accessibility pass (#237,
+  #242).
 
 ### Fixed
 

--- a/website/assets/css/site.css
+++ b/website/assets/css/site.css
@@ -186,10 +186,19 @@ pre code {
   background: var(--code-bg) !important;
 }
 
+/* A real <table> (not display:block) so browsers keep announcing it as a table
+   to assistive tech; horizontal scrolling for wide tables lives on the
+   .table-wrap container emitted by the table render hook and the spec-reference
+   shortcode instead. */
 table {
-  display: block;
-  overflow-x: auto;
+  display: table;
+  width: 100%;
   border-collapse: collapse;
+  margin: 1rem 0;
+}
+
+.table-wrap {
+  overflow-x: auto;
   margin: 1rem 0;
 }
 
@@ -320,4 +329,56 @@ tbody tr:nth-child(even) {
 
 #where-to-go + ul li a:first-child {
   font-weight: 600;
+}
+
+/* --- performance: skip off-screen layout on the heaviest pages (#237) --- */
+/* content-visibility:auto lets the browser skip layout and paint of off-screen
+   code blocks and tables — the real-world pages reach ~1.7 MB with 1,896 <pre>
+   blocks — while contain-intrinsic-size gives a placeholder box so the scrollbar
+   stays stable and remembered sizes avoid re-layout thrash on scroll. */
+main pre,
+main .table-wrap {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 6rem;
+}
+
+/* --- accessibility: skip-to-content link (#242) --- */
+.skip-link {
+  position: absolute;
+  left: -9999px;
+  top: 0;
+  z-index: 10;
+  padding: 0.5rem 0.85rem;
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 0 0 6px 0;
+}
+
+.skip-link:focus {
+  left: 0;
+}
+
+/* --- accessibility: copy button reachable by keyboard and touch (#242) --- */
+/* Previously only pre:hover revealed it, so keyboard users tabbed onto an
+   invisible control and touch devices (no hover) never saw it at all. */
+pre:focus-within .copy,
+.copy:focus-visible {
+  opacity: 1;
+}
+
+@media (hover: none) {
+  pre .copy {
+    opacity: 1;
+  }
+}
+
+/* --- accessibility: visible focus outlines (#242) --- */
+header nav a:focus-visible,
+.hlink:focus-visible,
+.copy:focus-visible,
+main a:focus-visible {
+  outline: 2px solid var(--link);
+  outline-offset: 2px;
+  border-radius: 2px;
 }

--- a/website/layouts/_markup/render-table.html
+++ b/website/layouts/_markup/render-table.html
@@ -1,0 +1,26 @@
+{{- /* Wrap markdown tables in a horizontally-scrollable container instead of
+     making the <table> itself display:block (which strips the implicit ARIA
+     table role, so screen readers stop announcing it as a table). The table
+     stays a real table; only the wrapper scrolls. */ -}}
+<div class="table-wrap">
+<table>
+<thead>
+{{- range .THead }}
+<tr>
+{{- range . }}
+<th{{ with .Alignment }} style="text-align: {{ . }}"{{ end }}>{{ .Text }}</th>
+{{- end }}
+</tr>
+{{- end }}
+</thead>
+<tbody>
+{{- range .TBody }}
+<tr>
+{{- range . }}
+<td{{ with .Alignment }} style="text-align: {{ . }}"{{ end }}>{{ .Text }}</td>
+{{- end }}
+</tr>
+{{- end }}
+</tbody>
+</table>
+</div>

--- a/website/layouts/_shortcodes/spec-reference.html
+++ b/website/layouts/_shortcodes/spec-reference.html
@@ -54,12 +54,14 @@
   {{- if $node -}}
 <h3 id="spec-{{ $s.id }}"><code>{{ $s.title }}</code> <a class="hlink" href="#spec-{{ $s.id }}" aria-label="Link to this section">#</a></h3>
 {{- with $desc }}<p>{{ . | markdownify }}</p>{{ end }}
+<div class="table-wrap">
 <table>
 <thead><tr><th>Key</th><th>Type</th><th>Description</th><th>Since</th></tr></thead>
 <tbody>
 {{- partial "spec-rows.html" (dict "root" $schema "node" $node "base" $base "depth" 0 "since" $since) -}}
 </tbody>
 </table>
+</div>
   {{- end -}}
 {{- end -}}
 </div>

--- a/website/layouts/baseof.html
+++ b/website/layouts/baseof.html
@@ -38,6 +38,7 @@
 <link rel="stylesheet" href="{{ $css.RelPermalink }}">
 </head>
 <body>
+<a class="skip-link" href="#main">Skip to content</a>
 <header>
 <nav>
 <a class="brand" href="{{ site.Home.RelPermalink }}">atago</a>
@@ -48,19 +49,30 @@
 <a class="sponsor" href="https://github.com/sponsors/nao1215">&#9825; Sponsor</a>
 </nav>
 </header>
-<main>
+<main id="main">
 {{ block "main" . }}{{ end }}
 </main>
 <footer>
 <p>MIT licensed · <a href="https://github.com/nao1215/atago">nao1215/atago</a> · every page on this site is generated from files committed in the repository.</p>
 </footer>
 <script>
-if (navigator.clipboard && window.isSecureContext) {
-  document.querySelectorAll("pre").forEach(function (pre) {
+// Lazy copy buttons: building a button for every <pre> at load is ~1,896
+// synchronous DOM insertions on the heaviest real-world page, before first
+// paint. Create each button only when its block scrolls near the viewport, via
+// IntersectionObserver — off-screen blocks stay button-free, and a block a
+// finger can reach on a touch device is one that has scrolled into view. CSS
+// reveals the button on hover, keyboard focus, and always on hover-less pointers.
+(function () {
+  if (!(navigator.clipboard && window.isSecureContext)) return;
+  var main = document.getElementById("main");
+  if (!main) return;
+  function addButton(pre) {
+    if (pre.querySelector(".copy")) return;
     var b = document.createElement("button");
     b.type = "button";
     b.className = "copy";
     b.textContent = "copy";
+    b.setAttribute("aria-label", "Copy code to clipboard");
     b.addEventListener("click", function () {
       var code = pre.querySelector("code");
       navigator.clipboard.writeText(code ? code.innerText : pre.innerText).then(function () {
@@ -72,8 +84,19 @@ if (navigator.clipboard && window.isSecureContext) {
       });
     });
     pre.appendChild(b);
-  });
-}
+  }
+  var pres = main.querySelectorAll("pre");
+  if ("IntersectionObserver" in window) {
+    var io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (en) {
+        if (en.isIntersecting) { addButton(en.target); io.unobserve(en.target); }
+      });
+    }, { rootMargin: "300px" });
+    pres.forEach(function (pre) { io.observe(pre); });
+  } else {
+    pres.forEach(addButton);
+  }
+})();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Presentation-only performance and accessibility pass (no tool behavior change).

### #237 — cut the render cost of the huge real-world pages
- `content-visibility: auto` with a `contain-intrinsic-size` estimate on `main pre` and `main .table-wrap`, so the browser skips layout/paint of the off-screen code blocks and tables that make the real-world pages (mimixbox ~1.7 MB, 1,896 `<pre>`) slow to first paint.
- Copy buttons are now created lazily via `IntersectionObserver` as each block scrolls near the viewport, instead of building ~1,900 buttons synchronously at load. Off-screen blocks stay button-free; touch devices still get a button once a block scrolls into view (falls back to eager creation without IntersectionObserver).

### #242 — accessibility pass
- A skip-to-content link (`#main` on `<main>`) as the first body element, visually hidden until focused.
- Copy buttons reachable by keyboard and touch: `:focus-visible` and `pre:focus-within` reveal them, and `@media (hover: none)` shows them persistently.
- Real `<table>` semantics restored: `table` is no longer `display: block` (which dropped the implicit ARIA table role); horizontal scroll moved to a `.table-wrap` wrapper emitted by a new markdown table render hook and by the spec-reference shortcode, so screen readers keep announcing the Reference's spec-key tables.
- Visible `:focus-visible` outlines for nav, heading-anchor, copy, and in-content links.

## Verification

`make website` builds clean. Verified in `public/`:
- skip link present; `<main id=main>`; no eager `querySelectorAll("pre").forEach` button loop; `IntersectionObserver` present.
- markdown tables and all 33 reference tables wrapped in `.table-wrap` (33/33), each a real `<table>` with intact `<thead>/<tbody>`; home "why" table renders correctly.
- `content-visibility:auto` present in the bundled CSS.

Closes #237, closes #242.
