### PR TITLE
ci: pin external tool versions

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -3,9 +3,11 @@ name: Dogfood
 # atago's strongest product proof is its dogfood matrix — running the real
 # hermetic atago binary against real third-party CLIs (#77). The hermetic
 # self-hosted suite runs on every push (e2e.yml); this workflow continuously
-# exercises the go-installable dogfood slices (gup, sqly, truss) so real-world
-# regressions surface on a dedicated, clearly-owned workflow instead of only when
-# a maintainer runs `make dogfood` by hand.
+# exercises the dogfood slices (gup, sqly, truss) so real-world regressions
+# surface on a dedicated, clearly-owned workflow instead of only when a
+# maintainer runs `make dogfood` by hand. Like thirdparty.yml, these external
+# CLIs are pinned so scheduled CI stays deterministic and version bumps are
+# intentional reviewable changes.
 #
 # It is intentionally NOT gated on push: it depends on external tools whose
 # availability atago does not control, so it runs on a schedule and on demand to
@@ -29,8 +31,8 @@ jobs:
       fail-fast: false
       matrix:
         tool:
-          - { name: gup, module: "github.com/nao1215/gup@latest", dir: "./test/e2e/tools/gup" }
-          - { name: sqly, module: "github.com/nao1215/sqly@latest", dir: "./test/e2e/tools/sqly" }
+          - { name: gup, module: "github.com/nao1215/gup@v1.7.1", dir: "./test/e2e/tools/gup" }
+          - { name: sqly, module: "github.com/nao1215/sqly@v0.27.3", dir: "./test/e2e/tools/sqly" }
           # truss moved from a Go module to the Rust crate `truss-image`
           # (installing the `truss` binary).
           - { name: truss, dir: "./test/e2e/tools/truss" }
@@ -52,7 +54,7 @@ jobs:
           set -e
           case "${{ matrix.tool.name }}" in
             truss)
-              cargo install truss-image --locked
+              cargo install truss-image --version 0.11.5 --locked
               echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
               ;;
             *)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,8 +45,8 @@ jobs:
   # representative slice of that proof must gate every PR, not only the daily
   # schedules. One flagship self-hosted server (caddy) and one dogfood CLI
   # (sqly) run here at PINNED versions so the required check stays
-  # deterministic; the daily thirdparty.yml / dogfood.yml matrices keep
-  # tracking @latest to catch upstream drift.
+  # deterministic; the daily thirdparty.yml / dogfood.yml matrices keep the
+  # broader external-tool coverage on their own pinned versions.
   e2e-representative:
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -67,7 +67,7 @@ jobs:
         run: |
           set -e
           go install github.com/caddyserver/caddy/v2/cmd/caddy@v2.11.4
-          go install github.com/nao1215/sqly@v0.26.0
+          go install github.com/nao1215/sqly@v0.27.3
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run the caddy suite (self-hosted web server, awesome-selfhosted)
@@ -117,7 +117,7 @@ jobs:
       - name: Install pinned sqly for the interactive pty check
         shell: bash
         run: |
-          go install github.com/nao1215/sqly@v0.26.0
+          go install github.com/nao1215/sqly@v0.27.3
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       # --parallel 1 keeps the concurrent ConPTY sessions from starving each

--- a/.github/workflows/thirdparty.yml
+++ b/.github/workflows/thirdparty.yml
@@ -7,10 +7,10 @@ name: ThirdParty
 # gate (e2e.yml e2e-representative); these depend on external modules/releases,
 # so like the dogfood matrix they run on a schedule and on demand to keep the
 # required push checks fast and deterministic. Each program is its own matrix
