### PR TITLE
fix(ci): stabilize scheduled dogfood and minio runs

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -31,7 +31,9 @@ jobs:
         tool:
           - { name: gup, module: "github.com/nao1215/gup@latest", dir: "./test/e2e/tools/gup" }
           - { name: sqly, module: "github.com/nao1215/sqly@latest", dir: "./test/e2e/tools/sqly" }
-          - { name: truss, module: "github.com/nao1215/truss@latest", dir: "./test/e2e/tools/truss" }
+          # truss moved from a Go module to the Rust crate `truss-image`
+          # (installing the `truss` binary).
+          - { name: truss, dir: "./test/e2e/tools/truss" }
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -48,8 +50,16 @@ jobs:
       - name: Install ${{ matrix.tool.name }} onto PATH
         run: |
           set -e
-          go install "${{ matrix.tool.module }}"
-          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+          case "${{ matrix.tool.name }}" in
+            truss)
+              cargo install truss-image --locked
+              echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+              ;;
+            *)
+              go install "${{ matrix.tool.module }}"
+              echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+              ;;
+          esac
 
       - name: Report the dogfood target
         run: |

--- a/internal/security/masker.go
+++ b/internal/security/masker.go
@@ -68,6 +68,9 @@ func NewMasker(values []string) *Masker {
 		}
 	}
 	for _, x := range values {
+		if len(x) < minSecretLen {
+			continue
+		}
 		add(x)
 		// Mask the alternate line-ending form too. Normalize to LF first so a
 		// value with mixed or CRLF endings still yields a stable LF and CRLF pair.

--- a/internal/security/masker_test.go
+++ b/internal/security/masker_test.go
@@ -199,6 +199,17 @@ func TestMasker_LineEndingVariantsNoLeak(t *testing.T) {
 	}
 }
 
+// TestMasker_ShortSecretDoesNotQualifyViaCRLFVariant is a regression for the
+// short-secret floor: a 3-byte secret like "0\n\"" must stay ignored even
+// though its CRLF spelling is 4 bytes long.
+func TestMasker_ShortSecretDoesNotQualifyViaCRLFVariant(t *testing.T) {
+	t.Parallel()
+	m := NewMasker([]string{"0\n\""})
+	if !m.Empty() {
+		t.Fatalf("short secret unexpectedly produced a non-empty masker: %+v", m)
+	}
+}
+
 // TestNewMaskerForSpec_FromEnvSources verifies that a declared secret injected
 // through any env-bearing location — a pty step, suite.env, suite.setup /
 // suite.teardown steps, scenario teardown steps, and defaults.scenario.env — is

--- a/test/e2e/thirdparty/minio/minio.atago.yaml
+++ b/test/e2e/thirdparty/minio/minio.atago.yaml
@@ -74,6 +74,11 @@ scenarios:
           runner: s3_authz
           method: GET
           path: /
+          retry:
+            times: 20
+            interval: 250ms
+            until:
+              status: 403
       - assert:
           status: 403
           body:

--- a/test/e2e/tools/gup/sandbox_home.atago.yaml
+++ b/test/e2e/tools/gup/sandbox_home.atago.yaml
@@ -10,6 +10,10 @@ version: "1"
 
 suite:
   name: gup read-only subcommands (no HOME writes)
+  env:
+    # Go 1.26 telemetry writes under HOME on first process startup; disable it
+    # so this spec measures gup's own footprint rather than toolchain noise.
+    GOTELEMETRY: "off"
 
 scenarios:
   - name: gup version writes nothing to the workdir or its sandbox home


### PR DESCRIPTION
## Summary
- install the scheduled dogfood truss target from the published Rust crate instead of the removed Go module
- disable Go telemetry in the gup sandbox-home dogfood spec so HOME-write assertions measure gup itself
- retry MinIO anonymous-root requests until the server leaves its transient initialization state
- ignore too-short secrets before generating CRLF masking variants to fix the FuzzNormalize regression

## Testing
- go test ./internal/security ./internal/snapshot ./internal/loader -count=1
- go test ./internal/security -run TestMasker_ShortSecretDoesNotQualifyViaCRLFVariant -count=1 -v
- ./dist/atago run test/e2e/atago/retry.atago.yaml
- ./dist/atago run test/e2e/tools/gup
- ./dist/atago run test/e2e/thirdparty/minio/minio.atago.yaml
- ./dist/atago run test/e2e/tools/truss
- cargo install truss-image --locked --root /tmp/truss-image-smoke
- /tmp/truss-image-smoke/bin/truss --version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved secret masking so short values are not incorrectly recognized through line-ending variants.
  - Increased reliability of anonymous S3 access checks by retrying until the expected access-denied response is available.

- **Chores**
  - Updated tool installation in automated workflows.
  - Disabled Go telemetry in sandbox footprint checks for more accurate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->