### PR TITLE
refactor(cli): split runCmd into parseRunFlags and finishRun

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -23,10 +23,117 @@ import (
 	"github.com/nao1215/atago/internal/report"
 )
 
+// runOptions is the validated result of parsing `atago run`'s flags: the plain
+// configuration the run pipeline needs, with every ExitConfig-worthy check
+// already done by parseRunFlags. Keeping it a plain struct lets finishRun's
+// exit-code invariants be exercised by a unit test instead of only through full
+// CLI invocations (#246).
+type runOptions struct {
+	label           string
+	format          report.Format
+	paths           []string
+	updateSnapshots bool
+	parallel        int
+	failFast        bool
+	repeat          int
+	retryFailed     int
+	filter          csvFlag
+	tag             csvFlag
+	skipTag         csvFlag
+	artifactsDir    string
+	rerunFailed     bool
+	verbose         bool
+	ci              bool
+	stdout          io.Writer
+	stderr          io.Writer
+}
+
+// selectionActive reports whether the user narrowed the run with a name/tag
+// selector — the shared guard for the rerun-matched-nothing and
+// selection-matched-nothing warnings.
+func (o *runOptions) selectionActive() bool {
+	return len(o.filter) > 0 || len(o.tag) > 0 || len(o.skipTag) > 0
+}
+
 // runCmd implements `atago run`. label is the command name to name in error
 // messages ("atago run", or "atago snapshot update" when snapshotCmd delegates