-# leg so a failure localizes to one external dependency. `go install` legs
-# track @latest (integrity comes from the Go checksum database); prebuilt
-# binary legs (prometheus, gitea) are pinned to a version + SHA256 instead,
-# since a raw CDN download has no implicit integrity check.
+# leg so a failure localizes to one external dependency. Every external tool is
+# pinned deliberately: `go install` legs pin a module version (integrity still
+# comes from the Go checksum database), and raw binary-download legs pin a
+# version + SHA256 because a CDN download has no implicit integrity check.
 on:
   workflow_dispatch:
   schedule:
@@ -31,13 +31,13 @@ jobs:
         program:
           - name: caddy
             dir: ./test/e2e/thirdparty/caddy
-            install: go install github.com/caddyserver/caddy/v2/cmd/caddy@latest
+            install: go install github.com/caddyserver/caddy/v2/cmd/caddy@v2.11.4
           - name: pushgateway
             dir: ./test/e2e/thirdparty/pushgateway
-            install: go install github.com/prometheus/pushgateway@latest
+            install: go install github.com/prometheus/pushgateway@v1.11.3
           - name: webhook
             dir: ./test/e2e/thirdparty/webhook
-            install: go install github.com/adnanh/webhook@latest
+            install: go install github.com/adnanh/webhook@v0.0.0-20260212225928-857e708f87a6
           # jq/openssl/sqlite3 ship on the runner image; the guard installs
           # them only if a future image drops one.
           - name: jq
@@ -51,7 +51,7 @@ jobs:
             install: command -v sqlite3 >/dev/null || (sudo apt-get update && sudo apt-get install -y sqlite3)
           - name: fzf
             dir: ./test/e2e/thirdparty/fzf
-            install: go install github.com/junegunn/fzf@latest
+            install: go install github.com/junegunn/fzf@v0.74.0
           # htop drives the pty runner's alternate-screen rendering and named
           # function keys; from apt where the runner image lacks it.
           - name: htop
@@ -62,25 +62,25 @@ jobs:
             install: command -v redis-server >/dev/null || (sudo apt-get update && sudo apt-get install -y redis-server redis-tools)
           - name: hugo
             dir: ./test/e2e/thirdparty/hugo
-            install: go install github.com/gohugoio/hugo@latest
+            install: go install github.com/gohugoio/hugo@v0.164.0
           - name: restic
             dir: ./test/e2e/thirdparty/restic
-            install: go install github.com/restic/restic/cmd/restic@latest
+            install: go install github.com/restic/restic/cmd/restic@v0.19.1
           - name: rclone
             dir: ./test/e2e/thirdparty/rclone
-            install: go install github.com/rclone/rclone@latest
+            install: go install github.com/rclone/rclone@v1.74.4
           - name: minio
             dir: ./test/e2e/thirdparty/minio
             install: |
-              go install github.com/minio/minio@latest
-              go install github.com/minio/mc@latest
+              go install github.com/minio/minio@v0.0.0-20260212201848-7aac2a2c5b7c
+              go install github.com/minio/mc@v0.0.0-20251106162529-77f82e18b540
           # The AWS CLI is driven against a local MinIO S3 endpoint (#32): a
           # cloud CLI tested with no cloud account, fully offline. minio is the
           # server; the aws CLI ships on the runner image (installed if absent).
           - name: awscli
             dir: ./test/e2e/thirdparty/awscli
             install: |
-              go install github.com/minio/minio@latest
+              go install github.com/minio/minio@v0.0.0-20260212201848-7aac2a2c5b7c
               command -v aws >/dev/null || (sudo apt-get update && sudo apt-get install -y awscli)
           # python3 ships on every runner image; the guard installs it only if
           # a future image drops it. The pty scenarios exercise the REPL.
@@ -108,41 +108,42 @@ jobs:
           - name: age
             dir: ./test/e2e/thirdparty/age
             install: |
-              go install filippo.io/age/cmd/age@latest
-              go install filippo.io/age/cmd/age-keygen@latest
+              go install filippo.io/age/cmd/age@v1.3.1
+              go install filippo.io/age/cmd/age-keygen@v1.3.1
           # kustomize renders Kubernetes manifests offline and deterministically
           # (build/create/edit); go-installed from the kustomize module.
           - name: kustomize
             dir: ./test/e2e/thirdparty/kustomize
