### PR TITLE
docs: add a copy-pasteable 30-second trial to README and the site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- The README, landing page, and getting-started guide now open with a
+  "Try it in 30 seconds" block: a copy-pasteable, zero-install
+  `go run github.com/nao1215/atago@latest record … -- git --version` /
+  `run` loop against a command everyone already has, producing a green
+  `PASSED` in under a minute before any install or fictional binary (#230).
 - Website SEO, social, and landing improvements (no tool behavior change): the
   landing page now leads with a visible `<h1>` tagline above a right-sized logo
   (with explicit `width`/`height` on the logo and embedded GIFs to eliminate

--- a/README.md
+++ b/README.md
@@ -19,6 +19,30 @@ Documentation: **https://nao1215.github.io/atago/**
 
 ![demo](./doc/img/demo.gif)
 
+## Try it in 30 seconds
+
+No install, no fictional binary — if you have Go, paste this. It records a real
+run of a command you already have, then replays it as a test:
+
+```shell
+go run github.com/nao1215/atago@latest record --out demo.atago.yaml -- git --version
+go run github.com/nao1215/atago@latest run demo.atago.yaml
+```
+
+```text
+.
+
+PASSED  1 scenario: 1 passed, 0 failed, 0 errored, 0 skipped
+```
+
+`record` runs `git --version` once and writes a spec from what it observed — the
+exit code, the version line on stdout, an empty stderr. `run` replays it. Open
+`demo.atago.yaml` and you have a real test you can tighten, not YAML you wrote
+from scratch. (Swap `git --version` for any command you have: `go version`,
+`jq --version`, `ls -la`.)
+
+Then point it at your own tool:
+
 ```shell
 atago record --out mytool.atago.yaml -- mytool convert input.txt  # turn a real run into a spec
 atago run mytool.atago.yaml                                       # replay it as a test

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -6,6 +6,25 @@ atago tests real CLI behavior from plain YAML: commands, files, snapshots, servi
 
 ![atago running a spec suite](/img/demo.gif)
 
+## Try it in 30 seconds
+
+No install, no fictional binary — if you have Go, paste this. It records a real run of a command you already have, then replays it as a test:
+
+```shell
+go run github.com/nao1215/atago@latest record --out demo.atago.yaml -- git --version
+go run github.com/nao1215/atago@latest run demo.atago.yaml
+```
+
+```text
+.
+
+PASSED  1 scenario: 1 passed, 0 failed, 0 errored, 0 skipped
+```
+
+`record` runs `git --version` once and writes a spec from what it observed — the exit code, the version line on stdout, an empty stderr. `run` replays it. Open `demo.atago.yaml` and you have a real test you can tighten, not YAML you wrote from scratch. (Swap `git --version` for any command you have: `go version`, `jq --version`, `ls -la`.)
+
+Then point it at your own tool:
+
 ```shell
 atago record --out mytool.atago.yaml -- mytool convert input.txt  # turn a real run into a spec
 atago run mytool.atago.yaml                                       # replay it as a test

--- a/website/content/getting-started.md
+++ b/website/content/getting-started.md
@@ -4,6 +4,23 @@ title: Getting started
 description: Record a real run of your CLI, read the spec atago wrote, and keep it as a test — then assert on files, snapshots, interactive prompts, and server peers.
 ---
 
+## Try it in 30 seconds
+
+Before installing anything, prove the loop against a command you already have. If you have Go, paste this — it records a real run and replays it as a test:
+
+```shell
+go run github.com/nao1215/atago@latest record --out demo.atago.yaml -- git --version
+go run github.com/nao1215/atago@latest run demo.atago.yaml
+```
+
+```text
+.
+
+PASSED  1 scenario: 1 passed, 0 failed, 0 errored, 0 skipped
+```
+
+Open `demo.atago.yaml`: `record` captured the exit code, the version line on stdout, and an empty stderr, so you have a real test to tighten rather than YAML written from scratch. Swap `git --version` for any command you have (`go version`, `jq --version`, `ls -la`). Then [install atago](/install/) and point it at your own tool.
+
 ## Start from a real run
 
 You don't write the first spec — your tool does. `atago record -- <command>` runs it once and generates a spec from what it observed (exit code, output, created files):


### PR DESCRIPTION
## Summary

Fixes #230. The first command a visitor saw was `atago record … -- mytool convert input.txt`, which can't be pasted (`mytool` doesn't exist) and sits above a `go install`-first Install section — so time-to-first-success meant read, install, invent a command, adapt.

Adds a **"Try it in 30 seconds"** block to the README, the website landing page, and the getting-started guide (as step zero), using the zero-install path the module already supports:

```shell
go run github.com/nao1215/atago@latest record --out demo.atago.yaml -- git --version
go run github.com/nao1215/atago@latest run demo.atago.yaml
```

It records a real run of a command everyone already has and replays it to a green `PASSED` in under a minute — demonstrating the actual differentiator (record, don't write) instead of describing it. The existing `mytool` example is kept, moved directly below the pasteable one. Pure README/site copy; no product change.

## Verification

Ran the exact loop with the built binary: `git --version` records a clean spec (`exit_code: 0`, `stdout contains "git version …"`, `stderr empty`) and `run` reports `PASSED 1 scenario`. Chose `git --version` over the issue's `git status` because `record` executes in an isolated temp workdir (no repo), where `git status` exits 128 — a confusing first impression; `git --version` is deterministic and exits 0 everywhere Go runs. `make website` builds clean and both pages render the block.

Closes #230.
