### PR TITLE
fix(loader): reject explicit YAML tags before decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- The spec loader now rejects explicit YAML tags (`!foo`, `!!str`, a bare `!`)
+  with an error naming the tag and its line/column, instead of letting them
+  reach the decoder. atago's schema is closed and fully typed, so a tag could
+  only restate or contradict it, and no spec, example, or doc authored one.
+  `!!binary` stays accepted because `atago record` emits it for captures that
+  are not valid UTF-8.
+
+### Fixed
+
+- Loading a spec no longer provokes a runtime nil-pointer panic on the way to a
+  parse error. A tagged node on a list field made goccy/go-yaml v1.19.2 nil-deref
+  inside `decodeSlice`; the loader recovered from it, but `internal/loader` was
+  then the only package raising real runtime panics on every test run, and the
+  only one whose Windows CI job kept dying with Go GC heap-corruption fatal
+  errors (`found pointer to free object`). Rejecting the tags up front takes the
+  loader test suite from 9 recovered panics per run to zero.
+
 ## [0.12.0] - 2026-07-26
 
 A minor release focused on PTY/TUI correctness, reproducible third-party CI,

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 
 	"github.com/goccy/go-yaml"
+	"github.com/goccy/go-yaml/ast"
+	"github.com/goccy/go-yaml/parser"
 	"github.com/nao1215/atago/internal/spec"
 )
 
@@ -50,11 +52,90 @@ func Load(path string) (*spec.Spec, error) {
 	return LoadBytes(path, data)
 }
 
+// binaryTag is the one explicit YAML tag a spec may carry. `atago record`
+// writes it when a captured stream is not valid UTF-8, so recorded specs must
+// keep loading; every other tag is an authoring mistake.
+const binaryTag = "!!binary"
+
+// explicitTagError describes the first unsupported explicit YAML tag in a spec
+// document, or returns "" when the document has none. atago's schema is closed
+// and fully typed — every field's Go type already fixes how its value is read —
+// so a tag can only ever restate or contradict the schema, and no spec,
+// example, or doc in this repository authors one.
+//
+// Turning tags away up front is also what keeps the decoder's nil-panic path
+// out of everyday use. When a tagged node lands on a list field,
+// goccy/go-yaml v1.19.2 panics: ast.TagNode.ArrayRange returns a nil
+// *ArrayNodeIter whenever the tag's value is not a sequence, and decodeSlice
+// dereferences it without a nil check (decode.go:1593 -> ast.go:1543).
+// decodeSpec recovers from that, but internal/loader is then the only package
+// here that raises a real runtime nil dereference on every test run, and it is
+// also the only package that has crashed Windows CI with Go GC heap-corruption
+// fatal errors ("found pointer to free object"). Not provoking the panic costs
+// nothing and removes that correlation.
+//
+// A `!!binary` over a list field still reaches the panic, because record's
+// output has to stay loadable; decodeSpec's recover remains the backstop for
+// that residue.
+//
+// A parse failure yields no usable AST; that case reports "" so the decoder can
+// produce its own, better-positioned syntax error.
+func explicitTagError(data []byte) string {
+	f, err := parser.ParseBytes(data, 0)
+	if err != nil || f == nil || len(f.Docs) == 0 {
+		return ""
+	}
+	// Decode reads a single document, so only that document can reach the panic.
+	v := &tagFinder{}
+	ast.Walk(v, f.Docs[0])
+	if v.found == nil || v.found.Start == nil {
+		return ""
+	}
+	pos := v.found.Start.Position
+	name := strings.TrimSpace(v.found.Start.Value)
+	where := ""
+	if pos != nil {
+		where = fmt.Sprintf("[%d:%d] ", pos.Line, pos.Column)
+	}
+	if name == "" || name == "!" {
+		return where + "explicit YAML tag is not supported in a spec: remove the tag"
+	}
+	return fmt.Sprintf("%sexplicit YAML tag %q is not supported in a spec: remove the tag", where, name)
+}
+
+// tagFinder is an ast.Visitor that stops at the first unsupported explicit tag
+// it meets.
+type tagFinder struct {
+	found *ast.TagNode
+}
+
+// Visit records the first unsupported *ast.TagNode and then stops descending.
+// A `!!binary` scalar is skipped over rather than accepted wholesale: the walk
+// continues into its children so a tag nested under it is still caught. Walk
+// also calls Visit(nil) after a node's children, which the type assertion
+// ignores.
+func (v *tagFinder) Visit(n ast.Node) ast.Visitor {
+	if v.found != nil {
+		return nil
+	}
+	tag, ok := n.(*ast.TagNode)
+	if !ok {
+		return v
+	}
+	if tag.Start != nil && strings.TrimSpace(tag.Start.Value) == binaryTag {
+		return v
+	}
+	v.found = tag
+	return nil
+}
+
 // decodeSpec decodes one YAML document into s, converting a panic from the
 // third-party decoder into an ordinary error. goccy/go-yaml can nil-panic on
 // some malformed input (a bare `!` tag over a broken mapping, found by
 // FuzzLoadBytes); atago's contract is that loading untrusted spec bytes never
 // crashes the process, so recover here and let the caller report a parse error.