-            install: go install sigs.k8s.io/kustomize/kustomize/v5@latest
+            install: go install sigs.k8s.io/kustomize/kustomize/v5@v5.8.1
           # actionlint statically lints GitHub Actions workflows offline; the
           # specs disable shellcheck so results do not depend on its presence.
           - name: actionlint
             dir: ./test/e2e/thirdparty/actionlint
-            install: go install github.com/rhysd/actionlint/cmd/actionlint@latest
+            install: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
           # sops encrypts structured files with age as the key backend; both are
           # go-installed (age and age-keygen provide the throwaway keys).
           - name: sops
             dir: ./test/e2e/thirdparty/sops
             install: |
-              go install github.com/getsops/sops/v3/cmd/sops@latest
-              go install filippo.io/age/cmd/age@latest
-              go install filippo.io/age/cmd/age-keygen@latest
+              go install github.com/getsops/sops/v3/cmd/sops@v3.13.2
+              go install filippo.io/age/cmd/age@v1.3.1
+              go install filippo.io/age/cmd/age-keygen@v1.3.1
           # aqua is a declarative CLI version manager; the suite runs a real
           # `aqua install` from a local registry + local HTTP file server (python3
-          # ships on the runner) and its offline surface. aqua fetches its pinned
-          # aqua-proxy bootstrap from GitHub during install.
+          # ships on the runner) and its offline surface. v2.61.0 raised its
+          # minimum Go toolchain to 1.26.5, so pin v2.60.2 to stay compatible
+          # with this repo's current Go setup while still testing a recent aqua.
           - name: aqua
             dir: ./test/e2e/thirdparty/aqua
-            install: go install github.com/aquaproj/aqua/v2/cmd/aqua@latest
+            install: go install github.com/aquaproj/aqua/v2/cmd/aqua@v2.60.2
           # ecspresso deploys ECS services. The suite renders offline AND runs a
           # real deploy against moto (an in-memory AWS mock, pip-installed) with
           # the aws CLI (preinstalled on the runner) observing the ECS state.
           - name: ecspresso
             dir: ./test/e2e/thirdparty/ecspresso
             install: |
-              go install github.com/kayac/ecspresso/v2/cmd/ecspresso@latest
-              pipx install 'moto[server]'
+              go install github.com/kayac/ecspresso/v2/cmd/ecspresso@v2.8.5
+              pipx install 'moto[server]==5.2.2'
           - name: terraform
             dir: ./test/e2e/thirdparty/terraform
             install: |
@@ -156,19 +157,19 @@ jobs:
           - name: coredns
             dir: ./test/e2e/thirdparty/coredns
             install: |
-              go install github.com/coredns/coredns@latest
+              go install github.com/coredns/coredns@v1.14.6
               command -v dig >/dev/null || (sudo apt-get update && sudo apt-get install -y bind9-dnsutils)
           - name: nats
             dir: ./test/e2e/thirdparty/nats
             install: |
-              go install github.com/nats-io/nats-server/v2@latest
-              go install github.com/nats-io/natscli/nats@latest
+              go install github.com/nats-io/nats-server/v2@v2.14.3
+              go install github.com/nats-io/natscli/nats@v0.4.0
           - name: mailpit
             dir: ./test/e2e/thirdparty/mailpit
-            install: go install github.com/axllent/mailpit@latest
+            install: go install github.com/axllent/mailpit@v1.30.4
           - name: transfersh
             dir: ./test/e2e/thirdparty/transfersh
-            install: go install github.com/dutchcoders/transfer.sh@latest
+            install: go install github.com/dutchcoders/transfer.sh@v1.6.1
           # Gotify compiles its web UI into the binary, so `go install` cannot
           # build it; pinned release zip + SHA256. Gotify publishes no checksum
           # sidecars, so this SHA was recorded from a verified download

