### PR TITLE
feat(website): sticky TOC sidebar and a live cookbook recipe filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project follows [Semantic Versioning](https://semver.org/).
   `<table>` semantics (horizontal scroll moved to a wrapper so screen readers
   keep announcing the Reference tables) round out an accessibility pass (#237,
   #242).
+- Website cookbook and reference navigation (no tool behavior change): on wide
+  viewports the "On this page" list becomes a sticky sidebar next to the content
+  (the collapsible box stays on narrow screens), and the cookbook gains a live
+  recipe filter — typing a keyword hides the non-matching recipe sections and
+  their sidebar entries — turning the 63-recipe single scroll into a browsable
+  catalogue without splitting the committed file or changing any anchor (#241).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project follows [Semantic Versioning](https://semver.org/).
   (the collapsible box stays on narrow screens), and the cookbook gains a live
   recipe filter — typing a keyword hides the non-matching recipe sections and
   their sidebar entries — turning the 63-recipe single scroll into a browsable
-  catalogue without splitting the committed file or changing any anchor (#241).
+  catalog without splitting the committed file or changing any anchor (#241).
 
 ### Fixed
 

--- a/website/assets/css/site.css
+++ b/website/assets/css/site.css
@@ -382,3 +382,87 @@ main a:focus-visible {
   outline-offset: 2px;
   border-radius: 2px;
 }
+/* --- cookbook / reference: sticky TOC sidebar on wide viewports (#241) --- */
+/* Anchor jumps land clear of the top edge instead of flush against it. */
+main h2,
+main h3 {
+  scroll-margin-top: 1rem;
+}
+
+/* Narrow (and any non-toc page): keep the collapsible inline TOC, no sidebar. */
+.sidebar {
+  display: none;
+}
+
+.toc-filter {
+  width: 100%;
+  box-sizing: border-box;
+  margin-bottom: 0.75rem;
+  padding: 0.4rem 0.6rem;
+  font: inherit;
+  color: var(--fg);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+
+@media (min-width: 1200px) {
+  /* Widen the column band for TOC pages so a sidebar fits beside the 56rem
+     article instead of wasting the margin the narrow cap leaves. */
+  main:has(.page.has-toc) {
+    max-width: 76rem;
+  }
+
+  .page.has-toc {
+    display: grid;
+    grid-template-columns: 15rem minmax(0, 1fr);
+    gap: 2.5rem;
+    align-items: start;
+  }
+
+  .page.has-toc article {
+    max-width: 56rem;
+    min-width: 0;
+  }
+
+  .sidebar {
+    display: block;
+  }
+
+  .sidebar-inner {
+    position: sticky;
+    top: 1rem;
+    max-height: calc(100vh - 2rem);
+    overflow-y: auto;
+    font-size: 0.9rem;
+  }
+
+  .toc-nav ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .toc-nav ul ul {
+    padding-left: 0.9rem;
+  }
+
+  .toc-nav li {
+    margin: 0.15rem 0;
+  }
+
+  .toc-nav a {
+    text-decoration: none;
+    color: var(--muted);
+  }
+
+  .toc-nav a:hover {
+    color: var(--fg);
+    text-decoration: underline;
+  }
+
+  /* The inline collapsible TOC is redundant once the sidebar is shown. */
+  .toc-inline {
+    display: none;
+  }
+}

--- a/website/content/_content.gotmpl
+++ b/website/content/_content.gotmpl
@@ -39,7 +39,8 @@
       "title" "Cookbook"
       "params" (dict
         "description" "50+ copyable atago specs indexed by task, plus the runnable, CI-tested example for every feature."
-        "toc" true)
+        "toc" true
+        "filter" true)
       "content" (dict "mediaType" "text/markdown" "value" $merged)) }}
 {{ end }}
 

--- a/website/layouts/baseof.html
+++ b/website/layouts/baseof.html
@@ -98,5 +98,49 @@
   }
 })();
 </script>
