### PR TITLE
build(release): publish multi-arch image to ghcr

### DIFF
--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -30,10 +30,20 @@ jobs:
       - name: Install Syft (SBOM generator)
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
-      # Signing stays skipped on purpose: keyless cosign needs an OIDC id-token,
-      # which fork PRs cannot mint, and a PR-signed cert identity would differ
-      # from the release.yml identity users verify against. Everything else the
-      # release promises — SBOMs, checksums, runnable archives — builds here.
+      - name: Enable QEMU for arm64 container builds
+        run: docker run --privileged --rm tonistiigi/binfmt --install arm64
+
+      - name: Create buildx builder
+        run: |
+          docker buildx create --name atago-release-smoke --use
+          docker buildx inspect --bootstrap
+
+      # Signing and publishing stay skipped on purpose: keyless cosign needs an
+      # OIDC id-token, which fork PRs cannot mint, and a PR-signed cert identity
+      # would differ from the release.yml identity users verify against. The
+      # local docker image build still runs here via skip_push templates, so the
+      # release promises — runnable archives and a runnable GHCR image — build on
+      # every PR without publishing anything.
       - name: Build artifacts for smoke test
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
@@ -46,3 +56,6 @@ jobs:
       # binary through version -> init -> run.
       - name: Smoke-test artifacts before publishing
         run: ./scripts/smoke_artifacts.sh dist
+
+      - name: Smoke-test Docker image before publishing
+        run: ./scripts/smoke_docker_image.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
   id-token: write
   attestations: write
 
@@ -33,6 +34,17 @@ jobs:
 
       - name: Install Syft (SBOM generator)
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
+      - name: Enable QEMU for arm64 container builds
+        run: docker run --privileged --rm tonistiigi/binfmt --install arm64
+
+      - name: Create buildx builder
+        run: |
+          docker buildx create --name atago-release --use
+          docker buildx inspect --bootstrap
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,6 +61,23 @@ homebrew_casks:
             system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/atago"]
           end
 
+dockers_v2:
+  - images:
+      - "ghcr.io/nao1215/atago"
+    tags:
+      - "{{ .Version }}"
+      - "latest"
+    dockerfile: Dockerfile.goreleaser
+    platforms:
+      - "linux/amd64"
+      - "linux/arm64"
+    labels:
+      org.opencontainers.image.created: "{{ .Date }}"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+      org.opencontainers.image.version: "{{ .Version }}"
+      org.opencontainers.image.source: "https://github.com/nao1215/atago"
+      org.opencontainers.image.licenses: "MIT"
+
 snapshot:
   version_template: "{{ incpatch .Version }}-next"
 release:

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,12 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG TARGETOS=linux
+ARG TARGETARCH
+
+COPY ${TARGETOS}/${TARGETARCH}/atago /usr/local/bin/atago
+
+ENTRYPOINT ["/usr/local/bin/atago"]