--- a/test/e2e/thirdparty/aqua/install.atago.yaml
+++ b/test/e2e/thirdparty/aqua/install.atago.yaml
@@ -11,8 +11,8 @@ suite:
 # `aqua install` downloads it from 127.0.0.1, lands it under AQUA_ROOT_DIR, and
 # `aqua exec` runs it. AQUA_ROOT_DIR and the policy file are pinned inside the
 # workdir. (aqua still fetches its pinned aqua-proxy bootstrap from GitHub on
-# install, the one external dependency of aqua's own design.)
-# Install: go install github.com/aquaproj/aqua/v2/cmd/aqua@latest
+# install, the one external dependency of aqua's own design.) Install: see
+# .github/workflows/thirdparty.yml for the pinned CI version.
 
 permissions:
   network:

--- a/test/e2e/thirdparty/awscli/awscli.atago.yaml
+++ b/test/e2e/thirdparty/awscli/awscli.atago.yaml
@@ -6,9 +6,9 @@ suite:
 # Drives the real AWS CLI against a local MinIO S3 endpoint (#32): test a
 # cloud CLI with no cloud account, no network, fully hermetic. MinIO is
 # started per scenario as a background service (its client peers already have
-# a suite here); `aws --endpoint-url` points at it. Install:
-#   go install github.com/minio/minio@latest   (server)
-#   pip install awscli / apt-get install awscli (client)
+# a suite here); `aws --endpoint-url` points at it. Install: see
+# .github/workflows/thirdparty.yml for the pinned server version and the CI
+# client-install path.
 #
 # Each scenario binds its own port and data dir so the suite runs under the
 # default scenario concurrency. Credentials come from scenario env; the

--- a/test/e2e/thirdparty/caddy/caddy.atago.yaml
+++ b/test/e2e/thirdparty/caddy/caddy.atago.yaml
@@ -6,8 +6,8 @@ suite:
 # Exercises Caddy (https://caddyserver.com/, from awesome-selfhosted) as a
 # third-party target: pure CLI behavior (version/adapt/fmt/validate), and the
 # real server started as a background service with a TCP readiness probe and
-# queried through the http runner. Install with:
-#   go install github.com/caddyserver/caddy/v2/cmd/caddy@latest
+# queried through the http runner. Install: see
+# .github/workflows/thirdparty.yml for the pinned CI version.
 
 permissions:
   network:

--- a/test/e2e/thirdparty/coredns/coredns.atago.yaml
+++ b/test/e2e/thirdparty/coredns/coredns.atago.yaml
@@ -8,8 +8,8 @@ suite:
 # for, which is the point: the real server is booted from an authored Corefile
 # and zone file, queried with the stock `dig` client over actual DNS (A, TXT,
 # CNAME chasing, NXDOMAIN, and the REFUSED answer for out-of-zone names), and
-# its health plugin is probed through the http runner. Install with:
-#   go install github.com/coredns/coredns@latest
+# its health plugin is probed through the http runner. Install: see
+# .github/workflows/thirdparty.yml for the pinned CI version.
 # (`dig` ships with bind9-dnsutils, preinstalled on GitHub runners.)
 #
 # Each server scenario binds its own port so the suite runs under the default

--- a/test/e2e/thirdparty/ecspresso/deploy.atago.yaml
+++ b/test/e2e/thirdparty/ecspresso/deploy.atago.yaml
@@ -11,10 +11,8 @@ suite:
 # the ECS state change is observed with `aws ecs describe-services`, not just
 # asserted from ecspresso's logs. `--no-wait` is used because moto never runs
 # tasks, so a wait-for-stable would hang; the registration and service update
