### PR TITLE
fix(engine): fail a step killed by its timeout when nothing asserts on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,20 @@ and this project follows [Semantic Versioning](https://semver.org/).
   `!!binary` stays accepted because `atago record` emits it for captures that
   are not valid UTF-8.
 
+- A command killed by its timeout now fails the step when no assert inspects the
+  result. Asserting on a killed command still works and still reports the
+  timeout as an observable outcome, and `timeout: "0"` still opts a step out of
+  every timeout level.
+
 ### Fixed
+
+- A hanging command no longer passes. A step killed by `run.timeout`,
+  `runner.timeout`, `defaults.run.timeout`, `suite.timeout`, or the built-in 60s
+  default reported passed whenever the spec did not assert on the result, so the
+  bare `run:` step a first-time user writes went green after the timeout fired.
+  That is the outcome the timeout defaults exist to prevent, only slower. The
+  same false green applied to a `pty` step whose session never waited on the
+  program.
 
 - Loading a spec no longer provokes a runtime nil-pointer panic on the way to a
   parse error. A tagged node on a list field made goccy/go-yaml v1.19.2 nil-deref

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 390 scenarios
+74 suites · 391 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -434,11 +434,12 @@
   - [a failing setup errors every scenario and none runs (exit 4)](#scenario-a-failing-setup-errors-every-scenario-and-none-runs-exit-4)
   - [a suite service starts once and its store reaches every scenario](#scenario-a-suite-service-starts-once-and-its-store-reaches-every-scenario)
   - [a failing suite teardown is loud but does not flip the verdict](#scenario-a-failing-suite-teardown-is-loud-but-does-not-flip-the-verdict)
-- [atago self-hosting / step timeouts (suite default + escape hatch)](#atago-self-hosting--step-timeouts-suite-default--escape-hatch) — 7 scenarios
+- [atago self-hosting / step timeouts (suite default + escape hatch)](#atago-self-hosting--step-timeouts-suite-default--escape-hatch) — 8 scenarios
   - [suite.timeout kills a hanging step and the hint names it](#scenario-suitetimeout-kills-a-hanging-step-and-the-hint-names-it)
   - [a step timeout beats the suite timeout and the hint says run.timeout](#scenario-a-step-timeout-beats-the-suite-timeout-and-the-hint-says-runtimeout)
   - [timeout zero disables a short suite bound](#scenario-timeout-zero-disables-a-short-suite-bound)
   - [a killed step fails even when nothing asserts on it](#scenario-a-killed-step-fails-even-when-nothing-asserts-on-it)
+  - [an assert that ignores the result does not mask the kill](#scenario-an-assert-that-ignores-the-result-does-not-mask-the-kill)
   - [an assert on the killed result keeps the timeout observable](#scenario-an-assert-on-the-killed-result-keeps-the-timeout-observable)
   - [timeout zero keeps an unasserted step green](#scenario-timeout-zero-keeps-an-unasserted-step-green)
   - [an invalid suite.timeout is a load-time error](#scenario-an-invalid-suitetimeout-is-a-load-time-error)
@@ -7537,6 +7538,39 @@ ${atago} run unobserved.atago.yaml
 #### Then
 - exit code is `1`
 - stdout contains `run completes before its timeout`, `was killed`, `suite.timeout`
+### Scenario: an assert that ignores the result does not mask the kill
+_skipped on Windows_
+#### Given
+- Fixture file `file_assert.atago.yaml` is created.
+#### Inputs
+_Fixture `file_assert.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: file-assert
+scenarios:
+  - name: the assert reads a file the step did not produce
+    steps:
+      - fixture:
+          file: made.txt
+          content: |
+            hi
+      - run:
+          shell: true
+          command: sleep 300
+          timeout: 500ms
+      - assert:
+          file:
+            path: made.txt
+            contains: hi
+```
+#### When
+```shell
+${atago} run file_assert.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `run completes before its timeout`, `run.timeout`
 ### Scenario: an assert on the killed result keeps the timeout observable
 _skipped on Windows_
 #### Given

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 387 scenarios
+74 suites · 390 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -434,10 +434,13 @@
   - [a failing setup errors every scenario and none runs (exit 4)](#scenario-a-failing-setup-errors-every-scenario-and-none-runs-exit-4)
   - [a suite service starts once and its store reaches every scenario](#scenario-a-suite-service-starts-once-and-its-store-reaches-every-scenario)
   - [a failing suite teardown is loud but does not flip the verdict](#scenario-a-failing-suite-teardown-is-loud-but-does-not-flip-the-verdict)
-- [atago self-hosting / step timeouts (suite default + escape hatch)](#atago-self-hosting--step-timeouts-suite-default--escape-hatch) — 4 scenarios
+- [atago self-hosting / step timeouts (suite default + escape hatch)](#atago-self-hosting--step-timeouts-suite-default--escape-hatch) — 7 scenarios
   - [suite.timeout kills a hanging step and the hint names it](#scenario-suitetimeout-kills-a-hanging-step-and-the-hint-names-it)
   - [a step timeout beats the suite timeout and the hint says run.timeout](#scenario-a-step-timeout-beats-the-suite-timeout-and-the-hint-says-runtimeout)
   - [timeout zero disables a short suite bound](#scenario-timeout-zero-disables-a-short-suite-bound)
+  - [a killed step fails even when nothing asserts on it](#scenario-a-killed-step-fails-even-when-nothing-asserts-on-it)
+  - [an assert on the killed result keeps the timeout observable](#scenario-an-assert-on-the-killed-result-keeps-the-timeout-observable)
+  - [timeout zero keeps an unasserted step green](#scenario-timeout-zero-keeps-an-unasserted-step-green)
   - [an invalid suite.timeout is a load-time error](#scenario-an-invalid-suitetimeout-is-a-load-time-error)
 - [atago self-hosting / tui](#atago-self-hosting--tui) — 4 scenarios
   - [a pty step exports a usable TERM by default](#scenario-a-pty-step-exports-a-usable-term-by-default)
@@ -7506,6 +7509,83 @@ scenarios:
 #### When
 ```shell
 ${atago} run optout.atago.yaml
+```
+#### Then
+- exit code is `0`
+### Scenario: a killed step fails even when nothing asserts on it
+_skipped on Windows_
+#### Given
+- Fixture file `unobserved.atago.yaml` is created.
+#### Inputs
+_Fixture `unobserved.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: unobserved
+  timeout: 1s
+scenarios:
+  - name: nothing looks at the killed command
+    steps:
+      - run:
+          shell: true
+          command: sleep 300
+```
+#### When
+```shell
+${atago} run unobserved.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `run completes before its timeout`, `was killed`, `suite.timeout`
+### Scenario: an assert on the killed result keeps the timeout observable
+_skipped on Windows_
+#### Given
+- Fixture file `observed.atago.yaml` is created.
+#### Inputs
+_Fixture `observed.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: observed
+scenarios:
+  - name: the assert inspects the timeout instead of ignoring it
+    steps:
+      - run:
+          shell: true
+          command: sleep 300
+          timeout: 500ms
+      - assert:
+          exit_code:
+            not: 0
+```
+#### When
+```shell
+${atago} run observed.atago.yaml
+```
+#### Then
+- exit code is `0`
+### Scenario: timeout zero keeps an unasserted step green
+_skipped on Windows_
+#### Given
+- Fixture file `optout_bare.atago.yaml` is created.
+#### Inputs
+_Fixture `optout_bare.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: optout-bare
+  timeout: 500ms
+scenarios:
+  - name: the opted-out step is never killed so nothing fails it
+    steps:
+      - run:
+          shell: true
+          command: sleep 1
+          timeout: "0"
+```
+#### When
+```shell
+${atago} run optout_bare.atago.yaml
 ```
 #### Then
 - exit code is `0`

--- a/examples/timeouts.atago.yaml
+++ b/examples/timeouts.atago.yaml
@@ -12,6 +12,10 @@ version: "1"
 # timeout fails with "the command timed out after ... and was killed" and the
 # hint names WHICH level supplied the timeout (run.timeout / runner.timeout /
 # defaults.run.timeout / suite.timeout / built-in 60s default timeout).
+#
+# The kill fails the step on its own, so a bare `run:` with nothing asserting on
+# it still goes red. Add an assert on the result (`exit_code: {not: 0}`) when a
+# timeout is the outcome you are testing for, and the step stays green.
 # Runs green as-is on every OS: atago run examples/timeouts.atago.yaml
 
 suite:

--- a/internal/engine/stepexec.go
+++ b/internal/engine/stepexec.go
@@ -15,6 +15,25 @@ import (
 	"github.com/nao1215/atago/internal/store"
 )
 
+// assertReadsResult reports whether an assert inspects the runner result of the
+// step it follows, rather than something that step left behind. file, dir,
+// image, pdf, and mock targets read the filesystem or a mock server's log, so
+// they say nothing about whether the command itself finished.
+//
+// A target not listed here counts as not reading the result, which is the loud
+// direction: a new target added without updating this function leaves a timeout
+// kill failing rather than silently green.
+func assertReadsResult(a *spec.Assert) bool {
+	if a == nil {
+		return false
+	}
+	return a.ExitCode != nil || a.Stdout != nil || a.Stderr != nil ||
+		a.Status != nil || a.Header != nil || a.Body != nil ||
+		a.Rows != nil || a.GRPCStatus != nil || a.Message != nil ||
+		a.Value != nil || a.Screen != nil ||
+		a.Duration != nil || a.Changes != nil
+}
+
 // resultObserved reports whether an assert step inspects the result produced by
 // the step at index i. Only the assert steps before the next result-producing
 // step count: once another run/http/query/grpc/pty/cdp step lands, it replaces
@@ -23,7 +42,9 @@ func resultObserved(steps []spec.Step, i int) bool {
 	for k := i + 1; k < len(steps); k++ {
 		switch steps[k].Kind() {
 		case spec.StepAssert:
-			return true
+			if assertReadsResult(steps[k].Assert) {
+				return true
+			}
 		case spec.StepRun, spec.StepHTTP, spec.StepQuery, spec.StepGRPC, spec.StepPTY, spec.StepCDP:
 			return false
 		}

--- a/internal/engine/stepexec.go
+++ b/internal/engine/stepexec.go
@@ -15,6 +15,58 @@ import (
 	"github.com/nao1215/atago/internal/store"
 )
 
+// resultObserved reports whether an assert step inspects the result produced by
+// the step at index i. Only the assert steps before the next result-producing
+// step count: once another run/http/query/grpc/pty/cdp step lands, it replaces
+// the current result, so a later assert is looking at that one instead.
+func resultObserved(steps []spec.Step, i int) bool {
+	for k := i + 1; k < len(steps); k++ {
+		switch steps[k].Kind() {
+		case spec.StepAssert:
+			return true
+		case spec.StepRun, spec.StepHTTP, spec.StepQuery, spec.StepGRPC, spec.StepPTY, spec.StepCDP:
+			return false
+		}
+	}
+	return false
+}
+
+// timeoutKillCheck turns an unobserved timeout kill into a failing check, or
+// returns nil when the command exited on its own or an assert inspects it.
+//
+// A timeout is a guard, not an outcome to observe: issue #17 added the
+// suite/built-in defaults so "an unconfigured hanging command can no longer
+// stall a run", and a killed command that still reports passed delivers the
+// same green verdict as before, only later. Asserting on the killed result
+// catches it — that is the documented way to treat a timeout as an observable
+// outcome, and it keeps working. But it requires the author to have anticipated
+// the hang, and the bare `run:` step a first-time user writes had nothing to
+// notice it.
+//
+// The escape hatch is unchanged: `timeout: "0"` at any level opts the step out,
+// and a step that is never killed never reaches this check. Target is
+// exit_code so the console failure block appends the captured output the
+// command produced before it was killed, which is usually where the hang shows.
+func timeoutKillCheck(res *runner.Result, steps []spec.Step, i int) *assert.CheckResult {
+	if res == nil || !res.TimedOut || resultObserved(steps, i) {
+		return nil
+	}
+	source := res.TimeoutSource
+	if source == "" {
+		source = "run.timeout"
+	}
+	elapsed := res.Duration.Round(time.Millisecond)
+	return &assert.CheckResult{
+		Target:   string(spec.AssertExitCode),
+		Desc:     "run completes before its timeout",
+		Expected: "the command to exit on its own",
+		Actual:   fmt.Sprintf("the command timed out after %s and was killed", elapsed),
+		Hint: fmt.Sprintf(
+			"the command hit its %s after %s and was killed before exiting; raise the timeout if the command is merely slow, or set timeout: \"0\" to let it run unbounded",
+			source, elapsed),
+	}
+}
+
 // unresolvedRunRefMsg explains a run field that references a ${name} no variable
 // defines. field names the spec field ("run.command"/"run.cwd"). shellExpandable
 // says whether enabling shell could expand it: true for the command argv, false
@@ -101,7 +153,7 @@ func runRefGuard(st *store.Store, run *spec.Run, runners map[string]spec.Runner)
 // baseline before every attempt, so the recorded delta reflects only the final
 // (converged) attempt rather than the cumulative delta of all attempts (#251).
 // It is nil for the teardown path and for every non-run step kind.
-func (x *scenarioRun) execStep(ctx context.Context, i int, step *spec.Step, beforeAttempt func()) (StepResult, Status, bool) {
+func (x *scenarioRun) execStep(ctx context.Context, steps []spec.Step, i int, step *spec.Step, beforeAttempt func()) (StepResult, Status, bool) {
 	sr := StepResult{Index: i, Kind: step.Kind()}
 	status := StatusPassed
 	secViolation := false
@@ -135,6 +187,11 @@ func (x *scenarioRun) execStep(ctx context.Context, i int, step *spec.Step, befo
 			if !assert.AllOK(untilChecks) {
 				status = StatusFailed
 			}
+		}
+		if ck := timeoutKillCheck(r, steps, i); ck != nil {
+			x.e.recordChecks(x.masker, []*assert.CheckResult{ck}, x.rc.specPath, x.sc.Name, x.idx, i)
+			sr.Checks = append(sr.Checks, ck)
+			status = StatusFailed
 		}
 	case spec.StepAssert:
 		crs := assert.CheckAll(expandAssert(x.st, step.Assert), x.current, assert.Env{
@@ -206,6 +263,12 @@ func (x *scenarioRun) execStep(ctx context.Context, i int, step *spec.Step, befo
 			x.e.recordChecks(x.masker, []*assert.CheckResult{ck}, x.rc.specPath, x.sc.Name, x.idx, i)
 			sr.Checks = []*assert.CheckResult{ck}
 			status = StatusFailed
+		} else if ck := timeoutKillCheck(r, steps, i); ck != nil {
+			// No expect failed, so nothing else would notice that the program
+			// never exited before the session timeout killed it.
+			x.e.recordChecks(x.masker, []*assert.CheckResult{ck}, x.rc.specPath, x.sc.Name, x.idx, i)
+			sr.Checks = []*assert.CheckResult{ck}
+			status = StatusFailed
 		}
 	case spec.StepCDP:
 		r, err := x.e.runCDP(ctx, expandCDP(x.st, step.CDP), x.workdir, x.st, x.rc, x.browserConns)
@@ -266,7 +329,7 @@ func (x *scenarioRun) runSteps(ctx context.Context, leadingFixtures int) {
 			rescan()
 		}
 
-		sr, status, secViolation := x.execStep(ctx, i, step, rescan)
+		sr, status, secViolation := x.execStep(ctx, x.sc.Steps, i, step, rescan)
 		if scanChanges && x.current != nil {
 			post, _ := fsdelta.Scan(x.workdir)
 			delta := fsdelta.Diff(preScan, post)
@@ -308,7 +371,7 @@ func (x *scenarioRun) runTeardown(ctx context.Context) {
 			defer cancel()
 		}
 		for i := range x.sc.Teardown {
-			sr, _, secViolation := x.execStep(tctx, i, &x.sc.Teardown[i], nil) // teardown never carries a changes assert
+			sr, _, secViolation := x.execStep(tctx, x.sc.Teardown, i, &x.sc.Teardown[i], nil) // teardown never carries a changes assert
 			// A teardown failure never changes the scenario verdict — the behavior
 			// under test was decided by the steps above. But a security-policy
 			// breach (e.g. a denied network host contacted during cleanup) is not a

--- a/internal/engine/timeout_test.go
+++ b/internal/engine/timeout_test.go
@@ -223,3 +223,101 @@ scenarios:
 		t.Errorf("hint = %q, want it to name run.timeout", hint)
 	}
 }
+
+// TestEngine_TimeoutKillFailsWithoutAssert pins what issue #17 set out to
+// deliver: a hanging command must fail, not stall. Every other timeout test
+// here pairs the killed step with an `assert: exit_code: 0`, so the failure
+// they observe comes from the assertion, not from the kill. A spec that just
+// runs a command — the shape a first-time user writes — used to go green after
+// the timeout fired, which is the "no failure, just a frozen run" outcome #17
+// exists to prevent, only slower.
+func TestEngine_TimeoutKillFailsWithoutAssert(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name, src, wantSource string
+	}{
+		{
+			name: "step timeout with no assert",
+			src: `
+version: "1"
+suite:
+  name: s
+scenarios:
+  - name: the killed step has nothing asserting on it
+    steps:
+      - run: {shell: true, timeout: 150ms, command: ` + sleepCmd(5) + `}
+`,
+			wantSource: "run.timeout",
+		},
+		{
+			name: "suite timeout with no assert",
+			src: `
+version: "1"
+suite:
+  name: s
+  timeout: 150ms
+scenarios:
+  - name: the killed step has nothing asserting on it
+    steps:
+      - run: {shell: true, command: ` + sleepCmd(5) + `}
+`,
+			wantSource: "suite.timeout",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			res := runSpec(t, tc.src)
+			if res.Status != StatusFailed {
+				t.Fatalf("status = %s, want failed (a killed command must not pass): %+v", res.Status, res.Scenarios)
+			}
+			if hint := timeoutHint(t, res); !strings.Contains(hint, tc.wantSource) {
+				t.Errorf("hint = %q, want it to name %s", hint, tc.wantSource)
+			}
+		})
+	}
+}
+
+// TestEngine_TimeoutZeroStillPassesWithoutAssert guards the escape hatch
+// against the fix above: opting out of the timeout means the command is never
+// killed, so a bare run step with no assert stays green.
+func TestEngine_TimeoutZeroStillPassesWithoutAssert(t *testing.T) {
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: s
+  timeout: 150ms
+scenarios:
+  - name: an opted-out step is never killed
+    steps:
+      - run: {shell: true, timeout: "0", command: `+sleepCmd(1)+`}
+`)
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed (timeout 0 must keep the step unbounded): %+v", res.Status, res.Scenarios)
+	}
+}
+
+// TestEngine_PTYTimeoutFailsWithoutExpect covers the same false green on the
+// pty side. A session whose expectations all pass (or that has none) leaves
+// nothing to notice that the program never exited before the session timeout.
+func TestEngine_PTYTimeoutFailsWithoutExpect(t *testing.T) {
+	skipOnWindows(t)
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: s
+scenarios:
+  - name: the session sends but never waits for the program to finish
+    steps:
+      - pty:
+          command: `+sleepCmd(5)+`
+          timeout: 150ms
+          session:
+            - send: "x"
+`)
+	if res.Status != StatusFailed {
+		t.Fatalf("status = %s, want failed (a killed pty program must not pass): %+v", res.Status, res.Scenarios)
+	}
+}

--- a/internal/engine/timeout_test.go
+++ b/internal/engine/timeout_test.go
@@ -278,6 +278,36 @@ scenarios:
 	}
 }
 
+// TestEngine_TimeoutKillFailsWhenAssertIgnoresTheResult pins that only an
+// assert reading the killed command's own result counts as observing it. A
+// file/dir/image/pdf/mock assert inspects something the step wrote, not whether
+// the command finished, so it must not suppress the timeout failure.
+func TestEngine_TimeoutKillFailsWhenAssertIgnoresTheResult(t *testing.T) {
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: s
+scenarios:
+  - name: the assert looks at a file, not at the killed command
+    steps:
+      - fixture:
+          file: made.txt
+          content: "hi\n"
+      - run: {shell: true, timeout: 150ms, command: `+sleepCmd(5)+`}
+      - assert:
+          file:
+            path: made.txt
+            contains: hi
+`)
+	if res.Status != StatusFailed {
+		t.Fatalf("status = %s, want failed (a file assert does not observe the kill): %+v", res.Status, res.Scenarios)
+	}
+	if hint := timeoutHint(t, res); !strings.Contains(hint, "run.timeout") {
+		t.Errorf("hint = %q, want it to name run.timeout", hint)
+	}
+}
+
 // TestEngine_TimeoutZeroStillPassesWithoutAssert guards the escape hatch
 // against the fix above: opting out of the timeout means the command is never
 // killed, so a bare run step with no assert stays green.

--- a/test/e2e/atago/timeouts.atago.yaml
+++ b/test/e2e/atago/timeouts.atago.yaml
@@ -94,6 +94,84 @@ scenarios:
       - assert:
           exit_code: 0
 
+  - name: a killed step fails even when nothing asserts on it
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: unobserved.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: unobserved
+              timeout: 1s
+            scenarios:
+              - name: nothing looks at the killed command
+                steps:
+                  - run:
+                      shell: true
+                      command: sleep 300
+      - run:
+          command: ${atago} run unobserved.atago.yaml
+          timeout: 30s
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "run completes before its timeout"
+              - "was killed"
+              - "suite.timeout"
+
+  - name: an assert on the killed result keeps the timeout observable
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: observed.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: observed
+            scenarios:
+              - name: the assert inspects the timeout instead of ignoring it
+                steps:
+                  - run:
+                      shell: true
+                      command: sleep 300
+                      timeout: 500ms
+                  - assert:
+                      exit_code:
+                        not: 0
+      - run:
+          command: ${atago} run observed.atago.yaml
+          timeout: 30s
+      - assert:
+          exit_code: 0
+
+  - name: timeout zero keeps an unasserted step green
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: optout_bare.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: optout-bare
+              timeout: 500ms
+            scenarios:
+              - name: the opted-out step is never killed so nothing fails it
+                steps:
+                  - run:
+                      shell: true
+                      command: sleep 1
+                      timeout: "0"
+      - run:
+          command: ${atago} run optout_bare.atago.yaml
+          timeout: 30s
+      - assert:
+          exit_code: 0
+
   - name: an invalid suite.timeout is a load-time error
     steps:
       - fixture:

--- a/test/e2e/atago/timeouts.atago.yaml
+++ b/test/e2e/atago/timeouts.atago.yaml
@@ -122,6 +122,41 @@ scenarios:
               - "was killed"
               - "suite.timeout"
 
+  - name: an assert that ignores the result does not mask the kill
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: file_assert.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: file-assert
+            scenarios:
+              - name: the assert reads a file the step did not produce
+                steps:
+                  - fixture:
+                      file: made.txt
+                      content: |
+                        hi
+                  - run:
+                      shell: true
+                      command: sleep 300
+                      timeout: 500ms
+                  - assert:
+                      file:
+                        path: made.txt
+                        contains: hi
+      - run:
+          command: ${atago} run file_assert.atago.yaml
+          timeout: 30s
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "run completes before its timeout"
+              - "run.timeout"
+
   - name: an assert on the killed result keeps the timeout observable
     skip:
       os: windows


### PR DESCRIPTION
## Summary

A command killed by its timeout reported passed whenever the spec did not assert on the result, so the bare `run:` step a first-time user writes went green after the timeout fired. That is the outcome the timeout defaults were added to prevent, only slower. A killed step now fails on its own when nothing observes it, while asserting on a timeout keeps working exactly as before.

## Changes

- `internal/engine/stepexec.go`: add `timeoutKillCheck`, `resultObserved`, and `assertReadsResult`, and call them from the run and pty branches of `execStep`. A timed-out result with no assert step observing it produces a failing check; `execStep` takes the enclosing step slice so the scenario and teardown loops each scope the lookahead to their own steps.
- `internal/engine/timeout_test.go`: add `TestEngine_TimeoutKillFailsWithoutAssert` (step-level and suite-level kills), `TestEngine_PTYTimeoutFailsWithoutExpect`, and `TestEngine_TimeoutZeroStillPassesWithoutAssert` guarding the escape hatch.
- `test/e2e/atago/timeouts.atago.yaml`: add three self-hosted scenarios covering the unobserved kill, the observed kill that stays green, and `timeout: "0"` on an unasserted step.
- `examples/timeouts.atago.yaml`, `doc/e2e/atago.md`, `CHANGELOG.md`: document the rule.

## Design Decisions

Every timeout test in the repository paired the killed step with `assert: exit_code: 0`, so the failure they observed came from the assertion rather than from the kill. Removing the assert made the same spec pass. `suite.timeout` and the built-in 60s default therefore bounded a hang's duration but not its verdict, which is the gap issue #17 set out to close: "an unconfigured hanging command can no longer stall a run" and "a first-time user whose command hangs gets no failure, just a frozen run until Ctrl-C". The header comment in `examples/timeouts.atago.yaml` already promised that a killed step fails; only the no-assert path did not deliver it.

The narrow rule is deliberate. `internal/runner/cmd/cmd.go` documents a timeout as "an observable outcome, not an error: mark it TimedOut and let assertions inspect it", and three tests (`TestEngine_SSHStepTimeoutHonored`, `TestEngine_SSHRunnerTimeoutIsObservable`, `TestEngine_CmdRunnerCwdAndTimeout`) pin that a killed step asserted with `exit_code: {not: 0}` passes. Failing every kill unconditionally would have broken all three and removed a documented capability. Failing only an unobserved kill composes with that design instead: assert on the result and the timeout stays an outcome you inspect, write nothing and atago refuses to call it green. All three tests pass unchanged.

`resultObserved` stops at the next result-producing step (run/http/query/grpc/pty/cdp) rather than scanning to the end of the scenario, because that step replaces `x.current` and any assert after it is inspecting that later result, not the killed one.

The check carries `Target: exit_code` so the console failure block appends the output the command produced before it was killed, which is usually where a hang shows what it was waiting on.

## Limitations

Only the step kinds that produce a `runner.Result` with `TimedOut` are covered: run (cmd and ssh) and pty. http, query, and grpc surface a timeout as a step error, which already fails the scenario, so they need no equivalent.

The rule keys on which assertion targets the following assert sets, not on whether the assert would actually have caught this particular kill. `duration` and `changes` read the killed step's own result, so they count as observing it even though neither inspects completion directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Timed-out commands and terminal sessions now correctly fail steps when their results are not inspected.
  * Timeout outcomes remain available for explicit assertions.
  * Fixed false-green results across configured and default timeout limits.
  * `timeout: "0"` continues to disable timeout enforcement.

* **Documentation**
  * Added guidance and expanded end-to-end coverage for timeout behavior, including unasserted steps and terminal sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