--- a/README.md
+++ b/README.md
@@ -248,6 +248,28 @@ jobs:
       - run: atago run --ci --report gha ./specs
 ```
 
+On GitLab CI (or any CI that starts from a container image), use the published
+GHCR image:
+
+```yaml
+image: ghcr.io/nao1215/atago:latest
+
+stages: [test]
+
+behavior-specs:
+  stage: test
+  script:
+    - atago run --ci --report junit ./specs > junit.xml
+  artifacts:
+    when: always
+    reports:
+      junit: junit.xml
+```
+
+The image contains `atago` and `ca-certificates`; if your scenarios drive `git`,
+`jq`, a browser, or your own CLI binary, build FROM `ghcr.io/nao1215/atago:latest`
+and layer those tools on top.
+
 - `--report json|junit|gha|tap` picks the report format; the JSON shape is stable and versioned.
 - `--ci` enables deterministic, color-free output. It also turns an empty selection into a hard error: a `--filter`/`--tag`/`--skip-tag` that matches no scenario fails the run (exit 3) instead of passing an empty suite, so a typo cannot silently disable your specs. Without `--ci` the same case is a warning that still exits 0.
 - `--artifacts-dir DIR` persists the exact payloads a failed assertion compared — plus, for a failed scenario, its background services' logs and each mock server's recorded requests — so a failure stays reviewable after the job ends.

--- a/scripts/smoke_docker_image.sh
+++ b/scripts/smoke_docker_image.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Smoke-test the GoReleaser-built container image before a tagged release can
+# publish it. This proves the image was tagged locally (including latest) and
+# that the host can run `atago version` from it.
+set -eu
+
+repo="${1:-ghcr.io/nao1215/atago}"
+
+fail() {
+	echo "docker-smoke: $1" >&2
+	exit 1
+}
+
+command -v docker >/dev/null || fail "docker is not installed"
+
+images="$(docker image ls --format '{{.Repository}}:{{.Tag}}' "$repo")"
+[ -n "$images" ] || fail "no local docker images found for $repo"
+
+printf '%s\n' "$images" | grep -q "^${repo}:latest\$" || fail "missing latest tag for $repo"
+host_image="$(printf '%s\n' "$images" | grep "^${repo}:" | head -n1)"
+[ -n "$host_image" ] || fail "no runnable image tag found for $repo"
+
+version_out="$(docker run --rm "$host_image" version)"
+case "$version_out" in
+atago\ *) ;;
+*) fail "unexpected 'atago version' output from ${host_image}: ${version_out}" ;;
+esac
+
+if docker buildx imagetools inspect "${repo}:latest" >/tmp/atago-imagetools.txt 2>/dev/null; then
+	grep -q 'linux/amd64' /tmp/atago-imagetools.txt || fail "latest manifest is missing linux/amd64"
+	grep -q 'linux/arm64' /tmp/atago-imagetools.txt || fail "latest manifest is missing linux/arm64"
+fi
+
+echo "docker-smoke: ${host_image} runs ${version_out}"

--- a/website/content/ci.md
+++ b/website/content/ci.md
@@ -25,6 +25,28 @@ jobs:
       - run: atago run --ci --report gha ./specs
 ```
 
+On GitLab CI (or any CI that starts from a container image), use the published
+GHCR image:
+
+```yaml
+image: ghcr.io/nao1215/atago:latest
+
+stages: [test]
+
+behavior-specs:
+  stage: test
+  script:
+    - atago run --ci --report junit ./specs > junit.xml
+  artifacts:
+    when: always
+    reports:
+      junit: junit.xml
+```
+
+The image contains `atago` and `ca-certificates`; if your scenarios drive `git`,
+`jq`, a browser, or your own CLI binary, build FROM `ghcr.io/nao1215/atago:latest`
+and layer those tools on top.
+
 - `--report json|junit|gha|tap` picks the report format; the JSON shape is stable and versioned ([sample JSON](/samples/report.json), [JUnit](/samples/report.junit.xml), [TAP](/samples/report.tap)).
 - `--ci` enables deterministic, color-free output. It also turns an empty selection into a hard error: a `--filter`/`--tag`/`--skip-tag` that matches no scenario fails the run (exit 3) instead of passing an empty suite, so a typo cannot silently disable your specs. Without `--ci` the same case is a warning that still exits 0.
 - `--artifacts-dir DIR` persists the exact payloads a failed assertion compared — plus, for a failed scenario, its background services' logs and each mock server's recorded requests — so a failure stays reviewable after the job ends.


### PR DESCRIPTION
## Summary

Publish a multi-arch GHCR image for atago via GoReleaser, wire the release workflows to bootstrap cross-arch container builds, and document the zero-install GitLab CI path.

## Changes
- add `Dockerfile.goreleaser` plus a `dockers_v2` GoReleaser config that builds linux/amd64 and linux/arm64 images for `ghcr.io/nao1215/atago`
- grant `packages: write`, log in to GHCR, and bootstrap QEMU/buildx in the release workflows so arm64 image builds work in CI
- add a Docker smoke script and call it from `release-smoke.yml`, and document `image: ghcr.io/nao1215/atago:latest` usage in the README and the website CI page

## Design Decisions
- use `dockers_v2` instead of the deprecated `dockers` / `docker_manifests` blocks that `goreleaser check` warned about
- keep the image intentionally minimal (`atago` + `ca-certificates`) and document that users layer their own CLI/browser/tooling on top

## Verification
- `go test ./...`
- `goreleaser check`
- `goreleaser release --snapshot --clean --skip=publish,sign,sbom`
- `env SMOKE_SKIP_SBOM=1 ./scripts/smoke_artifacts.sh dist`

## Limitations
- I did not run `./scripts/smoke_docker_image.sh` locally because the follow-up elevated Docker execution was rejected after the snapshot build; `release-smoke.yml` now runs it in CI.

Closes #233.