### PR TITLE
fix(cli): harden finishRun against incomplete results

### DIFF
--- a/internal/assertdesc/describe_test.go
+++ b/internal/assertdesc/describe_test.go
@@ -26,7 +26,6 @@ func TestDescribeHeader(t *testing.T) {
 		{"bare", &spec.HeaderMatch{Name: "X"}, `bare X`},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := DescribeHeader(tt.h, style); got != tt.want {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -240,23 +240,47 @@ func parseRunFlags(label string, args []string, stdout, stderr io.Writer) (*runO
 }
 
 func finishRun(opts *runOptions, suiteResults []*engine.SuiteResult, loadErrs []error, progress *report.Progress, elapsed time.Duration, ctx context.Context) int {
+	failIncomplete := func() int {
+		if progress != nil {
+			progress.Done()
+		}
+		fmt.Fprintln(opts.stderr, opts.label+": internal error: incomplete run results")
+		return ExitInternal
+	}
+
+	if len(suiteResults) != len(opts.paths) || len(loadErrs) != len(opts.paths) {
+		return failIncomplete()
+	}
+
 	results := make([]*engine.SuiteResult, 0, len(opts.paths))
 	exit := ExitOK
 	loadFailures := 0
-	for i := range opts.paths {
-		if loadErrs[i] != nil {
-			fmt.Fprintf(opts.stderr, "%v\n", loadErrs[i])
-			exit = worseExit(exit, exitForLoadError(loadErrs[i]))
+	remainingResults := suiteResults
+	remainingLoadErrs := loadErrs
+	for range opts.paths {
+		loadErr, nextLoadErrs, ok := shiftSlice(remainingLoadErrs)
+		if !ok {
+			return failIncomplete()
+		}
+		suiteResult, nextResults, ok := shiftSlice(remainingResults)
+		if !ok {
+			return failIncomplete()
+		}
+		remainingLoadErrs = nextLoadErrs
+		remainingResults = nextResults
+		if loadErr != nil {
+			fmt.Fprintf(opts.stderr, "%v\n", loadErr)
+			exit = worseExit(exit, exitForLoadError(loadErr))
 			loadFailures++
 			continue
 		}
 		// A nil result with no load error is a spec fail-fast (or an interrupt)
 		// skipped before running: it contributes no scenarios, so omit it.
-		if suiteResults[i] == nil {
+		if suiteResult == nil {
 			continue
 		}
-		results = append(results, suiteResults[i])
-		exit = worseExit(exit, exitForSuite(suiteResults[i]))
+		results = append(results, suiteResult)
+		exit = worseExit(exit, exitForSuite(suiteResult))
 	}
 	if progress != nil {
 		progress.Done()
@@ -361,6 +385,14 @@ func finishRun(opts *runOptions, suiteResults []*engine.SuiteResult, loadErrs []
 		exit = worseExit(exit, ExitExec)
 	}
 	return exit
+}
+
+func shiftSlice[T any](values []T) (T, []T, bool) {
+	var zero T
+	if len(values) == 0 {
+		return zero, nil, false
+	}
+	return values[0], values[1:], true
 }
 
 // runSpecs loads and executes every spec in paths under ctx, returning each

--- a/internal/cli/run_split_test.go
+++ b/internal/cli/run_split_test.go
@@ -196,6 +196,31 @@ func TestFinishRun_InterruptedWithoutResultsSkipsReport(t *testing.T) {
 	}
 }
 
+func TestFinishRun_IncompleteResultSlicesReturnInternal(t *testing.T) {
+	var out, errb bytes.Buffer
+	opts := &runOptions{
+		label:  "atago run",
+		format: report.FormatJSON,
+		paths:  []string{"one.atago.yaml", "two.atago.yaml"},
+		stdout: &out,
+		stderr: &errb,
+	}
+
+	if got := finishRun(opts, []*engine.SuiteResult{{
+		Suite:    "one",
+		SpecPath: "one.atago.yaml",
+		Status:   engine.StatusPassed,
+	}}, []error{nil}, nil, 5*time.Millisecond, context.Background()); got != ExitInternal {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitInternal, errb.String())
+	}
+	if out.Len() != 0 {
+		t.Fatalf("stdout = %q, want no report for incomplete internal results", out.String())
+	}
+	if !strings.Contains(errb.String(), "internal error: incomplete run results") {
+		t.Fatalf("stderr = %q, want the incomplete-results diagnostic", errb.String())
+	}
+}
+
 func TestFinishRun_ReportWriteFailureReturnsInternal(t *testing.T) {
 	dir := t.TempDir()
 	withWorkdir(t, dir, func() {


### PR DESCRIPTION
## Summary
- harden finishRun so incomplete internal result slices return ExitInternal instead of panicking
- add a regression test that reproduces the prior out-of-range panic
- remove the Go 1.22-unneeded loop variable copy in assertdesc tests to restore golangci-lint on main

## Testing
- golangci-lint run
- go test ./...