### PR TITLE
feat(assert): show the actual directory listing when a dir assert fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- A failed `dir:` assertion now lists what the directory actually holds instead
+  of reporting only an abstraction (`missing`, `present`, `3 entries`,
+  `no match among 2 entries`). Every matcher in the family is covered, in both
+  direct and recursive mode, and the listing marks directories with a trailing
+  slash and shows symlink targets. It is capped at 40 entries so a large tree
+  cannot bury the rest of the report. This needs no spec change: every existing
+  `dir:` assertion produces the better failure block as-is. A count failure also
+  reads "has 1 entry" rather than "has 1 entries".
+
 ## [0.13.0] - 2026-07-26
 
 A minor release focused on removing false greens. A command killed by its

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 391 scenarios
+74 suites · 394 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -67,10 +67,13 @@
   - [an unsupported defaults field is a load-time error (exit 2)](#scenario-an-unsupported-defaults-field-is-a-load-time-error-exit-2)
   - [defaults.run.env merges per key and a step env wins the collisions](#scenario-defaultsrunenv-merges-per-key-and-a-step-env-wins-the-collisions)
   - [a step opts out of defaults.run.shell with an explicit shell false](#scenario-a-step-opts-out-of-defaultsrunshell-with-an-explicit-shell-false)
-- [atago self-hosting / dir assertion](#atago-self-hosting--dir-assertion) — 3 scenarios
+- [atago self-hosting / dir assertion](#atago-self-hosting--dir-assertion) — 6 scenarios
   - [directory/tree assertions cover a multi-file generator](#scenario-directorytree-assertions-cover-a-multi-file-generator)
   - [a missing directory can be asserted absent](#scenario-a-missing-directory-can-be-asserted-absent)
   - [a dangling symlink is a present directory entry (membership uses Lstat)](#scenario-a-dangling-symlink-is-a-present-directory-entry-membership-uses-lstat)
+  - [a failed dir assert lists what the directory actually holds](#scenario-a-failed-dir-assert-lists-what-the-directory-actually-holds)
+  - [a failed count assert lists the entries it counted](#scenario-a-failed-count-assert-lists-the-entries-it-counted)
+  - [a failed recursive assert lists the walked tree](#scenario-a-failed-recursive-assert-lists-the-walked-tree)
 - [atago self-hosting / recursive dir asserts + tree snapshots](#atago-self-hosting--recursive-dir-asserts--tree-snapshots) — 3 scenarios
   - [record, compare green, then a mutation names the changed paths](#scenario-record-compare-green-then-a-mutation-names-the-changed-paths)
   - [recursive matchers and ignore globs walk the tree](#scenario-recursive-matchers-and-ignore-globs-walk-the-tree)
@@ -1630,6 +1633,87 @@ mkdir -p linkdir && ln -s /nonexistent-target-xyz linkdir/planted
 #### Then
 - exit code is `0`
 - dir `linkdir` contains `planted`, does not contain `never-planted`
+### Scenario: a failed dir assert lists what the directory actually holds
+#### Given
+- Fixture file `listing.atago.yaml` is created.
+#### Inputs
+_Fixture `listing.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: listing
+scenarios:
+  - name: the generator produced the wrong tree
+    steps:
+      - fixture: {file: out/index.html, content: "x"}
+      - fixture: {file: out/app.js, content: "x"}
+      - run: {command: echo built}
+      - assert:
+          dir:
+            path: out
+            contains: [style.css]
+```
+#### When
+```shell
+${atago} run listing.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `app.js`, `index.html`
+### Scenario: a failed count assert lists the entries it counted
+#### Given
+- Fixture file `counted.atago.yaml` is created.
+#### Inputs
+_Fixture `counted.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: counted
+scenarios:
+  - name: the count is off
+    steps:
+      - fixture: {file: out/only.txt, content: "x"}
+      - run: {command: echo built}
+      - assert:
+          dir:
+            path: out
+            count: 4
+```
+#### When
+```shell
+${atago} run counted.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `only.txt`, `has 1 entry`
+### Scenario: a failed recursive assert lists the walked tree
+#### Given
+- Fixture file `walked.atago.yaml` is created.
+#### Inputs
+_Fixture `walked.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: walked
+scenarios:
+  - name: the nested path is missing
+    steps:
+      - fixture: {file: out/assets/app.css, content: "x"}
+      - fixture: {file: out/index.html, content: "x"}
+      - run: {command: echo built}
+      - assert:
+          dir:
+            path: out
+            recursive: true
+            contains: [assets/missing.css]
+```
+#### When
+```shell
+${atago} run walked.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `assets/app.css`, `index.html`
 ## atago self-hosting / recursive dir asserts + tree snapshots
 Source: `test/e2e/atago/dir_tree.atago.yaml`
 ### Scenario: record, compare green, then a mutation names the changed paths

--- a/doc/e2e/hugo.md
+++ b/doc/e2e/hugo.md
@@ -1,11 +1,15 @@
 # atago Behavior Specs
 ## Summary
-2 suites · 6 scenarios
+2 suites · 10 scenarios
 ## Contents
-- [hugo (scaffold + build CLI, tree-snapshot testbed)](#hugo-scaffold--build-cli-tree-snapshot-testbed) — 3 scenarios
+- [hugo (scaffold + build CLI, tree-snapshot testbed)](#hugo-scaffold--build-cli-tree-snapshot-testbed) — 7 scenarios
   - [new site scaffolds the documented directory tree](#scenario-new-site-scaffolds-the-documented-directory-tree)
   - [new content plus a minimal layout builds the public tree](#scenario-new-content-plus-a-minimal-layout-builds-the-public-tree)
   - [building outside a site directory fails with a config hint](#scenario-building-outside-a-site-directory-fails-with-a-config-hint)
+  - [scaffolding into a non-empty directory is refused until --force](#scenario-scaffolding-into-a-non-empty-directory-is-refused-until---force)
+  - [creating content that already exists is refused](#scenario-creating-content-that-already-exists-is-refused)
+  - [drafts stay out of the build until --buildDrafts asks for them](#scenario-drafts-stay-out-of-the-build-until---builddrafts-asks-for-them)
+  - [rebuilding an unchanged site is byte-for-byte idempotent](#scenario-rebuilding-an-unchanged-site-is-byte-for-byte-idempotent)
 - [hugo server (suite-wide service + http peer)](#hugo-server-suite-wide-service--http-peer) — 3 scenarios
   - [the home page lists the post](#scenario-the-home-page-lists-the-post)
   - [the post page renders its title](#scenario-the-post-page-renders-its-title)
@@ -21,7 +25,7 @@ hugo new site mysite
 #### Then
 - exit code is `0`
 - stdout contains `Congratulations`
-- dir `mysite` contains `archetypes`, contains `content`, contains `layouts`, contains `static`, contains `themes`
+- dir `mysite` contains `archetypes`, contains `archetypes/default.md`, contains `assets`, contains `content`, contains `data`, contains `hugo.toml`, contains `i18n`, contains `layouts`, contains `static`, contains `themes`, has 2 entries, (recursive)
 - file `mysite/hugo.toml` contains `baseURL`
 ### Scenario: new content plus a minimal layout builds the public tree
 _only when `hugo version` succeeds_
@@ -57,7 +61,7 @@ hugo --minify --buildDrafts
   - file `mysite/public/index.html` contains `HOME`
   - file `mysite/public/index.html` contains `/posts/hello/`
   - file `mysite/public/posts/hello/index.html` contains `<h1>Hello</h1>`
-  - dir `mysite/public` contains `index.html`, contains `sitemap.xml`, contains `posts/hello/index.html`
+  - dir `mysite/public` contains `index.html`, contains `sitemap.xml`, contains `posts/hello/index.html`, matches glob `*.xml`, (recursive)
 ### Scenario: building outside a site directory fails with a config hint
 _only when `hugo version` succeeds_
 #### When
@@ -67,6 +71,102 @@ hugo
 #### Then
 - exit code is not `0`
 - stderr matches `/(?i)config/`
+### Scenario: scaffolding into a non-empty directory is refused until --force
+_only when `hugo version` succeeds_
+#### Given
+- Fixture file `occupied/keep.txt` is created.
+#### Inputs
+_Fixture `occupied/keep.txt`:_
+```text
+not written by hugo
+```
+#### When
+```shell
+hugo new site occupied
+hugo new site occupied --force
+```
+#### Then
+- after `hugo new site occupied`:
+  - exit code is `1`
+  - stderr contains `already exists and is not empty`, `--force`
+  - file `occupied/keep.txt` contains `not written by hugo`
+  - dir `occupied` does not contain `hugo.toml`
+- after `hugo new site occupied --force`:
+  - exit code is `0`
+  - stdout contains `Congratulations`
+  - dir `occupied` contains `hugo.toml`, contains `keep.txt`
+### Scenario: creating content that already exists is refused
+_only when `hugo version` succeeds_
+#### When
+```shell
+hugo new site mysite --quiet
+hugo new content posts/dup.md
+hugo new content posts/dup.md
+```
+#### Then
+- after `hugo new content posts/dup.md`:
+  - exit code is `0`
+- after `hugo new content posts/dup.md`:
+  - exit code is `1`
+  - stderr contains `conflicts with existing content`
+### Scenario: drafts stay out of the build until --buildDrafts asks for them
+_only when `hugo version` succeeds_
+#### Given
+- Fixture file `mysite/layouts/home.html` is created.
+- Fixture file `mysite/layouts/single.html` is created.
+- Fixture file `mysite/layouts/list.html` is created.
+#### Inputs
+_Fixture `mysite/layouts/home.html`:_
+```text
+<!DOCTYPE html><html><body><h1>HOME</h1></body></html>
+```
+_Fixture `mysite/layouts/single.html`:_
+```text
+<html><body><h1>{{ .Title }}</h1></body></html>
+```
+_Fixture `mysite/layouts/list.html`:_
+```text
+<html><body>list</body></html>
+```
+#### When
+```shell
+hugo new site mysite --quiet
+hugo new content posts/draft-post.md
+hugo --quiet
+hugo --quiet --buildDrafts
+```
+#### Then
+- after `hugo new content posts/draft-post.md`:
+  - exit code is `0`
+  - file `mysite/content/posts/draft-post.md` contains `draft = true`
+- after `hugo --quiet`:
+  - exit code is `0`
+  - dir `mysite/public/posts` does not contain `draft-post`
+- after `hugo --quiet --buildDrafts`:
+  - exit code is `0`
+  - dir `mysite/public/posts` contains `draft-post`
+  - file `mysite/public/posts/draft-post/index.html` contains `Draft Post`
+### Scenario: rebuilding an unchanged site is byte-for-byte idempotent
+_only when `hugo version` succeeds_
+#### Given
+- Fixture file `mysite/layouts/home.html` is created.
+#### Inputs
+_Fixture `mysite/layouts/home.html`:_
+```text
+<!DOCTYPE html><html><body><h1>HOME</h1></body></html>
+```
+#### When
+```shell
+hugo new site mysite --quiet
+hugo --quiet
+cd mysite && hugo --quiet
+```
+#### Then
+- after `hugo --quiet`:
+  - exit code is `0`
+- after `cd mysite && hugo --quiet`:
+  - exit code is `0`
+  - the step changed exactly created nothing, modified nothing, deleted nothing
 ## hugo server (suite-wide service + http peer)
 Source: `test/e2e/thirdparty/hugo/hugo_server.atago.yaml`
 ### Scenario: the home page lists the post

--- a/internal/assert/dir.go
+++ b/internal/assert/dir.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/nao1215/atago/internal/security"
 	"github.com/nao1215/atago/internal/spec"
@@ -97,7 +98,7 @@ func checkDirChildren(d *spec.DirAssert, dirPath string) *CheckResult {
 			return &CheckResult{
 				Desc:     fmt.Sprintf("assert dir %q contains %q", d.Path, child),
 				Expected: fmt.Sprintf("child %q present", child),
-				Actual:   "missing",
+				Actual:   dirListing(dirPath),
 				Hint:     fmt.Sprintf("expected %q to exist under %q", child, d.Path),
 			}
 		}
@@ -113,7 +114,7 @@ func checkDirChildren(d *spec.DirAssert, dirPath string) *CheckResult {
 			return &CheckResult{
 				Desc:     fmt.Sprintf("assert dir %q does not contain %q", d.Path, child),
 				Expected: fmt.Sprintf("child %q absent", child),
-				Actual:   "present",
+				Actual:   dirListing(dirPath),
 				Hint:     fmt.Sprintf("expected %q not to exist under %q", child, d.Path),
 			}
 		}
@@ -131,24 +132,33 @@ func checkDirCounts(d *spec.DirAssert, dirPath string) *CheckResult {
 	}
 	n := len(entries)
 	if d.Count != nil && n != *d.Count {
-		return dirCountFailure(d, n, fmt.Sprintf("exactly %d entries", *d.Count))
+		return dirCountFailure(d, n, fmt.Sprintf("exactly %d entries", *d.Count), dirListing(dirPath))
 	}
 	if d.MinCount != nil && n < *d.MinCount {
-		return dirCountFailure(d, n, fmt.Sprintf("at least %d entries", *d.MinCount))
+		return dirCountFailure(d, n, fmt.Sprintf("at least %d entries", *d.MinCount), dirListing(dirPath))
 	}
 	if d.MaxCount != nil && n > *d.MaxCount {
-		return dirCountFailure(d, n, fmt.Sprintf("at most %d entries", *d.MaxCount))
+		return dirCountFailure(d, n, fmt.Sprintf("at most %d entries", *d.MaxCount), dirListing(dirPath))
 	}
 	return nil
 }
 
-func dirCountFailure(d *spec.DirAssert, got int, want string) *CheckResult {
+func dirCountFailure(d *spec.DirAssert, got int, want, listing string) *CheckResult {
 	return &CheckResult{
 		Desc:     fmt.Sprintf("assert dir %q entry count", d.Path),
 		Expected: want,
-		Actual:   fmt.Sprintf("%d entries", got),
-		Hint:     fmt.Sprintf("directory %q has %d entries, expected %s", d.Path, got, want),
+		Actual:   listing,
+		Hint:     fmt.Sprintf("directory %q has %s, expected %s", d.Path, pluralEntries(got), want),
 	}
+}
+
+// pluralEntries renders an entry count with the right noun, so a failure reads
+// "has 1 entry" instead of "has 1 entries".
+func pluralEntries(n int) string {
+	if n == 1 {
+		return "1 entry"
+	}
+	return fmt.Sprintf("%d entries", n)
 }
 
 func checkDirGlob(d *spec.DirAssert, dirPath string) *CheckResult {
@@ -176,9 +186,55 @@ func checkDirGlob(d *spec.DirAssert, dirPath string) *CheckResult {
 	return &CheckResult{
 		Desc:     fmt.Sprintf("assert dir %q glob %q", d.Path, d.Glob),
 		Expected: fmt.Sprintf("at least one entry matching %q", d.Glob),
-		Actual:   fmt.Sprintf("no match among %d entries", len(names)),
+		Actual:   dirListing(dirPath),
 		Hint:     fmt.Sprintf("no direct entry of %q matched glob %q", d.Path, d.Glob),
 	}
+}
+
+// dirListingLimit caps how many entries a failure block lists. A generator that
+// produced thousands of files would otherwise bury the rest of the report.
+const dirListingLimit = 40
+
+// dirListing renders a directory's direct entries for a failure block: one
+// sorted name per line, directories marked with a trailing slash. A directory
+// assertion that failed is asking "what did the step actually produce?", and
+// answering with a count alone ("3 entries") makes the reader re-run the
+// generator by hand. This mirrors what a file assertion does by showing the
+// file's content.
+//
+// A read error becomes the listing text rather than an error return: the caller
+// is already reporting a failure and the read problem is the useful detail.
+func dirListing(dirPath string) string {
+	entries, err := os.ReadDir(dirPath)
+	if err != nil {
+		return fmt.Sprintf("(could not read directory: %v)", err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() {
+			name += "/"
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return renderListing(names, "entries")
+}
+
+// renderListing joins names one per line, capping the list at dirListingLimit
+// and reporting how many were elided. noun labels what is being listed so the
+// direct and recursive callers can say "entries" or "paths".
+func renderListing(names []string, noun string) string {
+	if len(names) == 0 {
+		return fmt.Sprintf("(no %s)", noun)
+	}
+	shown := names
+	suffix := ""
+	if len(names) > dirListingLimit {
+		shown = names[:dirListingLimit]
+		suffix = fmt.Sprintf("\n... (%d more)", len(names)-dirListingLimit)
+	}
+	return strings.Join(shown, "\n") + suffix
 }
 
 func dirStatActual(info os.FileInfo, err error) string {

--- a/internal/assert/dir_test.go
+++ b/internal/assert/dir_test.go
@@ -1,8 +1,10 @@
 package assert
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/nao1215/atago/internal/spec"
@@ -130,5 +132,88 @@ func TestCheckDir_NotADirectory(t *testing.T) {
 	}
 	if cr := checkDirOK(t, wd, &spec.DirAssert{Path: "afile", Count: ptrInt(0)}); cr.OK {
 		t.Error("a regular file is not a directory; count constraint should fail")
+	}
+}
+
+// TestCheckDir_FailureShowsListing pins the diagnostic contract for directory
+// assertions: a failure must show what the directory actually holds, the way a
+// file assertion shows the file's content and a changes assertion shows the
+// observed delta. Reporting only "missing" or "3 entries" forces the reader to
+// re-run the generator by hand to learn what it produced.
+func TestCheckDir_FailureShowsListing(t *testing.T) {
+	wd := makeTree(t)
+	cases := []struct {
+		name string
+		dir  *spec.DirAssert
+		want []string
+	}{
+		{
+			name: "contains names the entries that are there",
+			dir:  &spec.DirAssert{Path: "site", Contains: []string{"style.css"}},
+			want: []string{"about.html", "assets/", "index.html"},
+		},
+		{
+			name: "not_contains shows the listing too",
+			dir:  &spec.DirAssert{Path: "site", NotContains: []string{"index.html"}},
+			want: []string{"about.html", "assets/", "index.html"},
+		},
+		{
+			name: "count shows which entries were counted",
+			dir:  &spec.DirAssert{Path: "site", Count: ptrInt(9)},
+			want: []string{"about.html", "assets/", "index.html"},
+		},
+		{
+			name: "glob shows the entries it tried to match",
+			dir:  &spec.DirAssert{Path: "site", Glob: "*.js"},
+			want: []string{"about.html", "assets/", "index.html"},
+		},
+		{
+			name: "recursive contains shows the walked tree",
+			dir:  &spec.DirAssert{Path: "site", Recursive: true, Contains: []string{"nope.txt"}},
+			want: []string{"assets/app.css", "index.html"},
+		},
+		{
+			name: "recursive glob shows the walked tree",
+			dir:  &spec.DirAssert{Path: "site", Recursive: true, Glob: "*.js"},
+			want: []string{"assets/app.css", "index.html"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cr := checkDirOK(t, wd, tc.dir)
+			if cr.OK {
+				t.Fatalf("assertion should have failed: %+v", cr)
+			}
+			for _, want := range tc.want {
+				if !strings.Contains(cr.Actual, want) {
+					t.Errorf("Actual = %q, want it to list %q", cr.Actual, want)
+				}
+			}
+		})
+	}
+}
+
+// TestCheckDir_ListingIsBounded keeps a huge directory from flooding the
+// failure block: the listing is capped and says how many entries it elided.
+func TestCheckDir_ListingIsBounded(t *testing.T) {
+	wd := t.TempDir()
+	big := filepath.Join(wd, "big")
+	if err := os.MkdirAll(big, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	for i := range 200 {
+		if err := os.WriteFile(filepath.Join(big, fmt.Sprintf("f%03d.txt", i)), []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cr := checkDirOK(t, wd, &spec.DirAssert{Path: "big", Contains: []string{"nope"}})
+	if cr.OK {
+		t.Fatal("assertion should have failed")
+	}
+	if n := strings.Count(cr.Actual, "\n"); n > dirListingLimit+3 {
+		t.Errorf("Actual has %d lines, want the listing capped near %d", n, dirListingLimit)
+	}
+	if !strings.Contains(cr.Actual, "more") {
+		t.Errorf("Actual = %q, want it to say how many entries were elided", cr.Actual)
 	}
 }

--- a/internal/assert/tree.go
+++ b/internal/assert/tree.go
@@ -144,6 +144,25 @@ func ignoredPath(rel string, ignore []string) bool {
 // checkDirRecursive evaluates the recursive matcher family over the walked
 // tree (#25): contains/not_contains against relative paths, counts over files
 // only, glob against each relative path (or basename for /-less patterns).
+// treeListing renders a walked tree for a failure block: one sorted
+// /-separated path per line, directories marked with a trailing slash and
+// symlinks shown with their target, capped like dirListing.
+func treeListing(entries []treeEntry) string {
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		switch e.kind {
+		case "dir":
+			names = append(names, e.rel+"/")
+		case "link":
+			names = append(names, e.rel+" -> "+e.target)
+		default:
+			names = append(names, e.rel)
+		}
+	}
+	sort.Strings(names)
+	return renderListing(names, "paths")
+}
+
 func checkDirRecursive(d *spec.DirAssert, dirPath string) *CheckResult {
 	entries, err := walkTree(dirPath, d.Ignore)
 	if err != nil {
@@ -157,13 +176,16 @@ func checkDirRecursive(d *spec.DirAssert, dirPath string) *CheckResult {
 			files++
 		}
 	}
+	// Rendered once and reused: every failure below answers the same question,
+	// "what does the tree actually hold?".
+	listing := treeListing(entries)
 
 	for _, child := range d.Contains {
 		if !present[path.Clean(filepath.ToSlash(child))] {
 			return &CheckResult{
 				Desc:     fmt.Sprintf("assert dir %q contains %q", d.Path, child),
 				Expected: fmt.Sprintf("path %q present in the tree", child),
-				Actual:   "missing",
+				Actual:   listing,
 				Hint:     fmt.Sprintf("expected %q to exist under %q (recursive)", child, d.Path),
 			}
 		}
@@ -173,20 +195,20 @@ func checkDirRecursive(d *spec.DirAssert, dirPath string) *CheckResult {
 			return &CheckResult{
 				Desc:     fmt.Sprintf("assert dir %q does not contain %q", d.Path, child),
 				Expected: fmt.Sprintf("path %q absent from the tree", child),
-				Actual:   "present",
+				Actual:   listing,
 				Hint:     fmt.Sprintf("expected %q not to exist under %q (recursive)", child, d.Path),
 			}
 		}
 	}
 
 	if d.Count != nil && files != *d.Count {
-		return dirCountFailure(d, files, fmt.Sprintf("exactly %d files in the tree", *d.Count))
+		return dirCountFailure(d, files, fmt.Sprintf("exactly %d files in the tree", *d.Count), listing)
 	}
 	if d.MinCount != nil && files < *d.MinCount {
-		return dirCountFailure(d, files, fmt.Sprintf("at least %d files in the tree", *d.MinCount))
+		return dirCountFailure(d, files, fmt.Sprintf("at least %d files in the tree", *d.MinCount), listing)
 	}
 	if d.MaxCount != nil && files > *d.MaxCount {
-		return dirCountFailure(d, files, fmt.Sprintf("at most %d files in the tree", *d.MaxCount))
+		return dirCountFailure(d, files, fmt.Sprintf("at most %d files in the tree", *d.MaxCount), listing)
 	}
 
 	if d.Glob != "" {
@@ -207,7 +229,7 @@ func checkDirRecursive(d *spec.DirAssert, dirPath string) *CheckResult {
 			return &CheckResult{
 				Desc:     fmt.Sprintf("assert dir %q glob %q", d.Path, d.Glob),
 				Expected: fmt.Sprintf("at least one tree entry matching %q", d.Glob),
-				Actual:   fmt.Sprintf("no match among %d entries", len(entries)),
+				Actual:   listing,
 				Hint:     fmt.Sprintf("no entry under %q matched glob %q (recursive)", d.Path, d.Glob),
 			}
 		}

--- a/test/e2e/atago/dir.atago.yaml
+++ b/test/e2e/atago/dir.atago.yaml
@@ -50,3 +50,87 @@ scenarios:
             path: linkdir
             contains: [planted]
             not_contains: [never-planted]
+
+  - name: a failed dir assert lists what the directory actually holds
+    steps:
+      - fixture:
+          file: listing.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: listing
+            scenarios:
+              - name: the generator produced the wrong tree
+                steps:
+                  - fixture: {file: out/index.html, content: "x"}
+                  - fixture: {file: out/app.js, content: "x"}
+                  - run: {command: echo built}
+                  - assert:
+                      dir:
+                        path: out
+                        contains: [style.css]
+      - run:
+          command: ${atago} run listing.atago.yaml
+      # The failure must name the files that ARE there, so the reader does not
+      # have to re-run the generator by hand to find out.
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "app.js"
+              - "index.html"
+
+  - name: a failed count assert lists the entries it counted
+    steps:
+      - fixture:
+          file: counted.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: counted
+            scenarios:
+              - name: the count is off
+                steps:
+                  - fixture: {file: out/only.txt, content: "x"}
+                  - run: {command: echo built}
+                  - assert:
+                      dir:
+                        path: out
+                        count: 4
+      - run:
+          command: ${atago} run counted.atago.yaml
+      # Singular noun when exactly one entry was found, and the entry is named.
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "only.txt"
+              - "has 1 entry"
+
+  - name: a failed recursive assert lists the walked tree
+    steps:
+      - fixture:
+          file: walked.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: walked
+            scenarios:
+              - name: the nested path is missing
+                steps:
+                  - fixture: {file: out/assets/app.css, content: "x"}
+                  - fixture: {file: out/index.html, content: "x"}
+                  - run: {command: echo built}
+                  - assert:
+                      dir:
+                        path: out
+                        recursive: true
+                        contains: [assets/missing.css]
+      - run:
+          command: ${atago} run walked.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "assets/app.css"
+              - "index.html"

--- a/test/e2e/thirdparty/hugo/hugo.atago.yaml
+++ b/test/e2e/thirdparty/hugo/hugo.atago.yaml
@@ -21,20 +21,25 @@ scenarios:
           exit_code: 0
           stdout:
             contains: Congratulations
-      # Friction inventory for #25: pinning the scaffold takes one dir assert
-      # per level plus a file assert for the config — a recursive `tree:`
-      # assertion (or a directory-tree snapshot) would collapse all of this
-      # into a single declarative block, and would also catch UNEXPECTED
-      # entries, which `contains` cannot.
+      # Recursive mode pins the whole scaffold in one block, including the
+      # nested archetype, and rejects UNEXPECTED entries via the file count —
+      # `contains` alone would pass on a scaffold that grew extra files.
       - assert:
           dir:
             path: mysite
+            recursive: true
             contains:
               - archetypes
+              - archetypes/default.md
+              - assets
               - content
+              - data
+              - hugo.toml
+              - i18n
               - layouts
               - static
               - themes
+            count: 2
       - assert:
           file:
             path: mysite/hugo.toml
@@ -82,16 +87,15 @@ scenarios:
           file:
             path: mysite/public/posts/hello/index.html
             contains: "<h1>Hello</h1>"
-      # More #25 friction: "the build produced exactly these files and nothing
-      # else" is inexpressible today — count/glob check one directory level
-      # at a time.
       - assert:
           dir:
             path: mysite/public
+            recursive: true
             contains:
               - index.html
               - sitemap.xml
               - posts/hello/index.html
+            glob: "*.xml"
 
   - name: building outside a site directory fails with a config hint
     only:
@@ -105,3 +109,137 @@ scenarios:
       - assert:
           stderr:
             matches: "(?i)config"
+
+  - name: scaffolding into a non-empty directory is refused until --force
+    only:
+      command: hugo version
+    steps:
+      - fixture:
+          file: occupied/keep.txt
+          content: |
+            not written by hugo
+      - run:
+          command: hugo new site occupied
+      # hugo names the conflict and the flag that overrides it, rather than
+      # failing bare. The pre-existing file must survive the refusal.
+      - assert:
+          exit_code: 1
+          stderr:
+            contains:
+              - "already exists and is not empty"
+              - "--force"
+      - assert:
+          file:
+            path: occupied/keep.txt
+            contains: not written by hugo
+      - assert:
+          dir:
+            path: occupied
+            not_contains: [hugo.toml]
+      - run:
+          command: hugo new site occupied --force
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: Congratulations
+      # --force scaffolds alongside the existing file instead of wiping it.
+      - assert:
+          dir:
+            path: occupied
+            contains: [hugo.toml, keep.txt]
+
+  - name: creating content that already exists is refused
+    only:
+      command: hugo version
+    steps:
+      - run:
+          command: hugo new site mysite --quiet
+      - run:
+          command: hugo new content posts/dup.md
+          cwd: mysite
+      - assert:
+          exit_code: 0
+      - run:
+          command: hugo new content posts/dup.md
+          cwd: mysite
+      - assert:
+          exit_code: 1
+          stderr:
+            contains: conflicts with existing content
+
+  - name: drafts stay out of the build until --buildDrafts asks for them
+    only:
+      command: hugo version
+    steps:
+      - run:
+          command: hugo new site mysite --quiet
+      - fixture:
+          file: mysite/layouts/home.html
+          content: '<!DOCTYPE html><html><body><h1>HOME</h1></body></html>'
+      - fixture:
+          file: mysite/layouts/single.html
+          content: '<html><body><h1>{{ .Title }}</h1></body></html>'
+      - fixture:
+          file: mysite/layouts/list.html
+          content: '<html><body>list</body></html>'
+      - run:
+          command: hugo new content posts/draft-post.md
+          cwd: mysite
+      - assert:
+          exit_code: 0
+          file:
+            path: mysite/content/posts/draft-post.md
+            contains: "draft = true"
+      - run:
+          command: hugo --quiet
+          cwd: mysite
+      # Negative space: the draft must NOT be published by a default build.
+      - assert:
+          exit_code: 0
+      - assert:
+          dir:
+            path: mysite/public/posts
+            not_contains: [draft-post]
+      - run:
+          command: hugo --quiet --buildDrafts
+          cwd: mysite
+      # Same input, one flag flipped: now the page exists and renders.
+      - assert:
+          exit_code: 0
+      - assert:
+          dir:
+            path: mysite/public/posts
+            contains: [draft-post]
+      - assert:
+          file:
+            path: mysite/public/posts/draft-post/index.html
+            contains: "Draft Post"
+
+  - name: rebuilding an unchanged site is byte-for-byte idempotent
+    only:
+      command: hugo version
+    steps:
+      - run:
+          command: hugo new site mysite --quiet
+      - fixture:
+          file: mysite/layouts/home.html
+          content: '<!DOCTYPE html><html><body><h1>HOME</h1></body></html>'
+      - run:
+          command: hugo --quiet
+          cwd: mysite
+      - assert:
+          exit_code: 0
+      # Building again over an already-built site changes nothing at all:
+      # not the sources, and not even the rendered output, which pins the
+      # generator as deterministic rather than merely non-destructive.
+      # changes is content-based and exhaustive in both directions, so any
+      # embedded timestamp or reordered map would show up here.
+      - run:
+          shell: true
+          command: cd mysite && hugo --quiet
+      - assert:
+          exit_code: 0
+          changes:
+            created: []
+            modified: []
+            deleted: []


### PR DESCRIPTION
## Summary

A failed `dir:` assertion reported an abstraction and never the directory itself, so the reader had to re-run the generator by hand to learn what it produced. The failure block now lists the actual entries, the way a `file:` failure shows the file's content and a `changes:` failure shows the observed delta. No spec changes are needed: all 26 existing `dir:` assertions in this repository produce the better output as-is.

## Changes

- `internal/assert/dir.go`: add `dirListing`, `renderListing`, and `pluralEntries`; use the listing as `Actual` for the `contains`, `not_contains`, `count`/`min_count`/`max_count`, and `glob` failures.
- `internal/assert/tree.go`: add `treeListing` and use it for the same matcher family in recursive mode, rendered once per check and reused.
- `internal/assert/dir_test.go`: add `TestCheckDir_FailureShowsListing` (six failure modes across direct and recursive) and `TestCheckDir_ListingIsBounded`.
- `test/e2e/atago/dir.atago.yaml`: add three self-hosted scenarios asserting the listing reaches the console report for a `contains` failure, a `count` failure, and a recursive failure.
- `test/e2e/thirdparty/hugo/hugo.atago.yaml`: deepen the suite from 3 to 7 scenarios (see below).
- `CHANGELOG.md`, `doc/e2e/*.md`: record the change and regenerate the behavior docs.

## Design Decisions

Before this change every failure path built `Actual` from a summary: `missing`, `present`, `3 entries`, `no match among 2 entries`. That answers "did the assertion hold" but not "what did the step actually produce", which is the question a failing directory assertion raises. `file:` and `changes:` already answer it, so this closes an inconsistency inside one assertion family rather than adding a new capability.

The listing is capped at 40 entries with a `... (N more)` suffix. A static-site build or an extracted archive can hold thousands of files, and an uncapped listing would push the rest of the report off screen — the same reason stream excerpts are truncated.

Directories carry a trailing slash and symlinks render as `path -> target`, so a failure distinguishes a file named `assets` from a directory named `assets/` without a second run. Recursive mode reuses the already-walked entries instead of re-reading the tree, since every failure in that path answers the same question.

`pluralEntries` fixes a smaller wart in the same blocks: the count hint read "has 1 entries".

## Deepened hugo coverage

The hugo spec carried friction comments written before recursive dir assertions and tree snapshots existed (#25), noting that catching unexpected entries and pinning a whole tree were inexpressible. Both are expressible now, so the comments are replaced by assertions that use them, and four contract branches are added from behavior verified against hugo v0.164.0:

- scaffolding into a non-empty directory exits 1 naming `--force`, leaves the pre-existing file intact, and writes no `hugo.toml`; `--force` then scaffolds alongside that file rather than wiping it
- `hugo new content` on an existing path exits 1 with a conflict message
- a draft page is absent from a default build and present after `--buildDrafts`, with the rendered title checked (negative space, then the same input with one flag flipped)
- rebuilding an unchanged site is byte-for-byte idempotent, which `changes:` can state exactly because it is content-based and exhaustive in both directions

## Limitations

The listing shows names, not content or sizes, so a failure caused by a file having the wrong bytes still needs a `file:` assertion to diagnose. Adding size or mode would change what the family reports rather than fix the missing-context gap this addresses.

`exists:` failures keep their `exists=false` actual: when the directory is absent there is nothing to list, and when it is present the assertion has already passed.