### PR TITLE
docs(changelog): prepare v0.13.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,31 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-07-26
+
+A minor release focused on removing false greens. A command killed by its
+timeout no longer reports passed when nothing asserts on it, and the spec loader
+turns away explicit YAML tags instead of provoking a decoder panic on the way to
+a parse error. Three more third-party CLI suites join the real-world coverage.
+
+### Added
+
+- Third-party coverage grows by three pinned suites: gum (15 scenarios),
+  lazygit (21), and helix (21). Each downloads a fixed release verified against
+  its published SHA256, so the scheduled matrix stays reproducible.
+
 ### Changed
 
+- A command killed by its timeout now fails the step when no assert reads its
+  result. Asserting on a killed command still works and still reports the
+  timeout as an observable outcome, and `timeout: "0"` still opts a step out of
+  every timeout level.
 - The spec loader now rejects explicit YAML tags (`!foo`, `!!str`, a bare `!`)
   with an error naming the tag and its line/column, instead of letting them
   reach the decoder. atago's schema is closed and fully typed, so a tag could
   only restate or contradict it, and no spec, example, or doc authored one.
   `!!binary` stays accepted because `atago record` emits it for captures that
   are not valid UTF-8.
-
-- A command killed by its timeout now fails the step when no assert inspects the
-  result. Asserting on a killed command still works and still reports the
-  timeout as an observable outcome, and `timeout: "0"` still opts a step out of
-  every timeout level.
 
 ### Fixed
 
@@ -30,7 +42,6 @@ and this project follows [Semantic Versioning](https://semver.org/).
   That is the outcome the timeout defaults exist to prevent, only slower. The
   same false green applied to a `pty` step whose session never waited on the
   program.
-
 - Loading a spec no longer provokes a runtime nil-pointer panic on the way to a
   parse error. A tagged node on a list field made goccy/go-yaml v1.19.2 nil-deref
   inside `decodeSlice`; the loader recovered from it, but `internal/loader` was


### PR DESCRIPTION
## Summary

Cuts v0.13.0. The release is a minor bump rather than a patch because two user-visible contracts changed: a command killed by its timeout now fails when nothing asserts on it, and the spec loader rejects explicit YAML tags.

## Changes

- `CHANGELOG.md`: move the Unreleased entries into a `## [0.13.0] - 2026-07-26` section with a release summary, and add the gum, lazygit, and helix third-party suites under Added.

## Design Decisions

The three third-party suites (#288, #289, #290) merged after v0.12.0 was tagged and none of them touched the changelog, so they had no section to live in. They are recorded here rather than left out, matching how v0.12.0 recorded the yazi corpus.

Minor rather than patch: both changed contracts can turn a spec that passed on v0.12.0 red. A spec relying on a timed-out step passing without an assert now fails, which is the point of the fix, and a spec authoring an explicit YAML tag is now rejected. Under SemVer a backward-incompatible change in 0.x bumps the minor version.

The generated release notes come from Conventional Commit subjects and will file both changes under fixes, which understates them. The Changed section here is the accurate account.