-// here), so a diagnostic identifies the command the user actually invoked.
+// here), so a diagnostic identifies the command the user actually invoked. It is
+// the ~40-line pipeline between parseRunFlags (flag parse + validation) and
+// finishRun (post-run bookkeeping and the final exit code) (#246).
 func runCmd(label string, args []string, stdout, stderr io.Writer) int {
+	opts, exit, done := parseRunFlags(label, args, stdout, stderr)
+	if done {
+		return exit
+	}
+
+	eng := engine.New()
+	eng.UpdateSnapshots = opts.updateSnapshots
+	eng.Parallel = opts.parallel
+	eng.FailFast = opts.failFast
+	eng.Repeat = opts.repeat
+	eng.RetryFailed = opts.retryFailed
+	eng.FilterNames = opts.filter
+	eng.Tags = opts.tag
+	eng.SkipTags = opts.skipTag
+	if strings.TrimSpace(opts.artifactsDir) != "" {
+		eng.Artifacts = artifact.NewDir(opts.artifactsDir)
+	}
+
+	paths := opts.paths
+	// --rerun-failed restricts this run to the scenarios recorded as failing on
+	// the previous run (#64); the selection and canonicalization invariants live
+	// with the ledger primitives in rerun.go.
+	if opts.rerunFailed {
+		narrowed, exitNow, done := applyRerunSelection(label, stderr, paths, eng)
+		if done {
+			return exitNow
+		}
+		paths = narrowed
+	}
+	opts.paths = paths
+
+	// In console mode, stream a live dot per scenario as it finishes, so a run
+	// visibly zips along. JSON output stays pure (no dots on stdout).
+	// --verbose (#6) replaces the dots with a full per-scenario trace; with a
+	// machine report the trace goes to stderr so stdout stays machine-readable.
+	var progress *report.Progress
+	switch {
+	case opts.verbose && opts.format == report.FormatConsole:
+		eng.OnScenario = report.NewVerbose(stdout).Scenario
+	case opts.verbose:
+		eng.OnScenario = report.NewVerbose(stderr).Scenario
+	case opts.format == report.FormatConsole:
+		progress = report.NewProgress(stdout)
+		eng.OnScenario = progress.Scenario
+	}
+
+	// Cancel the whole run on Ctrl-C / SIGTERM. NotifyContext restores the default
+	// signal disposition on the second signal, so an unresponsive run can still be
+	// force-killed. The context threads into every scenario and runner so an
+	// interrupt stops scheduling new work and unwinds in-flight cleanup promptly.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	// With --parallel > 1, run suites concurrently too, sharing one global
+	// semaphore so the TOTAL number of in-flight scenarios across every suite is
+	// capped at N. This parallelizes both many-small-suites and few-large-suites
+	// runs. Results are reassembled in input order for a deterministic report.
+	if opts.parallel > 1 {
+		eng.Sem = make(chan struct{}, opts.parallel)
+	}
+	start := time.Now()
+	suiteResults, loadErrs := runSpecs(ctx, eng, paths)
+	elapsed := time.Since(start)
+
+	return finishRun(opts, suiteResults, loadErrs, progress, elapsed, ctx)
+}
+
+// parseRunFlags parses and validates `atago run`'s flags into a runOptions. The
+// bool return is true when parsing already decided the outcome (a --help, a bad
+// flag, an unknown --report, no matching spec files, or a failed bounds check),
+// in which case the int is the exit code to return immediately; otherwise it is
+// ExitOK and the caller proceeds with the returned options.
+func parseRunFlags(label string, args []string, stdout, stderr io.Writer) (*runOptions, int, bool) {
 	fs := flag.NewFlagSet(label, flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	reportFmt := fs.String("report", "console", "report format: console|json|junit|gha|tap")
@@ -51,9 +158,9 @@ func runCmd(label string, args []string, stdout, stderr io.Writer) int {
 	}
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
-			return ExitOK
+			return nil, ExitOK, true
 		}
-		return ExitConfig
+		return nil, ExitConfig, true
 	}
 	if *ci {
 		// Force deterministic, color-free output. Secret masking is always on.
@@ -63,7 +170,7 @@ func runCmd(label string, args []string, stdout, stderr io.Writer) int {
 	format := report.Format(*reportFmt)
 	if !format.Valid() {
 		fmt.Fprintf(stderr, label+": unknown --report %q (want console, json, junit, gha, or tap)\n", *reportFmt)
-		return ExitConfig
+		return nil, ExitConfig, true
 	}
 
 	targets := fs.Args()
@@ -74,11 +181,11 @@ func runCmd(label string, args []string, stdout, stderr io.Writer) int {
 	paths, err := collectSpecFiles(targets)
 	if err != nil {
 		fmt.Fprintf(stderr, label+": %v\n", err)
-		return ExitConfig
+		return nil, ExitConfig, true
 	}
 	if len(paths) == 0 {
 		fmt.Fprintln(stderr, label+": no *.atago.yaml (or *.atago.yml) files found")
-		return ExitConfig
+		return nil, ExitConfig, true
 	}
 
 	// --repeat and --retry-failed answer opposite questions (does it flake? /
@@ -87,11 +194,11 @@ func runCmd(label string, args []string, stdout, stderr io.Writer) int {
 	// changes nothing and must not be rejected alongside --retry-failed.
 	if *repeat > 1 && *retryFailed > 0 {
 		fmt.Fprintln(stderr, label+": --repeat and --retry-failed are mutually exclusive (repeat detects flakiness, retry-failed tolerates it)")
-		return ExitConfig
+		return nil, ExitConfig, true
 	}
 	if *repeat < 0 || *retryFailed < 0 {
 		fmt.Fprintln(stderr, label+": --repeat and --retry-failed must be >= 0")
-		return ExitConfig
+		return nil, ExitConfig, true
 	}
 	// A negative --parallel is a typo, not a request: the engine would clamp it to
 	// sequential and exit 0, silently ignoring the mistake. Reject it with the same
@@ -99,18 +206,8 @@ func runCmd(label string, args []string, stdout, stderr io.Writer) int {
 	// is left to mean the default (like repeat/retry allow 0).
 	if *parallel < 0 {
 		fmt.Fprintln(stderr, label+": --parallel must be >= 0")
-		return ExitConfig
+		return nil, ExitConfig, true
 	}
-
-	eng := engine.New()
-	eng.UpdateSnapshots = *updateSnapshots
-	eng.Parallel = *parallel
-	eng.FailFast = *failFast
-	eng.Repeat = *repeat
-	eng.RetryFailed = *retryFailed
-	eng.FilterNames = filter
-	eng.Tags = tag
-	eng.SkipTags = skipTag
 	if strings.TrimSpace(*artifactsDir) != "" {
 		// Fail fast if the artifacts dir cannot be used. An existing regular file at
 		// the path, or a directory that cannot be created, would otherwise make
@@ -118,61 +215,37 @@ func runCmd(label string, args []string, stdout, stderr io.Writer) int {
 		// produced no reviewable failures when in fact none could be written.
 		if err := ensureArtifactsDir(*artifactsDir); err != nil {
 			fmt.Fprintf(stderr, label+": --artifacts-dir %q is not usable: %v\n", *artifactsDir, err)
-			return ExitConfig
+			return nil, ExitConfig, true
 		}
-		eng.Artifacts = artifact.NewDir(*artifactsDir)
 	}
+	return &runOptions{
+		label:           label,
+		format:          format,
+		paths:           paths,
+		updateSnapshots: *updateSnapshots,
+		parallel:        *parallel,
+		failFast:        *failFast,
+		repeat:          *repeat,
+		retryFailed:     *retryFailed,
+		filter:          filter,
+		tag:             tag,
+		skipTag:         skipTag,
+		artifactsDir:    *artifactsDir,
+		rerunFailed:     *rerunFailed,
+		verbose:         *verbose,
+		ci:              *ci,
+		stdout:          stdout,
+		stderr:          stderr,
+	}, ExitOK, false
+}
 
-	// --rerun-failed restricts this run to the scenarios recorded as failing on
-	// the previous run (#64); the selection and canonicalization invariants live
-	// with the ledger primitives in rerun.go.
-	if *rerunFailed {
-		narrowed, exitNow, done := applyRerunSelection(label, stderr, paths, eng)
-		if done {
-			return exitNow
-		}
-		paths = narrowed
-	}
-
-	// In console mode, stream a live dot per scenario as it finishes, so a run
-	// visibly zips along. JSON output stays pure (no dots on stdout).
-	// --verbose (#6) replaces the dots with a full per-scenario trace; with a
-	// machine report the trace goes to stderr so stdout stays machine-readable.
-	var progress *report.Progress
-	switch {
-	case *verbose && format == report.FormatConsole:
-		eng.OnScenario = report.NewVerbose(stdout).Scenario
-	case *verbose:
-		eng.OnScenario = report.NewVerbose(stderr).Scenario
-	case format == report.FormatConsole:
-		progress = report.NewProgress(stdout)
-		eng.OnScenario = progress.Scenario
-	}
-
-	// Cancel the whole run on Ctrl-C / SIGTERM. NotifyContext restores the default
-	// signal disposition on the second signal, so an unresponsive run can still be
-	// force-killed. The context threads into every scenario and runner so an
-	// interrupt stops scheduling new work and unwinds in-flight cleanup promptly.
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
-
-	// With --parallel > 1, run suites concurrently too, sharing one global
-	// semaphore so the TOTAL number of in-flight scenarios across every suite is
-	// capped at N. This parallelizes both many-small-suites and few-large-suites
-	// runs. Results are reassembled in input order for a deterministic report.
-	if *parallel > 1 {
-		eng.Sem = make(chan struct{}, *parallel)
-	}
-	start := time.Now()
-	suiteResults, loadErrs := runSpecs(ctx, eng, paths)
-	elapsed := time.Since(start)
-
-	results := make([]*engine.SuiteResult, 0, len(paths))
+func finishRun(opts *runOptions, suiteResults []*engine.SuiteResult, loadErrs []error, progress *report.Progress, elapsed time.Duration, ctx context.Context) int {
+	results := make([]*engine.SuiteResult, 0, len(opts.paths))
 	exit := ExitOK
 	loadFailures := 0
-	for i := range paths {
+	for i := range opts.paths {
 		if loadErrs[i] != nil {
-			fmt.Fprintf(stderr, "%v\n", loadErrs[i])
+			fmt.Fprintf(opts.stderr, "%v\n", loadErrs[i])
 			exit = worseExit(exit, exitForLoadError(loadErrs[i]))
 			loadFailures++
 			continue
@@ -206,10 +279,9 @@ func runCmd(label string, args []string, stdout, stderr io.Writer) int {
 	// selection is why nothing ran, blaming a rename/removal is wrong (and
 	// contradicts the selection warning below). The excluded failures are still
 	// preserved into the ledger via rerunPreserved above, so no work is lost.
-	selectionActive := len(filter) > 0 || len(tag) > 0 || len(skipTag) > 0
-	rerunMatchedNothing := *rerunFailed && !selectionActive && len(results) > 0 && ranScenarios == 0 && ctx.Err() == nil
+	rerunMatchedNothing := opts.rerunFailed && !opts.selectionActive() && len(results) > 0 && ranScenarios == 0 && ctx.Err() == nil
 	if rerunMatchedNothing {
-		fmt.Fprintln(stderr, label+": warning: no recorded failing scenarios matched the current specs (renamed or removed?); the recorded failures were kept, not cleared")
+		fmt.Fprintln(opts.stderr, opts.label+": warning: no recorded failing scenarios matched the current specs (renamed or removed?); the recorded failures were kept, not cleared")
 		exit = worseExit(exit, ExitConfig)
 	}
 
@@ -219,7 +291,7 @@ func runCmd(label string, args []string, stdout, stderr io.Writer) int {
 	// and when a --rerun-failed matched nothing (its unmapped failures must
 	// survive).
 	if len(results) > 0 && !rerunMatchedNothing {
-		updateRerunLedger(label, stderr, results, ranScenarios)
+		updateRerunLedger(opts.label, opts.stderr, results, ranScenarios)
 	}
 
 	// Every spec failed to load, or an interrupt skipped every suite before it
@@ -227,7 +299,7 @@ func runCmd(label string, args []string, stdout, stderr io.Writer) int {
 	// that was interrupted before completing must never exit 0.
 	if len(results) == 0 {
 		if ctx.Err() != nil {
-			fmt.Fprintln(stderr, label+": interrupted")
+			fmt.Fprintln(opts.stderr, opts.label+": interrupted")
 			return worseExit(exit, ExitExec)
 		}
 		return exit
@@ -237,7 +309,7 @@ func runCmd(label string, args []string, stdout, stderr io.Writer) int {
 	// ran, nothing failed) but stays loud; under --ci it is a hard config error so
 	// a typo'd --filter/--tag/--skip-tag cannot silently disable the whole suite in
 	// a pipeline forever.
-	if selectionActive {
+	if opts.selectionActive() {
 		total := 0
 		for _, r := range results {
 			total += len(r.Scenarios)
@@ -249,43 +321,43 @@ func runCmd(label string, args []string, stdout, stderr io.Writer) int {
 		// case the task must fail on, not "the specs had nothing to run".
 		if total == 0 && ctx.Err() == nil {
 			var sel []string
-			if len(filter) > 0 {
-				sel = append(sel, fmt.Sprintf("--filter %q", strings.Join(filter, ",")))
+			if len(opts.filter) > 0 {
+				sel = append(sel, fmt.Sprintf("--filter %q", strings.Join(opts.filter, ",")))
 			}
-			if len(tag) > 0 {
-				sel = append(sel, fmt.Sprintf("--tag %q", strings.Join(tag, ",")))
+			if len(opts.tag) > 0 {
+				sel = append(sel, fmt.Sprintf("--tag %q", strings.Join(opts.tag, ",")))
 			}
-			if len(skipTag) > 0 {
-				sel = append(sel, fmt.Sprintf("--skip-tag %q", strings.Join(skipTag, ",")))
+			if len(opts.skipTag) > 0 {
+				sel = append(sel, fmt.Sprintf("--skip-tag %q", strings.Join(opts.skipTag, ",")))
 			}
-			tagActive := len(tag) > 0 || len(skipTag) > 0
+			tagActive := len(opts.tag) > 0 || len(opts.skipTag) > 0
 			// The note is selector-aware: --filter matches names by case-sensitive
 			// substring, but --tag/--skip-tag compare tags for EXACT equality
 			// (engine.hasAnyTag uses ==). A single "substring" note for tags would send
 			// users fixing the wrong thing, so name each selector's real rule.
-			note := selectorNoMatchNote(len(filter) > 0, tagActive)
-			if *ci {
-				fmt.Fprintf(stderr, label+": no scenarios matched %s under --ci; refusing to exit 0 (an empty selection would silently disable the suite). %s. Run `atago list` to see available scenarios and tags.\n", strings.Join(sel, " "), note)
+			note := selectorNoMatchNote(len(opts.filter) > 0, tagActive)
+			if opts.ci {
+				fmt.Fprintf(opts.stderr, opts.label+": no scenarios matched %s under --ci; refusing to exit 0 (an empty selection would silently disable the suite). %s. Run `atago list` to see available scenarios and tags.\n", strings.Join(sel, " "), note)
 				exit = worseExit(exit, ExitConfig)
 			} else {
 				hint := note
 				if tagActive {
 					hint += "; run `atago list` to see the available tags"
 				}
-				fmt.Fprintf(stderr, label+": warning: no scenarios matched %s (%s)\n", strings.Join(sel, " "), hint)
+				fmt.Fprintf(opts.stderr, opts.label+": warning: no scenarios matched %s (%s)\n", strings.Join(sel, " "), hint)
 			}
 		}
 	}
 
-	if err := report.Render(stdout, format, results, report.WithLoadFailures(loadFailures), report.WithElapsed(elapsed)); err != nil {
-		fmt.Fprintf(stderr, label+": failed to write report: %v\n", err)
+	if err := report.Render(opts.stdout, opts.format, results, report.WithLoadFailures(loadFailures), report.WithElapsed(elapsed)); err != nil {
+		fmt.Fprintf(opts.stderr, opts.label+": failed to write report: %v\n", err)
 		return worseExit(exit, ExitInternal)
 	}
 	// An interrupted run never reports success, even in the rare case where the
 	// signal landed between scenarios and every scheduled one was skipped: the run
 	// did not complete, so the exit code is at least an execution error (4).
 	if ctx.Err() != nil {
-		fmt.Fprintln(stderr, label+": interrupted")
+		fmt.Fprintln(opts.stderr, opts.label+": interrupted")
 		exit = worseExit(exit, ExitExec)
 	}
 	return exit

--- a/internal/cli/run_split_test.go
+++ b/internal/cli/run_split_test.go
@@ -1,0 +1,228 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nao1215/atago/internal/engine"
+	"github.com/nao1215/atago/internal/report"
+)
+
+func TestParseRunFlags_ReturnsValidatedOptions(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+
+	dir := t.TempDir()
+	spec := writeSpec(t, dir, "ok.atago.yaml", passingSpec)
+	arts := filepath.Join(dir, "artifacts")
+	var out, errb bytes.Buffer
+
+	opts, exit, done := parseRunFlags("atago run", []string{
+		"--report", "json",
+		"--update-snapshots",
+		"--parallel", "3",
+		"--fail-fast",
+		"--filter", "alpha,beta",
+		"--tag", "slow",
+		"--skip-tag", "net",
+		"--artifacts-dir", arts,
+		"--rerun-failed",
+		"--retry-failed", "2",
+		"--verbose",
+		"--ci",
+		spec,
+	}, &out, &errb)
+	if done {
+		t.Fatalf("done = true, want false (exit=%d, stderr=%s)", exit, errb.String())
+	}
+	if exit != ExitOK {
+		t.Fatalf("exit = %d, want %d", exit, ExitOK)
+	}
+	if opts == nil {
+		t.Fatal("opts = nil, want a populated runOptions")
+	}
+	if opts.label != "atago run" || opts.format != report.FormatJSON {
+		t.Fatalf("opts = %+v, want label/report preserved", opts)
+	}
+	if !opts.updateSnapshots || !opts.failFast || !opts.rerunFailed || !opts.verbose || !opts.ci {
+		t.Fatalf("opts = %+v, want boolean flags preserved", opts)
+	}
+	if opts.parallel != 3 || opts.retryFailed != 2 {
+		t.Fatalf("opts = %+v, want parallel=3 retryFailed=2", opts)
+	}
+	if !reflect.DeepEqual([]string(opts.filter), []string{"alpha", "beta"}) {
+		t.Fatalf("filter = %v, want [alpha beta]", opts.filter)
+	}
+	if !reflect.DeepEqual([]string(opts.tag), []string{"slow"}) {
+		t.Fatalf("tag = %v, want [slow]", opts.tag)
+	}
+	if !reflect.DeepEqual([]string(opts.skipTag), []string{"net"}) {
+		t.Fatalf("skipTag = %v, want [net]", opts.skipTag)
+	}
+	if !reflect.DeepEqual(opts.paths, []string{spec}) {
+		t.Fatalf("paths = %v, want [%s]", opts.paths, spec)
+	}
+	if opts.artifactsDir != arts {
+		t.Fatalf("artifactsDir = %q, want %q", opts.artifactsDir, arts)
+	}
+	if got := os.Getenv("NO_COLOR"); got != "1" {
+		t.Fatalf("NO_COLOR = %q, want 1", got)
+	}
+	if info, err := os.Stat(arts); err != nil || !info.IsDir() {
+		t.Fatalf("artifacts dir was not validated/created: stat err=%v isDir=%v", err, err == nil && info.IsDir())
+	}
+}
+
+func TestParseRunFlags_RejectsUnusableArtifactsDir(t *testing.T) {
+	dir := t.TempDir()
+	spec := writeSpec(t, dir, "ok.atago.yaml", passingSpec)
+	afile := filepath.Join(dir, "artifacts-file")
+	if err := os.WriteFile(afile, []byte("not a dir"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var out, errb bytes.Buffer
+
+	opts, exit, done := parseRunFlags("atago run", []string{"--artifacts-dir", afile, spec}, &out, &errb)
+	if !done {
+		t.Fatalf("done = false, want true (opts=%+v)", opts)
+	}
+	if exit != ExitConfig {
+		t.Fatalf("exit = %d, want %d", exit, ExitConfig)
+	}
+	if opts != nil {
+		t.Fatalf("opts = %+v, want nil on config error", opts)
+	}
+	if !strings.Contains(errb.String(), "is not usable") {
+		t.Fatalf("stderr = %q, want the artifacts-dir validation error", errb.String())
+	}
+}
+
+func TestFinishRun_RerunMatchedNothingKeepsLedger(t *testing.T) {
+	dir := t.TempDir()
+	withWorkdir(t, dir, func() {
+		if err := saveRerunState([]failedEntry{{SpecPath: "spec.atago.yaml", Scenario: "still failing"}}); err != nil {
+			t.Fatal(err)
+		}
+
+		var out, errb bytes.Buffer
+		opts := &runOptions{
+			label:       "atago run",
+			format:      report.FormatJSON,
+			paths:       []string{"spec.atago.yaml"},
+			rerunFailed: true,
+			stdout:      &out,
+			stderr:      &errb,
+		}
+		suiteResults := []*engine.SuiteResult{{
+			Suite:    "sample",
+			SpecPath: "spec.atago.yaml",
+			Status:   engine.StatusPassed,
+		}}
+
+		if got := finishRun(opts, suiteResults, []error{nil}, nil, 5*time.Millisecond, context.Background()); got != ExitConfig {
+			t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitConfig, errb.String())
+		}
+		if !strings.Contains(errb.String(), "no recorded failing scenarios matched the current specs") {
+			t.Fatalf("stderr = %q, want the rerun-matched-nothing warning", errb.String())
+		}
+
+		st, err := loadRerunState()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(st.Failed) != 1 || st.Failed[0].Scenario != "still failing" {
+			t.Fatalf("ledger = %+v, want the preserved failing scenario", st.Failed)
+		}
+	})
+}
+
+func TestFinishRun_CIEmptySelectionExitsConfig(t *testing.T) {
+	dir := t.TempDir()
+	withWorkdir(t, dir, func() {
+		var out, errb bytes.Buffer
+		opts := &runOptions{
+			label:  "atago run",
+			format: report.FormatJSON,
+			paths:  []string{"spec.atago.yaml"},
+			filter: csvFlag{"missing"},
+			ci:     true,
+			stdout: &out,
+			stderr: &errb,
+		}
+		suiteResults := []*engine.SuiteResult{{
+			Suite:    "sample",
+			SpecPath: "spec.atago.yaml",
+			Status:   engine.StatusPassed,
+		}}
+
+		if got := finishRun(opts, suiteResults, []error{nil}, nil, 5*time.Millisecond, context.Background()); got != ExitConfig {
+			t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitConfig, errb.String())
+		}
+		s := errb.String()
+		if !strings.Contains(s, `no scenarios matched --filter "missing" under --ci`) {
+			t.Fatalf("stderr = %q, want the empty-selection CI error", s)
+		}
+		if !strings.Contains(s, "case-sensitive substring") {
+			t.Fatalf("stderr = %q, want the selector note", s)
+		}
+	})
+}
+
+func TestFinishRun_InterruptedWithoutResultsSkipsReport(t *testing.T) {
+	var out, errb bytes.Buffer
+	opts := &runOptions{
+		label:  "atago run",
+		format: report.FormatJSON,
+		paths:  []string{"spec.atago.yaml"},
+		stdout: &out,
+		stderr: &errb,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if got := finishRun(opts, []*engine.SuiteResult{nil}, []error{nil}, nil, 5*time.Millisecond, ctx); got != ExitExec {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitExec, errb.String())
+	}
+	if out.Len() != 0 {
+		t.Fatalf("stdout = %q, want no report when every suite was skipped by the interrupt", out.String())
+	}
+	if !strings.Contains(errb.String(), "interrupted") {
+		t.Fatalf("stderr = %q, want the interrupt diagnostic", errb.String())
+	}
+}
+
+func TestFinishRun_ReportWriteFailureReturnsInternal(t *testing.T) {
+	dir := t.TempDir()
+	withWorkdir(t, dir, func() {
+		var errb bytes.Buffer
+		opts := &runOptions{
+			label:  "atago run",
+			format: report.FormatJSON,
+			paths:  []string{"spec.atago.yaml"},
+			stdout: errWriter{},
+			stderr: &errb,
+		}
+		suiteResults := []*engine.SuiteResult{{
+			Suite:    "sample",
+			SpecPath: "spec.atago.yaml",
+			Status:   engine.StatusPassed,
+			Scenarios: []engine.ScenarioResult{{
+				Name:   "ok",
+				Suite:  "sample",
+				Status: engine.StatusPassed,
+			}},
+		}}
+
+		if got := finishRun(opts, suiteResults, []error{nil}, nil, 5*time.Millisecond, context.Background()); got != ExitInternal {
+			t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitInternal, errb.String())
+		}
+		if !strings.Contains(errb.String(), "failed to write report: boom") {
+			t.Fatalf("stderr = %q, want the report write failure", errb.String())
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Split `runCmd` into a thin execution pipeline, a validated `parseRunFlags` stage, and a `finishRun` stage that owns the exit-code and warning invariants.

## Changes
- extract validated run options into `runOptions` and move flag/bounds/artifacts-dir checks into `parseRunFlags`
- move post-run load-error folding, rerun-ledger handling, empty-selection warnings, report rendering, and interrupt exit handling into `finishRun`
- add direct unit coverage for `parseRunFlags` and `finishRun` so the tricky exit paths are testable without full CLI invocations

## Design Decisions
- keep the split mechanical and leave `runSpecs` unchanged, matching the issue scope
- validate `--artifacts-dir` during flag parsing so `runCmd` only wires already-checked options into the engine

## Verification
- `go test ./internal/cli`
- `go test ./...`

Closes #246.