+<script>
+// Live recipe filter for the cookbook: type "pty" or "snapshot" and only the
+// matching h2 sections (and their TOC entries) stay visible. Sections are
+// contiguous sibling runs between h2 headings, so group the article's children
+// by heading and toggle each group. No-op on pages without a .toc-filter input.
+(function () {
+  var input = document.querySelector(".toc-filter");
+  if (!input) return;
+  var main = document.getElementById("main");
+  var article = main && main.querySelector("article");
+  if (!article) return;
+  var groups = [];
+  var cur = null;
+  Array.prototype.forEach.call(article.children, function (node) {
+    if (node.tagName === "H2") {
+      cur = { heading: node, nodes: [node], text: node.textContent.toLowerCase() };
+      groups.push(cur);
+    } else if (cur) {
+      cur.nodes.push(node);
+      cur.text += " " + node.textContent.toLowerCase();
+    }
+  });
+  var tocLinks = {};
+  document.querySelectorAll(".toc-nav a, .toc-inline a").forEach(function (a) {
+    var href = a.getAttribute("href");
+    if (href && href.charAt(0) === "#") {
+      var id = href.slice(1);
+      (tocLinks[id] = tocLinks[id] || []).push(a);
+    }
+  });
+  function apply() {
+    var q = input.value.trim().toLowerCase();
+    groups.forEach(function (g) {
+      var show = !q || g.text.indexOf(q) !== -1;
+      g.nodes.forEach(function (n) { n.hidden = !show; });
+      (tocLinks[g.heading.id] || []).forEach(function (a) {
+        var li = a.closest("li");
+        if (li) li.hidden = !show;
+      });
+    });
+  }
+  input.addEventListener("input", apply);
+})();
+</script>
 </body>
 </html>

--- a/website/layouts/page.html
+++ b/website/layouts/page.html
@@ -1,12 +1,22 @@
 {{ define "main" }}
+<div class="page{{ if .Params.toc }} has-toc{{ end }}">
+{{ if .Params.toc }}
+<aside class="sidebar" aria-label="On this page">
+<div class="sidebar-inner">
+{{ if .Params.filter }}<input type="search" class="toc-filter" placeholder="Filter recipes…" aria-label="Filter recipes by keyword" autocomplete="off">{{ end }}
+<nav class="toc-nav">{{ .TableOfContents }}</nav>
+</div>
+</aside>
+{{ end }}
 <article>
 <h1>{{ .Title }}</h1>
 {{ if .Params.toc }}
-<details class="toc">
+<details class="toc toc-inline">
 <summary>On this page</summary>
 {{ .TableOfContents }}
 </details>
 {{ end }}
 {{ .Content }}
 </article>
+</div>
 {{ end }}


### PR DESCRIPTION
## Summary

Presentation-only cookbook/reference navigation (no tool behavior change). The committed `doc/cookbook.md` stays one file; only `layouts/page.html`, CSS, and a small script change, and no URL or anchor changes.

### #241 — cookbook: sticky sidebar + live recipe filter
- On wide viewports (≥1200px) the "On this page" list renders as a `position: sticky` sidebar beside the content, using the width the 56rem cap otherwise wastes; the collapsible `<details>` box stays on narrow screens.
- The cookbook gains a live filter input above the recipes: typing "pty" or "snapshot" hides every non-matching h2 section and its sidebar TOC entry (sections are contiguous sibling runs grouped by heading). The filter is opt-in via a page param, so the reference page gets the sidebar but not the recipe filter.
- `scroll-margin-top` on headings so anchor jumps land cleanly.

## Verification

`make website` builds clean. Verified in `public/`:
- cookbook: `<div class="page has-toc">`, `<aside class=sidebar>`, and the `toc-filter` search input present.
- reference: sidebar present, no filter input.
- real-world tool pages: no sidebar (unchanged).
- Existing anchors unchanged (the merged-page section anchors still resolve).

Closes #241.
