### PR TITLE
fix(engine): mask secrets and guard unresolved refs in suite setup/teardown steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,14 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- A failing assertion inside `suite.setup`/`suite.teardown` now masks declared
+  secrets in its reported `Expected`/`Actual`/`Hint` fields and writes
+  `--artifacts-dir` sidecars, matching scenario-level asserts. The suite path
+  previously set the check payloads raw, so a secret printed by a setup command
+  and echoed into an assert-failure block leaked into the console/JSON reports
+  (the leak class #12 fixed for scenarios); and a suite run step with an
+  unresolved `${name}` now errors with the same explained diagnostic instead of
+  leaking the literal reference into argv (#243).
 - A network-policy (`permissions.network.allow`) violation raised by a
   `teardown` step now sets `SecurityViolation` and exits 6, instead of being
   silently swallowed so a spec that contacted a denied host during cleanup

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -157,7 +157,7 @@ func (e *Engine) Run(ctx context.Context, s *spec.Spec, specPath string) *SuiteR
 	if suiteRT != nil {
 		defer suiteRT.stop()
 		var setupOK bool
-		res.Setup, setupOK = e.runSuiteSteps(ctx, s.Suite.Setup, suiteRT, rc, true)
+		res.Setup, setupOK = e.runSuiteSteps(ctx, s.Suite.Setup, suiteRT, rc, true, "suite setup")
 		if !setupOK {
 			// Every selected scenario is errored with the suite-setup phase
 			// named; none of their steps run. Teardown still runs: a partially

--- a/internal/engine/stepexec.go
+++ b/internal/engine/stepexec.go
@@ -45,6 +45,52 @@ func leakedRunRefMsg(field, name string) string {
 		field, name, name, name)
 }
 
+// runRefGuard checks a run step for a ${...} reference that nothing could ever
+// expand and that would therefore leak verbatim into the child's argv. It
+// returns an explained error message, or "" when the step is clean. The rules,
+// all skipped for an ssh runner (a remote shell may expand a bare ${name}):
+//
+//   - no-shell command: an unresolved ${name}/${env:NAME} is a typo — with no
+//     shell nothing expands it, so the literal text would run;
+//   - shell command: a bare ${name} passes (the shell expands it), but an unset
+//     ${env:NAME} is atago-only syntax no shell understands, so it still errors;
+//   - cwd: passed to cmd.Dir verbatim, never shell-expanded, so any unresolved
+//     ${name} is guarded regardless of shell;
+//   - a ${...} dragged in by a substituted store/matrix value survives single-
+//     pass expansion into a no-shell argv (or cwd) and is caught too (#249).
+//
+// It is shared by execStep (scenario steps) and runSuiteSteps (suite setup and
+// teardown) so both enforce the identical guard instead of one loop drifting
+// from the other (#243).
+func runRefGuard(st *store.Store, run *spec.Run, runners map[string]spec.Runner) string {
+	if isSSHRunner(run.Runner, runners) {
+		return ""
+	}
+	if !run.ShellEnabled() {
+		if names := st.Unresolved(run.Command); len(names) > 0 {
+			return unresolvedRunRefMsg("run.command", names[0], true)
+		}
+	} else {
+		for _, name := range st.Unresolved(run.Command) {
+			if strings.HasPrefix(name, "env:") {
+				return unresolvedRunRefMsg("run.command", name, true)
+			}
+		}
+	}
+	if names := st.Unresolved(run.Cwd); len(names) > 0 {
+		return unresolvedRunRefMsg("run.cwd", names[0], false)
+	}
+	if !run.ShellEnabled() {
+		if _, leaked := st.ExpandDetectingLeaks(run.Command); len(leaked) > 0 {
+			return leakedRunRefMsg("run.command", leaked[0])
+		}
+	}
+	if _, leaked := st.ExpandDetectingLeaks(run.Cwd); len(leaked) > 0 {
+		return leakedRunRefMsg("run.cwd", leaked[0])
+	}
+	return ""
+}
+
 // execStep runs one step and returns its result, its status contribution
 // (passed/failed/error), and whether it breached the security policy. It is
 // shared by the Steps loop and the Teardown loop; only the caller decides
@@ -67,58 +113,9 @@ func (x *scenarioRun) execStep(ctx context.Context, i int, step *spec.Step, befo
 			status = StatusError
 		}
 	case spec.StepRun:
-		// A ${name} that no variable defines is left verbatim so a shell can
-		// still expand it — but a local run without `shell: true`
-		// has no shell, so nothing could ever expand it and the literal text
-		// would leak into argv. That is almost always a typo; error with the
-		// reference named instead of running a garbled command (#UX). A named
-		// cmd runner runs the command as local argv too, so it is guarded like
-		// the default runner; only an ssh runner (remote, where a remote shell
-		// may expand it) is exempt.
-		if !isSSHRunner(step.Run.Runner, x.rc.runners) {
-			if !step.Run.ShellEnabled() {
-				if names := x.st.Unresolved(step.Run.Command); len(names) > 0 {
-					sr.ErrMsg = unresolvedRunRefMsg("run.command", names[0], true)
-					return sr, StatusError, false
-				}
-			} else {
-				// A shell can expand a bare ${name}, so those pass through — but
-				// ${env:NAME} is atago-only syntax NO shell understands: POSIX sh
-				// dies with a cryptic "Bad substitution" and cmd.exe forwards the
-				// literal text. An unset ${env:NAME} under shell: true is the same
-				// authoring error as without a shell; fail it with the same
-				// explained message instead of handing it to the shell.
-				for _, name := range x.st.Unresolved(step.Run.Command) {
-					if strings.HasPrefix(name, "env:") {
-						sr.ErrMsg = unresolvedRunRefMsg("run.command", name, true)
-						return sr, StatusError, false
-					}
-				}
-			}
-			// cwd is passed to cmd.Dir verbatim; no shell ever expands it, so an
-			// unresolved ${name} is always a typo that would make the child fail to
-			// start in a literal "${name}" directory and surface as a misleading
-			// "executable not found". Guard it regardless of shell.
-			if names := x.st.Unresolved(step.Run.Cwd); len(names) > 0 {
-				sr.ErrMsg = unresolvedRunRefMsg("run.cwd", names[0], false)
-				return sr, StatusError, false
-			}
-			// The guards above run on the raw fields, where the outer ${p}/${path}
-			// IS defined. But a store/matrix value can itself contain a ${...}
-			// reference, and expansion is single-pass — so substituting such a value
-			// leaves an unexpanded reference that leaks verbatim into a no-shell argv
-			// (or into cwd, which no shell ever expands). Catch that leaked reference
-			// here instead of running a garbled command (#249).
-			if !step.Run.ShellEnabled() {
-				if _, leaked := x.st.ExpandDetectingLeaks(step.Run.Command); len(leaked) > 0 {
-					sr.ErrMsg = leakedRunRefMsg("run.command", leaked[0])
-					return sr, StatusError, false
-				}
-			}
-			if _, leaked := x.st.ExpandDetectingLeaks(step.Run.Cwd); len(leaked) > 0 {
-				sr.ErrMsg = leakedRunRefMsg("run.cwd", leaked[0])
-				return sr, StatusError, false
-			}
+		if msg := runRefGuard(x.st, step.Run, x.rc.runners); msg != "" {
+			sr.ErrMsg = msg
+			return sr, StatusError, false
 		}
 		run := mergeScenarioEnv(x.scEnv, expandRun(x.st, step.Run), x.st)
 		r, untilChecks, err := x.e.runStep(ctx, run, x.st, x.workdir, x.specDir, x.rc, x.sshConns, beforeAttempt)

--- a/internal/engine/suite.go
+++ b/internal/engine/suite.go
@@ -92,7 +92,7 @@ func (e *Engine) newSuiteRuntime(s *spec.Spec) (*suiteRuntime, error) {
 // is then errored by the caller. Teardown (stopOnFailure=false) always runs
 // every step: cleanups of independent resources must not shadow each other.
 // The returned bool reports whether every step succeeded.
-func (e *Engine) runSuiteSteps(ctx context.Context, steps []spec.Step, rt *suiteRuntime, rc runConfig, stopOnFailure bool) ([]StepResult, bool) {
+func (e *Engine) runSuiteSteps(ctx context.Context, steps []spec.Step, rt *suiteRuntime, rc runConfig, stopOnFailure bool, label string) ([]StepResult, bool) {
 	var out []StepResult
 	var current *runner.Result
 	ok := true
@@ -115,6 +115,14 @@ func (e *Engine) runSuiteSteps(ctx context.Context, steps []spec.Step, rt *suite
 				failed = true
 			}
 		case spec.StepRun:
+			// Same unresolved/leaked-${name} guard the scenario path enforces, so a
+			// typo in suite.setup errors with the explained diagnostic instead of
+			// leaking the literal reference into argv (#243).
+			if msg := runRefGuard(rt.st, step.Run, rc.runners); msg != "" {
+				sr.ErrMsg = msg
+				failed = true
+				break
+			}
 			run := mergeScenarioEnv(rt.env, expandRun(rt.st, step.Run), rt.st)
 			r, untilChecks, err := e.runStep(ctx, run, rt.st, rt.dir, rc.specDir, rc, rt.sshConns, nil) // suite setup/teardown steps carry no changes assert
 			if err != nil {
@@ -125,6 +133,10 @@ func (e *Engine) runSuiteSteps(ctx context.Context, steps []spec.Step, rt *suite
 			current = r
 			sr.Run = maskResult(rc.masker, r)
 			if len(untilChecks) > 0 {
+				// recordChecks masks secrets in the check payloads and writes any
+				// --artifacts-dir sidecars, exactly as the scenario path does — the
+				// suite path used to set sr.Checks raw and leak both (#243).
+				e.recordChecks(rc.masker, untilChecks, rc.specPath, label, -1, i)
 				sr.Checks = untilChecks
 				if !assert.AllOK(untilChecks) {
 					failed = true
@@ -154,6 +166,7 @@ func (e *Engine) runSuiteSteps(ctx context.Context, steps []spec.Step, rt *suite
 					return nil, false
 				},
 			})
+			e.recordChecks(rc.masker, crs, rc.specPath, label, -1, i)
 			sr.Checks = crs
 			if !assert.AllOK(crs) {
 				failed = true
@@ -228,6 +241,6 @@ func (e *Engine) runSuiteTeardown(ctx context.Context, s *spec.Spec, rt *suiteRu
 		tctx, cancel = context.WithTimeout(context.Background(), teardownInterruptTimeout)
 		defer cancel()
 	}
-	out, _ := e.runSuiteSteps(tctx, s.Suite.Teardown, rt, rc, false)
+	out, _ := e.runSuiteSteps(tctx, s.Suite.Teardown, rt, rc, false, "suite teardown")
 	return out
 }

--- a/internal/engine/suite_setup_test.go
+++ b/internal/engine/suite_setup_test.go
@@ -318,3 +318,86 @@ scenarios:
 		t.Fatalf("scenario should be errored by the setup failure: %+v", res.Scenarios)
 	}
 }
+
+// TestEngine_SuiteSetupAssertMasksSecrets is a regression for #243: a suite.setup
+// assert failure whose Actual/Hint carry a declared secret must be masked before
+// it reaches the reports, exactly as a scenario-level assert failure already is
+// (#12). The suite path used to set sr.Checks directly, bypassing maskCheck, so a
+// secret printed by a setup command leaked into the console/JSON failure block.
+func TestEngine_SuiteSetupAssertMasksSecrets(t *testing.T) {
+	const secret = "ghp_suite_setup_secret_value"
+	t.Setenv("ATAGO_TEST_SECRET", secret)
+	src := `
+version: "1"
+suite:
+  name: s
+  setup:
+    - run:
+        shell: true
+        command: echo token-` + envRef("ATAGO_TEST_SECRET") + `
+    - assert:
+        stdout: {equals: this-will-not-match}
+secrets:
+  - ATAGO_TEST_SECRET
+scenarios:
+  - name: never runs
+    steps:
+      - run: {shell: true, command: echo unreached}
+`
+	s, err := loader.LoadBytes("t.atago.yaml", []byte(src))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	res := New().Run(context.Background(), s, "t.atago.yaml")
+	if res.Status != StatusError {
+		t.Fatalf("status = %s, want error (setup assert fails)", res.Status)
+	}
+	// The failing setup assert is step index 1; its check's Actual holds the
+	// setup command's stdout, which contains the secret. It must be masked.
+	if len(res.Setup) < 2 {
+		t.Fatalf("recorded %d setup steps, want >= 2", len(res.Setup))
+	}
+	for _, sr := range res.Setup {
+		for _, cr := range sr.Checks {
+			blob := cr.Desc + "\n" + cr.Expected + "\n" + cr.Actual + "\n" + cr.Hint
+			if strings.Contains(blob, secret) {
+				t.Errorf("suite setup check leaked the raw secret:\n%s", blob)
+			}
+		}
+	}
+}
+
+// TestEngine_SuiteSetupUnresolvedVarGuard is a regression for #243: a suite.setup
+// run whose command references an undefined ${name} with no shell must error with
+// the same explained diagnostic the scenario path gives, instead of leaking the
+// literal ${name} into argv. The suite path called runStep directly, skipping the
+// unresolved-reference guard.
+func TestEngine_SuiteSetupUnresolvedVarGuard(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: s
+  setup:
+    - run: {command: "echo ${undefined_setup_var}"}
+scenarios:
+  - name: never runs
+    steps:
+      - run: {shell: true, command: echo unreached}
+`
+	s, err := loader.LoadBytes("t.atago.yaml", []byte(src))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	res := New().Run(context.Background(), s, "t.atago.yaml")
+	if res.Status != StatusError {
+		t.Fatalf("status = %s, want error (unresolved ${name} in setup)", res.Status)
+	}
+	if len(res.Setup) < 1 {
+		t.Fatalf("recorded %d setup steps, want >= 1", len(res.Setup))
+	}
+	msg := res.Setup[0].ErrMsg
+	if !strings.Contains(msg, "undefined_setup_var") || !strings.Contains(msg, "no variable with that name") {
+		t.Errorf("setup err = %q, want the explained unresolved-reference diagnostic", msg)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #243: `runSuiteSteps` had diverged from the scenario-level `execStep`, and the drift produced two concrete bugs plus an artifacts gap.

- **Secret-masking gap (security).** The scenario path routes every check through `recordChecks` → `maskCheck`, which masks declared secrets in the `Desc`/`Expected`/`Actual`/`Hint` fields; the suite path set `sr.Checks` raw. A secret printed by a `suite.setup` command and echoed into an assert-failure block therefore leaked verbatim into the console and JSON reports — the exact leak class #12 fixed for scenarios.
- **Unresolved-var guard gap.** The scenario path guards an unresolved `${name}`/`${env:NAME}` (and a `${...}` dragged in by a substituted store/matrix value) with an explained error; the suite path called `runStep` directly, so the same typo in `suite.setup` leaked the literal `${name}` into argv.
- **Artifacts gap.** Suite check failures now also write `--artifacts-dir` sidecars, like scenario checks.

The shared guard is extracted into `runRefGuard(st, run, runners)` and called from both `execStep` and `runSuiteSteps`, and the suite path now calls `recordChecks` — so both loops enforce masking, artifacts, and the reference guard from one source instead of drifting again.

## Tests (TDD, written first)

- `TestEngine_SuiteSetupAssertMasksSecrets` — a `suite.setup` assert failure whose `Actual` holds a declared secret must not leak it (failed before the fix).
- `TestEngine_SuiteSetupUnresolvedVarGuard` — a `suite.setup` no-shell run with an undefined `${name}` errors with the explained diagnostic (ran literally before the fix).

Full `internal/engine`, `internal/report`, `internal/assert` suites pass; `golangci-lint` clean.

Closes #243.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Suite setup and teardown failures now hide sensitive values in failure details and include artifact sidecar files, matching other assertion behavior.
  * Unresolved variable references in run steps now fail with a clearer diagnostic instead of appearing in the executed command or working directory.
  * Reference checks now apply consistently across suite and scenario execution paths, improving error handling and preventing leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->