### PR TITLE
fix(spec): collect suite service env/ready vars and surface them in the manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `atago manifest` now reports the suite lifecycle's variable references in a new
+  `suite_variables` field (mirroring a scenario's `variables`), and the manifest
+  schema gains the previously-undocumented `suite_env`, `suite_setup`,
+  `suite_teardown`, and `suite_variables` fields (#244).
+
 ### Changed
 
 - Website SEO, social, and landing improvements (no tool behavior change): the
@@ -41,6 +48,10 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- A suite-level `service:` step's `env` values and `ready` file/port/log probes
+  are now counted as variable references by the shared collector, so a
+  `suite.setup` service like `env: {DSN: ${...}}` / `ready: {file: ${suitedir}/…}`
+  is no longer under-reported by `atago manifest`/`explain` (#244).
 - A failing assertion inside `suite.setup`/`suite.teardown` now masks declared
   secrets in its reported `Expected`/`Actual`/`Hint` fields and writes
   `--artifacts-dir` sidecars, matching scenario-level asserts. The suite path

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -78,10 +78,15 @@ type Spec struct {
 	// (#7): env exported to every scenario, steps run once before any scenario
 	// (setup may contain service steps starting suite-wide peers), and steps
 	// that always run after the last scenario.
-	SuiteEnv      []string   `json:"suite_env,omitempty"`
-	SuiteSetup    []Step     `json:"suite_setup,omitempty"`
-	SuiteTeardown []Step     `json:"suite_teardown,omitempty"`
-	Scenarios     []Scenario `json:"scenarios"`
+	SuiteEnv      []string `json:"suite_env,omitempty"`
+	SuiteSetup    []Step   `json:"suite_setup,omitempty"`
+	SuiteTeardown []Step   `json:"suite_teardown,omitempty"`
+	// SuiteVariables is the sorted union of ${name} references across the suite
+	// setup/teardown steps (their commands, env, service ready probes, asserts).
+	// It mirrors a scenario's Variables so tooling can see which variables the
+	// suite lifecycle depends on.
+	SuiteVariables []string   `json:"suite_variables,omitempty"`
+	Scenarios      []Scenario `json:"scenarios"`
 }
 
 // Network summarizes the spec's network policy.
@@ -238,6 +243,7 @@ func buildSpec(in Input) Spec {
 	for i := range s.Suite.Teardown {
 		out.SuiteTeardown = append(out.SuiteTeardown, buildStep(i, &s.Suite.Teardown[i], suiteVars))
 	}
+	out.SuiteVariables = spec.SortedKeys(suiteVars)
 	for i := range s.Scenarios {
 		out.Scenarios = append(out.Scenarios, buildScenario(&s.Scenarios[i], in.Source))
 	}

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -490,7 +490,18 @@ func TestBuildSpec_SuiteLifecycle(t *testing.T) {
 			Name:    "life",
 			Timeout: "30s",
 			Env:     map[string]string{"ZED": "secretz", "ALPHA": "secreta"},
-			Setup:   []spec.Step{{Run: &spec.Run{Command: "build"}}},
+			Setup: []spec.Step{
+				{Run: &spec.Run{Command: "build ${srcdir}"}},
+				// A suite service whose env value and ready probe reference variables:
+				// the manifest must report them (previously CollectStepVars' service
+				// case dropped env/ready, and no suite-variable list was output) (#244).
+				{Service: &spec.Service{
+					Name:    "db",
+					Command: "./db",
+					Env:     map[string]string{"DSN": "${dsn_ref}"},
+					Ready:   &spec.Ready{File: "${suitedir}/ready-${tag}"},
+				}},
+			},
 			Teardown: []spec.Step{
 				{Run: &spec.Run{Command: "cleanup"}},
 			},
@@ -505,8 +516,16 @@ func TestBuildSpec_SuiteLifecycle(t *testing.T) {
 	if strings.Join(sp.SuiteEnv, ",") != "ALPHA,ZED" {
 		t.Errorf("suite env keys = %v, want [ALPHA ZED]", sp.SuiteEnv)
 	}
-	if len(sp.SuiteSetup) != 1 || sp.SuiteSetup[0].Command != "build" {
+	if len(sp.SuiteSetup) != 2 || sp.SuiteSetup[0].Command != "build ${srcdir}" {
 		t.Errorf("suite setup = %+v", sp.SuiteSetup)
+	}
+	// The suite-variable union must include the run command's ref AND the suite
+	// service's env-value and ready-probe refs (the #244 drift).
+	sv := strings.Join(sp.SuiteVariables, ",")
+	for _, want := range []string{"srcdir", "dsn_ref", "suitedir", "tag"} {
+		if !strings.Contains(","+sv+",", ","+want+",") {
+			t.Errorf("suite_variables = %v, want it to include %q", sp.SuiteVariables, want)
+		}
 	}
 	if len(sp.SuiteTeardown) != 1 || sp.SuiteTeardown[0].Command != "cleanup" {
 		t.Errorf("suite teardown = %+v", sp.SuiteTeardown)

--- a/internal/spec/walk.go
+++ b/internal/spec/walk.go
@@ -75,7 +75,13 @@ func CollectStepVars(set map[string]bool, step *Step) {
 		// counted like file/content/symlink — omitting it under-reported it.
 		CollectVars(set, step.Fixture.File, step.Fixture.Content, step.Fixture.Symlink, step.Fixture.From)
 	case StepService:
-		CollectVars(set, step.Service.Command, step.Service.Cwd)
+		// Delegate to CollectServiceVars — the single source of truth for a
+		// service's variable-bearing fields — instead of re-listing them here.
+		// This case had drifted: it collected only command/cwd, missing the env
+		// values and ready.file/port/log that expandService actually expands, so a
+		// suite.setup `service:` with `env: {DSN: ${...}}` or `ready: {file:
+		// ${suitedir}/ready}` was under-reported by `atago manifest` (#244).
+		CollectServiceVars(set, step.Service)
 	case StepRun:
 		r := step.Run
 		// stdout_to/stderr_to are ${name}-expanded by the engine (expandRun), so a

--- a/internal/spec/walk_test.go
+++ b/internal/spec/walk_test.go
@@ -247,8 +247,22 @@ func TestCollectStepVars_KnownFields(t *testing.T) {
 func TestCollectStepVars_RemainingKinds(t *testing.T) {
 	t.Parallel()
 
-	if got := collectStep(&Step{Service: &Service{Name: "s", Command: "echo ${scmd}", Cwd: "${scwd}"}}); !hasVar(got, "scmd") || !hasVar(got, "scwd") {
-		t.Errorf("service step vars = %v", got)
+	// A service STEP (a suite.setup `service:`) must collect the same fields as a
+	// scenario-level service — command, cwd, env values, AND ready.file/port/log —
+	// because CollectStepVars is what the manifest walks for suite.setup steps. It
+	// used to collect only command/cwd, under-reporting env/ready (#244).
+	svcStep := &Step{Service: &Service{
+		Name:    "s",
+		Command: "echo ${scmd}",
+		Cwd:     "${scwd}",
+		Env:     map[string]string{"DSN": "${senv}"},
+		Ready:   &Ready{File: "${sready_file}", Port: "${sready_port}", Log: "up ${sready_log}"},
+	}}
+	got := collectStep(svcStep)
+	for _, want := range []string{"scmd", "scwd", "senv", "sready_file", "sready_port", "sready_log"} {
+		if !hasVar(got, want) {
+			t.Errorf("service step field %q not collected; got %v", want, got)
+		}
 	}
 	if got := collectStep(&Step{Query: &Query{Runner: "d", SQL: "SELECT ${col}"}}); !hasVar(got, "col") {
 		t.Errorf("query step vars = %v", got)
@@ -275,7 +289,7 @@ func TestCollectStepVars_RemainingKinds(t *testing.T) {
 		{Upload: &CDPUpload{Selector: "${up_sel}", File: "${up_file}"}},
 		{Download: &CDPDownload{Click: "${dl_click}", Dir: "${dl_dir}"}},
 	}}}
-	got := collectStep(cdp)
+	got = collectStep(cdp)
 	for _, want := range []string{
 		"nav", "wv", "wh", "clk", "chk", "unchk", "txt", "evl",
 		"sk_sel", "sk_val", "pr_sel", "pr_key", "se_sel", "se_val",

--- a/schema/manifest.schema.json
+++ b/schema/manifest.schema.json
@@ -45,6 +45,34 @@
           "description": "Suite-level default step timeout (suite.timeout, #17); omitted when the built-in default applies.",
           "type": "string"
         },
+        "suite_env": {
+          "description": "Sorted names of suite-level environment variables exported to every scenario (values never exposed). Omitted when none.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "suite_setup": {
+          "description": "Steps run once before any scenario (#7); may include service steps starting suite-wide peers. Omitted when none.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/step"
+          }
+        },
+        "suite_teardown": {
+          "description": "Steps that always run after the last scenario (#7). Omitted when none.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/step"
+          }
+        },
+        "suite_variables": {
+          "description": "Variable names referenced anywhere in the suite setup/teardown steps, sorted (omitted when none).",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "secrets": {
           "description": "Declared secret names (omitted when none).",
           "type": "array",

--- a/schema_test.go
+++ b/schema_test.go
@@ -492,6 +492,66 @@ func TestManifestExample_Conforms(t *testing.T) {
 	}
 }
 
+// TestManifest_SuiteLifecycleConforms builds a manifest for a spec that exercises
+// the suite lifecycle — env, setup (with a service), teardown, and the derived
+// suite_variables — and validates the output against the manifest schema. The
+// schema previously omitted every suite_* field except suite_timeout, so a
+// suite-bearing manifest would have failed its own published schema (#244).
+func TestManifest_SuiteLifecycleConforms(t *testing.T) {
+	src := `
+version: "1"
+suite:
+  name: life
+  env:
+    SHARED: shared-value
+  setup:
+    - run: {shell: true, command: "echo build ${srcdir}"}
+    - service:
+        name: db
+        command: ./db
+        env:
+          DSN: "${dsn_ref}"
+        ready:
+          file: "${suitedir}/ready"
+  teardown:
+    - run: {shell: true, command: cleanup}
+scenarios:
+  - name: sc
+    steps:
+      - run: {shell: true, command: echo hi}
+`
+	s, err := loader.LoadBytes("life.atago.yaml", []byte(src))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	doc := manifest.Build([]manifest.Input{{Spec: s, Path: "life.atago.yaml"}})
+	blob, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	var v any
+	if err := json.Unmarshal(blob, &v); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+	schema := compileSchema(t, "schema/manifest.schema.json")
+	if err := schema.Validate(v); err != nil {
+		t.Errorf("suite-lifecycle manifest does not conform to schema:\n%v", err)
+	}
+	// The suite service's env value and ready-probe references must surface.
+	sv := doc.Specs[0].SuiteVariables
+	for _, want := range []string{"srcdir", "dsn_ref", "suitedir"} {
+		found := false
+		for _, got := range sv {
+			if got == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("suite_variables = %v, want it to include %q", sv, want)
+		}
+	}
+}
+
 // TestReportExample_Conforms validates the committed report example against the
 // report schema. The report embeds wall-clock duration_ms fields, so the
 // committed example zeroes them and is guarded by schema conformance rather than


### PR DESCRIPTION
## Summary

Fixes #244: the per-step "which fields carry `${name}` references" inventory in `CollectStepVars` had drifted from what the engine actually expands. The `StepService` case collected only `command`/`cwd`, while `expandService` also expands the service's `env` values and `ready.file`/`ready.port`/`ready.log` probes. Suite-setup service steps flow through `CollectStepVars`, so a `suite.setup` service with `env: {DSN: ${...}}` or `ready: {file: ${suitedir}/ready}` had its variables dropped.

- `CollectStepVars`' service case now delegates to `CollectServiceVars` — the single source of truth for a service's variable-bearing fields — so it can never drift from the scenario-service path again.
- Made the fix user-visible: `atago manifest` now reports the suite lifecycle's variable union in a new `suite_variables` field (the collected set was previously accumulated and then dropped). Added `suite_env`, `suite_setup`, `suite_teardown`, and `suite_variables` to `schema/manifest.schema.json`, which had omitted every suite field except `suite_timeout` — so a suite-bearing manifest previously failed its own published schema.

## Tests (TDD)

- `TestCollectStepVars_RemainingKinds` extended: a service step's `env` and `ready.file/port/log` refs are collected (dropped before the fix).
- `TestBuildSpec_SuiteLifecycle` extended: `suite_variables` includes a suite service's env-value and ready-probe refs.
- `TestManifest_SuiteLifecycleConforms` (new): a manifest exercising suite env/setup/service/teardown validates against `manifest.schema.json` and surfaces the suite variables.

Full `internal/spec`, `internal/manifest`, `internal/explain`, schema, sitegen, and docgen suites pass; `golangci-lint` clean.

Closes #244.
