### PR TITLE
test: stabilize dogfood and third-party CI specs

### DIFF
--- a/doc/e2e/gup.md
+++ b/doc/e2e/gup.md
@@ -53,6 +53,8 @@ gup version
 ### Scenario: gup list is a pure read of GOBIN and writes nothing
 _only when `gup list` succeeds · skipped on Windows_
 #### Given
+- Fixture file `emptybin/.keep` is created.
+- Environment variables are set: GOBIN.
 - The command runs with an isolated home under `${workdir}/.atago-home` (HOME/XDG or APPDATA redirected).
 #### When
 ```shell

--- a/doc/e2e/minio.md
+++ b/doc/e2e/minio.md
@@ -44,37 +44,37 @@ hello object storage
 ```
 #### When
 ```shell
-mc alias set local http://127.0.0.1:18122 atago atago-secret-key
-mc mb local/atago-bucket
-mc cp upload.txt local/atago-bucket/
-mc ls --json local/atago-bucket
-mc cat local/atago-bucket/upload.txt
-mc cp local/atago-bucket/upload.txt downloaded.txt
-mc rm local/atago-bucket/upload.txt
-mc ls local/atago-bucket
+mc alias set lifecycle http://127.0.0.1:18122 atago atago-secret-key
+mc mb lifecycle/atago-bucket
+mc cp upload.txt lifecycle/atago-bucket/
+mc ls --json lifecycle/atago-bucket
+mc cat lifecycle/atago-bucket/upload.txt
+mc cp lifecycle/atago-bucket/upload.txt downloaded.txt
+mc rm lifecycle/atago-bucket/upload.txt
+mc ls lifecycle/atago-bucket
 ```
 #### Then
-- after `mc alias set local http://127.0.0.1:18122 atago atago-secret-key`:
+- after `mc alias set lifecycle http://127.0.0.1:18122 atago atago-secret-key`:
   - exit code is `0`
-- after `mc mb local/atago-bucket`:
+- after `mc mb lifecycle/atago-bucket`:
   - exit code is `0`
   - stdout contains `Bucket created successfully`
-- after `mc cp upload.txt local/atago-bucket/`:
+- after `mc cp upload.txt lifecycle/atago-bucket/`:
   - exit code is `0`
-- after `mc ls --json local/atago-bucket`:
+- after `mc ls --json lifecycle/atago-bucket`:
   - exit code is `0`
   - stdout at `$.key` equals `upload.txt`
   - stdout at `$.size` equals `20`
-- after `mc cat local/atago-bucket/upload.txt`:
+- after `mc cat lifecycle/atago-bucket/upload.txt`:
   - exit code is `0`
   - stdout equals an exact value
-- after `mc cp local/atago-bucket/upload.txt downloaded.txt`:
+- after `mc cp lifecycle/atago-bucket/upload.txt downloaded.txt`:
   - exit code is `0`
   - file `downloaded.txt` contains `hello object storage`
-- after `mc rm local/atago-bucket/upload.txt`:
+- after `mc rm lifecycle/atago-bucket/upload.txt`:
   - exit code is `0`
   - stdout contains `Removed`
-- after `mc ls local/atago-bucket`:
+- after `mc ls lifecycle/atago-bucket`:
   - exit code is `0`
   - stdout is empty
 ### Scenario: bucket versioning can be enabled and reported
@@ -82,16 +82,16 @@ mc ls local/atago-bucket
 - Background service `minio` is started: `minio server data --address 127.0.0.1:18123`.
 #### When
 ```shell
-mc alias set local http://127.0.0.1:18123 atago atago-secret-key
-mc mb local/versioned
-mc version enable local/versioned
-mc version info --json local/versioned
+mc alias set versioned http://127.0.0.1:18123 atago atago-secret-key
+mc mb versioned/versioned
+mc version enable versioned/versioned
+mc version info --json versioned/versioned
 ```
 #### Then
-- after `mc version enable local/versioned`:
+- after `mc version enable versioned/versioned`:
   - exit code is `0`
   - stdout contains `versioning is enabled`
-- after `mc version info --json local/versioned`:
+- after `mc version info --json versioned/versioned`:
   - exit code is `0`
   - stdout at `$.versioning.status` equals `Enabled`
 ### Scenario: an anonymous download policy publishes a bucket read-only
@@ -105,18 +105,18 @@ published via bucket policy
 ```
 #### When
 ```shell