-# are synchronous and complete before it returns.
-# Install:
-#   pip install 'moto[server]'
-#   go install github.com/kayac/ecspresso/v2/cmd/ecspresso@latest
+# are synchronous and complete before it returns. Install: see
+# .github/workflows/thirdparty.yml for the pinned CI versions.
 
 permissions:
   network:

--- a/test/e2e/thirdparty/hugo/hugo.atago.yaml
+++ b/test/e2e/thirdparty/hugo/hugo.atago.yaml
@@ -9,7 +9,7 @@ suite:
 # builds files worth asserting on. The server half lives in
 # hugo_server.atago.yaml. Every scenario probes for hugo first so the suite
 # skips cleanly where it is absent.
-# Install with: go install github.com/gohugoio/hugo@latest / brew install hugo
+# Install: see .github/workflows/thirdparty.yml for the pinned CI version.
 scenarios:
   - name: new site scaffolds the documented directory tree
     only:

--- a/test/e2e/thirdparty/mailpit/mailpit.atago.yaml
+++ b/test/e2e/thirdparty/mailpit/mailpit.atago.yaml
@@ -7,8 +7,8 @@ suite:
 # email corner) as a third-party target — a protocol pairing nothing else in
 # this directory covers: real messages are delivered over SMTP with the stock
 # curl client (smtp://), then asserted through Mailpit's REST API — capture,
-# full-text search, MIME attachments, and mailbox teardown. Install with:
-#   go install github.com/axllent/mailpit@latest
+# full-text search, MIME attachments, and mailbox teardown. Install: see
+# .github/workflows/thirdparty.yml for the pinned CI version.
 #
 # Each scenario binds its own SMTP+HTTP port pair so the suite runs under the
 # default scenario concurrency.

--- a/test/e2e/thirdparty/minio/minio.atago.yaml
+++ b/test/e2e/thirdparty/minio/minio.atago.yaml
@@ -8,8 +8,7 @@ suite:
 # background service per scenario, health probed over HTTP, driven end-to-end
 # with the mc client (bucket + object lifecycle, versioning, anonymous
 # policies), and the unauthenticated failure mode asserted as S3 XML. Install:
-#   go install github.com/minio/minio@latest
-#   go install github.com/minio/mc@latest
+# see .github/workflows/thirdparty.yml for the pinned CI versions.
 #
 # Each scenario binds its own port so the suite runs under the default
 # scenario concurrency. Pin MC_CONFIG_DIR under the scenario workdir so mc
@@ -42,7 +41,7 @@ defaults:
 
 # mc seeds a builtin "local" alias for http://localhost:9000. Use distinct
 # alias names here so a resolution fallback cannot silently talk to that default
-# during fresh @latest CI installs.
+# during fresh CI installs.
 
 scenarios:
   - name: the server reports itself alive over the health API

--- a/test/e2e/thirdparty/nats/nats.atago.yaml
+++ b/test/e2e/thirdparty/nats/nats.atago.yaml
@@ -9,9 +9,8 @@ suite:
 # driven with the official nats CLI through request/reply (a second background
 # service answers), JetStream persistence (stream create → publish → counted
 # state → purge), and the JetStream KV store, while the monitoring endpoint is
-# asserted through the http runner. Install with:
-#   go install github.com/nats-io/nats-server/v2@latest
-#   go install github.com/nats-io/natscli/nats@latest
+# asserted through the http runner. Install: see
+# .github/workflows/thirdparty.yml for the pinned CI versions.
 #
 # Each scenario binds its own port so the suite runs under the default
 # scenario concurrency.

--- a/test/e2e/thirdparty/pushgateway/pushgateway.atago.yaml
+++ b/test/e2e/thirdparty/pushgateway/pushgateway.atago.yaml
@@ -6,7 +6,7 @@ suite:
 # Exercises Prometheus Pushgateway (from awesome-selfhosted's monitoring
 # corner) as a third-party target. Its push API takes the raw text exposition
 # format — the workload the http step's `body:` payload exists for. Install:
