### PR TITLE
fix(e2e): gate redis scenarios on both redis-server and redis-cli

### DIFF
--- a/doc/e2e/redis.md
+++ b/doc/e2e/redis.md
@@ -12,7 +12,7 @@
 ## redis (server + client, signal-step testbed)
 Source: `test/e2e/thirdparty/redis/redis.atago.yaml`
 ### Scenario: server boots (log readiness) and answers PING
-_only when `redis-server --version` succeeds · skipped on Windows_
+_only when `redis-server --version && redis-cli --version` succeeds · skipped on Windows_
 #### Given
 - Background service `redis` is started: `redis-server --port 16379 --save '' --appendonly no`.
 #### When
@@ -23,7 +23,7 @@ redis-cli -p 16379 PING
 - exit code is `0`
 - stdout equals an exact value
 ### Scenario: server boots (port readiness) and round-trips SET/GET/INCR
-_only when `redis-server --version` succeeds · skipped on Windows_
+_only when `redis-server --version && redis-cli --version` succeeds · skipped on Windows_
 #### Given
 - Background service `redis` is started: `redis-server --port 16380 --save '' --appendonly no`.
 #### When
@@ -47,7 +47,7 @@ redis-cli -p 16380 INCR counter
   - exit code is `0`
   - stdout equals an exact value
 ### Scenario: EXPIRE and TTL report lifetime state
-_only when `redis-server --version` succeeds · skipped on Windows_
+_only when `redis-server --version && redis-cli --version` succeeds · skipped on Windows_
 #### Given
 - Background service `redis` is started: `redis-server --port 16381 --save '' --appendonly no`.
 #### When
@@ -83,7 +83,7 @@ redis-cli -p 16999 PING
 - exit code is `1`
 - stderr contains `Connection refused`
 ### Scenario: an unknown command reports ERR without killing the server
-_only when `redis-server --version` succeeds · skipped on Windows_
+_only when `redis-server --version && redis-cli --version` succeeds · skipped on Windows_
 #### Given
 - Background service `redis` is started: `redis-server --port 16382 --save '' --appendonly no`.
 #### When
@@ -98,7 +98,7 @@ redis-cli -p 16382 PING
   - exit code is `0`
   - stdout equals an exact value
 ### Scenario: SHUTDOWN NOSAVE stops the server and PING starts failing
-_only when `redis-server --version` succeeds · skipped on Windows_
+_only when `redis-server --version && redis-cli --version` succeeds · skipped on Windows_
 #### Given
 - Background service `redis` is started: `redis-server --port 16383 --save '' --appendonly no`.
 #### When

--- a/test/e2e/thirdparty/redis/redis.atago.yaml
+++ b/test/e2e/thirdparty/redis/redis.atago.yaml
@@ -10,7 +10,12 @@ suite:
 # planned `signal:` step (#23) — until that lands, the shutdown scenario uses
 # SHUTDOWN NOSAVE plus a retry-polled PING as the declarative stand-in.
 # Every scenario probes for redis first so the suite skips cleanly where it
-# is absent; redis-server is POSIX-only, so the suite skips on Windows.
+# is absent; redis-server is POSIX-only, so the suite skips on Windows. Because
+# the two binaries ship in separate packages on some hosts (redis-server vs
+# redis-tools), each scenario that starts a server AND talks to it gates on BOTH
+# `redis-server` and `redis-cli` (a single shell probe joined with `&&`), so a
+# host with only one installed skips instead of failing on the missing binary
+# (#200). The client-only "connection refused" scenario gates on redis-cli alone.
 # Install with: apt-get install redis-server redis-tools / brew install redis
 #
 # Each scenario binds its own port: scenarios run in parallel and must not
@@ -18,7 +23,7 @@ suite:
 scenarios:
   - name: server boots (log readiness) and answers PING
     only:
-      command: redis-server --version
+      command: redis-server --version && redis-cli --version
     skip:
       os: windows
     services:
@@ -37,7 +42,7 @@ scenarios:
 
   - name: server boots (port readiness) and round-trips SET/GET/INCR
     only:
-      command: redis-server --version
+      command: redis-server --version && redis-cli --version
     skip:
       os: windows
     services:
@@ -75,7 +80,7 @@ scenarios:
 
   - name: EXPIRE and TTL report lifetime state
     only:
-      command: redis-server --version
+      command: redis-server --version && redis-cli --version
     skip:
       os: windows
     services:
@@ -133,7 +138,7 @@ scenarios:
 
   - name: an unknown command reports ERR without killing the server
     only:
-      command: redis-server --version
+      command: redis-server --version && redis-cli --version
     skip:
       os: windows
     services:
@@ -159,7 +164,7 @@ scenarios:
 
   - name: SHUTDOWN NOSAVE stops the server and PING starts failing
     only:
-      command: redis-server --version
+      command: redis-server --version && redis-cli --version
     skip:
       os: windows
     services:


### PR DESCRIPTION
## Summary

Fixes #200: the redis third-party E2E suite gated each server scenario on only `redis-server --version`, but those scenarios also invoke `redis-cli`. On a host that ships the server and client in separate packages (`redis-server` vs `redis-tools`) with only one installed, the suite ran instead of skipping and then failed on the missing binary.

Each scenario that starts a server **and** talks to it now gates on **both** binaries via a single shell probe joined with `&&`:

```yaml
only:
  command: redis-server --version && redis-cli --version
```

The client-only "connection refused" scenario keeps gating on `redis-cli` alone.

## Audit

I audited every `test/e2e/thirdparty/*` suite for the same single-binary-gate-but-multi-binary-invocation pattern. Redis is the only clear case: the others gate on the single binary they invoke, or gate on services/ports rather than a binary probe.

## Verification

- `atago run` on a host with both binaries: 6/6 scenarios pass.
- `atago run` with `redis-cli` hidden from `PATH` (server present): **6/6 skip** cleanly instead of failing — the exact regression #200 describes.
- `doc/e2e/redis.md` regenerated from the spec (the gate now reads `only when redis-server --version && redis-cli --version succeeds`).

Closes #200.
