### PR TITLE
fix(ci): allow release smoke without local latest tag

### DIFF
--- a/scripts/smoke_docker_image.sh
+++ b/scripts/smoke_docker_image.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 # Smoke-test the GoReleaser-built container image before a tagged release can
-# publish it. This proves the image was tagged locally (including latest) and
-# that the host can run `atago version` from it.
+# publish it. Snapshot builds used by release-smoke do not always load a local
+# `latest` tag, so prove at least one local tag runs; when `latest` is present
+# we still prefer it and inspect its multi-arch manifest too.
 set -eu
 
 repo="${1:-ghcr.io/nao1215/atago}"
@@ -16,8 +17,9 @@ command -v docker >/dev/null || fail "docker is not installed"
 images="$(docker image ls --format '{{.Repository}}:{{.Tag}}' "$repo")"
 [ -n "$images" ] || fail "no local docker images found for $repo"
 
-printf '%s\n' "$images" | grep -q "^${repo}:latest\$" || fail "missing latest tag for $repo"
-host_image="$(printf '%s\n' "$images" | grep "^${repo}:" | head -n1)"
+latest_image="$(printf '%s\n' "$images" | grep "^${repo}:latest\$" || true)"
+host_image="$latest_image"
+[ -n "$host_image" ] || host_image="$(printf '%s\n' "$images" | grep "^${repo}:" | head -n1)"
 [ -n "$host_image" ] || fail "no runnable image tag found for $repo"
 
 version_out="$(docker run --rm "$host_image" version)"

--- a/smoke_docker_image_test.go
+++ b/smoke_docker_image_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package main
 
 import (

--- a/smoke_docker_image_test.go
+++ b/smoke_docker_image_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSmokeDockerImage_AllowsVersionOnlyLocalTag(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	binDir := filepath.Join(tmp, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(tmp, "docker-run-image.txt")
+	dockerPath := filepath.Join(binDir, "docker")
+	dockerStub := `#!/bin/sh
+set -eu
+
+case "${1:-}" in
+image)
+	if [ "${2:-}" = "ls" ]; then
+		printf '%s\n' "${DOCKER_STUB_IMAGES:-}"
+		exit 0
+	fi
+	;;
+run)
+	if [ "${2:-}" = "--rm" ]; then
+		printf '%s\n' "${3:-}" >"${DOCKER_STUB_LOG:?}"
+		printf '%s\n' "${DOCKER_STUB_VERSION_OUTPUT:-atago test}"
+		exit 0
+	fi
+	;;
+buildx)
+	if [ "${2:-}" = "imagetools" ] && [ "${3:-}" = "inspect" ]; then
+		exit 1
+	fi
+	;;
+esac
+
+echo "unexpected docker invocation: $*" >&2
+exit 1
+`
+	if err := os.WriteFile(dockerPath, []byte(dockerStub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.CommandContext(context.Background(), "sh", "./scripts/smoke_docker_image.sh", "ghcr.io/nao1215/atago")
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"DOCKER_STUB_IMAGES=ghcr.io/nao1215/atago:v0.10.0-next",
+		"DOCKER_STUB_VERSION_OUTPUT=atago v0.10.0-next",
+		"DOCKER_STUB_LOG="+logPath,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("smoke_docker_image.sh failed: %v\n%s", err, out)
+	}
+	if got := strings.TrimSpace(string(out)); !strings.Contains(got, "docker-smoke: ghcr.io/nao1215/atago:v0.10.0-next runs atago v0.10.0-next") {
+		t.Fatalf("stdout = %q, want success output for the version tag", got)
+	}
+	image, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(image)); got != "ghcr.io/nao1215/atago:v0.10.0-next" {
+		t.Fatalf("docker run image = %q, want the only local tag", got)
+	}
+}


### PR DESCRIPTION
## Summary
- let the Docker smoke script fall back to any local tag when snapshot builds do not load :latest
- keep preferring :latest when it exists, and preserve the manifest inspection for published latest images
- add a regression test that stubs docker and reproduces the prior failure mode

## Testing
- go test ./...
- golangci-lint run