### PR TITLE
refactor(assertdesc): share assert describers across docgen and explain

### DIFF
--- a/internal/assertdesc/describe.go
+++ b/internal/assertdesc/describe.go
@@ -1,0 +1,322 @@
+package assertdesc
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/nao1215/atago/internal/spec"
+)
+
+type HeaderStyle struct {
+	Name  func(string) string
+	Value func(string) string
+	Regex func(string) string
+	Bare  func(string) string
+}
+
+func DescribeHeader(h *spec.HeaderMatch, style HeaderStyle) string {
+	switch {
+	case h.Contains != nil:
+		return style.Name(h.Name) + " contains " + style.Value(*h.Contains)
+	case h.Equals != nil:
+		return style.Name(h.Name) + " equals " + style.Value(*h.Equals)
+	case h.Matches != nil:
+		return style.Name(h.Name) + " matches " + style.Regex(*h.Matches)
+	default:
+		return style.Bare(h.Name)
+	}
+}
+
+type JSONStyle struct {
+	Prefix  func(string) string
+	Equals  func(any) string
+	Matches func(string) string
+	Length  func(int) string
+	Compare func(string, any) string
+	Default string
+}
+
+func DescribeJSONChecks(list spec.JSONChecks, style JSONStyle) string {
+	parts := make([]string, len(list))
+	for i := range list {
+		parts[i] = strings.TrimSpace(style.Prefix(list[i].Path) + " " + DescribeJSONMatcher(&list[i], style))
+	}
+	return strings.Join(parts, "; ")
+}
+
+func DescribeJSONMatcher(j *spec.JSONAssert, style JSONStyle) string {
+	switch {
+	case j.Equals != nil:
+		return style.Equals(j.Equals)
+	case j.Matches != nil:
+		return style.Matches(*j.Matches)
+	case j.Length != nil:
+		return style.Length(*j.Length)
+	case j.Gt != nil:
+		return style.Compare(">", *j.Gt)
+	case j.Gte != nil:
+		return style.Compare(">=", *j.Gte)
+	case j.Lt != nil:
+		return style.Compare("<", *j.Lt)
+	case j.Lte != nil:
+		return style.Compare("<=", *j.Lte)
+	default:
+		return style.Default
+	}
+}
+
+type StreamStyle struct {
+	List      func(spec.StringList) string
+	Regex     func(string) string
+	Equals    string
+	NotEquals string
+	JSON      JSONStyle
+	YAML      JSONStyle
+	Snapshot  func(string) string
+	NoMatcher string
+}
+
+func DescribeStream(s *spec.StreamAssert, style StreamStyle) string {
+	switch {
+	case s.Empty != nil:
+		if *s.Empty {
+			return "is empty"
+		}
+		return "is not empty"
+	case s.Contains != nil:
+		return "contains " + style.List(s.Contains)
+	case s.NotContains != nil:
+		return "does not contain " + style.List(s.NotContains)
+	case s.Matches != nil:
+		return "matches " + style.Regex(*s.Matches)
+	case s.NotMatches != nil:
+		return "does not match " + style.Regex(*s.NotMatches)
+	case s.Equals != nil:
+		return style.Equals
+	case s.NotEquals != nil:
+		return style.NotEquals
+	case len(s.JSON) > 0:
+		return DescribeJSONChecks(s.JSON, style.JSON)
+	case len(s.YAML) > 0:
+		return DescribeJSONChecks(s.YAML, style.YAML)
+	case s.Snapshot != "":
+		return "matches snapshot " + style.Snapshot(s.Snapshot)
+	default:
+		return style.NoMatcher
+	}
+}
+
+type FileStyle struct {
+	Path       func(string) string
+	List       func(spec.StringList) string
+	JSON       JSONStyle
+	Snapshot   func(string) string
+	Checked    func(string) string
+	ExactBytes string
+}
+
+func DescribeFile(f *spec.FileAssert, style FileStyle) string {
+	switch {
+	case f.Exists != nil:
+		if *f.Exists {
+			return style.Path(f.Path) + " exists"
+		}
+		return style.Path(f.Path) + " does not exist"
+	case f.Contains != nil:
+		return style.Path(f.Path) + " contains " + style.List(f.Contains)
+	case f.Equals != nil:
+		return style.Path(f.Path) + " " + style.ExactBytes
+	case f.EqualsFile != nil:
+		return style.Path(f.Path) + " is byte-identical to " + style.Path(*f.EqualsFile)
+	case len(f.JSON) > 0:
+		return style.Path(f.Path) + " " + DescribeJSONChecks(f.JSON, style.JSON)
+	case f.Snapshot != "":
+		return style.Path(f.Path) + " matches snapshot " + style.Snapshot(f.Snapshot)
+	default:
+		return style.Checked(f.Path)
+	}
+}
+
+type ImageStyle struct {
+	Path      func(string) string
+	Format    func(string) string
+	SimilarTo func(string) string
+	Checked   func(string) string
+}
+
+func DescribeImage(im *spec.ImageAssert, style ImageStyle) string {
+	var parts []string
+	if im.Format != "" {
+		parts = append(parts, "is "+style.Format(im.Format))
+	}
+	if im.Width != nil {
+		parts = append(parts, fmt.Sprintf("width %d", *im.Width))
+	}
+	if im.Height != nil {
+		parts = append(parts, fmt.Sprintf("height %d", *im.Height))
+	}
+	if im.MinWidth != nil {
+		parts = append(parts, fmt.Sprintf("width >= %d", *im.MinWidth))
+	}
+	if im.MaxWidth != nil {
+		parts = append(parts, fmt.Sprintf("width <= %d", *im.MaxWidth))
+	}
+	if im.MinHeight != nil {
+		parts = append(parts, fmt.Sprintf("height >= %d", *im.MinHeight))
+	}
+	if im.MaxHeight != nil {
+		parts = append(parts, fmt.Sprintf("height <= %d", *im.MaxHeight))
+	}
+	if im.Alpha != nil {
+		if *im.Alpha {
+			parts = append(parts, "has alpha")
+		} else {
+			parts = append(parts, "has no alpha")
+		}
+	}
+	if im.SimilarTo != "" {
+		parts = append(parts, "similar to "+style.SimilarTo(im.SimilarTo))
+	}
+	if len(parts) == 0 {
+		return style.Checked(im.Path)
+	}
+	return style.Path(im.Path) + " " + strings.Join(parts, ", ")
+}
+
+type DirStyle struct {
+	Path    func(string) string
+	Item    func(string) string
+	Token   func(string) string
+	Checked func(string) string
+}
+
+func DescribeDir(d *spec.DirAssert, style DirStyle) string {
+	var parts []string
+	if d.Exists != nil {
+		if *d.Exists {
+			parts = append(parts, "exists")
+		} else {
+			parts = append(parts, "does not exist")
+		}
+	}
+	for _, c := range d.Contains {
+		parts = append(parts, "contains "+style.Item(c))
+	}
+	for _, c := range d.NotContains {
+		parts = append(parts, "does not contain "+style.Item(c))
+	}
+	if d.Count != nil {
+		parts = append(parts, fmt.Sprintf("has %d entries", *d.Count))
+	}
+	if d.MinCount != nil {
+		parts = append(parts, fmt.Sprintf("has >= %d entries", *d.MinCount))
+	}
+	if d.MaxCount != nil {
+		parts = append(parts, fmt.Sprintf("has <= %d entries", *d.MaxCount))
+	}
+	if d.Glob != "" {
+		parts = append(parts, "matches glob "+style.Token(d.Glob))
+	}
+	if d.Snapshot != "" {
+		parts = append(parts, "tree matches snapshot "+style.Token(d.Snapshot))
+	}
+	if d.Recursive {
+		parts = append(parts, "(recursive)")
+	}
+	if len(d.Ignore) > 0 {
+		parts = append(parts, "ignoring "+strings.Join(d.Ignore, ", "))
+	}
+	if len(parts) == 0 {
+		return style.Checked(d.Path)
+	}
+	return style.Path(d.Path) + " " + strings.Join(parts, ", ")
+}
+
+type PDFStyle struct {
+	Path    func(string) string
+	Value   func(string) string
+	Stream  func(*spec.StreamAssert) string
+	Checked func(string) string
+}
+
+func DescribePDF(p *spec.PDFAssert, style PDFStyle) string {
+	var parts []string
+	if p.Pages != nil {
+		parts = append(parts, fmt.Sprintf("%d pages", *p.Pages))
+	}
+	if p.MinPages != nil {
+		parts = append(parts, fmt.Sprintf(">= %d pages", *p.MinPages))
+	}
+	if p.MaxPages != nil {
+		parts = append(parts, fmt.Sprintf("<= %d pages", *p.MaxPages))
+	}
+	keys := make([]string, 0, len(p.Metadata))
+	for k := range p.Metadata {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s contains %s", k, style.Value(p.Metadata[k])))
+	}
+	if p.Text != nil {
+		parts = append(parts, "text "+style.Stream(p.Text))
+	}
+	if len(parts) == 0 {
+		return style.Checked(p.Path)
+	}
+	return style.Path(p.Path) + " " + strings.Join(parts, ", ")
+}
+
+type ChangesStyle struct {
+	Entry func(string) string
+	Join  string
+}
+
+func DescribeChanges(c *spec.ChangesAssert, style ChangesStyle) string {
+	var parts []string
+	for _, cat := range []struct {
+		name    string
+		entries *spec.StringList
+	}{
+		{"created", c.Created},
+		{"modified", c.Modified},
+		{"deleted", c.Deleted},
+	} {
+		if cat.entries == nil {
+			continue
+		}
+		if len(*cat.entries) == 0 {
+			parts = append(parts, cat.name+" nothing")
+			continue
+		}
+		formatted := make([]string, len(*cat.entries))
+		for i, entry := range *cat.entries {
+			formatted[i] = style.Entry(entry)
+		}
+		parts = append(parts, cat.name+" "+strings.Join(formatted, ", "))
+	}
+	if len(parts) == 0 {
+		return "nothing"
+	}
+	return strings.Join(parts, style.Join)
+}
+
+type MockStyle struct {
+	Name  func(string) string
+	Route func(string) string
+	Count func(int) string
+}
+
+func DescribeMock(m *spec.MockAssert, style MockStyle) string {
+	desc := "mock " + style.Name(m.Name)
+	if m.Method != "" || m.Path != "" {
+		desc += " received " + style.Route(strings.TrimSpace(strings.ToUpper(m.Method)+" "+m.Path))
+	} else {
+		desc += " received a request"
+	}
+	if m.Count != nil {
+		desc += style.Count(*m.Count)
+	}
+	return desc
+}

