### PR TITLE
docs(install): add aqua and mise install methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,21 @@ On Arch Linux, install the [`atago-bin`](https://aur.archlinux.org/packages/atag
 yay -S atago-bin   # or: paru -S atago-bin
 ```
 
+atago is in the [aqua](https://aquaproj.github.io/) standard registry. Add it to your `aqua.yaml`, then install it:
+
+```shell
+aqua g -i nao1215/atago
+aqua i
+```
+
+[mise](https://mise.jdx.dev/) can install it through the same registry with the aqua backend:
+
+```shell
+mise use -g aqua:nao1215/atago
+```
+
+If your installed `mise` release does not see `nao1215/atago` yet, update `mise` or enable floating registries with `mise settings registry_floating=true`.
+
 The [release page](https://github.com/nao1215/atago/releases) contains prebuilt binary archives for Linux, macOS, and Windows (amd64/arm64; `.tar.gz`, or `.zip` on Windows), plus `.deb`, `.rpm`, and `.apk` packages for Linux. Requires Go 1.26 or later when building from source.
 
 Runs on Linux, macOS, and Windows (CI tests all three).

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -65,7 +65,7 @@ atago (愛宕) is named for Mount Atago in Kyoto, whose shrine enshrines a deity
 
 ## Where to go
 
-- [Install](/install/) — `go install`, Homebrew, AUR, prebuilt binaries, a GitHub Action.
+- [Install](/install/) — `go install`, Homebrew, AUR, aqua, mise, prebuilt binaries, a GitHub Action.
 - [Getting started](/getting-started/) — record a real run, read the spec it wrote, keep it as a test.
 - [Cookbook](/cookbook/) — 50+ copyable recipes indexed by task, plus the runnable, CI-tested example for every feature.
 - [Use it in CI](/ci/) — report formats, retries, flake detection, artifacts, secret masking.

--- a/website/content/install.md
+++ b/website/content/install.md
@@ -19,6 +19,21 @@ On Arch Linux, install the [`atago-bin`](https://aur.archlinux.org/packages/atag
 yay -S atago-bin   # or: paru -S atago-bin
 ```
 
+atago is in the [aqua](https://aquaproj.github.io/) standard registry. Add it to your `aqua.yaml`, then install it:
+
+```shell
+aqua g -i nao1215/atago
+aqua i
+```
+
+[mise](https://mise.jdx.dev/) can install it through the same registry with the aqua backend:
+
+```shell
+mise use -g aqua:nao1215/atago
+```
+
+If your installed `mise` release does not see `nao1215/atago` yet, update `mise` or enable floating registries with `mise settings registry_floating=true`.
+
 The [release page](https://github.com/nao1215/atago/releases) contains prebuilt binary archives for Linux, macOS, and Windows (amd64/arm64; `.tar.gz`, or `.zip` on Windows), plus `.deb`, `.rpm`, and `.apk` packages for Linux. Requires Go 1.26 or later when building from source.
 
 Runs on Linux, macOS, and Windows (CI tests all three).


### PR DESCRIPTION
## Summary

Document aqua and mise installation for atago in the README and the hosted Install page.
Update the website home-page Install blurb to mention the new options.

## Changes

- add aqua install steps (`aqua g -i nao1215/atago` then `aqua i`) to `README.md` and `website/content/install.md`
- add `mise use -g aqua:nao1215/atago` with a brief `registry_floating` note
- update `website/content/_index.md` so the Install teaser mentions aqua and mise

## Design Decisions

- use `mise use -g aqua:nao1215/atago` instead of a shorthand because `aqua-registry` has `nao1215/atago`, while `jdx/mise` does not expose an `atago` shorthand entry in `registry/`
- keep aqua as `aqua g -i ...` followed by `aqua i` because aqua documents `g -i` as adding the package to `aqua.yaml`, and `i` as the install step

## Verification

- `make website`

## Sources

- https://github.com/aquaproj/aqua-registry/tree/main/pkgs/nao1215/atago
- https://aquaproj.github.io/docs/tutorial/search-packages/
- https://aquaproj.github.io/docs/tutorial/
- https://mise.jdx.dev/registry
- https://mise.jdx.dev/dev-tools/backends/aqua.html
- https://mise.jdx.dev/cli/use.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added installation instructions for aqua and mise, including configuration and troubleshooting guidance.
  * Updated installation overviews to highlight Homebrew, AUR, aqua, mise, prebuilt binaries, `go install`, and GitHub Actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->