### PR TITLE
refactor(assert): attach checkFile failure artifacts via one deferred hook

### DIFF
--- a/internal/assert/artifact_test.go
+++ b/internal/assert/artifact_test.go
@@ -1,6 +1,8 @@
 package assert
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/nao1215/atago/internal/runner"
@@ -54,6 +56,60 @@ func TestCheck_ArtifactPayloads(t *testing.T) {
 		}
 		if cr.ArtifactKind != "" || cr.ArtifactActual != nil {
 			t.Errorf("passing check leaked artifact: kind=%q actual=%q", cr.ArtifactKind, cr.ArtifactActual)
+		}
+	})
+}
+
+// TestCheck_FileArtifactPayloads guards the #247 convention: every file matcher
+// that reads the file's content attaches the "file" artifact with the file's
+// bytes on failure (via checkFile's shared deferred hook), so a new content
+// matcher inherits the --artifacts-dir sidecar instead of forgetting it. Matchers
+// that never read content (exists/executable) attach nothing.
+func TestCheck_FileArtifactPayloads(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	const body = "the actual file body\n"
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "other.txt"), []byte("different\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	env := Env{Workdir: dir}
+
+	// Each of these matchers fails and must carry the file bytes as the artifact.
+	content := map[string]*spec.FileAssert{
+		"contains":     {Path: "f.txt", Contains: spec.StringList{"absent-substring"}},
+		"not_contains": {Path: "f.txt", NotContains: spec.StringList{"actual"}},
+		"equals":       {Path: "f.txt", Equals: strp("nope")},
+		"equals_file":  {Path: "f.txt", EqualsFile: strp("other.txt")},
+		"json":         {Path: "f.txt", JSON: spec.JSONChecks{{Path: "$.x", Equals: "y"}}},
+	}
+	for name, fa := range content {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			cr := Check(&spec.Assert{File: fa}, &runner.Result{}, env)
+			if cr.OK {
+				t.Fatalf("%s: expected failure", name)
+			}
+			if cr.ArtifactKind != "file" {
+				t.Errorf("%s: ArtifactKind = %q, want file", name, cr.ArtifactKind)
+			}
+			if string(cr.ArtifactActual) != body {
+				t.Errorf("%s: ArtifactActual = %q, want the file body", name, cr.ArtifactActual)
+			}
+		})
+	}
+
+	// A failing exists/executable check reads no content, so it attaches nothing.
+	t.Run("exists attaches nothing", func(t *testing.T) {
+		t.Parallel()
+		cr := Check(&spec.Assert{File: &spec.FileAssert{Path: "missing.txt", Exists: boolp(true)}}, &runner.Result{}, env)
+		if cr.OK {
+			t.Fatal("expected failure")
+		}
+		if cr.ArtifactKind != "" || cr.ArtifactActual != nil {
+			t.Errorf("exists check leaked artifact: kind=%q actual=%q", cr.ArtifactKind, cr.ArtifactActual)
 		}
 	})
 }