--- a/internal/assertdesc/describe_test.go
+++ b/internal/assertdesc/describe_test.go
@@ -1,0 +1,156 @@
+package assertdesc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/nao1215/atago/internal/spec"
+)
+
+func TestDescribeHeader(t *testing.T) {
+	t.Parallel()
+	style := HeaderStyle{
+		Name:  func(s string) string { return "<" + s + ">" },
+		Value: func(s string) string { return fmt.Sprintf("%q", s) },
+		Regex: func(s string) string { return "/" + s + "/" },
+		Bare:  func(s string) string { return "bare " + s },
+	}
+	tests := []struct {
+		name string
+		h    *spec.HeaderMatch
+		want string
+	}{
+		{"contains", &spec.HeaderMatch{Name: "X", Contains: strptr("ok")}, `<X> contains "ok"`},
+		{"equals", &spec.HeaderMatch{Name: "X", Equals: strptr("1")}, `<X> equals "1"`},
+		{"matches", &spec.HeaderMatch{Name: "Auth", Matches: strptr("^Bearer ")}, `<Auth> matches /^Bearer /`},
+		{"bare", &spec.HeaderMatch{Name: "X"}, `bare X`},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := DescribeHeader(tt.h, style); got != tt.want {
+				t.Fatalf("DescribeHeader() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDescribeStreamAndFile(t *testing.T) {
+	t.Parallel()
+	jsonStyle := JSONStyle{
+		Prefix:  func(path string) string { return "at " + path },
+		Equals:  func(v any) string { return fmt.Sprintf("== %v", v) },
+		Matches: func(s string) string { return "matches /" + s + "/" },
+		Length:  func(n int) string { return fmt.Sprintf("length %d", n) },
+		Compare: func(op string, v any) string { return fmt.Sprintf("%s %v", op, v) },
+		Default: "checked",
+	}
+	streamStyle := StreamStyle{
+		List:      func(ss spec.StringList) string { return fmt.Sprint([]string(ss)) },
+		Regex:     func(s string) string { return "/" + s + "/" },
+		Equals:    "equals exact text",
+		NotEquals: "does not equal exact text",
+		JSON:      jsonStyle,
+		YAML: JSONStyle{
+			Prefix:  func(path string) string { return "yaml " + path },
+			Equals:  jsonStyle.Equals,
+			Matches: jsonStyle.Matches,
+			Length:  jsonStyle.Length,
+			Compare: jsonStyle.Compare,
+			Default: jsonStyle.Default,
+		},
+		Snapshot:  func(s string) string { return s },
+		NoMatcher: "(no matcher)",
+	}
+	fileStyle := FileStyle{
+		Path:       func(s string) string { return "[" + s + "]" },
+		List:       streamStyle.List,
+		JSON:       jsonStyle,
+		Snapshot:   func(s string) string { return "<" + s + ">" },
+		Checked:    func(s string) string { return "checked " + s },
+		ExactBytes: "equals exact bytes",
+	}
+
+	if got := DescribeStream(&spec.StreamAssert{JSON: spec.JSONChecks{{Path: "$.n", Gte: f64ptr(3)}}}, streamStyle); got != "at $.n >= 3" {
+		t.Fatalf("DescribeStream(JSON) = %q", got)
+	}
+	if got := DescribeStream(&spec.StreamAssert{Snapshot: "out.snap"}, streamStyle); got != "matches snapshot out.snap" {
+		t.Fatalf("DescribeStream(snapshot) = %q", got)
+	}
+	if got := DescribeFile(&spec.FileAssert{Path: "data.json", JSON: spec.JSONChecks{{Path: "$.ok", Equals: true}}}, fileStyle); got != "[data.json] at $.ok == true" {
+		t.Fatalf("DescribeFile(JSON) = %q", got)
+	}
+	if got := DescribeFile(&spec.FileAssert{Path: "raw.bin"}, fileStyle); got != "checked raw.bin" {
+		t.Fatalf("DescribeFile(default) = %q", got)
+	}
+}
+
+func TestDescribeChangesMockImageDirAndPDF(t *testing.T) {
+	t.Parallel()
+	if got := DescribeChanges(&spec.ChangesAssert{
+		Created:  &spec.StringList{"a.txt"},
+		Modified: &spec.StringList{},
+	}, ChangesStyle{
+		Entry: func(s string) string { return "<" + s + ">" },
+		Join:  " | ",
+	}); got != "created <a.txt> | modified nothing" {
+		t.Fatalf("DescribeChanges() = %q", got)
+	}
+
+	if got := DescribeMock(&spec.MockAssert{Name: "api", Method: "get", Path: "/v1", Count: intptr(2)}, MockStyle{
+		Name:  func(s string) string { return "<" + s + ">" },
+		Route: func(s string) string { return "[" + s + "]" },
+		Count: func(n int) string { return fmt.Sprintf(" x%d", n) },
+	}); got != "mock <api> received [GET /v1] x2" {
+		t.Fatalf("DescribeMock() = %q", got)
+	}
+
+	streamStyle := StreamStyle{
+		List:      func(ss spec.StringList) string { return fmt.Sprint([]string(ss)) },
+		Regex:     func(s string) string { return "/" + s + "/" },
+		Equals:    "equals exact text",
+		NotEquals: "does not equal exact text",
+		JSON:      JSONStyle{Prefix: func(path string) string { return path }, Equals: func(v any) string { return fmt.Sprint(v) }, Matches: func(s string) string { return s }, Length: func(n int) string { return fmt.Sprint(n) }, Compare: func(op string, v any) string { return fmt.Sprintf("%s %v", op, v) }, Default: "checked"},
+		YAML:      JSONStyle{Prefix: func(path string) string { return path }, Equals: func(v any) string { return fmt.Sprint(v) }, Matches: func(s string) string { return s }, Length: func(n int) string { return fmt.Sprint(n) }, Compare: func(op string, v any) string { return fmt.Sprintf("%s %v", op, v) }, Default: "checked"},
+		Snapshot:  func(s string) string { return s },
+		NoMatcher: "(no matcher)",
+	}
+
+	if got := DescribeImage(&spec.ImageAssert{Path: "out.png", Format: "png", Alpha: boolptr(true), SimilarTo: "base.png"}, ImageStyle{
+		Path:      func(s string) string { return "[" + s + "]" },
+		Format:    func(s string) string { return "<" + s + ">" },
+		SimilarTo: func(s string) string { return "(" + s + ")" },
+		Checked:   func(s string) string { return "checked " + s },
+	}); got != "[out.png] is <png>, has alpha, similar to (base.png)" {
+		t.Fatalf("DescribeImage() = %q", got)
+	}
+
+	if got := DescribeDir(&spec.DirAssert{Path: "site", Contains: []string{"index.html"}, Snapshot: "tree.snap", Recursive: true}, DirStyle{
+		Path:    func(s string) string { return "[" + s + "]" },
+		Item:    func(s string) string { return "<" + s + ">" },
+		Token:   func(s string) string { return "(" + s + ")" },
+		Checked: func(s string) string { return "checked " + s },
+	}); got != "[site] contains <index.html>, tree matches snapshot (tree.snap), (recursive)" {
+		t.Fatalf("DescribeDir() = %q", got)
+	}
+
+	if got := DescribePDF(&spec.PDFAssert{
+		Path:     "r.pdf",
+		Pages:    intptr(3),
+		Metadata: map[string]string{"title": "Q1"},
+		Text:     &spec.StreamAssert{Contains: spec.StringList{"total"}},
+	}, PDFStyle{
+		Path:    func(s string) string { return "[" + s + "]" },
+		Value:   func(s string) string { return "<" + s + ">" },
+		Stream:  func(s *spec.StreamAssert) string { return DescribeStream(s, streamStyle) },
+		Checked: func(s string) string { return "checked " + s },
+	}); got != "[r.pdf] 3 pages, title contains <Q1>, text contains [total]" {
+		t.Fatalf("DescribePDF() = %q", got)
+	}
+}
+
+func strptr(s string) *string   { return &s }
+func intptr(n int) *int         { return &n }
+func boolptr(b bool) *bool      { return &b }
+func f64ptr(f float64) *float64 { return &f }

--- a/internal/docgen/describe.go
+++ b/internal/docgen/describe.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/nao1215/atago/internal/assertdesc"
 	"github.com/nao1215/atago/internal/spec"
 	"github.com/nao1215/markdown"
 )
@@ -19,6 +20,83 @@ func codeList(subs spec.StringList) string {
 		parts[i] = markdown.Code(s)
 	}
 	return strings.Join(parts, ", ")
+}
+
+var docgenJSONStyle = assertdesc.JSONStyle{
+	Prefix:  func(path string) string { return "at " + markdown.Code(path) },
+	Equals:  func(v any) string { return "equals " + markdown.Code(fmt.Sprint(v)) },
+	Matches: func(s string) string { return "matches " + markdown.Code("/"+s+"/") },
+	Length:  func(n int) string { return fmt.Sprintf("has length %d", n) },
+	Compare: func(op string, v any) string { return "is " + markdown.Code(fmt.Sprintf("%s %v", op, v)) },
+	Default: "is checked",
+}
+
+var docgenYAMLStyle = assertdesc.JSONStyle{
+	Prefix:  func(path string) string { return "YAML at " + markdown.Code(path) },
+	Equals:  docgenJSONStyle.Equals,
+	Matches: docgenJSONStyle.Matches,
+	Length:  docgenJSONStyle.Length,
+	Compare: docgenJSONStyle.Compare,
+	Default: docgenJSONStyle.Default,
+}
+
+var docgenStreamStyle = assertdesc.StreamStyle{
+	List:      codeList,
+	Regex:     func(s string) string { return markdown.Code("/" + s + "/") },
+	Equals:    "equals an exact value",
+	NotEquals: "does not equal an exact value",
+	JSON:      docgenJSONStyle,
+	YAML:      docgenYAMLStyle,
+	Snapshot:  markdown.Code,
+	NoMatcher: "is checked",
+}
+
+var docgenFileStyle = assertdesc.FileStyle{
+	Path:       markdown.Code,
+	List:       codeList,
+	JSON:       docgenJSONStyle,
+	Snapshot:   markdown.Code,
+	Checked:    func(path string) string { return markdown.Code(path) + " is checked" },
+	ExactBytes: "equals exact bytes",
+}
+
+var docgenHeaderStyle = assertdesc.HeaderStyle{
+	Name:  markdown.Code,
+	Value: markdown.Code,
+	Regex: func(s string) string { return markdown.Code("/" + s + "/") },
+	Bare:  func(s string) string { return markdown.Code(s) + " is checked" },
+}
+
+var docgenImageStyle = assertdesc.ImageStyle{
+	Path:      markdown.Code,
+	Format:    markdown.Code,
+	SimilarTo: markdown.Code,
+	Checked:   func(path string) string { return markdown.Code(path) + " is checked" },
+}
+
+var docgenDirStyle = assertdesc.DirStyle{
+	Path:    markdown.Code,
+	Item:    markdown.Code,
+	Token:   markdown.Code,
+	Checked: func(path string) string { return markdown.Code(path) + " is checked" },
+}
+
+var docgenPDFStyle = assertdesc.PDFStyle{
+	Path:    markdown.Code,
+	Value:   markdown.Code,
+	Stream:  describeStream,
+	Checked: func(path string) string { return markdown.Code(path) + " is checked" },
+}
+
+var docgenChangesStyle = assertdesc.ChangesStyle{
+	Entry: markdown.Code,
+	Join:  ", ",
+}
+
+var docgenMockStyle = assertdesc.MockStyle{
+	Name:  markdown.Code,
+	Route: markdown.Code,
+	Count: func(n int) string { return fmt.Sprintf(" exactly %d time(s)", n) },
 }
 
 // describeAsserts renders an assertion as one Markdown "Then" bullet per target.
@@ -55,17 +133,7 @@ func describeTarget(a *spec.Assert, target spec.AssertTarget) string {
 		}
 		return "exit code is checked"
 	case spec.AssertMock:
-		m := a.Mock
-		desc := "mock " + markdown.Code(m.Name) + " received"
-		if m.Method != "" || m.Path != "" {
-			desc += " " + markdown.Code(strings.TrimSpace(strings.ToUpper(m.Method)+" "+m.Path))
-		} else {
-			desc += " a request"
-		}
-		if m.Count != nil {
-			desc += fmt.Sprintf(" exactly %d time(s)", *m.Count)
-		}
-		return desc
+		return describeMockAssert(a.Mock)
 	case spec.AssertScreen:
 		return "rendered screen " + describeStream(a.Screen)
 	case spec.AssertDuration:
@@ -115,258 +183,38 @@ func describeTarget(a *spec.Assert, target spec.AssertTarget) string {
 // describeChanges renders a workdir-delta assertion (#70) as a compact phrase
 // listing each set category. `modified: []` renders as "modified nothing".
 func describeChanges(c *spec.ChangesAssert) string {
-	var parts []string
-	for _, cat := range []struct {
-		name    string
-		entries *spec.StringList
-	}{
-		{"created", c.Created},
-		{"modified", c.Modified},
-		{"deleted", c.Deleted},
-	} {
-		if cat.entries == nil {
-			continue
-		}
-		if len(*cat.entries) == 0 {
-			parts = append(parts, cat.name+" nothing")
-			continue
-		}
-		parts = append(parts, cat.name+" "+codeList(*cat.entries))
-	}
-	if len(parts) == 0 {
-		return "nothing"
-	}
-	return strings.Join(parts, ", ")
+	return assertdesc.DescribeChanges(c, docgenChangesStyle)
 }
 
 func describeHeader(h *spec.HeaderMatch) string {
-	switch {
-	case h.Contains != nil:
-		return markdown.Code(h.Name) + " contains " + markdown.Code(*h.Contains)
-	case h.Equals != nil:
-		return markdown.Code(h.Name) + " equals " + markdown.Code(*h.Equals)
-	// A header `matches` regexp is a real matcher (the natural shape for auth
-	// headers like "^Bearer "); without this case it fell to the generic "is
-	// checked" and the documented constraint vanished from the doc, so a reviewer
-	// could not see it. Kept in step with explain.describeHeader.
-	case h.Matches != nil:
-		return markdown.Code(h.Name) + " matches " + markdown.Code("/"+*h.Matches+"/")
-	default:
-		return markdown.Code(h.Name) + " is checked"
-	}
+	return assertdesc.DescribeHeader(h, docgenHeaderStyle)
 }
 
 func describeImage(im *spec.ImageAssert) string {
-	parts := imageConstraints(im)
-	if len(parts) == 0 {
-		return markdown.Code(im.Path) + " is checked"
-	}
-	return markdown.Code(im.Path) + " " + strings.Join(parts, ", ")
-}
-
-// imageConstraints renders each set image constraint as a short phrase.
-func imageConstraints(im *spec.ImageAssert) []string {
-	var parts []string
-	if im.Format != "" {
-		parts = append(parts, "is "+markdown.Code(im.Format))
-	}
-	if im.Width != nil {
-		parts = append(parts, fmt.Sprintf("width %d", *im.Width))
-	}
-	if im.Height != nil {
-		parts = append(parts, fmt.Sprintf("height %d", *im.Height))
-	}
-	if im.MinWidth != nil {
-		parts = append(parts, fmt.Sprintf("width >= %d", *im.MinWidth))
-	}
-	if im.MaxWidth != nil {
-		parts = append(parts, fmt.Sprintf("width <= %d", *im.MaxWidth))
-	}
-	if im.MinHeight != nil {
-		parts = append(parts, fmt.Sprintf("height >= %d", *im.MinHeight))
-	}
-	if im.MaxHeight != nil {
-		parts = append(parts, fmt.Sprintf("height <= %d", *im.MaxHeight))
-	}
-	if im.Alpha != nil {
-		if *im.Alpha {
-			parts = append(parts, "has alpha")
-		} else {
-			parts = append(parts, "has no alpha")
-		}
-	}
-	if im.SimilarTo != "" {
-		parts = append(parts, "similar to "+markdown.Code(im.SimilarTo))
-	}
-	return parts
+	return assertdesc.DescribeImage(im, docgenImageStyle)
 }
 
 // describeDir renders a directory/tree assertion (#74) as a compact phrase
 // listing each set constraint.
 func describeDir(d *spec.DirAssert) string {
-	parts := dirConstraints(d)
-	if len(parts) == 0 {
-		return markdown.Code(d.Path) + " is checked"
-	}
-	return markdown.Code(d.Path) + " " + strings.Join(parts, ", ")
-}
-
-func dirConstraints(d *spec.DirAssert) []string {
-	var parts []string
-	if d.Exists != nil {
-		if *d.Exists {
-			parts = append(parts, "exists")
-		} else {
-			parts = append(parts, "does not exist")
-		}
-	}
-	for _, c := range d.Contains {
-		parts = append(parts, "contains "+markdown.Code(c))
-	}
-	for _, c := range d.NotContains {
-		parts = append(parts, "does not contain "+markdown.Code(c))
-	}
-	if d.Count != nil {
-		parts = append(parts, fmt.Sprintf("has %d entries", *d.Count))
-	}
-	if d.MinCount != nil {
-		parts = append(parts, fmt.Sprintf("has >= %d entries", *d.MinCount))
-	}
-	if d.MaxCount != nil {
-		parts = append(parts, fmt.Sprintf("has <= %d entries", *d.MaxCount))
-	}
-	if d.Glob != "" {
-		parts = append(parts, "matches glob "+markdown.Code(d.Glob))
-	}
-	if d.Snapshot != "" {
-		parts = append(parts, "tree matches snapshot "+markdown.Code(d.Snapshot))
-	}
-	if d.Recursive {
-		parts = append(parts, "(recursive)")
-	}
-	if len(d.Ignore) > 0 {
-		parts = append(parts, "ignoring "+strings.Join(d.Ignore, ", "))
-	}
-	return parts
+	return assertdesc.DescribeDir(d, docgenDirStyle)
 }
 
 // describePDF renders a PDF assertion (#73) as a compact phrase.
 func describePDF(p *spec.PDFAssert) string {
-	var parts []string
-	if p.Pages != nil {
-		parts = append(parts, fmt.Sprintf("%d pages", *p.Pages))
-	}
-	if p.MinPages != nil {
-		parts = append(parts, fmt.Sprintf(">= %d pages", *p.MinPages))
-	}
-	if p.MaxPages != nil {
-		parts = append(parts, fmt.Sprintf("<= %d pages", *p.MaxPages))
-	}
-	for _, k := range sortedMapKeys(p.Metadata) {
-		parts = append(parts, fmt.Sprintf("%s contains %s", k, markdown.Code(p.Metadata[k])))
-	}
-	if p.Text != nil {
-		parts = append(parts, "text "+describeStream(p.Text))
-	}
-	if len(parts) == 0 {
-		return markdown.Code(p.Path) + " is checked"
-	}
-	return markdown.Code(p.Path) + " " + strings.Join(parts, ", ")
-}
-
-// sortedMapKeys returns a string map's keys in sorted order for deterministic
-// rendering.
-func sortedMapKeys(m map[string]string) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
+	return assertdesc.DescribePDF(p, docgenPDFStyle)
 }
 
 func describeStream(s *spec.StreamAssert) string {
-	switch {
-	case s.Empty != nil:
-		if *s.Empty {
-			return "is empty"
-		}
-		return "is not empty"
-	case s.Contains != nil:
-		return "contains " + codeList(s.Contains)
-	case s.NotContains != nil:
-		return "does not contain " + codeList(s.NotContains)
-	case s.Matches != nil:
-		return "matches " + markdown.Code("/"+*s.Matches+"/")
-	case s.NotMatches != nil:
-		return "does not match " + markdown.Code("/"+*s.NotMatches+"/")
-	case s.Equals != nil:
-		return "equals an exact value"
-	case s.NotEquals != nil:
-		return "does not equal an exact value"
-	case len(s.JSON) > 0:
-		return jsonChecks("at ", s.JSON)
-	case len(s.YAML) > 0:
-		return jsonChecks("YAML at ", s.YAML)
-	case s.Snapshot != "":
-		return "matches snapshot " + markdown.Code(s.Snapshot)
-	default:
-		return "is checked"
-	}
+	return assertdesc.DescribeStream(s, docgenStreamStyle)
 }
 
 func describeFile(f *spec.FileAssert) string {
-	switch {
-	case f.Exists != nil:
-		if *f.Exists {
-			return markdown.Code(f.Path) + " exists"
-		}
-		return markdown.Code(f.Path) + " does not exist"
-	case f.Contains != nil:
-		return markdown.Code(f.Path) + " contains " + codeList(f.Contains)
-	case f.Equals != nil:
-		return markdown.Code(f.Path) + " equals exact bytes"
-	case f.EqualsFile != nil:
-		return markdown.Code(f.Path) + " is byte-identical to " + markdown.Code(*f.EqualsFile)
-	case len(f.JSON) > 0:
-		return markdown.Code(f.Path) + " " + jsonChecks("at ", f.JSON)
-	case f.Snapshot != "":
-		return markdown.Code(f.Path) + " matches snapshot " + markdown.Code(f.Snapshot)
-	default:
-		return markdown.Code(f.Path) + " is checked"
-	}
+	return assertdesc.DescribeFile(f, docgenFileStyle)
 }
 
-// jsonChecks renders a json/yaml matcher list (#156). A single check reads
-// exactly as it did before the list form ("<prefix>`path` matcher"); several
-// checks are joined with "; " so every asserted path appears in the doc.
-func jsonChecks(prefix string, list spec.JSONChecks) string {
-	parts := make([]string, len(list))
-	for i := range list {
-		parts[i] = prefix + markdown.Code(list[i].Path) + " " + jsonMatcher(&list[i])
-	}
-	return strings.Join(parts, "; ")
-}
-
-func jsonMatcher(j *spec.JSONAssert) string {
-	switch {
-	case j.Equals != nil:
-		return "equals " + markdown.Code(fmt.Sprint(j.Equals))
-	case j.Matches != nil:
-		return "matches " + markdown.Code("/"+*j.Matches+"/")
-	case j.Length != nil:
-		return fmt.Sprintf("has length %d", *j.Length)
-	case j.Gt != nil:
-		return "is " + markdown.Code(fmt.Sprintf("> %v", *j.Gt))
-	case j.Gte != nil:
-		return "is " + markdown.Code(fmt.Sprintf(">= %v", *j.Gte))
-	case j.Lt != nil:
-		return "is " + markdown.Code(fmt.Sprintf("< %v", *j.Lt))
-	case j.Lte != nil:
-		return "is " + markdown.Code(fmt.Sprintf("<= %v", *j.Lte))
-	default:
-		return "is checked"
-	}
+func describeMockAssert(m *spec.MockAssert) string {
+	return assertdesc.DescribeMock(m, docgenMockStyle)
 }
 
 func sortedEnvKeys(env map[string]string) []string {

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -6,10 +6,10 @@ package explain
 import (
 	"fmt"
 	"io"
-	"sort"
 	"strconv"
 	"strings"
 
+	"github.com/nao1215/atago/internal/assertdesc"
 	"github.com/nao1215/atago/internal/spec"
 )
 
@@ -263,42 +263,12 @@ func describeSignal(sg *spec.Signal) string {
 // describeChangesExplain renders a workdir-delta assertion (#70) as a compact
 // phrase for `atago explain`. `modified: []` renders as "modified nothing".
 func describeChangesExplain(c *spec.ChangesAssert) string {
-	var parts []string
-	for _, cat := range []struct {
-		name    string
-		entries *spec.StringList
-	}{
-		{"created", c.Created},
-		{"modified", c.Modified},
-		{"deleted", c.Deleted},
-	} {
-		if cat.entries == nil {
-			continue
-		}
-		if len(*cat.entries) == 0 {
-			parts = append(parts, cat.name+" nothing")
-			continue
-		}
-		parts = append(parts, cat.name+" "+strings.Join([]string(*cat.entries), ", "))
-	}
-	if len(parts) == 0 {
-		return "nothing"
-	}
-	return strings.Join(parts, "; ")
+	return assertdesc.DescribeChanges(c, explainChangesStyle)
 }
 
 // describeMockAssert renders a one-line summary of a mock assertion (#24).
 func describeMockAssert(m *spec.MockAssert) string {
-	desc := "mock " + m.Name
-	if m.Method != "" || m.Path != "" {
-		desc += " received " + strings.TrimSpace(strings.ToUpper(m.Method)+" "+m.Path)
-	} else {
-		desc += " received a request"
-	}
-	if m.Count != nil {
-		desc += fmt.Sprintf(" x%d", *m.Count)
-	}
-	return desc
+	return assertdesc.DescribeMock(m, explainMockStyle)
 }
 
 func describeFixture(f *spec.Fixture) string {
@@ -419,131 +389,21 @@ func describeTarget(a *spec.Assert, target spec.AssertTarget) string {
 }
 
 func describeHeader(h *spec.HeaderMatch) string {
-	switch {
-	case h.Contains != nil:
-		return fmt.Sprintf("%q contains %q", h.Name, *h.Contains)
-	case h.Equals != nil:
-		return fmt.Sprintf("%q equals %q", h.Name, *h.Equals)
-	// A header `matches` regexp is a real matcher (the natural shape for auth
-	// headers like "^Bearer "); without this case it fell to the name-only
-	// default and the documented constraint vanished from the explain output.
-	// Kept in step with docgen.describeHeader.
-	case h.Matches != nil:
-		return fmt.Sprintf("%q matches /%s/", h.Name, *h.Matches)
-	default:
-		return fmt.Sprintf("%q", h.Name)
-	}
+	return assertdesc.DescribeHeader(h, explainHeaderStyle)
 }
 
 func describeImage(im *spec.ImageAssert) string {
-	var parts []string
-	if im.Format != "" {
-		parts = append(parts, "is "+im.Format)
-	}
-	if im.Width != nil {
-		parts = append(parts, fmt.Sprintf("width %d", *im.Width))
-	}
-	if im.Height != nil {
-		parts = append(parts, fmt.Sprintf("height %d", *im.Height))
-	}
-	if im.MinWidth != nil {
-		parts = append(parts, fmt.Sprintf("width >= %d", *im.MinWidth))
-	}
-	if im.MaxWidth != nil {
-		parts = append(parts, fmt.Sprintf("width <= %d", *im.MaxWidth))
-	}
-	if im.MinHeight != nil {
-		parts = append(parts, fmt.Sprintf("height >= %d", *im.MinHeight))
-	}
-	if im.MaxHeight != nil {
-		parts = append(parts, fmt.Sprintf("height <= %d", *im.MaxHeight))
-	}
-	if im.Alpha != nil {
-		if *im.Alpha {
-			parts = append(parts, "has alpha")
-		} else {
-			parts = append(parts, "has no alpha")
-		}
-	}
-	if im.SimilarTo != "" {
-		parts = append(parts, "similar to "+im.SimilarTo)
-	}
-	if len(parts) == 0 {
-		return fmt.Sprintf("%q is checked", im.Path)
-	}
-	return fmt.Sprintf("%q %s", im.Path, strings.Join(parts, ", "))
+	return assertdesc.DescribeImage(im, explainImageStyle)
 }
 
 // describeDir renders a directory/tree assertion (#74) for explain output.
 func describeDir(d *spec.DirAssert) string {
-	var parts []string
-	if d.Exists != nil {
-		if *d.Exists {
-			parts = append(parts, "exists")
-		} else {
-			parts = append(parts, "does not exist")
-		}
-	}
-	for _, c := range d.Contains {
-		parts = append(parts, "contains "+c)
-	}
-	for _, c := range d.NotContains {
-		parts = append(parts, "does not contain "+c)
-	}
-	if d.Count != nil {
-		parts = append(parts, fmt.Sprintf("has %d entries", *d.Count))
-	}
-	if d.MinCount != nil {
-		parts = append(parts, fmt.Sprintf("has >= %d entries", *d.MinCount))
-	}
-	if d.MaxCount != nil {
-		parts = append(parts, fmt.Sprintf("has <= %d entries", *d.MaxCount))
-	}
-	if d.Glob != "" {
-		parts = append(parts, "matches glob "+d.Glob)
-	}
-	if d.Snapshot != "" {
-		parts = append(parts, "tree matches snapshot "+d.Snapshot)
-	}
-	if d.Recursive {
-		parts = append(parts, "(recursive)")
-	}
-	if len(d.Ignore) > 0 {
-		parts = append(parts, "ignoring "+strings.Join(d.Ignore, ", "))
-	}
-	if len(parts) == 0 {
-		return fmt.Sprintf("%q is checked", d.Path)
-	}
-	return fmt.Sprintf("%q %s", d.Path, strings.Join(parts, ", "))
+	return assertdesc.DescribeDir(d, explainDirStyle)
 }
 
 // describePDF renders a PDF assertion (#73) for explain output.
 func describePDF(p *spec.PDFAssert) string {
-	var parts []string
-	if p.Pages != nil {
-		parts = append(parts, fmt.Sprintf("%d pages", *p.Pages))
-	}
-	if p.MinPages != nil {
-		parts = append(parts, fmt.Sprintf(">= %d pages", *p.MinPages))
-	}
-	if p.MaxPages != nil {
-		parts = append(parts, fmt.Sprintf("<= %d pages", *p.MaxPages))
-	}
-	keys := make([]string, 0, len(p.Metadata))
-	for k := range p.Metadata {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		parts = append(parts, fmt.Sprintf("%s contains %q", k, p.Metadata[k]))
-	}
-	if p.Text != nil {
-		parts = append(parts, "text "+describeStream(p.Text))
-	}
-	if len(parts) == 0 {
-		return fmt.Sprintf("%q is checked", p.Path)
-	}
-	return fmt.Sprintf("%q %s", p.Path, strings.Join(parts, ", "))
+	return assertdesc.DescribePDF(p, explainPDFStyle)
 }
 
 // quoteList renders a contains/not_contains matcher argument. A single element
@@ -557,88 +417,89 @@ func quoteList(subs spec.StringList) string {
 	return strings.Join(parts, ", ")
 }
 
-func describeStream(s *spec.StreamAssert) string {
-	switch {
-	case s.Empty != nil:
-		if *s.Empty {
-			return "is empty"
-		}
-		return "is not empty"
-	case s.Contains != nil:
-		return "contains " + quoteList(s.Contains)
-	case s.NotContains != nil:
-		return "does not contain " + quoteList(s.NotContains)
-	case s.Matches != nil:
-		return fmt.Sprintf("matches /%s/", *s.Matches)
-	case s.NotMatches != nil:
-		return fmt.Sprintf("does not match /%s/", *s.NotMatches)
-	case s.Equals != nil:
-		return "equals exact text"
-	case s.NotEquals != nil:
-		return "does not equal exact text"
-	case len(s.JSON) > 0:
-		return jsonChecks("JSON", s.JSON)
-	case len(s.YAML) > 0:
-		return jsonChecks("YAML", s.YAML)
-	case s.Snapshot != "":
-		return "matches snapshot " + s.Snapshot
-	default:
-		return "(no matcher)"
-	}
+var explainJSONStyle = assertdesc.JSONStyle{
+	Prefix:  func(path string) string { return "JSON " + path },
+	Equals:  func(v any) string { return fmt.Sprintf("== %v", v) },
+	Matches: func(s string) string { return fmt.Sprintf("matches /%s/", s) },
+	Length:  func(n int) string { return fmt.Sprintf("length %d", n) },
+	Compare: func(op string, v any) string { return fmt.Sprintf("%s %v", op, v) },
+	Default: "",
 }
 
-// jsonChecks renders a json/yaml matcher list (#156): a single check reads as it
-// did before the list form ("<kind> <path> <matcher>"), several are joined with
-// "; ".
-func jsonChecks(kind string, list spec.JSONChecks) string {
-	parts := make([]string, len(list))
-	for i := range list {
-		parts[i] = fmt.Sprintf("%s %s %s", kind, list[i].Path, jsonMatcher(&list[i]))
-	}
-	return strings.Join(parts, "; ")
+var explainYAMLStyle = assertdesc.JSONStyle{
+	Prefix:  func(path string) string { return "YAML " + path },
+	Equals:  explainJSONStyle.Equals,
+	Matches: explainJSONStyle.Matches,
+	Length:  explainJSONStyle.Length,
+	Compare: explainJSONStyle.Compare,
+	Default: explainJSONStyle.Default,
+}
+
+var explainStreamStyle = assertdesc.StreamStyle{
+	List:      quoteList,
+	Regex:     func(s string) string { return fmt.Sprintf("/%s/", s) },
+	Equals:    "equals exact text",
+	NotEquals: "does not equal exact text",
+	JSON:      explainJSONStyle,
+	YAML:      explainYAMLStyle,
+	Snapshot:  func(s string) string { return s },
+	NoMatcher: "(no matcher)",
+}
+
+var explainFileStyle = assertdesc.FileStyle{
+	Path:       func(s string) string { return fmt.Sprintf("%q", s) },
+	List:       quoteList,
+	JSON:       explainJSONStyle,
+	Snapshot:   func(s string) string { return s },
+	Checked:    func(path string) string { return path },
+	ExactBytes: "equals exact bytes",
+}
+
+var explainHeaderStyle = assertdesc.HeaderStyle{
+	Name:  func(s string) string { return fmt.Sprintf("%q", s) },
+	Value: func(s string) string { return fmt.Sprintf("%q", s) },
+	Regex: func(s string) string { return fmt.Sprintf("/%s/", s) },
+	Bare:  func(s string) string { return fmt.Sprintf("%q", s) },
+}
+
+var explainImageStyle = assertdesc.ImageStyle{
+	Path:      func(s string) string { return fmt.Sprintf("%q", s) },
+	Format:    func(s string) string { return s },
+	SimilarTo: func(s string) string { return s },
+	Checked:   func(path string) string { return fmt.Sprintf("%q is checked", path) },
+}
+
+var explainDirStyle = assertdesc.DirStyle{
+	Path:    func(s string) string { return fmt.Sprintf("%q", s) },
+	Item:    func(s string) string { return s },
+	Token:   func(s string) string { return s },
+	Checked: func(path string) string { return fmt.Sprintf("%q is checked", path) },
+}
+
+var explainPDFStyle = assertdesc.PDFStyle{
+	Path:    func(s string) string { return fmt.Sprintf("%q", s) },
+	Value:   func(s string) string { return fmt.Sprintf("%q", s) },
+	Stream:  describeStream,
+	Checked: func(path string) string { return fmt.Sprintf("%q is checked", path) },
+}
+
+var explainChangesStyle = assertdesc.ChangesStyle{
+	Entry: func(s string) string { return s },
+	Join:  "; ",
+}
+
+var explainMockStyle = assertdesc.MockStyle{
+	Name:  func(s string) string { return s },
+	Route: func(s string) string { return s },
+	Count: func(n int) string { return fmt.Sprintf(" x%d", n) },
+}
+
+func describeStream(s *spec.StreamAssert) string {
+	return assertdesc.DescribeStream(s, explainStreamStyle)
 }
 
 func describeFile(f *spec.FileAssert) string {
-	switch {
-	case f.Exists != nil:
-		if *f.Exists {
-			return fmt.Sprintf("%q exists", f.Path)
-		}
-		return fmt.Sprintf("%q does not exist", f.Path)
-	case f.Contains != nil:
-		return fmt.Sprintf("%q contains %s", f.Path, quoteList(f.Contains))
-	case f.Equals != nil:
-		return fmt.Sprintf("%q equals exact bytes", f.Path)
-	case f.EqualsFile != nil:
-		return fmt.Sprintf("%q is byte-identical to %q", f.Path, *f.EqualsFile)
-	case len(f.JSON) > 0:
-		return fmt.Sprintf("%q %s", f.Path, jsonChecks("JSON", f.JSON))
-	case f.Snapshot != "":
-		return fmt.Sprintf("%q matches snapshot %s", f.Path, f.Snapshot)
-	default:
-		return f.Path
-	}
-}
-
-func jsonMatcher(j *spec.JSONAssert) string {
-	switch {
-	case j.Equals != nil:
-		return fmt.Sprintf("== %v", j.Equals)
-	case j.Matches != nil:
-		return fmt.Sprintf("matches /%s/", *j.Matches)
-	case j.Length != nil:
-		return fmt.Sprintf("length %d", *j.Length)
-	case j.Gt != nil:
-		return fmt.Sprintf("> %v", *j.Gt)
-	case j.Gte != nil:
-		return fmt.Sprintf(">= %v", *j.Gte)
-	case j.Lt != nil:
-		return fmt.Sprintf("< %v", *j.Lt)
-	case j.Lte != nil:
-		return fmt.Sprintf("<= %v", *j.Lte)
-	default:
-		return ""
-	}
+	return assertdesc.DescribeFile(f, explainFileStyle)
 }
 
 func writeList(b *strings.Builder, title string, items []string) {


### PR DESCRIPTION
## Summary

Move the duplicated assert-describer helper family out of `internal/docgen` and `internal/explain` into a shared `internal/assertdesc` package, while preserving each consumer's output style.

## Changes
- add shared describer helpers for headers, streams, files, images, dirs, PDFs, JSON matchers, changes, and mock assertions
- switch `internal/docgen` and `internal/explain` to thin style-specific wrappers around the shared helpers
- add dedicated unit coverage for the shared helper package and keep the existing docgen/explain matcher tests exercising the public outputs

## Design Decisions
- keep the top-level `describeTarget` wording in each package and centralize only the matcher family, so the human-facing phrasing differences stay stable
- use small style callback structs instead of a markdown-specific dependency in the shared package

## Verification
- `go test ./internal/assertdesc`
- `go test ./internal/docgen ./internal/explain`
- `go test ./...`

Closes #245.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added more consistent human-readable descriptions for assertions across headers, JSON/YAML, streams, files, images, directories, PDFs, changes, and mocks.
  - Improved formatting of matcher details, counts, ranges, snapshots, and metadata in user-facing output.

- **Refactor**
  - Centralized description rendering so the app uses shared formatting for both documentation and explain output.
  - Reduced duplication, making assertion text output more consistent across views.

- **Tests**
  - Added coverage for the new description output across multiple assertion types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->