-mc alias set local http://127.0.0.1:18124 atago atago-secret-key
-mc mb local/public-bucket
-mc cp page.txt local/public-bucket/
+mc alias set publichost http://127.0.0.1:18124 atago atago-secret-key
+mc mb publichost/public-bucket
+mc cp page.txt publichost/public-bucket/
 # HTTP GET /public-bucket/page.txt
-mc anonymous set download local/public-bucket
+mc anonymous set download publichost/public-bucket
 # HTTP GET /public-bucket/page.txt
 # HTTP PUT /public-bucket/forbidden.txt
 ```
 #### Then
 - after `HTTP GET /public-bucket/page.txt`:
   - HTTP status is `403`
-- after `mc anonymous set download local/public-bucket`:
+- after `mc anonymous set download publichost/public-bucket`:
   - exit code is `0`
   - stdout contains `is set to `download``
 - after `HTTP GET /public-bucket/page.txt`:

--- a/test/e2e/thirdparty/minio/minio.atago.yaml
+++ b/test/e2e/thirdparty/minio/minio.atago.yaml
@@ -12,8 +12,8 @@ suite:
 #   go install github.com/minio/mc@latest
 #
 # Each scenario binds its own port so the suite runs under the default
-# scenario concurrency. MC_CONFIG_DIR is workdir-relative, so mc state is
-# isolated per scenario too.
+# scenario concurrency. Pin MC_CONFIG_DIR under the scenario workdir so mc
+# state is isolated per scenario too.
 
 permissions:
   network:
@@ -38,7 +38,11 @@ defaults:
     env:
       MINIO_ROOT_USER: atago
       MINIO_ROOT_PASSWORD: atago-secret-key
-      MC_CONFIG_DIR: mcconfig
+      MC_CONFIG_DIR: "${workdir}/mcconfig"
+
+# mc seeds a builtin "local" alias for http://localhost:9000. Use distinct
+# alias names here so a resolution fallback cannot silently talk to that default
+# during fresh @latest CI installs.
 
 scenarios:
   - name: the server reports itself alive over the health API
@@ -93,11 +97,11 @@ scenarios:
           timeout: 30s
     steps:
       - run:
-          command: mc alias set local http://127.0.0.1:18122 atago atago-secret-key
+          command: mc alias set lifecycle http://127.0.0.1:18122 atago atago-secret-key
       - assert:
           exit_code: 0
       - run:
-          command: mc mb local/atago-bucket
+          command: mc mb lifecycle/atago-bucket
       - assert:
           exit_code: 0
           stdout:
@@ -106,11 +110,11 @@ scenarios:
           file: upload.txt
           content: "hello object storage"
       - run:
-          command: mc cp upload.txt local/atago-bucket/
+          command: mc cp upload.txt lifecycle/atago-bucket/
       - assert:
           exit_code: 0
       - run:
-          command: mc ls --json local/atago-bucket
+          command: mc ls --json lifecycle/atago-bucket
       - assert:
           exit_code: 0
           stdout:
@@ -123,13 +127,13 @@ scenarios:
               path: "$.size"
               equals: 20
       - run:
-          command: mc cat local/atago-bucket/upload.txt
+          command: mc cat lifecycle/atago-bucket/upload.txt
       - assert:
           exit_code: 0
           stdout:
             equals: hello object storage
       - run:
-          command: mc cp local/atago-bucket/upload.txt downloaded.txt
+          command: mc cp lifecycle/atago-bucket/upload.txt downloaded.txt
       - assert:
           exit_code: 0
       - assert:
@@ -137,13 +141,13 @@ scenarios:
             path: downloaded.txt
             contains: hello object storage
       - run:
-          command: mc rm local/atago-bucket/upload.txt
+          command: mc rm lifecycle/atago-bucket/upload.txt
       - assert:
           exit_code: 0
           stdout:
             contains: Removed
       - run:
-          command: mc ls local/atago-bucket
+          command: mc ls lifecycle/atago-bucket
       - assert:
           exit_code: 0
           stdout:
@@ -158,17 +162,17 @@ scenarios:
           timeout: 30s
     steps:
       - run:
-          command: mc alias set local http://127.0.0.1:18123 atago atago-secret-key
+          command: mc alias set versioned http://127.0.0.1:18123 atago atago-secret-key
       - run:
-          command: mc mb local/versioned
+          command: mc mb versioned/versioned
       - run:
-          command: mc version enable local/versioned
+          command: mc version enable versioned/versioned
       - assert:
           exit_code: 0
           stdout:
             contains: versioning is enabled
       - run:
-          command: mc version info --json local/versioned
+          command: mc version info --json versioned/versioned
       - assert:
           exit_code: 0
           stdout:
@@ -185,14 +189,14 @@ scenarios:
           timeout: 30s
     steps:
       - run:
-          command: mc alias set local http://127.0.0.1:18124 atago atago-secret-key
+          command: mc alias set publichost http://127.0.0.1:18124 atago atago-secret-key
       - run:
-          command: mc mb local/public-bucket
+          command: mc mb publichost/public-bucket
       - fixture:
           file: page.txt
           content: "published via bucket policy"
       - run:
-          command: mc cp page.txt local/public-bucket/
+          command: mc cp page.txt publichost/public-bucket/
       # Before the policy: anonymous reads are denied.
       - http:
           runner: s3_public
@@ -201,7 +205,7 @@ scenarios:
       - assert:
           status: 403
       - run:
-          command: mc anonymous set download local/public-bucket
+          command: mc anonymous set download publichost/public-bucket
       - assert:
           exit_code: 0
           stdout:

--- a/test/e2e/tools/gup/sandbox_home.atago.yaml
+++ b/test/e2e/tools/gup/sandbox_home.atago.yaml
@@ -1,11 +1,10 @@
 # Dogfood spec: exercises atago's sandbox_home + changes against the real `gup`
 # CLI (github.com/nao1215/gup). Requires `gup` on PATH. Run with: make dogfood
 #
-# gup's network-free subcommands (version/list) are pure reads — they write
-# NOTHING, not even to HOME. The changes assert with all three lists empty is
-# the strongest possible "touches nothing" statement, and sandbox_home
-# guarantees any stray dotfile write would land inside .atago-home where changes
-# would catch it.
+# gup's network-free subcommands (version/list) should not mutate the repo under
+# test. The changes assert with all three lists empty is the strongest possible
+# "touches nothing" statement, and sandbox_home guarantees any stray dotfile
+# write would land inside .atago-home where changes would catch it.
 version: "1"
 
 suite:
@@ -40,10 +39,17 @@ scenarios:
     skip:
       os: windows
     steps:
+      - fixture:
+          file: emptybin/.keep
+          content: ""
       - run:
           sandbox_home: true
           command: gup list
-      # Even under an isolated home, list produces no side effects.
+          env:
+            # Keep GOBIN explicit: when it is unset, current Go releases may
+            # create per-user state under HOME before gup reads the install set.
+            GOBIN: emptybin
+      # With an isolated, empty GOBIN, list produces no side effects.
       - assert:
           exit_code: 0
           changes:


### PR DESCRIPTION
## Summary
- make the gup sandbox-home spec provide an explicit empty GOBIN for the pure-read list case
- pin MinIO's MC_CONFIG_DIR under the scenario workdir and stop using mc's builtin local alias name
- keep the scheduled dogfood/third-party latest-tool workflows deterministic across fresh CI installs

## Verification
- env -u GOBIN PATH=/tmp/gup-ci-bin:/home/nao/.local/bin:/home/nao/.codex/tmp/arg0/codex-arg0JuXus7:/home/nao/.local/bin:/home/nao/.local/share/mise/installs/go/1.26.4/bin:/home/nao/.local/share/mise/installs/java/17.0.2/bin:/home/nao/.local/share/mise/installs/node/22.22.1/bin:/home/nao/.cargo/bin:/home/nao/.local/share/../bin:/home/nao/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/home/nao/Android/Sdk/cmdline-tools/latest/bin:/home/nao/Android/Sdk/platform-tools:/home/nao/Android/Sdk/emulator:/home/nao/.vscode/extensions/openai.chatgpt-26.707.31428-linux-x64/bin/linux-x86_64 ./dist/atago run test/e2e/tools/gup/sandbox_home.atago.yaml
- PATH=/tmp/minio-ci-bin:/home/nao/.local/bin:/home/nao/.codex/tmp/arg0/codex-arg0JuXus7:/home/nao/.local/bin:/home/nao/.local/share/mise/installs/go/1.26.4/bin:/home/nao/.local/share/mise/installs/java/17.0.2/bin:/home/nao/.local/share/mise/installs/node/22.22.1/bin:/home/nao/.cargo/bin:/home/nao/.local/share/../bin:/home/nao/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/home/nao/Android/Sdk/cmdline-tools/latest/bin:/home/nao/Android/Sdk/platform-tools:/home/nao/Android/Sdk/emulator:/home/nao/.vscode/extensions/openai.chatgpt-26.707.31428-linux-x64/bin/linux-x86_64 ./dist/atago run test/e2e/thirdparty/minio/minio.atago.yaml