### PR TITLE
fix(ci): pin awscli third-party installers

### DIFF
--- a/.github/workflows/thirdparty.yml
+++ b/.github/workflows/thirdparty.yml
@@ -82,12 +82,13 @@ jobs:
               go install github.com/minio/mc@RELEASE.2025-07-21T05-28-08Z
           # The AWS CLI is driven against a local MinIO S3 endpoint (#32): a
           # cloud CLI tested with no cloud account, fully offline. minio is the
-          # server; the AWS CLI itself comes from the pinned Ubuntu snapshot.
+          # server; the AWS CLI itself comes from the official pinned v2 bundle
+          # because Ubuntu's awscli package disappeared from the noble snapshot.
           - name: awscli
             dir: ./test/e2e/thirdparty/awscli
             install: |
               go install github.com/minio/minio@RELEASE.2025-07-18T21-56-31Z
-              bash ./scripts/install_ubuntu_snapshot_packages.sh awscli
+              bash ./scripts/install_awscli_pinned.sh
           # The pty scenarios exercise the real CPython REPL.
           - name: python
             dir: ./test/e2e/thirdparty/python
@@ -143,12 +144,13 @@ jobs:
             install: go install github.com/aquaproj/aqua/v2/cmd/aqua@v2.60.2
           # ecspresso deploys ECS services. The suite renders offline AND runs a
           # real deploy against moto (an in-memory AWS mock, pip-installed) with
-          # the aws CLI (preinstalled on the runner) observing the ECS state.
+          # the same pinned AWS CLI v2 bundle observing the ECS state.
           - name: ecspresso
             dir: ./test/e2e/thirdparty/ecspresso
             install: |
               go install github.com/kayac/ecspresso/v2/cmd/ecspresso@v2.8.5
               pipx install 'moto[server]==5.2.2'
+              bash ./scripts/install_awscli_pinned.sh
           - name: terraform
             dir: ./test/e2e/thirdparty/terraform
             install: |

--- a/drift_test.go
+++ b/drift_test.go
@@ -387,6 +387,12 @@ func TestThirdParty_InstallersArePinned(t *testing.T) {
 	if strings.Contains(yml, "command -v ") {
 		t.Error("thirdparty.yml still has command -v install guards; the third-party matrix must install fixed tool versions even if the runner image already ships one")
 	}
+	if strings.Contains(yml, "bash ./scripts/install_ubuntu_snapshot_packages.sh awscli") {
+		t.Error("thirdparty.yml still installs awscli from the Ubuntu snapshot; use the pinned official AWS CLI bundle because the package is no longer available there")
+	}
+	if strings.Contains(yml, "preinstalled on the runner") {
+		t.Error("thirdparty.yml still relies on a preinstalled runner tool; third-party CLIs must be installed at pinned versions inside the workflow")
+	}
 }
 
 // TestWindowsPortableSubset_Exists asserts every spec path in the single-source

--- a/drift_test.go
+++ b/drift_test.go
@@ -165,6 +165,21 @@ var (
 	thirdpartyRunsOnRe = regexp.MustCompile(`(?m)^\s*runs-on:\s*(\S+)\s*$`)
 )
 
+func thirdpartyMatrixBlock(t *testing.T, yml, name string) string {
+	t.Helper()
+	marker := "          - name: " + name + "\n"
+	start := strings.Index(yml, marker)
+	if start < 0 {
+		t.Fatalf("could not find thirdparty matrix block for %q", name)
+	}
+	rest := yml[start+len(marker):]
+	next := strings.Index(rest, "\n          - name: ")
+	if next < 0 {
+		return yml[start:]
+	}
+	return yml[start : start+len(marker)+next]
+}
+
 // collectSpecs mirrors cli.collectSpecFiles for a single directory target: every
 // *.atago.yaml/.yml under dir in filepath.WalkDir's lexical order, cleaned. The
 // cleaned path is what docgen prints as each scenario's `Source:`, so it must
@@ -387,11 +402,15 @@ func TestThirdParty_InstallersArePinned(t *testing.T) {
 	if strings.Contains(yml, "command -v ") {
 		t.Error("thirdparty.yml still has command -v install guards; the third-party matrix must install fixed tool versions even if the runner image already ships one")
 	}
-	if strings.Contains(yml, "bash ./scripts/install_ubuntu_snapshot_packages.sh awscli") {
-		t.Error("thirdparty.yml still installs awscli from the Ubuntu snapshot; use the pinned official AWS CLI bundle because the package is no longer available there")
-	}
-	if strings.Contains(yml, "preinstalled on the runner") {
-		t.Error("thirdparty.yml still relies on a preinstalled runner tool; third-party CLIs must be installed at pinned versions inside the workflow")
+
+	for _, leg := range []string{"awscli", "ecspresso"} {
+		block := thirdpartyMatrixBlock(t, yml, leg)
+		if !strings.Contains(block, "bash ./scripts/install_awscli_pinned.sh") {
+			t.Errorf("thirdparty.yml %s block does not install the pinned AWS CLI bundle", leg)
+		}
+		if strings.Contains(block, "install_ubuntu_snapshot_packages.sh") {
+			t.Errorf("thirdparty.yml %s block still installs awscli from the Ubuntu snapshot", leg)
+		}
 	}
 }
 

--- a/scripts/install_awscli_pinned.sh
+++ b/scripts/install_awscli_pinned.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ver="2.36.5"
+sha256="8e6c725ed2804bdbdd8d5d730998c19b3b09be06c2c31432673b5af12d2dff79"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+zip="$tmpdir/awscliv2.zip"
+curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${ver}.zip" -o "$zip"
+echo "${sha256}  ${zip}" | sha256sum -c -
+unzip -q "$zip" -d "$tmpdir"
+
+bin_dir="$(go env GOPATH)/bin"
+install_dir="$HOME/.local/aws-cli-${ver}"
+mkdir -p "$bin_dir"
+"$tmpdir/aws/install" --bin-dir "$bin_dir" --install-dir "$install_dir"


### PR DESCRIPTION
## Summary
The scheduled ThirdParty run on July 22, 2026 exposed that the pinned Ubuntu snapshot no longer provides the `awscli` package. This switches the affected workflow legs to the official pinned AWS CLI v2 bundle and keeps the installer integrity-checked.

## Changes
- add `scripts/install_awscli_pinned.sh` to download AWS CLI v2.36.5 and verify its SHA256 before install
- use the pinned installer in both the `awscli` and `ecspresso` third-party workflow legs
- extend the drift test so `awscli` cannot silently fall back to the Ubuntu snapshot or a preinstalled runner binary again

## Design Decisions
- keep MinIO pinned exactly as before and only replace the broken AWS CLI install path
- reuse one installer script so both workflow legs stay on the same AWS CLI version and checksum

## Limitations
- PR CI has to validate the GitHub-hosted runner path for the official AWS CLI bundle


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Standardized AWS CLI installation to use a verified, pinned version across automated workflows.
  - Added consistent installation coverage for related tooling environments.

- **Tests**
  - Strengthened checks to detect unpinned AWS CLI usage and reliance on preinstalled runner tools.
  - Helps maintain more reproducible and reliable automation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->