--- a/internal/assert/file.go
+++ b/internal/assert/file.go
@@ -11,10 +11,34 @@ import (
 
 // checkFile evaluates a file assertion. Relative paths resolve
 // against the scenario workdir and may not escape it.
-func checkFile(f *spec.FileAssert, env Env) *CheckResult {
+func checkFile(f *spec.FileAssert, env Env) (out *CheckResult) {
 	path, err := security.ResolveWorkdirPath("assert.file.path", env.Workdir, f.Path)
 	if err != nil {
 		return &CheckResult{Desc: fmt.Sprintf("assert file %q", f.Path), Hint: err.Error()}
+	}
+
+	// Attach the compared file bytes to any failing result that did not shape its
+	// own artifact, so --artifacts-dir can persist it (#48). This mirrors
+	// checkStream's single deferred hook, so a new file matcher inherits the
+	// attachment instead of each branch remembering it by hand (#247). A branch
+	// that reads the file records its bytes via read(); exists/executable never
+	// read and leave fileData nil (they attach nothing); checkSnapshot shapes its
+	// own artifact and is left untouched (it reads via readFile, not read).
+	var fileData []byte
+	defer func() {
+		if out != nil && !out.OK && out.ArtifactKind == "" && fileData != nil {
+			out.ArtifactKind = "file"
+			if out.ArtifactActual == nil {
+				out.ArtifactActual = fileData
+			}
+		}
+	}()
+	read := func(label, p string) ([]byte, *CheckResult) {
+		data, cr := readFile(label, p)
+		if cr == nil {
+			fileData = data
+		}
+		return data, cr
 	}
 
 	switch {
@@ -44,37 +68,33 @@ func checkFile(f *spec.FileAssert, env Env) *CheckResult {
 		}
 
 	case f.Contains != nil:
-		data, cr := readFile(f.Path, path)
+		data, cr := read(f.Path, path)
 		if cr != nil {
 			return cr
 		}
 		desc := fileContainsDesc(f.Path, f.Contains, true)
 		if sub, idx, missing := firstMissing(string(data), f.Contains); missing {
 			return &CheckResult{
-				Desc:           desc,
-				Expected:       fmt.Sprintf("file %q contains %q", f.Path, sub),
-				Actual:         excerpt(string(data)),
-				Hint:           fmt.Sprintf("the substring %q%s was not present in %q", sub, elementLabel(idx, len(f.Contains)), f.Path),
-				ArtifactKind:   "file",
-				ArtifactActual: data,
+				Desc:     desc,
+				Expected: fmt.Sprintf("file %q contains %q", f.Path, sub),
+				Actual:   excerpt(string(data)),
+				Hint:     fmt.Sprintf("the substring %q%s was not present in %q", sub, elementLabel(idx, len(f.Contains)), f.Path),
 			}
 		}
 		return pass(desc)
 
 	case f.NotContains != nil:
-		data, cr := readFile(f.Path, path)
+		data, cr := read(f.Path, path)
 		if cr != nil {
 			return cr
 		}
 		desc := fileContainsDesc(f.Path, f.NotContains, false)
 		if sub, idx, present := firstPresent(string(data), f.NotContains); present {
 			return &CheckResult{
-				Desc:           desc,
-				Expected:       fmt.Sprintf("file %q without %q", f.Path, sub),
-				Actual:         excerpt(string(data)),
-				Hint:           fmt.Sprintf("the substring %q%s was unexpectedly present in %q", sub, elementLabel(idx, len(f.NotContains)), f.Path),
-				ArtifactKind:   "file",
-				ArtifactActual: data,
+				Desc:     desc,
+				Expected: fmt.Sprintf("file %q without %q", f.Path, sub),
+				Actual:   excerpt(string(data)),
+				Hint:     fmt.Sprintf("the substring %q%s was unexpectedly present in %q", sub, elementLabel(idx, len(f.NotContains)), f.Path),
 			}
 		}
 		return pass(desc)
@@ -102,7 +122,7 @@ func checkFile(f *spec.FileAssert, env Env) *CheckResult {
 		}
 
 	case f.Equals != nil:
-		data, cr := readFile(f.Path, path)
+		data, cr := read(f.Path, path)
 		if cr != nil {
 			return cr
 		}
@@ -117,13 +137,11 @@ func checkFile(f *spec.FileAssert, env Env) *CheckResult {
 			Expected:         excerpt(*f.Equals),
 			Actual:           excerpt(string(data)),
 			Hint:             fmt.Sprintf("file %q did not equal the expected bytes exactly (no CRLF/newline normalization)", f.Path),
-			ArtifactKind:     "file",
-			ArtifactActual:   data,
 			ArtifactExpected: []byte(*f.Equals),
 		}
 
 	case f.EqualsFile != nil:
-		data, cr := readFile(f.Path, path)
+		data, cr := read(f.Path, path)
 		if cr != nil {
 			return cr
 		}
@@ -131,6 +149,8 @@ func checkFile(f *spec.FileAssert, env Env) *CheckResult {
 		if err != nil {
 			return &CheckResult{Desc: fmt.Sprintf("assert file %q equals_file %q", f.Path, *f.EqualsFile), Hint: err.Error()}
 		}
+		// The comparison file is read plainly (not via read): the failure artifact
+		// is the file under test, and the other file is carried as ArtifactExpected.
 		other, cr := readFile(*f.EqualsFile, otherPath)
 		if cr != nil {
 			return cr
@@ -144,24 +164,21 @@ func checkFile(f *spec.FileAssert, env Env) *CheckResult {
 			Expected:         fmt.Sprintf("bytes identical to %q", *f.EqualsFile),
 			Actual:           excerpt(string(data)),
 			Hint:             fmt.Sprintf("file %q is not byte-identical to %q (no CRLF/newline normalization)", f.Path, *f.EqualsFile),
-			ArtifactKind:     "file",
-			ArtifactActual:   data,
 			ArtifactExpected: other,
 		}
 
 	case len(f.JSON) > 0:
-		data, cr := readFile(f.Path, path)
+		data, cr := read(f.Path, path)
 		if cr != nil {
 			return cr
 		}
-		res := checkJSONChecks(fmt.Sprintf("assert file %q json", f.Path), f.Path, data, f.JSON, false)
-		if !res.OK && res.ArtifactKind == "" {
-			res.ArtifactKind = "file"
-			res.ArtifactActual = data
-		}
-		return res
+		// A failing json check inherits the "file" artifact from the deferred hook
+		// unless checkJSONChecks shaped its own.
+		return checkJSONChecks(fmt.Sprintf("assert file %q json", f.Path), f.Path, data, f.JSON, false)
 
 	case f.Snapshot != "":
+		// Read plainly so fileData stays nil: checkSnapshot shapes its own
+		// (normalized) artifact, and the deferred hook must not overwrite it.
 		data, cr := readFile(f.Path, path)
 		if cr != nil {
 			return cr


### PR DESCRIPTION
## Summary

Refactor only, no behavior change. Fixes #247: `checkFile` hand-attached the failure artifact (`ArtifactKind:"file"`, `ArtifactActual:data`) in each matcher branch, unlike its sibling `checkStream`, which attaches once via a single deferred hook. That per-branch pattern is an add-a-matcher-forget-the-artifact trap — a new file matcher (matches, sha256, yaml…) would silently ship without a `--artifacts-dir` sidecar (#48), invisible until review tooling comes up empty.

`checkFile` now adopts the `checkStream` convention:
- a `read()` helper records the file-under-test bytes once when a branch reads them;
- a single deferred hook attaches `kind:"file"` + those bytes to any failing result that did not shape its own artifact;
- the five hand-written attachments are deleted (each branch is now pure matcher logic), while `equals`/`equals_file` keep carrying their `ArtifactExpected`;
- `exists`/`executable` never read content, so they attach nothing; `checkSnapshot` shapes its own normalized artifact and is read plainly so the hook leaves it untouched.

## Tests

- Existing artifact/file assertions still pass (behavior preserved).
- New `TestCheck_FileArtifactPayloads` locks in the convention: every content matcher (contains, not_contains, equals, equals_file, json) carries the file bytes as the artifact on failure, and exists attaches nothing — so a future matcher that forgets the hook fails here.

`golangci-lint` clean.

Closes #247.