-#   go install github.com/prometheus/pushgateway@latest
+# see .github/workflows/thirdparty.yml for the pinned CI version.
 #
 # Each scenario binds its own port so the suite runs under the default
 # scenario concurrency.

--- a/test/e2e/thirdparty/rclone/rclone.atago.yaml
+++ b/test/e2e/thirdparty/rclone/rclone.atago.yaml
@@ -8,8 +8,8 @@ suite:
 # scenario hermetic: copy/sync semantics, machine-readable listings, integrity
 # checks and their failure mode, the obscure/reveal password round-trip, and
 # `rclone serve http` as a real background server queried through the http
-# runner. Install with:
-#   go install github.com/rclone/rclone@latest
+# runner. Install: see .github/workflows/thirdparty.yml for the pinned CI
+# version.
 
 permissions:
   network:

--- a/test/e2e/thirdparty/restic/restic.atago.yaml
+++ b/test/e2e/thirdparty/restic/restic.atago.yaml
@@ -8,8 +8,8 @@ suite:
 # repository — init, backup, list snapshots as JSON, restore, diff, integrity
 # check, retention, and the failure mode a wrong password must produce.
 # Everything is hermetic: the repository and the data live in the scenario's
-# isolated workdir. Install with:
-#   go install github.com/restic/restic/cmd/restic@latest
+# isolated workdir. Install: see .github/workflows/thirdparty.yml for the
+# pinned CI version.
 
 defaults:
   scenario:

--- a/test/e2e/thirdparty/transfersh/transfersh.atago.yaml
+++ b/test/e2e/thirdparty/transfersh/transfersh.atago.yaml
@@ -10,8 +10,8 @@ suite:
 # the response, the file is downloaded back to disk (`body_to`), and the
 # round-tripped bytes are verified with the image assertion target plus a
 # byte-for-byte cmp. The browser-style multipart upload path is exercised too
-# (`files:`). Install with:
-#   go install github.com/dutchcoders/transfer.sh@latest
+# (`files:`). Install: see .github/workflows/thirdparty.yml for the pinned CI
+# version.
 #
 # Each server scenario binds its own port so the suite runs under the default
 # scenario concurrency.

--- a/test/e2e/thirdparty/webhook/webhook.atago.yaml
+++ b/test/e2e/thirdparty/webhook/webhook.atago.yaml
@@ -12,9 +12,8 @@ suite:
 # not run when unsatisfied), an HMAC signature is verified against an
 # independently computed oracle, the http-methods allowlist rejects the wrong
 # verb, and a command that exits non-zero surfaces as a 500. Each scenario runs
-# its own daemon with a minimal hook config.
-# Install:
-#   go install github.com/adnanh/webhook@latest
+# its own daemon with a minimal hook config. Install: see
+# .github/workflows/thirdparty.yml for the pinned CI version.
 
 permissions:
   network:


### PR DESCRIPTION
## Summary
Pin external tool versions used by scheduled CI so upstream releases do not randomly break third-party and dogfood coverage.

## Changes
- replace go-installed `@latest` dependencies in `thirdparty.yml` with explicit versions
- pin `moto[server]`, `gup`, `sqly`, and `truss-image` in scheduled CI jobs
- pin `aqua` to `v2.60.2` because `v2.61.0` now requires Go `1.26.5`
- update spec comments to point at the workflow as the single source of truth for pinned install versions

## Testing
- `go test ./...`

## Notes
- apt-provided tools such as `jq`, `openssl`, and `sqlite3` are unchanged; this only removes drift from floating external installs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Pinned third-party CLI and server versions used in scheduled, end-to-end, and representative CI runs for more consistent results.
  - Updated several external-tool versions, including `sqly` and `truss-image`.

- **Documentation**
  - Updated third-party test setup guidance to reference the centrally maintained pinned versions.
  - Clarified how scheduled runs and pull-request gating handle external-tool coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->