+// explicitTagError already turns away the inputs known to reach that panic, so
+// this stays as a backstop for any shape not yet found.
 func decodeSpec(dec *yaml.Decoder, s *spec.Spec) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -75,6 +156,9 @@ func LoadBytes(path string, data []byte) (*spec.Spec, error) {
 	// field" error naming a field the author wrote right. Most YAML tooling strips
 	// a single leading BOM transparently.
 	data = bytes.TrimPrefix(data, []byte("\ufeff"))
+	if msg := explicitTagError(data); msg != "" {
+		return nil, &Error{Path: path, Kind: KindParse, Msg: msg}
+	}
 	var s spec.Spec
 	dec := yaml.NewDecoder(bytes.NewReader(data), yaml.Strict())
 	if err := decodeSpec(dec, &s); err != nil {

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -798,6 +798,115 @@ func TestLoadBytes_MalformedYAMLDoesNotPanic(t *testing.T) {
 	}
 }
 
+// TestLoadBytes_ExplicitTagRejected pins the tag rejection that keeps the
+// decoder's nil-panic path unreachable. Every input here reaches
+// ast.TagNode.ArrayRange -> nil *ArrayNodeIter -> decodeSlice panic in
+// goccy/go-yaml v1.19.2 when it is allowed through, so each must now be
+// rejected before decoding, with a message that names the tag and its position
+// instead of the opaque "malformed YAML" the recover path produces.
+func TestLoadBytes_ExplicitTagRejected(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "bare tag over a scalar where a list belongs",
+			src:  "scenarios:\n  ! 0",
+			want: []string{"explicit YAML tag", "[2:3]"},
+		},
+		{
+			name: "fuzz crasher 230de42ba4751bda",
+			src:  "A: 0\nrunners:\n 0: {0000000000000\"}\nscenarios:\n  ! 00",
+			want: []string{"explicit YAML tag", "[5:3]"},
+		},
+		{
+			name: "custom tag on a list field",
+			src:  "version: \"1\"\nsuite:\n  name: x\nscenarios: !foo 0\n",
+			want: []string{"!foo", "[4:12]"},
+		},
+		{
+			name: "std tag on a list field",
+			src:  "version: \"1\"\nsuite:\n  name: x\nscenarios: !!str 0\n",
+			want: []string{"!!str", "[4:12]"},
+		},
+		{
+			name: "tag on a nested list field",
+			src:  "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps: ! 0\n",
+			want: []string{"explicit YAML tag", "[6:12]"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := LoadBytes("t.atago.yaml", []byte(tt.src))
+			if err == nil {
+				t.Fatalf("LoadBytes() = nil error, want a parse error naming the tag")
+			}
+			if s != nil {
+				t.Errorf("LoadBytes() returned a non-nil spec alongside an error")
+			}
+			var lerr *Error
+			if !errors.As(err, &lerr) {
+				t.Fatalf("LoadBytes() error = %T, want *loader.Error", err)
+			}
+			if lerr.Kind != KindParse {
+				t.Errorf("kind = %v, want KindParse", lerr.Kind)
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error = %q, want substring %q", err.Error(), want)
+				}
+			}
+			// The recover path must no longer be what produces this error.
+			if strings.Contains(err.Error(), "malformed YAML") {
+				t.Errorf("error = %q, want the tag to be rejected before decoding", err.Error())
+			}
+		})
+	}
+}
+
+// TestLoadBytes_TagRejectionLeavesOtherErrorsAlone guards the blast radius of
+// the tag check: a spec with no explicit tag must keep loading, and a malformed
+// spec that the parser itself rejects must keep its original syntax error
+// rather than being reported as a tag problem.
+func TestLoadBytes_TagRejectionLeavesOtherErrorsAlone(t *testing.T) {
+	t.Parallel()
+	good := "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps:\n      - run: {command: echo}\n"
+	if _, err := LoadBytes("t.atago.yaml", []byte(good)); err != nil {
+		t.Errorf("LoadBytes(untagged spec) error = %v, want a clean load", err)
+	}
+	// An unclosed flow mapping is a syntax error the parser itself catches, so
+	// the tag check never gets a usable AST to walk.
+	broken := "version: \"1\"\nsuite: {name: x\n"
+	_, err := LoadBytes("t.atago.yaml", []byte(broken))
+	if err == nil {
+		t.Fatalf("LoadBytes(unclosed flow mapping) = nil error, want a parse error")
+	}
+	if strings.Contains(err.Error(), "explicit YAML tag") {
+		t.Errorf("error = %q, want the original syntax error, not a tag error", err.Error())
+	}
+}
+
+// TestLoadBytes_BinaryTagAccepted pins the one tag a spec may carry. `atago
+// record` emits !!binary whenever a captured stream is not valid UTF-8, so
+// rejecting it would make recorded specs unloadable — a round trip the record
+// package's own tests depend on.
+func TestLoadBytes_BinaryTagAccepted(t *testing.T) {
+	t.Parallel()
+	src := "version: \"1\"\nsuite:\n  name: x\nscenarios:\n  - name: a\n    steps:\n" +
+		"      - run: {command: echo}\n      - assert:\n          stdout:\n            equals: !!binary \"//4K\"\n"
+	if _, err := LoadBytes("t.atago.yaml", []byte(src)); err != nil {
+		t.Errorf("LoadBytes(!!binary scalar) error = %v, want a clean load", err)
+	}
+	// A tag nested under a !!binary node must still be caught: skipping the
+	// binary tag must not skip the rest of the subtree.
+	nested := "version: \"1\"\nsuite:\n  name: x\nscenarios: !!binary !foo 0\n"
+	if _, err := LoadBytes("t.atago.yaml", []byte(nested)); err == nil {
+		t.Errorf("LoadBytes(tag nested under !!binary) = nil error, want the inner tag rejected")
+	}
+}
+
 // specSteps assembles a minimal one-scenario spec whose steps are the given
 // flow-style step entries (each is the text after "- " in a steps list). It
 // keeps the many one-off validation cases readable without hand-indenting YAML.


