### PR TITLE
docs(readme): update repository badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![reviewdog](https://github.com/nao1215/atago/actions/workflows/reviewdog.yml/badge.svg)](https://github.com/nao1215/atago/actions/workflows/reviewdog.yml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/nao1215/atago.svg)](https://pkg.go.dev/github.com/nao1215/atago)
 ![GitHub](https://img.shields.io/github/license/nao1215/atago)
-[![Total Downloads](https://img.shields.io/github/downloads/nao1215/atago/total?label=downloads)](https://github.com/nao1215/atago/releases)
+[![GitHub Downloads (all assets, all releases)](https://img.shields.io/github/downloads/nao1215/atago/total)](https://github.com/nao1215/atago/releases)
 
 <p align="center">
   <img src="./doc/img/atago-logo.jpg" alt="atago logo" width="400" />


### PR DESCRIPTION
## Summary
Refresh the README badge section to show total GitHub downloads and remove the deprecated Go Report Card badge where it still appears.

## Changes
- add the GitHub downloads badge to the main README badge row
- remove the Go Report Card badge from repositories that still reference it
- keep existing badge ordering while normalizing the downloads badge link to the releases page

## Design Decisions
- use the same Shields.io GitHub downloads badge format across repositories
- keep the change documentation-only with no behavioral impact


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README download badge to display total GitHub downloads across all assets and releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->