### PR TITLE
feat(website): self-hosted Pagefind full-text search

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -34,6 +34,8 @@ jobs:
     env:
       HUGO_VERSION: 0.164.0
       HUGO_SHA256: d9c8b17285ea4ec004d9f814273ea910f2051ce02c284993fd1f91ba455ae50d
+      PAGEFIND_VERSION: 1.5.2
+      PAGEFIND_SHA256: afb824a9e7f64905a934900481cea5be679c03975e527329e0e5e6cc70f5feda
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -50,6 +52,14 @@ jobs:
 
       - name: Build website
         run: make website
+
+      - name: Index the site with Pagefind
+        run: |
+          curl -fsSL -o "${RUNNER_TEMP}/pagefind.tar.gz" \
+            "https://github.com/Pagefind/pagefind/releases/download/v${PAGEFIND_VERSION}/pagefind-v${PAGEFIND_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          echo "${PAGEFIND_SHA256}  ${RUNNER_TEMP}/pagefind.tar.gz" | sha256sum --check -
+          tar -C "${RUNNER_TEMP}" -xzf "${RUNNER_TEMP}/pagefind.tar.gz" pagefind
+          "${RUNNER_TEMP}/pagefind" --site website/public
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ and this project follows [Semantic Versioning](https://semver.org/).
   recipe filter — typing a keyword hides the non-matching recipe sections and
   their sidebar entries — turning the 63-recipe single scroll into a browsable
   catalog without splitting the committed file or changing any anchor (#241).
+- Website full-text search (no tool behavior change): a self-hosted Pagefind
+  index is built in CI (pinned binary, SHA-256 verified, no external hosts) and
+  a nav search box lazy-loads the search UI and WASM index only when focused, so
+  the landing weight is unchanged. Every recipe and spec key becomes directly
+  reachable across the cookbook, reference, and real-world pages (#236).
 
 ### Fixed
 

--- a/website/assets/css/site.css
+++ b/website/assets/css/site.css
@@ -466,3 +466,44 @@ main h3 {
     display: none;
   }
 }
+/* --- client-side search box in the nav (#236) --- */
+.search {
+  position: relative;
+  display: inline-flex;
+}
+
+.search-box {
+  font: inherit;
+  font-size: 0.9rem;
+  padding: 0.2rem 0.55rem;
+  width: 9rem;
+  max-width: 40vw;
+  color: var(--fg);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+
+/* Pagefind renders its input and results into this dropdown once loaded; the
+   CSS variables theme it to match the site in both light and dark. */
+.search-ui {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 0.4rem;
+  width: min(92vw, 24rem);
+  max-height: 72vh;
+  overflow-y: auto;
+  padding: 0.6rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
+  z-index: 30;
+  --pagefind-ui-primary: var(--link);
+  --pagefind-ui-text: var(--fg);
+  --pagefind-ui-background: var(--bg);
+  --pagefind-ui-border: var(--border);
+  --pagefind-ui-tag: var(--code-bg);
+  --pagefind-ui-font: inherit;
+}

--- a/website/layouts/baseof.html
+++ b/website/layouts/baseof.html
@@ -47,9 +47,13 @@
 {{- end }}
 <a href="https://github.com/nao1215/atago">GitHub</a>
 <a class="sponsor" href="https://github.com/sponsors/nao1215">&#9825; Sponsor</a>
+<div class="search">
+<input type="search" id="search-box" class="search-box" placeholder="Search…" aria-label="Search the documentation" autocomplete="off" data-pagefind-base="{{ relURL "" }}">
+<div id="search-ui" class="search-ui" hidden></div>
+</div>
 </nav>
 </header>
-<main id="main">
+<main id="main" data-pagefind-body>
 {{ block "main" . }}{{ end }}
 </main>
 <footer>
@@ -140,6 +144,47 @@
     });
   }
   input.addEventListener("input", apply);
+})();
+</script>
+<script>
+// Client-side search, lazy: the Pagefind UI (script, stylesheet, and the WASM
+// index chunks) is self-hosted under /pagefind/ and fetched only when the user
+// first focuses the search box, so it adds nothing to a normal page load. The
+// index is built in CI by the Pagefind pass in .github/workflows/website.yml;
+// on a local `make website` (no Pagefind) the assets are absent and the box
+// simply does nothing.
+(function () {
+  var box = document.getElementById("search-box");
+  var ui = document.getElementById("search-ui");
+  if (!box || !ui) return;
+  var base = box.getAttribute("data-pagefind-base") || "/";
+  var loaded = false;
+  function load() {
+    if (loaded) return;
+    loaded = true;
+    var css = document.createElement("link");
+    css.rel = "stylesheet";
+    css.href = base + "pagefind/pagefind-ui.css";
+    document.head.appendChild(css);
+    var s = document.createElement("script");
+    s.src = base + "pagefind/pagefind-ui.js";
+    s.onload = function () {
+      if (typeof PagefindUI === "undefined") return;
+      /* global PagefindUI */
+      new PagefindUI({ element: "#search-ui", showImages: false, showSubResults: true });
+      ui.hidden = false;
+      var real = ui.querySelector("input");
+      if (real) {
+        real.value = box.value;
+        real.focus();
+        real.dispatchEvent(new Event("input", { bubbles: true }));
+      }
+      box.hidden = true;
+    };
+    s.onerror = function () { loaded = false; }; // let a later focus retry
+    document.body.appendChild(s);
+  }
+  box.addEventListener("focus", load);
 })();
 </script>
 </body>


### PR DESCRIPTION
## Summary

Adds self-hosted full-text search to the site (no tool behavior change). Everything stays same-origin — no CDN, no external hosts — so it fits the site's strict constraint.

### #236 — client-side search with Pagefind
- `.github/workflows/website.yml` runs a Pagefind pass after the Hugo build, downloading a pinned Pagefind binary (v1.5.2, SHA-256 verified — same pattern as the existing Hugo install step) and indexing `website/public/` into self-contained UI + WASM index chunks.
- `baseof.html` adds a small nav search box that **lazy-loads** the Pagefind UI, stylesheet, and index only when the box is first focused, so a normal page load is unchanged. The dropdown is themed to match the site (CSS variables) in light and dark.
- `<main>` carries `data-pagefind-body` so the index covers page content, not the nav/footer/search chrome.

## Verification

`make website` builds clean; running the pinned Pagefind binary locally indexed **52 pages / 8,360 words** and emitted `pagefind/pagefind-ui.{js,css}` plus the index. Verified in `public/`:
- nav search box present with `data-pagefind-base=/atago/`; `<main data-pagefind-body>`.
- 52 fragments generated (one per page).
- `actionlint` passes on the updated workflow.

Note: `make website` alone (no Pagefind installed) leaves `/pagefind/` absent and the box is a harmless no-op; the index is produced only by the CI pass, which this PR's Website job exercises.

Closes #236.