### PR DESCRIPTION
## Summary

`internal/loader` is the only package in this repository whose Windows CI job keeps dying with Go GC heap-corruption fatal errors, and it is also the only package that raises real runtime nil-pointer panics on every test run. This makes the loader turn away explicit YAML tags before they reach the decoder, which removes the panics and replaces an opaque error with one that names the offending tag.

## Changes

- `internal/loader/loader.go`: add `explicitTagError` plus the `tagFinder` AST visitor, and call it from `LoadBytes` before decoding. `!!binary` is allowed through; every other explicit tag is rejected as a `KindParse` error carrying the tag name and its line/column.
- `internal/loader/loader_test.go`: add `TestLoadBytes_ExplicitTagRejected` (five shapes that reach the decoder panic, including the reduced fuzz crasher `230de42ba4751bda`), `TestLoadBytes_TagRejectionLeavesOtherErrorsAlone` (untagged specs still load; a parser-level syntax error keeps its own message), and `TestLoadBytes_BinaryTagAccepted` (record's output stays loadable, and a tag nested under `!!binary` is still caught).
- `CHANGELOG.md`: record the behavior change and the fix under Unreleased.

## Design Decisions

The underlying defect is upstream in goccy/go-yaml v1.19.2: `ast.TagNode.ArrayRange` returns a nil `*ArrayNodeIter` whenever the tag's value is not a sequence, and `decodeSlice` dereferences it without a nil check (`decode.go:1593` -> `ast/ast.go:1543`). Any tagged node landing on a list field therefore nil-panics. v1.19.2 is the latest release and this PR deliberately does not patch or fork the dependency.

`decodeSpec` already recovered from that panic, so the user-visible contract was fine. The problem is that provoking a real runtime nil dereference is not free: on Windows the fault goes through the runtime's structured-exception path, and `internal/loader` is the one package that has repeatedly failed CI with `found pointer to free object`, `s.allocCount != s.nelems && freeIndex == s.nelems`, and `unexpected signal during runtime execution` — all GC-sweep heap-consistency errors, on Windows only, seen as far back as 2026-07-15. Instrumenting the recover shows the loader test suite raising 9 recovered panics per run before this change and 0 after.

Rejecting tags outright is the right contract rather than a workaround. atago's schema is closed and fully typed, and `yaml.Strict()` already rejects unknown fields, so a tag can only restate or contradict the schema; no spec, example, or generated doc in this repository authors one. A stray tag previously produced `malformed YAML: the document could not be parsed`, which names neither the problem nor its location.

`!!binary` is the single exception because `atago record` emits it for captures that are not valid UTF-8, and the record round-trip tests depend on recorded specs staying loadable. The visitor skips over a `!!binary` node rather than accepting its whole subtree, so a tag nested underneath is still caught.

The AST walk covers only the first document, matching what `Decode` reads, and a parse failure yields `""` so the decoder still produces its own better-positioned syntax error.

## Limitations

`!!binary` over a list field (`scenarios: !!binary aGk=`) still reaches the decoder panic. Closing that would need either schema-aware knowledge of which YAML paths are lists or a change to record's output format; `decodeSpec`'s recover remains the backstop for that residue. This is a contrived shape rather than one the test suite exercises, so it no longer contributes panics to normal runs.

Whether removing these panics actually stops the Windows heap corruption cannot be proven from here — the correlation is strong (same package, Windows only, three GC-sweep signatures) but the fatal errors are flaky. The change stands on its own as a contract sharpening and a better error message regardless.