### PR TITLE
docs(thirdparty): describe what every third-party suite guarantees on the published pages

### DIFF
--- a/doc/e2e/actionlint.md
+++ b/doc/e2e/actionlint.md
@@ -13,6 +13,17 @@
   - [-ignore removes a matching finding](#scenario--ignore-removes-a-matching-finding)
   - [stdin mode lints piped content under the given filename](#scenario-stdin-mode-lints-piped-content-under-the-given-filename)
 ## actionlint (GitHub Actions workflow linter)
+[actionlint](https://github.com/rhysd/actionlint) statically checks GitHub
+Actions workflow YAML. It is offline and deterministic — the same workflow
+always produces the same findings — which makes its contract unusually
+precise to pin.
+
+What is guaranteed here: exit 0 and silence on a clean workflow, exit 1 with
+every problem printed as `file:line:col`, a rule tag, and a code snippet;
+distinct rule categories producing distinctly tagged errors; the JSON format
+agreeing with the human one over the same findings; and `-ignore` removing a
+matching error without hiding the rest.
+
 Source: `test/e2e/thirdparty/actionlint/actionlint.atago.yaml`
 ### Scenario: version prints a semantic version
 _only when `actionlint -version` succeeds_

--- a/doc/e2e/age.md
+++ b/doc/e2e/age.md
@@ -11,6 +11,16 @@
 - [age + changes (single-artifact generator)](#age--changes-single-artifact-generator) — 1 scenario
   - [age-keygen writes exactly the key file (HOME untouched)](#scenario-age-keygen-writes-exactly-the-key-file-home-untouched)
 ## age (modern file encryption)
+[age](https://age-encryption.org/) is a small, modern file-encryption CLI —
+a Go-native tool many people ship alongside their own commands, and the
+counterpart to the openssl suite here.
+
+What is guaranteed: an encrypt/decrypt round trip returns the original bytes
+exactly, including binary payloads; armored output stays ASCII and
+round-trips the same way; a passphrase typed at the interactive prompt works
+like a key file; and every failure — the wrong key, the wrong passphrase, a
+corrupted file — is refused loudly rather than yielding plausible garbage.
+
 Source: `test/e2e/thirdparty/age/age.atago.yaml`
 ### Scenario: keygen writes a key and reports the public half
 _only when `age --version` succeeds_
@@ -121,6 +131,16 @@ passphrase protected
 #### Generated artifacts
 - `secret.age`
 ## age + changes (single-artifact generator)
+A key generator should create the key and nothing else. This companion to
+the main age suite states that as an exact contract: `age-keygen` writes
+precisely one file, and the rest of the filesystem — including the user's
+home directory — is left untouched.
+
+The "HOME untouched" half is enforced rather than asserted in prose.
+`sandbox_home` moves HOME and the per-OS config/cache directories inside the
+scenario workdir, so a stray home write would show up in the workdir delta
+and break the exhaustive created list.
+
 Source: `test/e2e/thirdparty/age/changes.atago.yaml`
 ### Scenario: age-keygen writes exactly the key file (HOME untouched)
 _only when `age --version` succeeds_

--- a/doc/e2e/aqua.md
+++ b/doc/e2e/aqua.md
@@ -14,6 +14,18 @@
 - [aqua + install (declarative install of a real tool)](#aqua--install-declarative-install-of-a-real-tool) — 1 scenario
   - [install downloads the tool and makes it runnable](#scenario-install-downloads-the-tool-and-makes-it-runnable)
 ## aqua (declarative CLI version manager)
+[aqua](https://aquaproj.github.io/) manages CLI tools declaratively from an
+`aqua.yaml`. Actually installing a tool needs the network and the registry,
+so this suite pins the half that must work offline and identically every
+time — the half a developer hits before anything is downloaded.
+
+What is guaranteed: authoring a config and a policy leaves exactly the files
+it should; `aqua init` is idempotent, so re-running it does not corrupt an
+existing config; the offline generators (shell completion, root-dir) print
+usable output; and the exit codes keep a usage mistake (3) distinct from a
+runtime failure (1), so a script can tell "you typed it wrong" from "it
+broke".
+
 Source: `test/e2e/thirdparty/aqua/aqua.atago.yaml`
 ### Scenario: version prints without error
 _only when `aqua version` succeeds_
@@ -111,6 +123,18 @@ aqua bogus-subcommand-xyz
 - exit code is `3`
 - stderr contains `No help topic`
 ## aqua + install (declarative install of a real tool)
+The thing aqua exists to do: turn a line in a config file into a tool you
+can run. This suite exercises that end to end — declare a package, install
+it, execute it — rather than stopping at the offline surface its companion
+suite covers.
+
+It stays hermetic by moving only the registry, not the mechanism. A local
+registry describes an http package whose asset is a tiny self-authored
+"tool" served from a loopback file server, so `aqua install` performs a real
+download, lands a real binary under `AQUA_ROOT_DIR`, and `aqua exec` really
+runs it — with no dependency on the public registry or on GitHub for the
+tool itself.
+
 Source: `test/e2e/thirdparty/aqua/install.atago.yaml`
 ### Scenario: install downloads the tool and makes it runnable
 _only when `aqua version` succeeds_

--- a/doc/e2e/awscli.md
+++ b/doc/e2e/awscli.md
@@ -8,6 +8,19 @@
   - [a presigned URL is fetchable without credentials](#scenario-a-presigned-url-is-fetchable-without-credentials)
   - [head-object on a missing key fails with Not Found](#scenario-head-object-on-a-missing-key-fails-with-not-found)
 ## aws-cli against MinIO (offline cloud-CLI story)
+The real AWS CLI, tested with no AWS account, no credentials that matter,
+and no network beyond loopback. A MinIO server stands in for S3 and
+`aws --endpoint-url` is pointed at it, so the actual `aws` binary performs
+actual S3 requests against a real S3-compatible server.
+
+What is guaranteed: the bucket and object lifecycle a script depends on —
+create, upload, list, download, delete — plus the machine-readable JSON
+output those scripts parse, and the failure modes that must stay
+distinguishable (a missing bucket, a missing object, bad credentials).
+
+This is the answer to "how do I test a cloud CLI in CI?": swap the endpoint,
+keep the CLI.
+
 Source: `test/e2e/thirdparty/awscli/awscli.atago.yaml`
 ### Scenario: bucket and object lifecycle round-trips byte-identically
 _only when `aws --version` succeeds_

--- a/doc/e2e/caddy.md
+++ b/doc/e2e/caddy.md
@@ -10,6 +10,17 @@
   - [a config-driven server boots from an authored Caddyfile](#scenario-a-config-driven-server-boots-from-an-authored-caddyfile)
   - [the file server serves fixtures over real HTTP](#scenario-the-file-server-serves-fixtures-over-real-http)
 ## caddy (self-hosted web server)
+[Caddy](https://caddyserver.com/) has two faces, and both are covered here.
+
+As a CLI it is a config tool: `caddy adapt`, `fmt`, and `validate` must
+accept a well-formed Caddyfile, normalize it predictably, and reject a
+broken one with a diagnostic instead of starting anyway.
+
+As a server it must actually serve. A real `caddy run` is started as a
+background process, waited for on its port, and then queried over HTTP —
+so what is asserted is the response a browser would get, not a log line
+claiming the server came up.
+
 Source: `test/e2e/thirdparty/caddy/caddy.atago.yaml`
 ### Scenario: the standard module set is compiled in
 #### When

--- a/doc/e2e/coredns.md
+++ b/doc/e2e/coredns.md
@@ -9,6 +9,19 @@
   - [the health plugin answers over HTTP while DNS serves](#scenario-the-health-plugin-answers-over-http-while-dns-serves)
   - [a broken Corefile is rejected at startup](#scenario-a-broken-corefile-is-rejected-at-startup)
 ## coredns (self-hosted DNS server)
+[CoreDNS](https://coredns.io/) speaks DNS, a protocol atago has no runner
+for — which is exactly why this suite exists. A protocol you cannot address
+directly is still testable through the client everybody already has: the
+real server is booted from an authored Corefile and zone file, and `dig`
+asks it real questions.
+
+What is guaranteed: A and TXT records resolve to the authored values, a
+CNAME is chased to its target, a name that does not exist comes back
+NXDOMAIN rather than empty-but-successful, and a name outside the served
+zone is REFUSED instead of answered. The health plugin is checked over HTTP
+alongside, so "the process is up" and "the resolver is correct" are pinned
+separately.
+
 Source: `test/e2e/thirdparty/coredns/coredns.atago.yaml`
 ### Scenario: the binary reports its version
 #### When

--- a/doc/e2e/ecspresso.md
+++ b/doc/e2e/ecspresso.md
@@ -13,6 +13,16 @@
   - [an undefined must_env fails the render](#scenario-an-undefined-must_env-fails-the-render)
   - [a missing config file fails cleanly](#scenario-a-missing-config-file-fails-cleanly)
 ## ecspresso + deploy (real ECS deploy against a mock)
+The thing ecspresso exists to do: deploy an ECS service, and roll it when
+the definition changes. This suite runs that for real against a mock AWS
+endpoint (moto, an in-memory AWS mock), so no AWS account is involved and
+nothing is billed.
+
+The deploy is verified from the outside. Rather than trusting ecspresso's
+own log output, the resulting ECS state is read back with
+`aws ecs describe-services` — a second, independent client — so the
+assertion is about what the service actually looks like afterwards.
+
 Source: `test/e2e/thirdparty/ecspresso/deploy.atago.yaml`
 ### Scenario: deploy registers the task definition, creates the service, and rolls it
 _only when `command -v ecspresso && command -v moto_server && command -v aws` succeeds_
@@ -80,6 +90,23 @@ aws --endpoint-url http://127.0.0.1:15111 ecs list-task-definitions --query "len
   - exit code is `0`
   - stdout contains `2`
 ## ecspresso (Amazon ECS deploy tool)
+[ecspresso](https://github.com/kayac/ecspresso) deploys ECS services, which
+needs AWS — but everything that decides *what* gets deployed happens locally
+first. `ecspresso render` evaluates a task and service definition without
+touching a cluster, and that is the surface pinned here: the step where a
+mistake becomes a bad deploy.
+
+What is guaranteed: template functions expand to the documented values and
+fall back to their defaults when unset; jsonnet definitions resolve with
+external variables supplied; config paths resolve as documented; and the
+failure modes stay loud and distinct — an undefined `must_env` and a missing
+config file each fail with their own exit code rather than rendering
+something half-substituted.
+
+The rendered task definition is asserted as structured JSON, so a
+reformatting change cannot break the suite while a semantic change slips
+through.
+
 Source: `test/e2e/thirdparty/ecspresso/ecspresso.atago.yaml`
 ### Scenario: version prints without error
 _only when `ecspresso version` succeeds_

--- a/doc/e2e/ffmpeg.md
+++ b/doc/e2e/ffmpeg.md
@@ -12,6 +12,11 @@
   - [a missing input file fails with a not-found error](#scenario-a-missing-input-file-fails-with-a-not-found-error)
   - [ffprobe on non-media data reports invalid input](#scenario-ffprobe-on-non-media-data-reports-invalid-input)
 ## ffmpeg + changes (single-artifact encode)
+An encode should produce the output file and no debris. Media tools are
+notorious for temporary files, and this suite pins that ffmpeg leaves none:
+a synthesized encode creates exactly one file in the working directory, and
+the exhaustive delta names it.
+
 Source: `test/e2e/thirdparty/ffmpeg/changes.atago.yaml`
 ### Scenario: lavfi source encodes exactly one output file
 _only when `ffmpeg -version` succeeds_
@@ -23,6 +28,17 @@ ffmpeg -v error -f lavfi -i testsrc=duration=0.1:size=64x64 -y out.mp4
 - exit code is `0`
 - the step changed exactly created `out.mp4`, modified nothing, deleted nothing
 ## ffmpeg / ffprobe (media pipeline)
+A whole media pipeline in one suite: [ffmpeg](https://ffmpeg.org/)
+synthesizes a video, ffprobe describes it, and a frame is extracted back out
+of it.
+
+What is guaranteed is the thing a media tool must not get wrong — that the
+bytes it produced are really the media it claims. ffprobe's JSON is checked
+as structure (codec, duration, dimensions), and the extracted frame is
+verified as an actual image: its format, its pixel dimensions, and its
+similarity to the expected picture. A file that exists and has a plausible
+size is not enough.
+
 Source: `test/e2e/thirdparty/ffmpeg/ffmpeg.atago.yaml`
 ### Scenario: lavfi synthesizes a video file
 _only when `ffmpeg -version` succeeds_

--- a/doc/e2e/fzf.md
+++ b/doc/e2e/fzf.md
@@ -12,6 +12,17 @@
   - [aborting the finder exits 130](#scenario-aborting-the-finder-exits-130)
   - [the finder screen narrows to the typed query](#scenario-the-finder-screen-narrows-to-the-typed-query)
 ## fzf (third-party CLI, pty testbed)
+[fzf](https://github.com/junegunn/fzf) is the archetype of a CLI you cannot
+test by piping to it: it refuses to run without a terminal, redraws the
+screen as you type, and is driven entirely by keystrokes.
+
+Both halves are covered. `fzf --filter` is a plain program with a plain
+contract — given a query and a list on stdin, it prints the matches and
+exits with a code that says whether anything matched. The interactive
+scenarios run the real finder inside a pseudo-terminal and drive it the way
+a person does: type to narrow the list, move the selection, press Enter, and
+assert on what fzf finally printed.
+
 Source: `test/e2e/thirdparty/fzf/fzf.atago.yaml`
 ### Scenario: version prints a semantic version
 _only when `fzf --version` succeeds_

--- a/doc/e2e/git.md
+++ b/doc/e2e/git.md
@@ -14,6 +14,15 @@
 - [git + sandbox_home (global config in an isolated HOME)](#git--sandbox_home-global-config-in-an-isolated-home) — 1 scenario
   - [global user.name is written under the sandbox home and read back (POSIX)](#scenario-global-username-is-written-under-the-sandbox-home-and-read-back-posix)
 ## git + changes (a staged blob touches exactly index + one object)
+`git add` is documented as writing a blob and updating the index. This suite
+holds git to that literally: after initializing a repository, staging one
+file must create exactly two things on disk — the staging index, and one
+loose object under `.git/objects` — and nothing else anywhere.
+
+It is an exhaustive claim, not a spot check. Any extra file git wrote would
+fail the assertion, which is what makes it a real statement about git's
+footprint rather than a restatement of the documentation.
+
 Source: `test/e2e/thirdparty/git/changes.atago.yaml`
 ### Scenario: staging one file creates the index and a single loose object (POSIX)
 _skipped on Windows_
@@ -45,6 +54,18 @@ git init -q repo
 - exit code is `0`
 - the step changed exactly created `repo/.git/**`, modified nothing, deleted nothing
 ## git (third-party CLI, no build required)
+The proof that testing someone else's CLI takes no cooperation from it. git
+was not written with this test suite in mind, ships no hooks for it, and
+exposes nothing but a command line — and that is enough.
+
+What is guaranteed here is ordinary git as a script would meet it: a
+repository is initialized, files are staged and committed, history and
+status report the expected state, branches and tags behave, and the failure
+cases (a bad revision, a dirty tree) exit non-zero with a message.
+
+Every command uses git's own `-C`/`-c` flags instead of a shell, so this
+exact spec runs unchanged on Linux, macOS, and Windows.
+
 Source: `test/e2e/thirdparty/git/git.atago.yaml`
 ### Scenario: init creates an empty repository
 #### When
@@ -124,6 +145,16 @@ git -C repo checkout v9.9.9
   - exit code is not `0`
   - stderr contains `v9.9.9`
 ## git + sandbox_home (global config in an isolated HOME)
+`git config --global` writes to the user's home directory — the one thing a
+test must never do to the machine running it. This suite shows the
+alternative: the command runs with its home redirected inside the scenario's
+own workspace, so a genuine `--global` write happens, lands at a
+deterministic path, and disappears with the workspace.
+
+The isolated home persists across steps, not just within one: a later
+command reads the same setting back, proving it is a real home directory
+rather than a write that went nowhere.
+
 Source: `test/e2e/thirdparty/git/sandbox_home.atago.yaml`
 ### Scenario: global user.name is written under the sandbox home and read back (POSIX)
 _skipped on Windows_

--- a/doc/e2e/gitea.md
+++ b/doc/e2e/gitea.md
@@ -7,6 +7,17 @@
   - [the server boots from an authored app.ini and reports healthy](#scenario-the-server-boots-from-an-authored-appini-and-reports-healthy)
   - [admin CLI, REST API, and a real git clone interoperate](#scenario-admin-cli-rest-api-and-a-real-git-clone-interoperate)
 ## gitea (self-hosted git service)
+[Gitea](https://about.gitea.com/) is a whole git forge, and this suite meets
+it the way an administrator would: a real server is booted from an authored
+`app.ini` on SQLite, a user and an access token are provisioned through
+Gitea's own CLI, and everything after that goes over the REST API —
+creating a repository, committing files into it, opening issues.
+
+The suite ends by cloning that repository with real `git` over HTTP. That
+last step is the point: two independent third-party programs, neither aware
+of this test, are shown to interoperate — the forge really serves git, not
+just a JSON API that claims a repository exists.
+
 Source: `test/e2e/thirdparty/gitea/gitea.atago.yaml`
 ### Scenario: the binary reports its version
 #### When

--- a/doc/e2e/gotify.md
+++ b/doc/e2e/gotify.md
@@ -7,6 +7,20 @@
   - [an application pushes and the admin reads it back](#scenario-an-application-pushes-and-the-admin-reads-it-back)
   - [the app icon round-trips through a multipart upload](#scenario-the-app-icon-round-trips-through-a-multipart-upload)
 ## gotify (self-hosted notification server)
+[Gotify](https://gotify.net/) receives notifications and hands them back
+out. The full path is exercised against a real server on SQLite: an
+application is provisioned over the REST API, a message is pushed with that
+application's token, and it is read back with admin credentials — so the
+message is proven to have been stored and served, not merely accepted.
+
+The refusal matters as much as the delivery: pushing without valid
+credentials must fail rather than silently drop the notification.
+
+One scenario goes further than JSON. The application's icon is uploaded as a
+genuine multipart form-data request, downloaded back to disk, and verified
+as a real PNG — the same round trip a browser performs, asserted on the
+bytes that came back.
+
 Source: `test/e2e/thirdparty/gotify/gotify.atago.yaml`
 ### Scenario: the server reports health and version
 #### Given

--- a/doc/e2e/gum.md
+++ b/doc/e2e/gum.md
@@ -19,6 +19,19 @@
   - [file picker returns the selected file path](#scenario-file-picker-returns-the-selected-file-path)
   - [pager shows line numbers and quits on q](#scenario-pager-shows-line-numbers-and-quits-on-q)
 ## gum (third-party shell-script TUI toolkit)
+[gum](https://github.com/charmbracelet/gum) exists to put a real interface
+on a shell script, and it has two personalities to match.
+
+Some subcommands are ordinary filters — `join`, `table`, `log`,
+`version-check` — with output a script parses; those are pinned as plain
+stdout contracts.
+
+The rest are prompts that only exist in front of a person: `choose`,
+`filter`, `confirm`, `input`, `file`, `pager`. Those are driven inside a
+pseudo-terminal with real keystrokes, because they are the reason anyone
+installs gum, and a test that skipped them would cover everything except the
+product.
+
 Source: `test/e2e/thirdparty/gum/gum.atago.yaml`
 ### Scenario: version prints the pinned semantic version
 _only when `gum --version` succeeds_

--- a/doc/e2e/helix.md
+++ b/doc/e2e/helix.md
@@ -25,6 +25,16 @@
   - [unicode filenames and Japanese text save without mangling](#scenario-unicode-filenames-and-japanese-text-save-without-mangling)
   - [wide and combining characters round-trip through a save](#scenario-wide-and-combining-characters-round-trip-through-a-save)
 ## helix (third-party modal editor)
+[Helix](https://helix-editor.com/) is a modal text editor, driven here as a
+person drives it: the real TUI is launched in a terminal, keys are typed in
+normal and insert mode, and commands are issued at the prompt.
+
+What is asserted is what survives the editor — the file on disk. A save
+must write the edited text; a quit-without-saving must leave the original
+untouched; and a multi-file workflow must put each change in the right file.
+Full-screen snapshots are deliberately avoided: they break when a status bar
+changes, while "did the edit land?" is the contract that actually matters.
+
 Source: `test/e2e/thirdparty/helix/helix.atago.yaml`
 ### Scenario: version prints the pinned release
 _only when `hx --version` succeeds_

--- a/doc/e2e/htop.md
+++ b/doc/e2e/htop.md
@@ -8,6 +8,18 @@
   - [the finder loads its function-key bar and quits on q](#scenario-the-finder-loads-its-function-key-bar-and-quits-on-q)
   - [the rendered screen shows the live meters and column header](#scenario-the-rendered-screen-shows-the-live-meters-and-column-header)
 ## htop (third-party CLI, full-screen TUI testbed)
+[htop](https://htop.dev/) is a full-screen program in the strict sense: it
+switches the terminal to the alternate screen buffer, paints meters and a
+process table with cursor movement and color, and restores what was there
+before when it quits.
+
+That is a harder thing to assert than scrolling output, and it is what this
+suite pins. The rendered frame is reconstructed the way a terminal would
+reconstruct it — following the alternate-screen switch and the cursor
+movements — so the assertion is about what a user sees on screen, not about
+the raw escape sequences that produced it. Quitting cleanly, and leaving the
+terminal in a usable state, is part of the contract too.
+
 Source: `test/e2e/thirdparty/htop/htop.atago.yaml`
 ### Scenario: version prints a semantic version
 _only when `htop --version` succeeds_

--- a/doc/e2e/hugo.md
+++ b/doc/e2e/hugo.md
@@ -15,6 +15,20 @@
   - [the post page renders its title](#scenario-the-post-page-renders-its-title)
   - [an unknown path is a 404](#scenario-an-unknown-path-is-a-404)
 ## hugo (scaffold + build CLI, tree-snapshot testbed)
+[Hugo](https://gohugo.io/) is a scaffolder and a build tool in one binary,
+and both produce their result as a directory tree rather than as output on
+stdout.
+
+That shape is what this suite is about. `hugo new site` must generate the
+documented layout — the whole tree, asserted against a committed snapshot,
+so an unexpected new file or a silently dropped one both show up. `hugo
+--minify` must then turn content into a built site whose files exist and
+contain what they should.
+
+A generator is only trustworthy if the shape of what it generates is
+trustworthy, which is why the assertion is the tree, not a spot check on one
+file.
+
 Source: `test/e2e/thirdparty/hugo/hugo.atago.yaml`
 ### Scenario: new site scaffolds the documented directory tree
 _only when `hugo version` succeeds_
@@ -168,6 +182,16 @@ cd mysite && hugo --quiet
   - exit code is `0`
   - the step changed exactly created nothing, modified nothing, deleted nothing
 ## hugo server (suite-wide service + http peer)
+`hugo server` is the half of Hugo a developer actually looks at: the site,
+served over HTTP, rendered. This suite scaffolds a site, starts the real
+development server against it, and then asks for pages the way a browser
+would — so what is asserted is the HTML that reached the client.
+
+The ordering is the interesting constraint. A site must exist before a
+server can serve it, so the scaffold runs first and the server starts at
+exactly that point in the sequence, once, for the whole suite — the
+build-then-serve bootstrap every "run my app and test it" setup needs.
+
 Source: `test/e2e/thirdparty/hugo/hugo_server.atago.yaml`
 ### Scenario: the home page lists the post
 #### When

--- a/doc/e2e/jq.md
+++ b/doc/e2e/jq.md
@@ -16,6 +16,18 @@
   - [invalid JSON input fails loudly and keeps stdout clean](#scenario-invalid-json-input-fails-loudly-and-keeps-stdout-clean)
   - [streaming several documents produces one result per document](#scenario-streaming-several-documents-produces-one-result-per-document)
 ## jq (uncovered contracts — unicode passthrough + empty validation)
+Two guarantees the main jq suite leaves untested.
+
+First, that jq is safe for text that is not ASCII: multibyte characters must
+survive a round trip byte for byte, with no re-encoding and no escaping
+applied on the way through.
+
+Second, that `jq empty` works as the validator everyone uses it as. It
+consumes the document, prints nothing at all, and exits 0 — but exits 5 on
+malformed input. That combination (silent on success, non-zero on garbage)
+is what makes it usable as a JSON check in a script, and both halves are
+pinned here.
+
 Source: `test/e2e/thirdparty/jq/extra.atago.yaml`
 ### Scenario: multibyte unicode passes through unchanged
 #### Inputs
@@ -55,6 +67,16 @@ jq empty
   - stdout is empty
   - stderr contains `parse error`
 ## jq (third-party CLI, no build required)
+[jq](https://jqlang.github.io/jq/) is a filter: JSON in on stdin, JSON out
+on stdout, and an exit code that tells the calling script what happened.
+
+That exit-code contract is unusually rich, and it is what this suite pins,
+because a shell pipeline depends on it: 0 when the filter ran, 1 when `-e`
+saw a false or null result, 2 for a usage or system error, 3 for a program
+that does not compile, and 5 when the input was not valid JSON at all. Four
+different kinds of "it didn't work", each of which a script may need to
+handle differently — and each of which must not be confused for the others.
+
 Source: `test/e2e/thirdparty/jq/jq.atago.yaml`
 ### Scenario: identity filter echoes the document from stdin
 #### Inputs

--- a/doc/e2e/kustomize.md
+++ b/doc/e2e/kustomize.md
@@ -23,6 +23,16 @@
   - [a missing referenced resource is reported on stderr](#scenario-a-missing-referenced-resource-is-reported-on-stderr)
   - [the load restrictor refuses to read a file outside the root](#scenario-the-load-restrictor-refuses-to-read-a-file-outside-the-root)
 ## kustomize + changes (kustomization file authoring)
+`kustomize create` and `kustomize edit` modify your project in place, which
+makes their footprint part of their contract: they should write the
+kustomization file and leave everything else alone.
+
+That is stated here as an exhaustive claim. Each command's effect on the
+directory is compared before and after, so an extra file, a backup left
+behind, or a stray write into the user's home directory would all fail —
+the home directory included, because it is redirected inside the workspace
+where the delta can see it.
+
 Source: `test/e2e/thirdparty/kustomize/changes.atago.yaml`
 ### Scenario: create writes exactly the kustomization file
 _only when `kustomize version` succeeds_
@@ -100,6 +110,19 @@ kustomize edit set namespace staging
 - exit code is `1`
 - stderr contains `Missing kustomization file`
 ## kustomize (declarative Kubernetes config)
+[kustomize](https://kustomize.io/) turns a base set of Kubernetes manifests
+plus a list of edits into the final YAML you apply. No cluster is involved
+and no network is touched, which means the same inputs must always render
+the same bytes — the property everything else depends on.
+
+What is guaranteed: transformations compose in the defined order, so name
+prefixes, labels, and patches land predictably rather than by accident of
+evaluation order; generators derive the content hash that makes a config map
+change roll its consumers; the load restrictor refuses to read files outside
+the kustomization root, which is a security boundary and not a convenience;
+and a broken kustomization fails on stderr with exit 1 instead of emitting
+partial YAML someone might apply.
+
 Source: `test/e2e/thirdparty/kustomize/kustomize.atago.yaml`
 ### Scenario: version prints a semantic version
 _only when `kustomize version` succeeds_

--- a/doc/e2e/lazygit.md
+++ b/doc/e2e/lazygit.md
@@ -25,6 +25,16 @@
   - [g then enter pops the selected stash entry back into the worktree](#scenario-g-then-enter-pops-the-selected-stash-entry-back-into-the-worktree)
   - [g then escape cancels stash pop and keeps the stash stored](#scenario-g-then-escape-cancels-stash-pop-and-keeps-the-stash-stored)
 ## lazygit (third-party git TUI)
+[lazygit](https://github.com/jesseduffield/lazygit) is a terminal interface
+in front of a real repository: keystrokes stage files, write commits,
+discard changes, create branches, and push and pop stashes.
+
+Both sides of that are asserted. The rendered screen must show the user what
+they expect at each checkpoint — otherwise the tool is unusable even when it
+works — and the repository underneath must have actually changed, checked by
+reading git state afterwards. A TUI test that only looked at the screen
+would pass on a version that draws a commit it never made.
+
 Source: `test/e2e/thirdparty/lazygit/lazygit.atago.yaml`
 ### Scenario: version prints the pinned release
 _only when `lazygit --version` succeeds_

--- a/doc/e2e/mailpit.md
+++ b/doc/e2e/mailpit.md
@@ -9,6 +9,17 @@
   - [a MIME attachment survives delivery intact](#scenario-a-mime-attachment-survives-delivery-intact)
   - [deleting all messages empties the mailbox](#scenario-deleting-all-messages-empties-the-mailbox)
 ## mailpit (self-hosted email testing server)
+[Mailpit](https://mailpit.axllent.org/) catches email so it can be
+inspected, and testing it means using two protocols at once: mail goes in
+over SMTP and comes back out over HTTP.
+
+Messages are delivered by the stock `curl` client speaking real SMTP — no
+library shim, no injected fixture — and everything after that is asserted
+through Mailpit's REST API: that the message was captured with its headers
+and body intact, that full-text search finds it, that a MIME attachment
+survives as a distinct part, and that clearing the mailbox really empties
+it.
+
 Source: `test/e2e/thirdparty/mailpit/mailpit.atago.yaml`
 ### Scenario: the binary reports its version
 #### When

--- a/doc/e2e/minio.md
+++ b/doc/e2e/minio.md
@@ -9,6 +9,18 @@
   - [bucket versioning can be enabled and reported](#scenario-bucket-versioning-can-be-enabled-and-reported)
   - [an anonymous download policy publishes a bucket read-only](#scenario-an-anonymous-download-policy-publishes-a-bucket-read-only)
 ## minio (self-hosted object storage)
+[MinIO](https://min.io/) is S3-compatible object storage, driven here by its
+own `mc` client against a real server.
+
+What is guaranteed is the storage contract an application relies on: the
+bucket and object lifecycle end to end, versioning keeping earlier revisions
+retrievable rather than overwritten, and anonymous access policies actually
+granting and denying what they say.
+
+The unauthenticated case is checked as S3 XML, not just as a non-zero exit —
+because a client library parses that error document, and "denied" has to
+arrive in a form the client can understand.
+
 Source: `test/e2e/thirdparty/minio/minio.atago.yaml`
 ### Scenario: the server reports itself alive over the health API
 #### Given

--- a/doc/e2e/nats.md
+++ b/doc/e2e/nats.md
@@ -9,6 +9,19 @@
   - [a JetStream stream persists, counts, and purges messages](#scenario-a-jetstream-stream-persists-counts-and-purges-messages)
   - [the JetStream KV bucket stores and serves configuration](#scenario-the-jetstream-kv-bucket-stores-and-serves-configuration)
 ## nats (self-hosted messaging system)
+[NATS](https://nats.io/) is a message broker, which makes it the one
+workload here that needs two live participants to mean anything.
+
+Request/reply is tested with a real responder: a second background process
+subscribes and answers, so a request is proven to have reached something and
+come back — not merely to have been accepted by the broker.
+
+JetStream, the persistence layer, is followed through its whole cycle:
+create a stream, publish into it, read the stream's state back and count
+what is stored, then purge it and confirm the count fell. The key-value
+store built on top is exercised the same way, and the broker's monitoring
+endpoint is checked over HTTP alongside.
+
 Source: `test/e2e/thirdparty/nats/nats.atago.yaml`
 ### Scenario: the binary reports its version
 #### When

--- a/doc/e2e/ntfy.md
+++ b/doc/e2e/ntfy.md
@@ -8,6 +8,20 @@
   - [the bundled CLI publishes against the same server](#scenario-the-bundled-cli-publishes-against-the-same-server)
   - [deny-all access control locks a topic until a user is granted](#scenario-deny-all-access-control-locks-a-topic-until-a-user-is-granted)
 ## ntfy (self-hosted push notification service)
+[ntfy](https://ntfy.sh/) sends push notifications over plain HTTP, which
+means anything that can make a request can publish — and that is both its
+appeal and the reason its access control matters.
+
+The publish path is pinned with its metadata intact: a notification's title,
+priority, and tags must survive as sent and come back on the JSON feed.
+Topics must stay isolated, so a subscriber to one topic never sees another's
+messages. The bundled CLI is exercised against the same server as the raw
+HTTP client, so the two agree.
+
+Access control gets the same treatment as the happy path: with a deny-all
+default in place, publishing is refused; after a user is created and granted
+access through the admin CLI, the same publish succeeds.
+
 Source: `test/e2e/thirdparty/ntfy/ntfy.atago.yaml`
 ### Scenario: the binary reports its version
 #### When

--- a/doc/e2e/openssl.md
+++ b/doc/e2e/openssl.md
@@ -14,6 +14,14 @@
   - [a self-signed certificate carries the requested subject](#scenario-a-self-signed-certificate-carries-the-requested-subject)
   - [signing with the private key verifies with the public key](#scenario-signing-with-the-private-key-verifies-with-the-public-key)
 ## openssl + changes (key and cert generation footprints)
+A tool that generates private key material should write exactly the file you
+named and nothing else — no copy, no temporary file left in the directory,
+no cache entry elsewhere. With secrets, a stray extra file is a leak.
+
+This suite states that as an exhaustive contract: after generating a key,
+and after generating a certificate, the directory contains precisely the one
+new artifact that was asked for.
+
 Source: `test/e2e/thirdparty/openssl/changes.atago.yaml`
 ### Scenario: genrsa writes exactly the key file
 _only when `openssl version` succeeds_
@@ -39,6 +47,21 @@ openssl req -new -x509 -key key.pem -out cert.pem -subj /CN=atago-test -days 1
   - the step changed exactly created `cert.pem`, modified nothing, deleted nothing
   - file `cert.pem` contains `BEGIN CERTIFICATE`
 ## openssl (third-party CLI, no build required)
+[OpenSSL](https://www.openssl.org/) is the cryptography tool most scripts
+reach for, and cryptography is where "it produced output" is the least
+convincing evidence of anything.
+
+So each guarantee here is checked against something independent. Digests are
+pinned to their known values. A generated key is proven to work by deriving
+its public half and then signing and verifying with the pair — not by
+checking that a file appeared. Encryption is proven by decrypting back to
+the original bytes.
+
+And the failure case is treated as a feature: decrypting with the wrong
+password must fail loudly, because a crypto tool that silently emits garbage
+on a bad key is worse than one that crashes. A self-signed certificate is
+checked to carry the subject that was requested.
+
 Source: `test/e2e/thirdparty/openssl/openssl.atago.yaml`
 ### Scenario: sha256 digest of a fixed input is exact and stable
 #### Given

--- a/doc/e2e/pandoc.md
+++ b/doc/e2e/pandoc.md
@@ -13,6 +13,15 @@
   - [markdown survives a round-trip through HTML](#scenario-markdown-survives-a-round-trip-through-html)
   - [a missing input file fails cleanly](#scenario-a-missing-input-file-fails-cleanly)
 ## pandoc + changes (a conversion writes exactly its output)
+Converting a document should produce the converted document — and nothing
+besides. This suite states that exactly: with the source file present as the
+baseline, a conversion creates precisely one new file, the one named on the
+command line.
+
+Anything else pandoc happened to write would fail the assertion, which is
+what makes this a claim about its footprint rather than a check that the
+output exists.
+
 Source: `test/e2e/thirdparty/pandoc/changes.atago.yaml`
 ### Scenario: markdown-to-html creates exactly the output file
 _only when `pandoc --version` succeeds_
@@ -34,6 +43,18 @@ pandoc in.md -o out.html
 - the step changed exactly created `out.html`, modified nothing, deleted nothing
 - file `out.html` contains `<em>emphasis</em>`
 ## pandoc (document conversion filter)
+[Pandoc](https://pandoc.org/) converts documents between formats, and it can
+be used two entirely different ways: as a file-to-file converter, or as a
+filter in a pipeline reading stdin and writing stdout.
+
+Both are pinned, because a script may depend on either, and they must agree:
+the same input converted either way must produce the same document.
+
+Beyond the rendered output, pandoc can emit its internal AST as JSON — a
+structured oracle that says what pandoc *understood* the document to be, not
+merely what it printed. Asserting on that catches a parsing regression that
+happens to render plausibly.
+
 Source: `test/e2e/thirdparty/pandoc/pandoc.atago.yaml`
 ### Scenario: markdown converts to HTML and a binary docx
 _only when `pandoc --version` succeeds_

--- a/doc/e2e/prometheus.md
+++ b/doc/e2e/prometheus.md
@@ -8,6 +8,20 @@
   - [the server boots from an authored config and answers the query API](#scenario-the-server-boots-from-an-authored-config-and-answers-the-query-api)
   - [a self-scrape is ingested and queryable as up == 1](#scenario-a-self-scrape-is-ingested-and-queryable-as-up--1)
 ## prometheus (self-hosted monitoring system)
+[Prometheus](https://prometheus.io/) ships as two things, and this suite
+covers both.
+
+`promtool` is an ordinary CLI: it must accept a valid configuration and
+reject an invalid one with a diagnostic, and it must be able to unit-test
+alerting rules — catching a bad alert before it reaches production rather
+than during an incident.
+
+The server is booted from an authored config and then genuinely used: its
+health endpoints answer, its query API returns JSON that can be asserted as
+structure, and a metric it scraped from itself is polled until it appears.
+That last one closes the loop — configuration, scrape, storage, and query
+all had to work for the sample to be there.
+
 Source: `test/e2e/thirdparty/prometheus/prometheus.atago.yaml`
 ### Scenario: promtool accepts a valid config and rejects a broken one
 #### Given

--- a/doc/e2e/pushgateway.md
+++ b/doc/e2e/pushgateway.md
@@ -9,6 +9,16 @@
   - [POST merges into a group while PUT replaces it](#scenario-post-merges-into-a-group-while-put-replaces-it)
   - [a grouping label decorates every metric in the group](#scenario-a-grouping-label-decorates-every-metric-in-the-group)
 ## pushgateway (self-hosted metrics gateway)
+[Pushgateway](https://github.com/prometheus/pushgateway) exists so that a
+job too short-lived to be scraped can push its metrics somewhere Prometheus
+will find them later.
+
+Its API is unusual in that the payload is not JSON but Prometheus's own
+plain-text exposition format, sent as a raw request body. This suite pushes
+real metrics that way and then reads them back from the gateway's own
+endpoint — so what is asserted is that the gateway stored and re-exposed the
+samples, in the format a Prometheus scrape would consume.
+
 Source: `test/e2e/thirdparty/pushgateway/pushgateway.atago.yaml`
 ### Scenario: a pushed metric appears on the scrape endpoint
 #### Given

--- a/doc/e2e/python.md
+++ b/doc/e2e/python.md
@@ -13,6 +13,15 @@
   - [EOF (ctrl-d) ends the session cleanly](#scenario-eof-ctrl-d-ends-the-session-cleanly)
   - [a traceback is reported and the REPL recovers](#scenario-a-traceback-is-reported-and-the-repl-recovers)
 ## python3 + changes (bytecode cache footprint)
+Running a Python script quietly writes files you did not ask for: importing a
+local module leaves a compiled `.pyc` behind in `__pycache__`, while the
+entry script itself is never cached. That asymmetry surprises people, so it
+is pinned here exactly.
+
+The paired scenario pins the escape hatch: with `PYTHONDONTWRITEBYTECODE`
+set, the same run creates nothing at all — an empty delta, which is the
+strongest form this assertion can take.
+
 Source: `test/e2e/thirdparty/python/changes.atago.yaml`
 ### Scenario: importing a local module writes exactly one .pyc
 _only when `python3 --version` succeeds_
@@ -64,6 +73,20 @@ python3 main.py
 - stdout equals an exact value
 - the step changed exactly created nothing, modified nothing, deleted nothing
 ## python3 REPL (interactive pty testbed)
+The Python REPL is the canonical long-lived interactive session: it prints a
+prompt, waits, answers, and prompts again, for as many exchanges as you
+want.
+
+That conversational shape is what this suite pins — recognizing the `>>>`
+prompt, carrying on a multi-step exchange where each answer depends on the
+last, getting a traceback back for bad input without the session dying, and
+exiting cleanly on end-of-input. Python also behaves differently when it
+detects a terminal, so that branch is exercised too.
+
+Python is on every CI image, which makes this the most portable worked
+example here of testing an interactive program — and a template to copy for
+your own REPL.
+
 Source: `test/e2e/thirdparty/python/python.atago.yaml`
 ### Scenario: version and -c contracts (non-interactive)
 _only when `python3 --version` succeeds_

--- a/doc/e2e/rclone.md
+++ b/doc/e2e/rclone.md
@@ -11,6 +11,20 @@
   - [obscure and reveal round-trip a secret](#scenario-obscure-and-reveal-round-trip-a-secret)
   - [serve http publishes the tree over real HTTP](#scenario-serve-http-publishes-the-tree-over-real-http)
 ## rclone (self-hosted file sync program)
+[rclone](https://rclone.org/) moves files between storage backends, and the
+distinction it must never blur is copy versus sync: one adds, the other
+makes the destination match the source — including deleting what is no
+longer there. Getting that wrong destroys data, so both are pinned
+explicitly.
+
+Around them: machine-readable listings a script can parse, integrity
+checking that passes on matching trees and *fails* on a corrupted one, and
+the obscure/reveal password round trip returning the original secret.
+
+`rclone serve http` is started as a real server and queried over HTTP, so
+the serving half is proven from the outside too. Everything runs against the
+local backend, which keeps every scenario hermetic.
+
 Source: `test/e2e/thirdparty/rclone/rclone.atago.yaml`
 ### Scenario: version prints a semantic version
 #### When

--- a/doc/e2e/redis.md
+++ b/doc/e2e/redis.md
@@ -10,6 +10,20 @@
   - [an unknown command reports ERR without killing the server](#scenario-an-unknown-command-reports-err-without-killing-the-server)
   - [SHUTDOWN NOSAVE stops the server and PING starts failing](#scenario-shutdown-nosave-stops-the-server-and-ping-starts-failing)
 ## redis (server + client, signal-step testbed)
+Redis ships a server and a client together, so one suite can cover a whole
+round trip: start the server, wait for it to actually be ready, talk to it,
+and shut it down.
+
+Readiness is checked two ways — by the log line the server prints and by the
+port accepting connections — because those can disagree, and a test that
+starts sending commands too early is flaky rather than wrong.
+
+`redis-cli` has a crisp contract worth pinning: when its output is a pipe
+rather than a terminal it prints raw values (`PONG`, `OK`, bare integers),
+which is exactly what a script parses. Shutdown is the other end of the
+lifecycle: the server is asked to stop and is then polled until it really
+stops answering.
+
 Source: `test/e2e/thirdparty/redis/redis.atago.yaml`
 ### Scenario: server boots (log readiness) and answers PING
 _only when `redis-server --version && redis-cli --version` succeeds · skipped on Windows_

--- a/doc/e2e/restic.md
+++ b/doc/e2e/restic.md
@@ -11,6 +11,21 @@
   - [forget --keep-last 1 --prune drops the older snapshot](#scenario-forget---keep-last-1---prune-drops-the-older-snapshot)
   - [the wrong password cannot unlock the repository](#scenario-the-wrong-password-cannot-unlock-the-repository)
 ## restic (self-hosted backup program)
+A backup tool is only worth anything if the restore works, so this suite
+follows [restic](https://restic.net/) through the entire lifecycle rather
+than stopping at "the backup succeeded".
+
+A repository is initialized, real data is backed up, snapshots are listed as
+JSON, and the data is restored — and the restored files are compared against
+the originals. Beyond that: `diff` between snapshots reports what actually
+changed, the integrity check passes on a healthy repository, and retention
+policies remove the snapshots they say they will and keep the rest.
+
+The wrong password must fail. For an encrypted backup that is not an error
+path but the core guarantee: without the password the data is not
+recoverable, and that is asserted here as deliberately as the successful
+restore.
+
 Source: `test/e2e/thirdparty/restic/restic.atago.yaml`
 ### Scenario: version prints a semantic version
 #### When

--- a/doc/e2e/sops.md
+++ b/doc/e2e/sops.md
@@ -11,6 +11,21 @@
   - [a tampered ciphertext fails the MAC](#scenario-a-tampered-ciphertext-fails-the-mac)
   - [an encrypted-regex scopes which keys are encrypted](#scenario-an-encrypted-regex-scopes-which-keys-are-encrypted)
 ## sops + age (secrets encryption)
+[sops](https://github.com/getsops/sops) encrypts the *values* in a
+structured file while leaving its keys readable, so a secrets file stays
+reviewable in a pull request while its contents stay secret.
+
+That split is the contract pinned here: after encryption the structure is
+still legible and every value is hidden; after decryption the values come
+back; and a single field can be extracted without decrypting the rest.
+
+The negative guarantees carry equal weight. The wrong key must not decrypt.
+And flipping one byte of the ciphertext must fail the message
+authentication check rather than yielding subtly wrong plaintext — the
+integrity property that separates an encrypted file from an obfuscated one.
+A regex scoping which keys get encrypted is checked too, since a
+misconfigured scope is how secrets end up committed in the clear.
+
 Source: `test/e2e/thirdparty/sops/sops.atago.yaml`
 ### Scenario: version prints a semantic version offline
 _only when `sops --version --disable-version-check` succeeds_

--- a/doc/e2e/sqlite3.md
+++ b/doc/e2e/sqlite3.md
@@ -15,6 +15,19 @@
   - [bad SQL exits 1 with the error position on stderr](#scenario-bad-sql-exits-1-with-the-error-position-on-stderr)
   - [querying a missing table names it in the diagnostics](#scenario-querying-a-missing-table-names-it-in-the-diagnostics)
 ## sqlite3 + changes (workdir-delta of a database write)
+SQLite creates side files while it works — a rollback journal by default, or
+a write-ahead log and shared-memory file in WAL mode. A process that dies
+mid-transaction leaves them behind.
+
+This suite pins the cleanup guarantee: after a `sqlite3` process exits
+normally, those files are gone — deleted or checkpointed back into the
+database — and the only thing that changed on disk is the database file
+itself. In both journal modes.
+
+That is a stronger statement than "the write worked", and it is what makes a
+leftover journal file a detectable regression rather than something nobody
+notices until a restore.
+
 Source: `test/e2e/thirdparty/sqlite3/changes.atago.yaml`
 ### Scenario: default rollback-journal mode creates exactly the db file
 #### When
@@ -33,6 +46,19 @@ sqlite3 t.db "PRAGMA journal_mode=WAL; create table x(a); insert into x values(1
 - exit code is `0`
 - the step changed exactly created `t.db`, modified nothing, deleted nothing
 ## sqlite3 (third-party CLI, no build required)
+The `sqlite3` shell driven as a user drives it — the actual binary on a
+command line, not SQLite embedded as a library.
+
+What is guaranteed: one-shot SQL passed as an argument runs and prints its
+result; the machine-readable output modes (`-json`, `-csv`) produce output a
+script can parse; the dot-commands behave as documented, so `.dump` can
+reproduce a database, `.schema` reports it, and `.import` reads a file back
+in; and bad SQL fails with a message instead of a partial result.
+
+Durability gets its own attention: data written by one invocation must still
+be there for the next one, which is the whole reason to use a file-backed
+database rather than a pipe.
+
 Source: `test/e2e/thirdparty/sqlite3/sqlite3.atago.yaml`
 ### Scenario: one-shot SQL creates, inserts, and counts in a single invocation
 #### When

--- a/doc/e2e/ssh-keygen.md
+++ b/doc/e2e/ssh-keygen.md
@@ -10,6 +10,19 @@
   - [interactive passphrase generation prompts twice](#scenario-interactive-passphrase-generation-prompts-twice)
   - [the wrong passphrase is rejected](#scenario-the-wrong-passphrase-is-rejected)
 ## ssh-keygen (OpenSSH key generation)
+`ssh-keygen` is small, ships with OpenSSH everywhere, and happens to combine
+three things that are each awkward to test: an interactive passphrase
+prompt, files written to disk, and an exit code that carries meaning.
+
+All three are covered together. The passphrase is typed at the real prompt
+inside a terminal, the resulting key pair is asserted as files with the
+right shape and permissions, and the fingerprint output is checked — as is
+the failure when a key cannot be verified.
+
+Every key here is a throwaway generated inside the scenario's own workspace,
+which is discarded when the scenario ends. No real credential is involved at
+any point.
+
 Source: `test/e2e/thirdparty/ssh-keygen/ssh-keygen.atago.yaml`
 ### Scenario: non-interactive generation writes the key pair
 _only when `command -v ssh-keygen` succeeds_

--- a/doc/e2e/terraform.md
+++ b/doc/e2e/terraform.md
@@ -10,6 +10,19 @@
   - [fmt -check exits 3 on a misformatted file](#scenario-fmt--check-exits-3-on-a-misformatted-file)
   - [a broken configuration is rejected](#scenario-a-broken-configuration-is-rejected)
 ## terraform (offline via the builtin terraform_data resource)
+Terraform's exit codes are not a detail — they are the interface CI
+pipelines are built on. `terraform plan -detailed-exitcode` answers with 0
+for "nothing to do", 2 for "there are changes", and 1 for "it failed", and a
+pipeline that confuses 2 with 1 either blocks on every change or deploys
+through every error.
+
+That three-way contract is what this suite pins, alongside the ordinary path
+through init, validate, plan, and apply.
+
+It stays entirely offline by using only Terraform's builtin
+`terraform_data` resource, so `init` downloads no providers and no network
+access is needed to run any of it.
+
 Source: `test/e2e/thirdparty/terraform/terraform.atago.yaml`
 ### Scenario: init downloads nothing and validate reports valid
 _only when `terraform version` succeeds_

--- a/doc/e2e/transfersh.md
+++ b/doc/e2e/transfersh.md
@@ -7,6 +7,19 @@
   - [a binary upload round-trips byte-for-byte](#scenario-a-binary-upload-round-trips-byte-for-byte)
   - [a browser-style multipart upload is accepted too](#scenario-a-browser-style-multipart-upload-is-accepted-too)
 ## transfer.sh (self-hosted file sharing)
+[transfer.sh](https://github.com/dutchcoders/transfer.sh) takes a file and
+gives you a URL to fetch it back from. The only guarantee that matters is
+that what comes back is what went in.
+
+So this suite tests it with binary data rather than text. A PNG is uploaded
+as a raw request body, the share URL is captured from the response, the file
+is downloaded back to disk, and the bytes are compared to the original —
+both as a valid image and byte for byte. Text survives a lot of accidental
+mangling that binary does not.
+
+The browser-style multipart upload path is exercised as well, since that is
+how a file arrives from a web form rather than from `curl`.
+
 Source: `test/e2e/thirdparty/transfersh/transfersh.atago.yaml`
 ### Scenario: the binary reports its version
 #### When

--- a/doc/e2e/webhook.md
+++ b/doc/e2e/webhook.md
@@ -9,6 +9,20 @@
   - [the http-methods allowlist rejects the wrong verb](#scenario-the-http-methods-allowlist-rejects-the-wrong-verb)
   - [a command that exits non-zero surfaces as a 500](#scenario-a-command-that-exits-non-zero-surfaces-as-a-500)
 ## webhook (self-hosted webhook receiver)
+[webhook](https://github.com/adnanh/webhook) turns an HTTP request into a
+command execution, which makes it a piece of security-relevant plumbing:
+everything about it is a question of what should and should not run.
+
+The happy path is verified by its effect, not its response — the triggered
+command writes a file, and that file is checked on disk.
+
+The refusals are pinned just as carefully. When a trigger rule is not
+satisfied the command must not run at all, which is asserted by the absence
+of its effect rather than by the status code. An HMAC signature is verified
+against an independently computed value, so a forged one is rejected. The
+allowed-methods list rejects the wrong verb. And a command that exits
+non-zero surfaces as a 500 instead of being reported as success.
+
 Source: `test/e2e/thirdparty/webhook/webhook.atago.yaml`
 ### Scenario: a post runs the command, returns its output, and writes its file
 #### Given

--- a/doc/e2e/yazi.md
+++ b/doc/e2e/yazi.md
@@ -170,6 +170,21 @@
   - [block shell command creates a symlink to a spaced filename](#scenario-block-shell-command-creates-a-symlink-to-a-spaced-filename)
   - [block shell command creates a symlink to a spaced directory](#scenario-block-shell-command-creates-a-symlink-to-a-spaced-directory)
 ## yazi (third-party terminal file manager) / chooser selection
+Used as a file chooser, yazi's job is to hand a shell script the paths the
+user picked. The rule that matters — and the one easiest to get wrong — is
+that an explicit selection beats whatever the cursor happens to be sitting
+on. A user who selects three files and then moves the cursor elsewhere must
+still get those three.
+
+Every way of selecting is put through that test: pressing space on
+individual entries, sweeping a range in visual mode, selecting everything at
+once, and inverting a selection. Toggling the same entry twice must clear
+it, not select it again.
+
+Files and directories are covered separately, and so are names containing
+spaces — the classic point where a path list gets silently split into the
+wrong number of entries.
+
 Source: `test/e2e/thirdparty/yazi/chooser_selection.atago.yaml`
 ### Scenario: chooser-file writes a space-selected file instead of the hovered file
 _only when `yazi --version` succeeds · skipped on Windows_
@@ -534,6 +549,23 @@ b
 #### Then
 - file `chosen.txt` contains `/b two`
 ## yazi (third-party terminal file manager) / entry args
+Where yazi starts depends on what you pass it, and the two cases differ: a
+directory argument opens that directory, while a file argument opens its
+parent with the file already hovered — so it can be chosen immediately, or
+left behind for a sibling.
+
+Quitting must then report the right working directory. A shell wrapper uses
+that value to cd, so reporting the file's own path, or the directory the
+user started in rather than the one they navigated to, sends the caller to
+the wrong place.
+
+Several arguments open several tabs, and this suite checks that they land in
+the given order and that switching between them by number, or by stepping to
+the next one, selects from the tab actually in front of the user.
+
+Spaced, hidden, and nested paths are covered throughout, since those are
+where argument handling usually breaks.
+
 Source: `test/e2e/thirdparty/yazi/entry_args.atago.yaml`
 ### Scenario: starting on an explicit directory writes that cwd on quit
 _only when `yazi --version` succeeds · skipped on Windows_
@@ -787,6 +819,24 @@ c
 #### Then
 - file `cwd.txt` contains `/three`
 ## yazi (third-party terminal file manager) / links and overwrite
+The operations here are the ones that can lose data, so each is pinned in
+both directions.
+
+Cancelling a pending cut or copy must really cancel it: a later paste must
+do nothing, rather than quietly completing the operation the user thought
+they had abandoned.
+
+Overwriting must really overwrite. When the destination already exists, the
+forced paste has to replace it — for a file and for a whole directory
+subtree, under both copy and move — and the result on disk is checked
+afterwards, not just the absence of an error.
+
+Hardlinking is covered as its own case, since a hardlink that silently
+degrades into a copy looks identical until something writes through it.
+
+Spaced names run through all of it, being where path handling tends to
+fail.
+
 Source: `test/e2e/thirdparty/yazi/links_and_overwrite.atago.yaml`
 ### Scenario: uppercase X cancels a cut before pasting
 _only when `yazi --version` succeeds · skipped on Windows_
@@ -975,6 +1025,21 @@ stat -c '%h' 'src/two words.txt'
 - file `dst/two words.txt` contains `alpha`
 - stdout equals an exact value
 ## yazi (third-party terminal file manager) / navigation and tabs
+Moving around is what a file manager does between operations, and it has to
+put the cursor exactly where the user believes it is — because the next
+keystroke acts on whatever is hovered.
+
+Arrow-key movement is therefore checked by its consequence: after moving,
+the entry that gets chosen must be the one the user moved to. Entering and
+leaving directories is checked the same way, including the working directory
+reported on quit after stepping back out.
+
+Tabs get the same treatment. Opening new tabs, switching by number, closing
+one and returning to the previous, and reordering tabs — after which the
+numbers must follow the new order, not the original one.
+
+Spaced names appear throughout.
+
 Source: `test/e2e/thirdparty/yazi/navigation_tabs.atago.yaml`
 ### Scenario: down arrow moves to the second file before choosing
 _only when `yazi --version` succeeds · skipped on Windows_
@@ -1199,6 +1264,18 @@ a
 #### Then
 - file `cwd.txt` contains `${workdir}`
 ## yazi (third-party terminal file manager) / search and tabs
+Two things a file manager offers beyond moving files: finding them, and
+keeping more than one place open at a time.
+
+Content search must locate a file by what is inside it, not by its name, and
+leave the user positioned on the match. The information panel must describe
+the entry currently hovered — the wrong entry's details is a subtle bug,
+since the panel still looks right.
+
+Tabs are checked as a pair of operations that must undo each other: opening
+a tab roots it at the current directory, and closing it returns to the
+directory the previous tab was showing.
+
 Source: `test/e2e/thirdparty/yazi/search_tabs.atago.yaml`
 ### Scenario: uppercase S content search finds the matching file
 _only when `rg --version` succeeds · skipped on Windows_
@@ -1282,6 +1359,19 @@ b
 #### Then
 - file `cwd.txt` contains `/one`
 ## yazi (third-party terminal file manager) / selection matrix
+One rule, checked against every combination that could break it: an
+operation acts on what is selected, not on what the cursor is pointing at.
+
+Select an entry, move the cursor somewhere else, then copy, move, or delete
+— and the selected entry must be the one affected, while the entry now under
+the cursor must be left alone. Acting on the hovered file instead is the
+failure mode that quietly destroys the wrong data.
+
+The matrix runs that rule across files and directories, single entries and
+visual-mode ranges, and copy, move, and permanent delete — with spaced names
+included, since a path that splits on a space turns one operation into
+several wrong ones.
+
 Source: `test/e2e/thirdparty/yazi/selection_matrix.atago.yaml`
 ### Scenario: space-selected file is moved even when the cursor moves away
 _only when `yazi --version` succeeds · skipped on Windows_
@@ -1535,6 +1625,23 @@ c
 - dir `src/a one` does not exist
 - file `src/c three/c.txt` contains `c`
 ## yazi (third-party terminal file manager)
+[yazi](https://yazi-rs.github.io/) is a file manager, so every keystroke is
+a potential file operation. A test that only checked the screen would pass
+on a version that draws a successful copy it never performed — and on a file
+manager, that class of bug destroys data.
+
+So both are asserted throughout: what the terminal displays, and what
+actually happened on disk afterwards.
+
+This suite covers the core interactions — hidden files staying hidden until
+toggled, live filtering narrowing the list, creating files and directories,
+renaming exactly one entry and nothing else, yank/paste and cut/paste
+between directories, and permanent deletion including the case where the
+confirmation is declined and the file must survive.
+
+The remaining yazi suites break out selection semantics, entry arguments,
+navigation and tabs, search, and hardlinks and overwrites.
+
 Source: `test/e2e/thirdparty/yazi/yazi.atago.yaml`
 ### Scenario: version prints a semantic version banner
 _only when `yazi --version` succeeds_

--- a/test/e2e/thirdparty/actionlint/actionlint.atago.yaml
+++ b/test/e2e/thirdparty/actionlint/actionlint.atago.yaml
@@ -2,16 +2,20 @@ version: "1"
 
 suite:
   name: actionlint (GitHub Actions workflow linter)
+  description: |
+    [actionlint](https://github.com/rhysd/actionlint) statically checks GitHub
+    Actions workflow YAML. It is offline and deterministic — the same workflow
+    always produces the same findings — which makes its contract unusually
+    precise to pin.
 
-# actionlint statically checks GitHub Actions workflow YAML: it is fully offline
-# and deterministic, exits 0 with no output on a clean workflow, and exits 1
-# printing each problem (with file:line:col, a rule tag like [job-needs], and a
-# code snippet) to stdout. That makes its contract precise to pin: the exit code
-# splits clean from problematic, distinct rule categories produce distinct
-# tagged errors, the JSON format is a structured oracle over the same findings,
-# and -ignore removes a matching error. Every workflow here is authored as a
-# fixture, and shellcheck is disabled (-shellcheck=) so the results do not depend
-# on whether shellcheck is present on the runner.
+    What is guaranteed here: exit 0 and silence on a clean workflow, exit 1 with
+    every problem printed as `file:line:col`, a rule tag, and a code snippet;
+    distinct rule categories producing distinctly tagged errors; the JSON format
+    agreeing with the human one over the same findings; and `-ignore` removing a
+    matching error without hiding the rest.
+
+# Every workflow is authored as a fixture, and shellcheck is disabled
+# (-shellcheck=) so results do not depend on whether shellcheck is on the runner.
 scenarios:
   - name: version prints a semantic version
     only:

--- a/test/e2e/thirdparty/age/age.atago.yaml
+++ b/test/e2e/thirdparty/age/age.atago.yaml
@@ -2,13 +2,19 @@ version: "1"
 
 suite:
   name: age (modern file encryption)
+  description: |
+    [age](https://age-encryption.org/) is a small, modern file-encryption CLI —
+    a Go-native tool many people ship alongside their own commands, and the
+    counterpart to the openssl suite here.
 
-# age is a small, modern encryption CLI with an exemplary UX contract (#38):
-# binary-safe round-trips, armored output, interactive passphrase mode, and
-# clean failure semantics. It complements the openssl specs with a Go-native
-# tool many users ship alongside their own CLIs. Keys and passphrases here are
-# throwaways generated inside each scenario's isolated workdir. Gate: only
-# where age is installed; pty scenarios are POSIX-only.
+    What is guaranteed: an encrypt/decrypt round trip returns the original bytes
+    exactly, including binary payloads; armored output stays ASCII and
+    round-trips the same way; a passphrase typed at the interactive prompt works
+    like a key file; and every failure — the wrong key, the wrong passphrase, a
+    corrupted file — is refused loudly rather than yielding plausible garbage.
+
+# Keys and passphrases are throwaways generated inside each scenario's isolated
+# workdir. Gate: only where age is installed; pty scenarios are POSIX-only.
 
 secrets:
   - PASSPHRASE

--- a/test/e2e/thirdparty/age/changes.atago.yaml
+++ b/test/e2e/thirdparty/age/changes.atago.yaml
@@ -2,13 +2,18 @@ version: "1"
 
 suite:
   name: age + changes (single-artifact generator)
+  description: |
+    A key generator should create the key and nothing else. This companion to
+    the main age suite states that as an exact contract: `age-keygen` writes
+    precisely one file, and the rest of the filesystem — including the user's
+    home directory — is left untouched.
 
-# Companion to age.atago.yaml: age-keygen writes exactly one file and touches
-# nothing else — not even HOME. sandbox_home points HOME (and the per-OS
-# config/cache dirs) INSIDE the workdir, so a home write would surface in the
-# delta and break the exhaustive created list below — the "HOME untouched"
-# claim is enforced by the assert, not just stated in prose. Gate: only where
-# age is installed.
+    The "HOME untouched" half is enforced rather than asserted in prose.
+    `sandbox_home` moves HOME and the per-OS config/cache directories inside the
+    scenario workdir, so a stray home write would show up in the workdir delta
+    and break the exhaustive created list.
+
+# Gate: only where age is installed.
 scenarios:
   - name: age-keygen writes exactly the key file (HOME untouched)
     only:

--- a/test/e2e/thirdparty/aqua/aqua.atago.yaml
+++ b/test/e2e/thirdparty/aqua/aqua.atago.yaml
@@ -2,13 +2,21 @@ version: "1"
 
 suite:
   name: aqua (declarative CLI version manager)
+  description: |
+    [aqua](https://aquaproj.github.io/) manages CLI tools declaratively from an
+    `aqua.yaml`. Actually installing a tool needs the network and the registry,
+    so this suite pins the half that must work offline and identically every
+    time — the half a developer hits before anything is downloaded.
 
-# aqua manages CLI tools declaratively from an aqua.yaml. Installing tools needs
-# the network and the registry, so this suite pins aqua's offline, deterministic
-# surface instead: authoring a config and a policy (with their filesystem side
-# effects), the idempotence of init, the offline generators (completion,
-# root-dir), and the exit-code semantics that separate a usage error (3) from a
-# runtime error (1). Gate: only where aqua is installed.
+    What is guaranteed: authoring a config and a policy leaves exactly the files
+    it should; `aqua init` is idempotent, so re-running it does not corrupt an
+    existing config; the offline generators (shell completion, root-dir) print
+    usable output; and the exit codes keep a usage mistake (3) distinct from a
+    runtime failure (1), so a script can tell "you typed it wrong" from "it
+    broke".
+
+# Gate: only where aqua is installed. The live-install half lives in
+# install.atago.yaml.
 scenarios:
   - name: version prints without error
     only:

--- a/test/e2e/thirdparty/aqua/install.atago.yaml
+++ b/test/e2e/thirdparty/aqua/install.atago.yaml
@@ -2,16 +2,22 @@ version: "1"
 
 suite:
   name: aqua + install (declarative install of a real tool)
+  description: |
+    The thing aqua exists to do: turn a line in a config file into a tool you
+    can run. This suite exercises that end to end — declare a package, install
+    it, execute it — rather than stopping at the offline surface its companion
+    suite covers.
 
-# Companion to aqua.atago.yaml: where that suite pins aqua's offline surface,
-# this one exercises aqua's essential function — declaratively installing a tool
-# and making it runnable — without reaching the live registry or GitHub for the
-# tool itself. A local registry (type: local) describes an http package whose
-# asset is a tiny self-authored "tool" served from a local HTTP file server, so
-# `aqua install` downloads it from 127.0.0.1, lands it under AQUA_ROOT_DIR, and
-# `aqua exec` runs it. AQUA_ROOT_DIR and the policy file are pinned inside the
-# workdir. (aqua still fetches its pinned aqua-proxy bootstrap from GitHub on
-# install, the one external dependency of aqua's own design.) Install: see
+    It stays hermetic by moving only the registry, not the mechanism. A local
+    registry describes an http package whose asset is a tiny self-authored
+    "tool" served from a loopback file server, so `aqua install` performs a real
+    download, lands a real binary under `AQUA_ROOT_DIR`, and `aqua exec` really
+    runs it — with no dependency on the public registry or on GitHub for the
+    tool itself.
+
+# aqua still fetches its pinned aqua-proxy bootstrap from GitHub on install, the
+# one external dependency of aqua's own design. AQUA_ROOT_DIR and the policy
+# file are pinned inside the workdir. Install: see
 # .github/workflows/thirdparty.yml for the pinned CI version.
 
 permissions:

--- a/test/e2e/thirdparty/awscli/awscli.atago.yaml
+++ b/test/e2e/thirdparty/awscli/awscli.atago.yaml
@@ -2,18 +2,26 @@ version: "1"
 
 suite:
   name: aws-cli against MinIO (offline cloud-CLI story)
+  description: |
+    The real AWS CLI, tested with no AWS account, no credentials that matter,
+    and no network beyond loopback. A MinIO server stands in for S3 and
+    `aws --endpoint-url` is pointed at it, so the actual `aws` binary performs
+    actual S3 requests against a real S3-compatible server.
 
-# Drives the real AWS CLI against a local MinIO S3 endpoint (#32): test a
-# cloud CLI with no cloud account, no network, fully hermetic. MinIO is
-# started per scenario as a background service (its client peers already have
-# a suite here); `aws --endpoint-url` points at it. Install: see
+    What is guaranteed: the bucket and object lifecycle a script depends on —
+    create, upload, list, download, delete — plus the machine-readable JSON
+    output those scripts parse, and the failure modes that must stay
+    distinguishable (a missing bucket, a missing object, bad credentials).
+
+    This is the answer to "how do I test a cloud CLI in CI?": swap the endpoint,
+    keep the CLI.
+
+# MinIO is started per scenario as a background service, each on its own port
+# and data dir so the suite runs under the default scenario concurrency.
+# Credentials come from scenario env; the secret key is declared under
+# `secrets:` so it is masked in reports. Install: see
 # .github/workflows/thirdparty.yml for the pinned server version and the CI
-# client-install path.
-#
-# Each scenario binds its own port and data dir so the suite runs under the
-# default scenario concurrency. Credentials come from scenario env; the
-# secret key is declared under `secrets:` so it is masked in reports.
-# Gate: only runs where the aws CLI is installed.
+# client-install path. Gate: only runs where the aws CLI is installed.
 
 secrets:
   - AWS_SECRET_ACCESS_KEY

--- a/test/e2e/thirdparty/caddy/caddy.atago.yaml
+++ b/test/e2e/thirdparty/caddy/caddy.atago.yaml
@@ -2,12 +2,19 @@ version: "1"
 
 suite:
   name: caddy (self-hosted web server)
+  description: |
+    [Caddy](https://caddyserver.com/) has two faces, and both are covered here.
 
-# Exercises Caddy (https://caddyserver.com/, from awesome-selfhosted) as a
-# third-party target: pure CLI behavior (version/adapt/fmt/validate), and the
-# real server started as a background service with a TCP readiness probe and
-# queried through the http runner. Install: see
-# .github/workflows/thirdparty.yml for the pinned CI version.
+    As a CLI it is a config tool: `caddy adapt`, `fmt`, and `validate` must
+    accept a well-formed Caddyfile, normalize it predictably, and reject a
+    broken one with a diagnostic instead of starting anyway.
+
+    As a server it must actually serve. A real `caddy run` is started as a
+    background process, waited for on its port, and then queried over HTTP —
+    so what is asserted is the response a browser would get, not a log line
+    claiming the server came up.
+
+# Install: see .github/workflows/thirdparty.yml for the pinned CI version.
 
 permissions:
   network:

--- a/test/e2e/thirdparty/coredns/coredns.atago.yaml
+++ b/test/e2e/thirdparty/coredns/coredns.atago.yaml
@@ -2,18 +2,24 @@ version: "1"
 
 suite:
   name: coredns (self-hosted DNS server)
+  description: |
+    [CoreDNS](https://coredns.io/) speaks DNS, a protocol atago has no runner
+    for — which is exactly why this suite exists. A protocol you cannot address
+    directly is still testable through the client everybody already has: the
+    real server is booted from an authored Corefile and zone file, and `dig`
+    asks it real questions.
 
-# Exercises CoreDNS (https://coredns.io/, from awesome-selfhosted's DNS
-# corner) as a third-party target — a protocol atago has no built-in runner
-# for, which is the point: the real server is booted from an authored Corefile
-# and zone file, queried with the stock `dig` client over actual DNS (A, TXT,
-# CNAME chasing, NXDOMAIN, and the REFUSED answer for out-of-zone names), and
-# its health plugin is probed through the http runner. Install: see
-# .github/workflows/thirdparty.yml for the pinned CI version.
-# (`dig` ships with bind9-dnsutils, preinstalled on GitHub runners.)
-#
-# Each server scenario binds its own port so the suite runs under the default
-# scenario concurrency.
+    What is guaranteed: A and TXT records resolve to the authored values, a
+    CNAME is chased to its target, a name that does not exist comes back
+    NXDOMAIN rather than empty-but-successful, and a name outside the served
+    zone is REFUSED instead of answered. The health plugin is checked over HTTP
+    alongside, so "the process is up" and "the resolver is correct" are pinned
+    separately.
+
+# `dig` ships with bind9-dnsutils, preinstalled on GitHub runners. Each server
+# scenario binds its own port so the suite runs under the default scenario
+# concurrency. Install: see .github/workflows/thirdparty.yml for the pinned CI
+# version.
 
 permissions:
   network:

--- a/test/e2e/thirdparty/ecspresso/deploy.atago.yaml
+++ b/test/e2e/thirdparty/ecspresso/deploy.atago.yaml
@@ -2,17 +2,21 @@ version: "1"
 
 suite:
   name: ecspresso + deploy (real ECS deploy against a mock)
+  description: |
+    The thing ecspresso exists to do: deploy an ECS service, and roll it when
+    the definition changes. This suite runs that for real against a mock AWS
+    endpoint (moto, an in-memory AWS mock), so no AWS account is involved and
+    nothing is billed.
 
-# Companion to ecspresso.atago.yaml: where that suite pins the offline render
-# surface, this one exercises ecspresso's essential function — deploying an ECS
-# service and rolling it on change — against a mock AWS endpoint (moto, an
-# in-memory Apache-2.0 AWS mock) so no real AWS account is used. ecspresso and
-# the aws CLI are pointed at moto with AWS_ENDPOINT_URL and dummy credentials;
-# the ECS state change is observed with `aws ecs describe-services`, not just
-# asserted from ecspresso's logs. `--no-wait` is used because moto never runs
-# tasks, so a wait-for-stable would hang; the registration and service update
-# are synchronous and complete before it returns. Install: see
-# .github/workflows/thirdparty.yml for the pinned CI versions.
+    The deploy is verified from the outside. Rather than trusting ecspresso's
+    own log output, the resulting ECS state is read back with
+    `aws ecs describe-services` — a second, independent client — so the
+    assertion is about what the service actually looks like afterwards.
+
+# `--no-wait` is used because moto never runs tasks, so a wait-for-stable would
+# hang; the registration and service update are synchronous and complete before
+# it returns. Install: see .github/workflows/thirdparty.yml for the pinned CI
+# versions.
 
 permissions:
   network:

--- a/test/e2e/thirdparty/ecspresso/ecspresso.atago.yaml
+++ b/test/e2e/thirdparty/ecspresso/ecspresso.atago.yaml
@@ -2,15 +2,27 @@ version: "1"
 
 suite:
   name: ecspresso (Amazon ECS deploy tool)
+  description: |
+    [ecspresso](https://github.com/kayac/ecspresso) deploys ECS services, which
+    needs AWS — but everything that decides *what* gets deployed happens locally
+    first. `ecspresso render` evaluates a task and service definition without
+    touching a cluster, and that is the surface pinned here: the step where a
+    mistake becomes a bad deploy.
 
-# ecspresso deploys ECS services, which needs AWS — but its render subcommand
-# evaluates a task/service definition locally, so this suite pins that offline,
-# deterministic surface: template functions and their defaults, jsonnet with
-# external variables, config resolution, and the failure modes (an undefined
-# must_env, a missing config file) with their distinct exit codes. The rendered
-# task definition is checked as structured JSON. Gate: only where ecspresso is
-# installed. ecspresso logs a version line to stderr on every run, so stderr is
-# not asserted empty on success.
+    What is guaranteed: template functions expand to the documented values and
+    fall back to their defaults when unset; jsonnet definitions resolve with
+    external variables supplied; config paths resolve as documented; and the
+    failure modes stay loud and distinct — an undefined `must_env` and a missing
+    config file each fail with their own exit code rather than rendering
+    something half-substituted.
+
+    The rendered task definition is asserted as structured JSON, so a
+    reformatting change cannot break the suite while a semantic change slips
+    through.
+
+# ecspresso logs a version line to stderr on every run, so stderr is not
+# asserted empty on success. Gate: only where ecspresso is installed. The live
+# deploy half lives in deploy.atago.yaml.
 scenarios:
   - name: version prints without error
     only:

--- a/test/e2e/thirdparty/ffmpeg/changes.atago.yaml
+++ b/test/e2e/thirdparty/ffmpeg/changes.atago.yaml
@@ -2,11 +2,14 @@ version: "1"
 
 suite:
   name: ffmpeg + changes (single-artifact encode)
+  description: |
+    An encode should produce the output file and no debris. Media tools are
+    notorious for temporary files, and this suite pins that ffmpeg leaves none:
+    a synthesized encode creates exactly one file in the working directory, and
+    the exhaustive delta names it.
 
-# Companion to ffmpeg.atago.yaml: a lavfi-sourced encode writes exactly one
-# output file and touches nothing else. A minimal proof that the delta engine
-# reports a clean single creation for a media tool. Encodes are kept tiny so
-# the job stays fast. Gate: only where ffmpeg is installed.
+# Encodes are kept tiny so the job stays fast. Gate: only where ffmpeg is
+# installed.
 scenarios:
   - name: lavfi source encodes exactly one output file
     only:

--- a/test/e2e/thirdparty/ffmpeg/ffmpeg.atago.yaml
+++ b/test/e2e/thirdparty/ffmpeg/ffmpeg.atago.yaml
@@ -2,12 +2,20 @@ version: "1"
 
 suite:
   name: ffmpeg / ffprobe (media pipeline)
+  description: |
+    A whole media pipeline in one suite: [ffmpeg](https://ffmpeg.org/)
+    synthesizes a video, ffprobe describes it, and a frame is extracted back out
+    of it.
 
-# A media pipeline in one package (#35): ffmpeg synthesizes video, ffprobe
-# reports a JSON contract, and extracted frames are verified with atago's
-# image assertions (format/dimensions/pixel similarity) — assertion types no
-# other third-party spec exercises together. Encodes are kept tiny (1s,
-# 320x240) so the job stays fast. Gate: only where ffmpeg is installed.
+    What is guaranteed is the thing a media tool must not get wrong — that the
+    bytes it produced are really the media it claims. ffprobe's JSON is checked
+    as structure (codec, duration, dimensions), and the extracted frame is
+    verified as an actual image: its format, its pixel dimensions, and its
+    similarity to the expected picture. A file that exists and has a plausible
+    size is not enough.
+
+# Encodes are kept tiny (1s, 320x240) so the job stays fast. Gate: only where
+# ffmpeg is installed.
 scenarios:
   - name: lavfi synthesizes a video file
     only:

--- a/test/e2e/thirdparty/fzf/fzf.atago.yaml
+++ b/test/e2e/thirdparty/fzf/fzf.atago.yaml
@@ -2,14 +2,20 @@ version: "1"
 
 suite:
   name: fzf (third-party CLI, pty testbed)
+  description: |
+    [fzf](https://github.com/junegunn/fzf) is the archetype of a CLI you cannot
+    test by piping to it: it refuses to run without a terminal, redraws the
+    screen as you type, and is driven entirely by keystrokes.
 
-# fzf is the archetype of a TTY-dependent CLI: it refuses to run without a
-# terminal, redraws the screen, and is driven entirely by keystrokes — the
-# perfect real-world testbed for the pty runner (#20). The non-interactive
-# --filter mode pins the plain-run contract; the pty scenarios drive the real
-# finder UI with expect/send. Every scenario probes for fzf first so the suite
-# skips cleanly where it is absent; the interactive scenarios are POSIX-only
-# (the pty runner does not support Windows).
+    Both halves are covered. `fzf --filter` is a plain program with a plain
+    contract — given a query and a list on stdin, it prints the matches and
+    exits with a code that says whether anything matched. The interactive
+    scenarios run the real finder inside a pseudo-terminal and drive it the way
+    a person does: type to narrow the list, move the selection, press Enter, and
+    assert on what fzf finally printed.
+
+# Every scenario probes for fzf first so the suite skips cleanly where it is
+# absent; the interactive scenarios are POSIX-only.
 scenarios:
   - name: version prints a semantic version
     only:

--- a/test/e2e/thirdparty/git/changes.atago.yaml
+++ b/test/e2e/thirdparty/git/changes.atago.yaml
@@ -2,14 +2,20 @@ version: "1"
 
 suite:
   name: git + changes (a staged blob touches exactly index + one object)
+  description: |
+    `git add` is documented as writing a blob and updating the index. This suite
+    holds git to that literally: after initializing a repository, staging one
+    file must create exactly two things on disk — the staging index, and one
+    loose object under `.git/objects` — and nothing else anywhere.
 
-# A practical workdir-delta over git internals, companion to git.atago.yaml.
-# `git init` (a prior step) lays down the whole .git tree as the delta
-# baseline; the immediately-following `git add` then touches exactly two new
-# files: the staging index and one loose object. Object files are hash-named at
-# EXACTLY two levels (objects/<2-hex>/<38-hex>), so the v1 glob
-# `repo/.git/objects/*/*` covers them precisely — path.Match '*' never crosses
-# '/', so it cannot match a deeper path by accident.
+    It is an exhaustive claim, not a spot check. Any extra file git wrote would
+    fail the assertion, which is what makes it a real statement about git's
+    footprint rather than a restatement of the documentation.
+
+# `git init` (a prior step) lays down the whole .git tree as the delta baseline.
+# Object files are hash-named at EXACTLY two levels (objects/<2-hex>/<38-hex>),
+# so the glob `repo/.git/objects/*/*` covers them precisely — path.Match '*'
+# never crosses '/', so it cannot match a deeper path by accident.
 #
 # Unlike the rest of the git suite (which runs unchanged on every OS), this
 # scenario is POSIX-only: git-for-windows applies core.autocrlf/filemode

--- a/test/e2e/thirdparty/git/git.atago.yaml
+++ b/test/e2e/thirdparty/git/git.atago.yaml
@@ -2,13 +2,18 @@ version: "1"
 
 suite:
   name: git (third-party CLI, no build required)
+  description: |
+    The proof that testing someone else's CLI takes no cooperation from it. git
+    was not written with this test suite in mind, ships no hooks for it, and
+    exposes nothing but a command line — and that is enough.
 
-# atago's dogfood suites test CLIs the author maintains; this suite tests a CLI
-# nobody here wrote. git is on every dev machine and CI runner, so it runs on
-# Linux/macOS/Windows in CI as living proof that testing an arbitrary
-# third-party CLI needs no test code — only observable behavior. Every command
-# uses git's own -C/-c flags instead of a shell, so the same spec runs
-# unchanged on every OS.
+    What is guaranteed here is ordinary git as a script would meet it: a
+    repository is initialized, files are staged and committed, history and
+    status report the expected state, branches and tags behave, and the failure
+    cases (a bad revision, a dirty tree) exit non-zero with a message.
+
+    Every command uses git's own `-C`/`-c` flags instead of a shell, so this
+    exact spec runs unchanged on Linux, macOS, and Windows.
 scenarios:
   - name: init creates an empty repository
     steps:

--- a/test/e2e/thirdparty/git/sandbox_home.atago.yaml
+++ b/test/e2e/thirdparty/git/sandbox_home.atago.yaml
@@ -2,12 +2,17 @@ version: "1"
 
 suite:
   name: git + sandbox_home (global config in an isolated HOME)
+  description: |
+    `git config --global` writes to the user's home directory — the one thing a
+    test must never do to the machine running it. This suite shows the
+    alternative: the command runs with its home redirected inside the scenario's
+    own workspace, so a genuine `--global` write happens, lands at a
+    deterministic path, and disappears with the workspace.
 
-# git --global writes to $HOME/.gitconfig. With sandbox_home the child's HOME
-# is redirected to ${workdir}/.atago-home, so the write is hermetic and the
-# result is inspectable at a deterministic path. A second sandbox_home step
-# reads the same value back — the isolated home is reused across steps.
-#
+    The isolated home persists across steps, not just within one: a later
+    command reads the same setting back, proving it is a real home directory
+    rather than a write that went nowhere.
+
 # POSIX-only: this pins the HOME-based path .atago-home/.gitconfig. On Windows
 # git resolves config through USERPROFILE (which sandbox_home also sets), but
 # the exact on-disk path was not verified here, so the scenario is gated.

--- a/test/e2e/thirdparty/gitea/gitea.atago.yaml
+++ b/test/e2e/thirdparty/gitea/gitea.atago.yaml
@@ -2,17 +2,21 @@ version: "1"
 
 suite:
   name: gitea (self-hosted git service)
+  description: |
+    [Gitea](https://about.gitea.com/) is a whole git forge, and this suite meets
+    it the way an administrator would: a real server is booted from an authored
+    `app.ini` on SQLite, a user and an access token are provisioned through
+    Gitea's own CLI, and everything after that goes over the REST API —
+    creating a repository, committing files into it, opening issues.
 
-# Exercises Gitea (https://about.gitea.com/, from awesome-selfhosted's
-# software-development corner) as a third-party target: the real server booted
-# from an authored app.ini with SQLite, administered through its CLI (user +
-# access token), then driven over the REST API — repository creation, file
-# commits, issues — and finally cloned with real git over HTTP, proving two
-# third-party programs interoperate under one spec. Install (prebuilt binary):
-#   see .github/workflows/thirdparty.yml for the download step
-#
-# Each server scenario binds its own port so the suite runs under the default
-# scenario concurrency.
+    The suite ends by cloning that repository with real `git` over HTTP. That
+    last step is the point: two independent third-party programs, neither aware
+    of this test, are shown to interoperate — the forge really serves git, not
+    just a JSON API that claims a repository exists.
+
+# Install (prebuilt binary): see .github/workflows/thirdparty.yml for the
+# download step. Each server scenario binds its own port so the suite runs under
+# the default scenario concurrency.
 
 permissions:
   network:

--- a/test/e2e/thirdparty/gotify/gotify.atago.yaml
+++ b/test/e2e/thirdparty/gotify/gotify.atago.yaml
@@ -2,17 +2,23 @@ version: "1"
 
 suite:
   name: gotify (self-hosted notification server)
+  description: |
+    [Gotify](https://gotify.net/) receives notifications and hands them back
+    out. The full path is exercised against a real server on SQLite: an
+    application is provisioned over the REST API, a message is pushed with that
+    application's token, and it is read back with admin credentials — so the
+    message is proven to have been stored and served, not merely accepted.
 
-# Exercises Gotify (https://gotify.net/, from awesome-selfhosted's
-# notification corner) as a third-party target: the real server booted with
-# SQLite, an application provisioned over the REST API, messages pushed with
-# the app token and read back with admin credentials, the failure mode for
-# missing credentials — and the app icon uploaded as a real multipart
-# form-data request (`files:`), then downloaded back (`body_to`) and verified
-# as a PNG with the image assertion target. Install (prebuilt release; the UI
-# is compiled in, so `go install` cannot build it):
-#   see .github/workflows/thirdparty.yml for the download-and-verify step
-#
+    The refusal matters as much as the delivery: pushing without valid
+    credentials must fail rather than silently drop the notification.
+
+    One scenario goes further than JSON. The application's icon is uploaded as a
+    genuine multipart form-data request, downloaded back to disk, and verified
+    as a real PNG — the same round trip a browser performs, asserted on the
+    bytes that came back.
+
+# Install (prebuilt release; the UI is compiled in, so `go install` cannot build
+# it): see .github/workflows/thirdparty.yml for the download-and-verify step.
 # Each server scenario binds its own port so the suite runs under the default
 # scenario concurrency. admin/admin is Gotify's out-of-the-box default user,
 # used here against throwaway per-scenario databases.

--- a/test/e2e/thirdparty/gum/gum.atago.yaml
+++ b/test/e2e/thirdparty/gum/gum.atago.yaml
@@ -2,11 +2,20 @@ version: "1"
 
 suite:
   name: gum (third-party shell-script TUI toolkit)
+  description: |
+    [gum](https://github.com/charmbracelet/gum) exists to put a real interface
+    on a shell script, and it has two personalities to match.
 
-# gum mixes plain stdout-oriented commands (`join`, `table`, `log`,
-# `version-check`) with real terminal prompts (`choose`, `filter`, `confirm`,
-# `input`, `file`, `pager`). This suite covers both: script-friendly output
-# contracts and the TTY-only flows that actually justify gum's existence.
+    Some subcommands are ordinary filters — `join`, `table`, `log`,
+    `version-check` — with output a script parses; those are pinned as plain
+    stdout contracts.
+
+    The rest are prompts that only exist in front of a person: `choose`,
+    `filter`, `confirm`, `input`, `file`, `pager`. Those are driven inside a
+    pseudo-terminal with real keystrokes, because they are the reason anyone
+    installs gum, and a test that skipped them would cover everything except the
+    product.
+
 # Install: see .github/workflows/thirdparty.yml for the pinned CI version.
 scenarios:
   - name: version prints the pinned semantic version

--- a/test/e2e/thirdparty/helix/helix.atago.yaml
+++ b/test/e2e/thirdparty/helix/helix.atago.yaml
@@ -2,12 +2,19 @@ version: "1"
 
 suite:
   name: helix (third-party modal editor)
+  description: |
+    [Helix](https://helix-editor.com/) is a modal text editor, driven here as a
+    person drives it: the real TUI is launched in a terminal, keys are typed in
+    normal and insert mode, and commands are issued at the prompt.
 
-# Helix is a real modal text editor: these scenarios drive the actual TUI
-# against isolated config/cache/home directories and assert durable file-system
-# side effects (saved files, discarded edits, and multi-file workflows) instead
-# of brittle full-screen snapshots.
-# Install: see .github/workflows/thirdparty.yml for the pinned CI version.
+    What is asserted is what survives the editor — the file on disk. A save
+    must write the edited text; a quit-without-saving must leave the original
+    untouched; and a multi-file workflow must put each change in the right file.
+    Full-screen snapshots are deliberately avoided: they break when a status bar
+    changes, while "did the edit land?" is the contract that actually matters.
+
+# Config, cache, and home directories are isolated per scenario. Install: see
+# .github/workflows/thirdparty.yml for the pinned CI version.
 scenarios:
   - name: version prints the pinned release
     only:

--- a/test/e2e/thirdparty/htop/htop.atago.yaml
+++ b/test/e2e/thirdparty/htop/htop.atago.yaml
@@ -2,16 +2,21 @@ version: "1"
 
 suite:
   name: htop (third-party CLI, full-screen TUI testbed)
+  description: |
+    [htop](https://htop.dev/) is a full-screen program in the strict sense: it
+    switches the terminal to the alternate screen buffer, paints meters and a
+    process table with cursor movement and color, and restores what was there
+    before when it quits.
 
-# htop is the archetype of a FULL-SCREEN TUI: it switches to the alternate
-# screen buffer, paints meters and a process table with cursor moves and
-# colors, and restores the primary screen when it quits. That makes it the
-# real-world testbed for the pty runner's screen rendering (#27) that fzf — a
-# partial-screen finder — does not reach: the vt100 emulator must track the
-# alternate-screen switch to render the live frame, and a full-screen program
-# must run and quit cleanly under the pty. Every scenario probes for htop first
-# so the suite skips cleanly where it is absent; the interactive scenarios are
-# POSIX-only (the pty runner does not support Windows).
+    That is a harder thing to assert than scrolling output, and it is what this
+    suite pins. The rendered frame is reconstructed the way a terminal would
+    reconstruct it — following the alternate-screen switch and the cursor
+    movements — so the assertion is about what a user sees on screen, not about
+    the raw escape sequences that produced it. Quitting cleanly, and leaving the
+    terminal in a usable state, is part of the contract too.
+
+# Every scenario probes for htop first so the suite skips cleanly where it is
+# absent; the interactive scenarios are POSIX-only.
 scenarios:
   - name: version prints a semantic version
     only:

--- a/test/e2e/thirdparty/hugo/hugo.atago.yaml
+++ b/test/e2e/thirdparty/hugo/hugo.atago.yaml
@@ -2,14 +2,24 @@ version: "1"
 
 suite:
   name: hugo (scaffold + build CLI, tree-snapshot testbed)
+  description: |
+    [Hugo](https://gohugo.io/) is a scaffolder and a build tool in one binary,
+    and both produce their result as a directory tree rather than as output on
+    stdout.
 
-# hugo is scaffolding + build + serve in one binary (#22). `hugo new site`
-# generates a directory tree — the exact workload that motivates recursive
-# dir assertions and directory-tree snapshots (#25) — and `hugo --minify`
-# builds files worth asserting on. The server half lives in
-# hugo_server.atago.yaml. Every scenario probes for hugo first so the suite
-# skips cleanly where it is absent.
-# Install: see .github/workflows/thirdparty.yml for the pinned CI version.
+    That shape is what this suite is about. `hugo new site` must generate the
+    documented layout — the whole tree, asserted against a committed snapshot,
+    so an unexpected new file or a silently dropped one both show up. `hugo
+    --minify` must then turn content into a built site whose files exist and
+    contain what they should.
+
+    A generator is only trustworthy if the shape of what it generates is
+    trustworthy, which is why the assertion is the tree, not a spot check on one
+    file.
+
+# The server half lives in hugo_server.atago.yaml. Every scenario probes for
+# hugo first so the suite skips cleanly where it is absent. Install: see
+# .github/workflows/thirdparty.yml for the pinned CI version.
 scenarios:
   - name: new site scaffolds the documented directory tree
     only:

--- a/test/e2e/thirdparty/hugo/hugo_server.atago.yaml
+++ b/test/e2e/thirdparty/hugo/hugo_server.atago.yaml
@@ -2,11 +2,19 @@ version: "1"
 
 suite:
   name: hugo server (suite-wide service + http peer)
-  # The site must exist BEFORE the server starts, so the scaffold happens in
-  # suite.setup (ordered steps in ${suitedir}) and the `service:` step starts
-  # `hugo server` at that exact point in the sequence — the build-then-serve
-  # bootstrap pattern (#7). Like the caddy suite, this file assumes hugo is
-  # on PATH (make thirdparty documents the toolset; CI installs it).
+  description: |
+    `hugo server` is the half of Hugo a developer actually looks at: the site,
+    served over HTTP, rendered. This suite scaffolds a site, starts the real
+    development server against it, and then asks for pages the way a browser
+    would — so what is asserted is the HTML that reached the client.
+
+    The ordering is the interesting constraint. A site must exist before a
+    server can serve it, so the scaffold runs first and the server starts at
+    exactly that point in the sequence, once, for the whole suite — the
+    build-then-serve bootstrap every "run my app and test it" setup needs.
+
+  # Like the caddy suite, this file assumes hugo is on PATH (make thirdparty
+  # documents the toolset; CI installs it).
   setup:
     - run:
         command: hugo new site mysite --quiet

--- a/test/e2e/thirdparty/jq/extra.atago.yaml
+++ b/test/e2e/thirdparty/jq/extra.atago.yaml
@@ -2,12 +2,18 @@ version: "1"
 
 suite:
   name: jq (uncovered contracts — unicode passthrough + empty validation)
+  description: |
+    Two guarantees the main jq suite leaves untested.
 
-# Two contracts the main jq suite does not pin: multibyte unicode survives a
-# round-trip byte-exact, and `jq empty` is the canonical "validate only" idiom
-# — it consumes the document, prints nothing, and exits 0 on valid JSON but 5
-# on malformed input (the same not-JSON code the suite already relies on
-# elsewhere, here proven for the validation use-case with clean stdout).
+    First, that jq is safe for text that is not ASCII: multibyte characters must
+    survive a round trip byte for byte, with no re-encoding and no escaping
+    applied on the way through.
+
+    Second, that `jq empty` works as the validator everyone uses it as. It
+    consumes the document, prints nothing at all, and exits 0 — but exits 5 on
+    malformed input. That combination (silent on success, non-zero on garbage)
+    is what makes it usable as a JSON check in a script, and both halves are
+    pinned here.
 scenarios:
   - name: multibyte unicode passes through unchanged
     steps:

--- a/test/e2e/thirdparty/jq/jq.atago.yaml
+++ b/test/e2e/thirdparty/jq/jq.atago.yaml
@@ -2,12 +2,18 @@ version: "1"
 
 suite:
   name: jq (third-party CLI, no build required)
+  description: |
+    [jq](https://jqlang.github.io/jq/) is a filter: JSON in on stdin, JSON out
+    on stdout, and an exit code that tells the calling script what happened.
 
-# jq is the first pure text-processing tool in the third-party matrix: a
-# filter program driven almost entirely by stdin, with a documented exit-code
-# contract (0 ok, 1 for false/null under -e, 2 for usage/system errors, 3 for
-# a program that does not compile, 5 when the input is not valid JSON). That
-# contract is exactly what atago's exit_code / stdout / stderr targets pin.
+    That exit-code contract is unusually rich, and it is what this suite pins,
+    because a shell pipeline depends on it: 0 when the filter ran, 1 when `-e`
+    saw a false or null result, 2 for a usage or system error, 3 for a program
+    that does not compile, and 5 when the input was not valid JSON at all. Four
+    different kinds of "it didn't work", each of which a script may need to
+    handle differently — and each of which must not be confused for the others.
+
+# The unicode and `jq empty` contracts live in extra.atago.yaml.
 scenarios:
   - name: identity filter echoes the document from stdin
     steps:

--- a/test/e2e/thirdparty/kustomize/changes.atago.yaml
+++ b/test/e2e/thirdparty/kustomize/changes.atago.yaml
@@ -2,13 +2,18 @@ version: "1"
 
 suite:
   name: kustomize + changes (kustomization file authoring)
+  description: |
+    `kustomize create` and `kustomize edit` modify your project in place, which
+    makes their footprint part of their contract: they should write the
+    kustomization file and leave everything else alone.
 
-# Companion to kustomize.atago.yaml: where that suite pins the render output,
-# this one pins the filesystem side effects of `kustomize create`, `kustomize
-# edit`, and `kustomize edit fix`. sandbox_home points HOME inside the workdir
-# so any stray home write would surface in the delta — the "touches only the
-# kustomization file" claim is enforced by the changes assert, not merely
-# asserted in prose. Gate: only where kustomize is installed.
+    That is stated here as an exhaustive claim. Each command's effect on the
+    directory is compared before and after, so an extra file, a backup left
+    behind, or a stray write into the user's home directory would all fail —
+    the home directory included, because it is redirected inside the workspace
+    where the delta can see it.
+
+# Gate: only where kustomize is installed.
 scenarios:
   - name: create writes exactly the kustomization file
     only:

--- a/test/e2e/thirdparty/kustomize/kustomize.atago.yaml
+++ b/test/e2e/thirdparty/kustomize/kustomize.atago.yaml
@@ -2,16 +2,22 @@ version: "1"
 
 suite:
   name: kustomize (declarative Kubernetes config)
+  description: |
+    [kustomize](https://kustomize.io/) turns a base set of Kubernetes manifests
+    plus a list of edits into the final YAML you apply. No cluster is involved
+    and no network is touched, which means the same inputs must always render
+    the same bytes — the property everything else depends on.
 
-# kustomize renders Kubernetes manifests declaratively: `kustomize build` reads a
-# kustomization.yaml plus its resources and emits the transformed, merged YAML on
-# stdout. It is fully offline and deterministic — no cluster, no network — which
-# makes it an exemplary contract to pin: the same inputs always render the same
-# bytes, transformations compose in a defined order, generators derive a content
-# hash, the load restrictor refuses to escape the kustomization root, and
-# failures report on stderr with exit 1. Every scenario authors its inputs with
-# fixtures inside the isolated workdir and probes for kustomize first so the
-# suite skips cleanly where it is absent.
+    What is guaranteed: transformations compose in the defined order, so name
+    prefixes, labels, and patches land predictably rather than by accident of
+    evaluation order; generators derive the content hash that makes a config map
+    change roll its consumers; the load restrictor refuses to read files outside
+    the kustomization root, which is a security boundary and not a convenience;
+    and a broken kustomization fails on stderr with exit 1 instead of emitting
+    partial YAML someone might apply.
+
+# Every scenario authors its inputs with fixtures inside the isolated workdir
+# and probes for kustomize first so the suite skips cleanly where it is absent.
 scenarios:
   - name: version prints a semantic version
     only:

--- a/test/e2e/thirdparty/lazygit/lazygit.atago.yaml
+++ b/test/e2e/thirdparty/lazygit/lazygit.atago.yaml
@@ -2,11 +2,17 @@ version: "1"
 
 suite:
   name: lazygit (third-party git TUI)
+  description: |
+    [lazygit](https://github.com/jesseduffield/lazygit) is a terminal interface
+    in front of a real repository: keystrokes stage files, write commits,
+    discard changes, create branches, and push and pop stashes.
 
-# lazygit is a real-world Git TUI: it stages, commits, discards, creates
-# branches, and manipulates stashes through a terminal UI while mutating an
-# actual repository. These scenarios therefore assert both the rendered UI
-# checkpoints and the repository side effects under the scenario workdir.
+    Both sides of that are asserted. The rendered screen must show the user what
+    they expect at each checkpoint — otherwise the tool is unusable even when it
+    works — and the repository underneath must have actually changed, checked by
+    reading git state afterwards. A TUI test that only looked at the screen
+    would pass on a version that draws a commit it never made.
+
 # Install: see .github/workflows/thirdparty.yml for the pinned CI version.
 scenarios:
   - name: version prints the pinned release

--- a/test/e2e/thirdparty/mailpit/mailpit.atago.yaml
+++ b/test/e2e/thirdparty/mailpit/mailpit.atago.yaml
@@ -2,16 +2,21 @@ version: "1"
 
 suite:
   name: mailpit (self-hosted email testing server)
+  description: |
+    [Mailpit](https://mailpit.axllent.org/) catches email so it can be
+    inspected, and testing it means using two protocols at once: mail goes in
+    over SMTP and comes back out over HTTP.
 
-# Exercises Mailpit (https://mailpit.axllent.org/, from awesome-selfhosted's
-# email corner) as a third-party target — a protocol pairing nothing else in
-# this directory covers: real messages are delivered over SMTP with the stock
-# curl client (smtp://), then asserted through Mailpit's REST API — capture,
-# full-text search, MIME attachments, and mailbox teardown. Install: see
-# .github/workflows/thirdparty.yml for the pinned CI version.
-#
+    Messages are delivered by the stock `curl` client speaking real SMTP — no
+    library shim, no injected fixture — and everything after that is asserted
+    through Mailpit's REST API: that the message was captured with its headers
+    and body intact, that full-text search finds it, that a MIME attachment
+    survives as a distinct part, and that clearing the mailbox really empties
+    it.
+
 # Each scenario binds its own SMTP+HTTP port pair so the suite runs under the
-# default scenario concurrency.
+# default scenario concurrency. Install: see .github/workflows/thirdparty.yml
+# for the pinned CI version.
 
 permissions:
   network:

--- a/test/e2e/thirdparty/minio/minio.atago.yaml
+++ b/test/e2e/thirdparty/minio/minio.atago.yaml
@@ -2,17 +2,23 @@ version: "1"
 
 suite:
   name: minio (self-hosted object storage)
+  description: |
+    [MinIO](https://min.io/) is S3-compatible object storage, driven here by its
+    own `mc` client against a real server.
 
-# Exercises MinIO (https://min.io/, from awesome-selfhosted's object storage
-# corner) as a third-party target: the real S3-compatible server booted as a
-# background service per scenario, health probed over HTTP, driven end-to-end
-# with the mc client (bucket + object lifecycle, versioning, anonymous
-# policies), and the unauthenticated failure mode asserted as S3 XML. Install:
-# see .github/workflows/thirdparty.yml for the pinned CI versions.
-#
-# Each scenario binds its own port so the suite runs under the default
-# scenario concurrency. Pin MC_CONFIG_DIR under the scenario workdir so mc
-# state is isolated per scenario too.
+    What is guaranteed is the storage contract an application relies on: the
+    bucket and object lifecycle end to end, versioning keeping earlier revisions
+    retrievable rather than overwritten, and anonymous access policies actually
+    granting and denying what they say.
+
+    The unauthenticated case is checked as S3 XML, not just as a non-zero exit —
+    because a client library parses that error document, and "denied" has to
+    arrive in a form the client can understand.
+
+# Each scenario binds its own port so the suite runs under the default scenario
+# concurrency; MC_CONFIG_DIR is pinned under the scenario workdir so mc state is
+# isolated per scenario too. Install: see .github/workflows/thirdparty.yml for
+# the pinned CI versions.
 
 permissions:
   network:

--- a/test/e2e/thirdparty/nats/nats.atago.yaml
+++ b/test/e2e/thirdparty/nats/nats.atago.yaml
@@ -2,18 +2,23 @@ version: "1"
 
 suite:
   name: nats (self-hosted messaging system)
+  description: |
+    [NATS](https://nats.io/) is a message broker, which makes it the one
+    workload here that needs two live participants to mean anything.
 
-# Exercises NATS (https://nats.io/, from awesome-selfhosted's messaging
-# corner) as a third-party target — a messaging workload unlike anything else
-# in this directory: the real broker runs as a background service and is
-# driven with the official nats CLI through request/reply (a second background
-# service answers), JetStream persistence (stream create → publish → counted
-# state → purge), and the JetStream KV store, while the monitoring endpoint is
-# asserted through the http runner. Install: see
-# .github/workflows/thirdparty.yml for the pinned CI versions.
-#
-# Each scenario binds its own port so the suite runs under the default
-# scenario concurrency.
+    Request/reply is tested with a real responder: a second background process
+    subscribes and answers, so a request is proven to have reached something and
+    come back — not merely to have been accepted by the broker.
+
+    JetStream, the persistence layer, is followed through its whole cycle:
+    create a stream, publish into it, read the stream's state back and count
+    what is stored, then purge it and confirm the count fell. The key-value
+    store built on top is exercised the same way, and the broker's monitoring
+    endpoint is checked over HTTP alongside.
+
+# Each scenario binds its own port so the suite runs under the default scenario
+# concurrency. Install: see .github/workflows/thirdparty.yml for the pinned CI
+# versions.
 
 permissions:
   network:

--- a/test/e2e/thirdparty/ntfy/ntfy.atago.yaml
+++ b/test/e2e/thirdparty/ntfy/ntfy.atago.yaml
@@ -2,17 +2,24 @@ version: "1"
 
 suite:
   name: ntfy (self-hosted push notification service)
+  description: |
+    [ntfy](https://ntfy.sh/) sends push notifications over plain HTTP, which
+    means anything that can make a request can publish — and that is both its
+    appeal and the reason its access control matters.
 
-# Exercises ntfy (https://ntfy.sh/, from awesome-selfhosted's notification
-# corner) as a third-party target: publish/subscribe push notifications over
-# plain HTTP — publishing with headers (title, priority, tags), polling the
-# JSON feed, topic isolation, the bundled CLI publishing against the same
-# server, and access control (deny-all default, user + grant via the admin
-# CLI, then authorized publish). Install (prebuilt release; `go install` is
-# blocked by replace directives):
-#   see .github/workflows/thirdparty.yml for the download-and-verify step
-#
-# Each server scenario binds its own port so the suite runs under the default
+    The publish path is pinned with its metadata intact: a notification's title,
+    priority, and tags must survive as sent and come back on the JSON feed.
+    Topics must stay isolated, so a subscriber to one topic never sees another's
+    messages. The bundled CLI is exercised against the same server as the raw
+    HTTP client, so the two agree.
+
+    Access control gets the same treatment as the happy path: with a deny-all
+    default in place, publishing is refused; after a user is created and granted
+    access through the admin CLI, the same publish succeeds.
+
+# Install (prebuilt release; `go install` is blocked by replace directives):
+# see .github/workflows/thirdparty.yml for the download-and-verify step. Each
+# server scenario binds its own port so the suite runs under the default
 # scenario concurrency.
 
 permissions:

--- a/test/e2e/thirdparty/openssl/changes.atago.yaml
+++ b/test/e2e/thirdparty/openssl/changes.atago.yaml
@@ -2,12 +2,17 @@ version: "1"
 
 suite:
   name: openssl + changes (key and cert generation footprints)
+  description: |
+    A tool that generates private key material should write exactly the file you
+    named and nothing else — no copy, no temporary file left in the directory,
+    no cache entry elsewhere. With secrets, a stray extra file is a leak.
 
-# Companion to openssl.atago.yaml: key/cert generation should write exactly the
-# file named by -out and nothing else. Each `changes:` assert pins one created
-# artifact; the second scenario's baseline includes key.pem (created by the
-# prior step, whose delta is not asserted there). Gate: only where openssl is
-# installed.
+    This suite states that as an exhaustive contract: after generating a key,
+    and after generating a certificate, the directory contains precisely the one
+    new artifact that was asked for.
+
+# The second scenario's baseline includes key.pem (created by the prior step,
+# whose delta is not asserted there). Gate: only where openssl is installed.
 scenarios:
   - name: genrsa writes exactly the key file
     only:

--- a/test/e2e/thirdparty/openssl/openssl.atago.yaml
+++ b/test/e2e/thirdparty/openssl/openssl.atago.yaml
@@ -2,13 +2,21 @@ version: "1"
 
 suite:
   name: openssl (third-party CLI, no build required)
+  description: |
+    [OpenSSL](https://www.openssl.org/) is the cryptography tool most scripts
+    reach for, and cryptography is where "it produced output" is the least
+    convincing evidence of anything.
 
-# openssl is the first cryptography tool in the third-party matrix. The suite
-# pins observable contracts a script would depend on: digests are exact and
-# stable, key generation produces working keys (proven by deriving the public
-# half and signing/verifying), encryption round-trips byte-for-byte, a WRONG
-# password fails loudly instead of producing garbage, and a self-signed
-# certificate carries the requested subject.
+    So each guarantee here is checked against something independent. Digests are
+    pinned to their known values. A generated key is proven to work by deriving
+    its public half and then signing and verifying with the pair — not by
+    checking that a file appeared. Encryption is proven by decrypting back to
+    the original bytes.
+
+    And the failure case is treated as a feature: decrypting with the wrong
+    password must fail loudly, because a crypto tool that silently emits garbage
+    on a bad key is worse than one that crashes. A self-signed certificate is
+    checked to carry the subject that was requested.
 scenarios:
   - name: sha256 digest of a fixed input is exact and stable
     steps:

--- a/test/e2e/thirdparty/pandoc/changes.atago.yaml
+++ b/test/e2e/thirdparty/pandoc/changes.atago.yaml
@@ -2,11 +2,17 @@ version: "1"
 
 suite:
   name: pandoc + changes (a conversion writes exactly its output)
+  description: |
+    Converting a document should produce the converted document — and nothing
+    besides. This suite states that exactly: with the source file present as the
+    baseline, a conversion creates precisely one new file, the one named on the
+    command line.
 
-# Companion to pandoc.atago.yaml: a file-to-file conversion should touch
-# nothing but its named output. The `changes:` assert states that as an exact
-# contract — the input is a fixture (baseline), and the single created file is
-# out.html. Gate: only where pandoc is installed.
+    Anything else pandoc happened to write would fail the assertion, which is
+    what makes this a claim about its footprint rather than a check that the
+    output exists.
+
+# Gate: only where pandoc is installed.
 scenarios:
   - name: markdown-to-html creates exactly the output file
     only:

--- a/test/e2e/thirdparty/pandoc/pandoc.atago.yaml
+++ b/test/e2e/thirdparty/pandoc/pandoc.atago.yaml
@@ -2,12 +2,21 @@ version: "1"
 
 suite:
   name: pandoc (document conversion filter)
+  description: |
+    [Pandoc](https://pandoc.org/) converts documents between formats, and it can
+    be used two entirely different ways: as a file-to-file converter, or as a
+    filter in a pipeline reading stdin and writing stdout.
 
-# The classic document-conversion filter (#36): file-to-file and
-# stdin-to-stdout modes, structured JSON output (its AST), and multi-format
-# artifacts. It exercises the stdin story hard — a concrete consumer of the
-# stdin: {file:} feature (#18). PDF output is out of scope (needs LaTeX).
-# Gate: only where pandoc is installed.
+    Both are pinned, because a script may depend on either, and they must agree:
+    the same input converted either way must produce the same document.
+
+    Beyond the rendered output, pandoc can emit its internal AST as JSON — a
+    structured oracle that says what pandoc *understood* the document to be, not
+    merely what it printed. Asserting on that catches a parsing regression that
+    happens to render plausibly.
+
+# PDF output is out of scope (needs LaTeX). Gate: only where pandoc is
+# installed.
 scenarios:
   - name: markdown converts to HTML and a binary docx
     only:

--- a/test/e2e/thirdparty/prometheus/prometheus.atago.yaml
+++ b/test/e2e/thirdparty/prometheus/prometheus.atago.yaml
@@ -2,16 +2,24 @@ version: "1"
 
 suite:
   name: prometheus (self-hosted monitoring system)
+  description: |
+    [Prometheus](https://prometheus.io/) ships as two things, and this suite
+    covers both.
 
-# Exercises Prometheus (https://prometheus.io/, from awesome-selfhosted's
-# monitoring corner) as a third-party target: promtool as a pure CLI (config
-# validation both ways, plus unit-testing alerting rules), and the real server
-# booted from an authored config — health endpoints, the query API as JSON,
-# and a self-scrape polled with http retry until the sample is ingested.
+    `promtool` is an ordinary CLI: it must accept a valid configuration and
+    reject an invalid one with a diagnostic, and it must be able to unit-test
+    alerting rules — catching a bad alert before it reaches production rather
+    than during an incident.
+
+    The server is booted from an authored config and then genuinely used: its
+    health endpoints answer, its query API returns JSON that can be asserted as
+    structure, and a metric it scraped from itself is polled until it appears.
+    That last one closes the loop — configuration, scrape, storage, and query
+    all had to work for the sample to be there.
+
 # Install (prebuilt release; `go install` is blocked by replace directives):
-#   see .github/workflows/thirdparty.yml for the download-and-unpack step
-#
-# Each server scenario binds its own port so the suite runs under the default
+# see .github/workflows/thirdparty.yml for the download-and-unpack step. Each
+# server scenario binds its own port so the suite runs under the default
 # scenario concurrency.
 
 permissions:

--- a/test/e2e/thirdparty/pushgateway/pushgateway.atago.yaml
+++ b/test/e2e/thirdparty/pushgateway/pushgateway.atago.yaml
@@ -2,14 +2,20 @@ version: "1"
 
 suite:
   name: pushgateway (self-hosted metrics gateway)
+  description: |
+    [Pushgateway](https://github.com/prometheus/pushgateway) exists so that a
+    job too short-lived to be scraped can push its metrics somewhere Prometheus
+    will find them later.
 
-# Exercises Prometheus Pushgateway (from awesome-selfhosted's monitoring
-# corner) as a third-party target. Its push API takes the raw text exposition
-# format — the workload the http step's `body:` payload exists for. Install:
-# see .github/workflows/thirdparty.yml for the pinned CI version.
-#
-# Each scenario binds its own port so the suite runs under the default
-# scenario concurrency.
+    Its API is unusual in that the payload is not JSON but Prometheus's own
+    plain-text exposition format, sent as a raw request body. This suite pushes
+    real metrics that way and then reads them back from the gateway's own
+    endpoint — so what is asserted is that the gateway stored and re-exposed the
+    samples, in the format a Prometheus scrape would consume.
+
+# Each scenario binds its own port so the suite runs under the default scenario
+# concurrency. Install: see .github/workflows/thirdparty.yml for the pinned CI
+# version.
 
 permissions:
   network:

--- a/test/e2e/thirdparty/python/changes.atago.yaml
+++ b/test/e2e/thirdparty/python/changes.atago.yaml
@@ -2,12 +2,17 @@ version: "1"
 
 suite:
   name: python3 + changes (bytecode cache footprint)
+  description: |
+    Running a Python script quietly writes files you did not ask for: importing a
+    local module leaves a compiled `.pyc` behind in `__pycache__`, while the
+    entry script itself is never cached. That asymmetry surprises people, so it
+    is pinned here exactly.
 
-# Companion to python.atago.yaml, pinning the filesystem side effect of an
-# import with the `changes:` assert. Importing a local module writes a compiled
-# __pycache__/*.pyc; the entry script itself is never cached. A paired scenario
-# proves PYTHONDONTWRITEBYTECODE=1 suppresses the cache entirely (created: [] —
-# the run touches nothing). Gate: only where python3 is installed.
+    The paired scenario pins the escape hatch: with `PYTHONDONTWRITEBYTECODE`
+    set, the same run creates nothing at all — an empty delta, which is the
+    strongest form this assertion can take.
+
+# Gate: only where python3 is installed.
 scenarios:
   - name: importing a local module writes exactly one .pyc
     only:

--- a/test/e2e/thirdparty/python/python.atago.yaml
+++ b/test/e2e/thirdparty/python/python.atago.yaml
@@ -2,13 +2,23 @@ version: "1"
 
 suite:
   name: python3 REPL (interactive pty testbed)
+  description: |
+    The Python REPL is the canonical long-lived interactive session: it prints a
+    prompt, waits, answers, and prompts again, for as many exchanges as you
+    want.
 
-# The python3 REPL is the canonical long-lived interactive session (#33):
-# prompt detection (>>>), multi-exchange expect/send, tracebacks, TTY
-# branching, and clean EOF exit. python3 ships on every CI image, so this is
-# the cheapest always-available pty workout and a copy-paste template for
-# testing your own REPL. Non-interactive `-c` contracts run everywhere; the
-# pty scenarios are POSIX-only. Gate: only where python3 is installed.
+    That conversational shape is what this suite pins — recognizing the `>>>`
+    prompt, carrying on a multi-step exchange where each answer depends on the
+    last, getting a traceback back for bad input without the session dying, and
+    exiting cleanly on end-of-input. Python also behaves differently when it
+    detects a terminal, so that branch is exercised too.
+
+    Python is on every CI image, which makes this the most portable worked
+    example here of testing an interactive program — and a template to copy for
+    your own REPL.
+
+# Non-interactive `-c` contracts run everywhere; the pty scenarios are
+# POSIX-only. Gate: only where python3 is installed.
 scenarios:
   - name: version and -c contracts (non-interactive)
     only:

--- a/test/e2e/thirdparty/rclone/rclone.atago.yaml
+++ b/test/e2e/thirdparty/rclone/rclone.atago.yaml
@@ -2,14 +2,22 @@ version: "1"
 
 suite:
   name: rclone (self-hosted file sync program)
+  description: |
+    [rclone](https://rclone.org/) moves files between storage backends, and the
+    distinction it must never blur is copy versus sync: one adds, the other
+    makes the destination match the source — including deleting what is no
+    longer there. Getting that wrong destroys data, so both are pinned
+    explicitly.
 
-# Exercises rclone (https://rclone.org/, from awesome-selfhosted's file
-# transfer corner) as a third-party target. The local backend keeps every
-# scenario hermetic: copy/sync semantics, machine-readable listings, integrity
-# checks and their failure mode, the obscure/reveal password round-trip, and
-# `rclone serve http` as a real background server queried through the http
-# runner. Install: see .github/workflows/thirdparty.yml for the pinned CI
-# version.
+    Around them: machine-readable listings a script can parse, integrity
+    checking that passes on matching trees and *fails* on a corrupted one, and
+    the obscure/reveal password round trip returning the original secret.
+
+    `rclone serve http` is started as a real server and queried over HTTP, so
+    the serving half is proven from the outside too. Everything runs against the
+    local backend, which keeps every scenario hermetic.
+
+# Install: see .github/workflows/thirdparty.yml for the pinned CI version.
 
 permissions:
   network:

--- a/test/e2e/thirdparty/redis/redis.atago.yaml
+++ b/test/e2e/thirdparty/redis/redis.atago.yaml
@@ -2,13 +2,20 @@ version: "1"
 
 suite:
   name: redis (server + client, signal-step testbed)
+  description: |
+    Redis ships a server and a client together, so one suite can cover a whole
+    round trip: start the server, wait for it to actually be ready, talk to it,
+    and shut it down.
 
-# Redis is a server+client pair in one package (#21): redis-server exercises
-# scenario services (readiness by log AND by port), redis-cli is a real-world
-# client with a crisp raw-output contract (PONG/OK/integers when stdout is a
-# pipe). Its clean shutdown semantics make it the proving ground for the
-# planned `signal:` step (#23) — until that lands, the shutdown scenario uses
-# SHUTDOWN NOSAVE plus a retry-polled PING as the declarative stand-in.
+    Readiness is checked two ways — by the log line the server prints and by the
+    port accepting connections — because those can disagree, and a test that
+    starts sending commands too early is flaky rather than wrong.
+
+    `redis-cli` has a crisp contract worth pinning: when its output is a pipe
+    rather than a terminal it prints raw values (`PONG`, `OK`, bare integers),
+    which is exactly what a script parses. Shutdown is the other end of the
+    lifecycle: the server is asked to stop and is then polled until it really
+    stops answering.
 # Every scenario probes for redis first so the suite skips cleanly where it
 # is absent; redis-server is POSIX-only, so the suite skips on Windows. Because
 # the two binaries ship in separate packages on some hosts (redis-server vs

--- a/test/e2e/thirdparty/restic/restic.atago.yaml
+++ b/test/e2e/thirdparty/restic/restic.atago.yaml
@@ -2,14 +2,25 @@ version: "1"
 
 suite:
   name: restic (self-hosted backup program)
+  description: |
+    A backup tool is only worth anything if the restore works, so this suite
+    follows [restic](https://restic.net/) through the entire lifecycle rather
+    than stopping at "the backup succeeded".
 
-# Exercises restic (https://restic.net/, from awesome-selfhosted's backup
-# corner) as a third-party target: a full backup lifecycle against a local
-# repository — init, backup, list snapshots as JSON, restore, diff, integrity
-# check, retention, and the failure mode a wrong password must produce.
+    A repository is initialized, real data is backed up, snapshots are listed as
+    JSON, and the data is restored — and the restored files are compared against
+    the originals. Beyond that: `diff` between snapshots reports what actually
+    changed, the integrity check passes on a healthy repository, and retention
+    policies remove the snapshots they say they will and keep the rest.
+
+    The wrong password must fail. For an encrypted backup that is not an error
+    path but the core guarantee: without the password the data is not
+    recoverable, and that is asserted here as deliberately as the successful
+    restore.
+
 # Everything is hermetic: the repository and the data live in the scenario's
-# isolated workdir. Install: see .github/workflows/thirdparty.yml for the
-# pinned CI version.
+# isolated workdir. Install: see .github/workflows/thirdparty.yml for the pinned
+# CI version.
 
 defaults:
   scenario:

--- a/test/e2e/thirdparty/sops/sops.atago.yaml
+++ b/test/e2e/thirdparty/sops/sops.atago.yaml
@@ -2,15 +2,25 @@ version: "1"
 
 suite:
   name: sops + age (secrets encryption)
+  description: |
+    [sops](https://github.com/getsops/sops) encrypts the *values* in a
+    structured file while leaving its keys readable, so a secrets file stays
+    reviewable in a pull request while its contents stay secret.
 
-# sops encrypts the values of a structured file while leaving its keys readable,
-# using age as the key backend here. The suite pins the contract that matters
-# for a secrets tool: encryption hides every value but the structure, decryption
-# recovers the values, a specific field can be extracted, the wrong key cannot
-# decrypt, a single flipped byte fails the MAC (the integrity guarantee), and a
-# regex can scope which keys are encrypted. Every age key is generated fresh
-# inside the workdir (never committed) and the plaintext values are throwaway
-# placeholders. Gate: only where both sops and age are installed.
+    That split is the contract pinned here: after encryption the structure is
+    still legible and every value is hidden; after decryption the values come
+    back; and a single field can be extracted without decrypting the rest.
+
+    The negative guarantees carry equal weight. The wrong key must not decrypt.
+    And flipping one byte of the ciphertext must fail the message
+    authentication check rather than yielding subtly wrong plaintext — the
+    integrity property that separates an encrypted file from an obfuscated one.
+    A regex scoping which keys get encrypted is checked too, since a
+    misconfigured scope is how secrets end up committed in the clear.
+
+# Every age key is generated fresh inside the workdir (never committed) and the
+# plaintext values are throwaway placeholders. Gate: only where both sops and
+# age are installed.
 scenarios:
   - name: version prints a semantic version offline
     only:

--- a/test/e2e/thirdparty/sqlite3/changes.atago.yaml
+++ b/test/e2e/thirdparty/sqlite3/changes.atago.yaml
@@ -2,13 +2,19 @@ version: "1"
 
 suite:
   name: sqlite3 + changes (workdir-delta of a database write)
+  description: |
+    SQLite creates side files while it works — a rollback journal by default, or
+    a write-ahead log and shared-memory file in WAL mode. A process that dies
+    mid-transaction leaves them behind.
 
-# The companion to sqlite3.atago.yaml, pinning the exact filesystem footprint
-# of a one-shot write with the `changes:` assert. Counterintuitively, the
-# rollback-journal (default) and WAL modes both create side files
-# (t.db-journal / t.db-wal / t.db-shm) DURING the invocation, but a clean
-# sqlite3 process close deletes or checkpoints them before it exits — so the
-# pre/post workdir delta ever only sees the database file itself.
+    This suite pins the cleanup guarantee: after a `sqlite3` process exits
+    normally, those files are gone — deleted or checkpointed back into the
+    database — and the only thing that changed on disk is the database file
+    itself. In both journal modes.
+
+    That is a stronger statement than "the write worked", and it is what makes a
+    leftover journal file a detectable regression rather than something nobody
+    notices until a restore.
 scenarios:
   - name: default rollback-journal mode creates exactly the db file
     steps:

--- a/test/e2e/thirdparty/sqlite3/sqlite3.atago.yaml
+++ b/test/e2e/thirdparty/sqlite3/sqlite3.atago.yaml
@@ -2,13 +2,19 @@ version: "1"
 
 suite:
   name: sqlite3 (third-party CLI, no build required)
+  description: |
+    The `sqlite3` shell driven as a user drives it — the actual binary on a
+    command line, not SQLite embedded as a library.
 
-# The sqlite3 shell is the first embedded-database CLI in the third-party
-# matrix (distinct from atago's db runner, which speaks to SQLite as a
-# library: this suite drives the /usr/bin/sqlite3 *binary* like a user would).
-# It pins the one-shot SQL contract, machine-readable -json/-csv output modes,
-# dot-command behavior (.dump/.schema/.import), durability of the database
-# file across invocations, and the bad-SQL failure mode.
+    What is guaranteed: one-shot SQL passed as an argument runs and prints its
+    result; the machine-readable output modes (`-json`, `-csv`) produce output a
+    script can parse; the dot-commands behave as documented, so `.dump` can
+    reproduce a database, `.schema` reports it, and `.import` reads a file back
+    in; and bad SQL fails with a message instead of a partial result.
+
+    Durability gets its own attention: data written by one invocation must still
+    be there for the next one, which is the whole reason to use a file-backed
+    database rather than a pipe.
 scenarios:
   - name: one-shot SQL creates, inserts, and counts in a single invocation
     steps:

--- a/test/e2e/thirdparty/ssh-keygen/ssh-keygen.atago.yaml
+++ b/test/e2e/thirdparty/ssh-keygen/ssh-keygen.atago.yaml
@@ -2,13 +2,20 @@ version: "1"
 
 suite:
   name: ssh-keygen (OpenSSH key generation)
+  description: |
+    `ssh-keygen` is small, ships with OpenSSH everywhere, and happens to combine
+    three things that are each awkward to test: an interactive passphrase
+    prompt, files written to disk, and an exit code that carries meaning.
 
-# ssh-keygen ships with OpenSSH on every CI image and mixes three atago
-# strengths in one small tool (#34): interactive passphrase prompts (pty),
-# generated-file assertions (the key pair on disk), and a crisp
-# stdout/exit-code contract (fingerprints, verification failures). Every key
-# here is a throwaway generated inside the scenario's isolated workdir — no
-# real credentials, and the workdir is discarded when the scenario ends.
+    All three are covered together. The passphrase is typed at the real prompt
+    inside a terminal, the resulting key pair is asserted as files with the
+    right shape and permissions, and the fingerprint output is checked — as is
+    the failure when a key cannot be verified.
+
+    Every key here is a throwaway generated inside the scenario's own workspace,
+    which is discarded when the scenario ends. No real credential is involved at
+    any point.
+
 # Gate: only where ssh-keygen is installed. pty scenarios are POSIX-only.
 
 secrets:

--- a/test/e2e/thirdparty/terraform/terraform.atago.yaml
+++ b/test/e2e/thirdparty/terraform/terraform.atago.yaml
@@ -2,19 +2,28 @@ version: "1"
 
 suite:
   name: terraform (offline via the builtin terraform_data resource)
-  # Deterministic, offline output: no CLI update checks, no telemetry, no
-  # interactive prompts. Only the builtin terraform_data resource is used, so
-  # `init` downloads nothing and the network allowlist stays untouched.
+  description: |
+    Terraform's exit codes are not a detail — they are the interface CI
+    pipelines are built on. `terraform plan -detailed-exitcode` answers with 0
+    for "nothing to do", 2 for "there are changes", and 1 for "it failed", and a
+    pipeline that confuses 2 with 1 either blocks on every change or deploys
+    through every error.
+
+    That three-way contract is what this suite pins, alongside the ordinary path
+    through init, validate, plan, and apply.
+
+    It stays entirely offline by using only Terraform's builtin
+    `terraform_data` resource, so `init` downloads no providers and no network
+    access is needed to run any of it.
+
+  # Deterministic output: no CLI update checks, no telemetry, no interactive
+  # prompts.
   env:
     TF_IN_AUTOMATION: "1"
     CHECKPOINT_DISABLE: "1"
     TF_CLI_ARGS: "-no-color"
 
-# terraform is a textbook multi-exit-code CLI (#37): `plan -detailed-exitcode`
-# returns 0 (no changes) / 1 (error) / 2 (changes) — the flagship consumer of
-# the exit_code: {in: [...]} matcher (#19). Kept fully offline via the builtin
-# terraform.io/builtin/terraform provider (terraform_data). Gate: only where
-# terraform is installed.
+# Gate: only where terraform is installed.
 scenarios:
   - name: init downloads nothing and validate reports valid
     only:

--- a/test/e2e/thirdparty/transfersh/transfersh.atago.yaml
+++ b/test/e2e/thirdparty/transfersh/transfersh.atago.yaml
@@ -2,19 +2,23 @@ version: "1"
 
 suite:
   name: transfer.sh (self-hosted file sharing)
+  description: |
+    [transfer.sh](https://github.com/dutchcoders/transfer.sh) takes a file and
+    gives you a URL to fetch it back from. The only guarantee that matters is
+    that what comes back is what went in.
 
-# Exercises transfer.sh (https://github.com/dutchcoders/transfer.sh, from
-# awesome-selfhosted's file-transfer corner) as a third-party target. This is
-# the suite the binary-payload spec features exist for: a PNG is uploaded as
-# the raw request body (`body_file`), the returned share URL is captured from
-# the response, the file is downloaded back to disk (`body_to`), and the
-# round-tripped bytes are verified with the image assertion target plus a
-# byte-for-byte cmp. The browser-style multipart upload path is exercised too
-# (`files:`). Install: see .github/workflows/thirdparty.yml for the pinned CI
-# version.
-#
+    So this suite tests it with binary data rather than text. A PNG is uploaded
+    as a raw request body, the share URL is captured from the response, the file
+    is downloaded back to disk, and the bytes are compared to the original —
+    both as a valid image and byte for byte. Text survives a lot of accidental
+    mangling that binary does not.
+
+    The browser-style multipart upload path is exercised as well, since that is
+    how a file arrives from a web form rather than from `curl`.
+
 # Each server scenario binds its own port so the suite runs under the default
-# scenario concurrency.
+# scenario concurrency. Install: see .github/workflows/thirdparty.yml for the
+# pinned CI version.
 
 permissions:
   network:

--- a/test/e2e/thirdparty/webhook/webhook.atago.yaml
+++ b/test/e2e/thirdparty/webhook/webhook.atago.yaml
@@ -2,17 +2,23 @@ version: "1"
 
 suite:
   name: webhook (self-hosted webhook receiver)
+  description: |
+    [webhook](https://github.com/adnanh/webhook) turns an HTTP request into a
+    command execution, which makes it a piece of security-relevant plumbing:
+    everything about it is a question of what should and should not run.
 
-# Exercises adnanh/webhook (from awesome-selfhosted's automation corner) as a
-# third-party target: the daemon reads its hook definitions from a JSON config
-# — written as a leading fixture, applied before the service starts — and an
-# HTTP request triggers a command whose real effect (a file written on disk)
-# and whose output are both observed. Beyond the happy path this pins the
-# contract's branches: trigger-rules gate execution (and prove the command did
-# not run when unsatisfied), an HMAC signature is verified against an
-# independently computed oracle, the http-methods allowlist rejects the wrong
-# verb, and a command that exits non-zero surfaces as a 500. Each scenario runs
-# its own daemon with a minimal hook config. Install: see
+    The happy path is verified by its effect, not its response — the triggered
+    command writes a file, and that file is checked on disk.
+
+    The refusals are pinned just as carefully. When a trigger rule is not
+    satisfied the command must not run at all, which is asserted by the absence
+    of its effect rather than by the status code. An HMAC signature is verified
+    against an independently computed value, so a forged one is rejected. The
+    allowed-methods list rejects the wrong verb. And a command that exits
+    non-zero surfaces as a 500 instead of being reported as success.
+
+# Each scenario runs its own daemon with a minimal hook config, written as a
+# leading fixture and applied before the service starts. Install: see
 # .github/workflows/thirdparty.yml for the pinned CI version.
 
 permissions:

--- a/test/e2e/thirdparty/yazi/chooser_selection.atago.yaml
+++ b/test/e2e/thirdparty/yazi/chooser_selection.atago.yaml
@@ -2,6 +2,21 @@ version: "1"
 
 suite:
   name: yazi (third-party terminal file manager) / chooser selection
+  description: |
+    Used as a file chooser, yazi's job is to hand a shell script the paths the
+    user picked. The rule that matters — and the one easiest to get wrong — is
+    that an explicit selection beats whatever the cursor happens to be sitting
+    on. A user who selects three files and then moves the cursor elsewhere must
+    still get those three.
+
+    Every way of selecting is put through that test: pressing space on
+    individual entries, sweeping a range in visual mode, selecting everything at
+    once, and inverting a selection. Toggling the same entry twice must clear
+    it, not select it again.
+
+    Files and directories are covered separately, and so are names containing
+    spaces — the classic point where a path list gets silently split into the
+    wrong number of entries.
 
 scenarios:
   - name: chooser-file writes a space-selected file instead of the hovered file

--- a/test/e2e/thirdparty/yazi/entry_args.atago.yaml
+++ b/test/e2e/thirdparty/yazi/entry_args.atago.yaml
@@ -2,6 +2,23 @@ version: "1"
 
 suite:
   name: yazi (third-party terminal file manager) / entry args
+  description: |
+    Where yazi starts depends on what you pass it, and the two cases differ: a
+    directory argument opens that directory, while a file argument opens its
+    parent with the file already hovered — so it can be chosen immediately, or
+    left behind for a sibling.
+
+    Quitting must then report the right working directory. A shell wrapper uses
+    that value to cd, so reporting the file's own path, or the directory the
+    user started in rather than the one they navigated to, sends the caller to
+    the wrong place.
+
+    Several arguments open several tabs, and this suite checks that they land in
+    the given order and that switching between them by number, or by stepping to
+    the next one, selects from the tab actually in front of the user.
+
+    Spaced, hidden, and nested paths are covered throughout, since those are
+    where argument handling usually breaks.
 
 scenarios:
   - name: starting on an explicit directory writes that cwd on quit

--- a/test/e2e/thirdparty/yazi/links_and_overwrite.atago.yaml
+++ b/test/e2e/thirdparty/yazi/links_and_overwrite.atago.yaml
@@ -2,6 +2,24 @@ version: "1"
 
 suite:
   name: yazi (third-party terminal file manager) / links and overwrite
+  description: |
+    The operations here are the ones that can lose data, so each is pinned in
+    both directions.
+
+    Cancelling a pending cut or copy must really cancel it: a later paste must
+    do nothing, rather than quietly completing the operation the user thought
+    they had abandoned.
+
+    Overwriting must really overwrite. When the destination already exists, the
+    forced paste has to replace it — for a file and for a whole directory
+    subtree, under both copy and move — and the result on disk is checked
+    afterwards, not just the absence of an error.
+
+    Hardlinking is covered as its own case, since a hardlink that silently
+    degrades into a copy looks identical until something writes through it.
+
+    Spaced names run through all of it, being where path handling tends to
+    fail.
 
 scenarios:
   - name: uppercase X cancels a cut before pasting

--- a/test/e2e/thirdparty/yazi/navigation_tabs.atago.yaml
+++ b/test/e2e/thirdparty/yazi/navigation_tabs.atago.yaml
@@ -2,6 +2,21 @@ version: "1"
 
 suite:
   name: yazi (third-party terminal file manager) / navigation and tabs
+  description: |
+    Moving around is what a file manager does between operations, and it has to
+    put the cursor exactly where the user believes it is — because the next
+    keystroke acts on whatever is hovered.
+
+    Arrow-key movement is therefore checked by its consequence: after moving,
+    the entry that gets chosen must be the one the user moved to. Entering and
+    leaving directories is checked the same way, including the working directory
+    reported on quit after stepping back out.
+
+    Tabs get the same treatment. Opening new tabs, switching by number, closing
+    one and returning to the previous, and reordering tabs — after which the
+    numbers must follow the new order, not the original one.
+
+    Spaced names appear throughout.
 
 scenarios:
   - name: down arrow moves to the second file before choosing

--- a/test/e2e/thirdparty/yazi/search_tabs.atago.yaml
+++ b/test/e2e/thirdparty/yazi/search_tabs.atago.yaml
@@ -2,6 +2,18 @@ version: "1"
 
 suite:
   name: yazi (third-party terminal file manager) / search and tabs
+  description: |
+    Two things a file manager offers beyond moving files: finding them, and
+    keeping more than one place open at a time.
+
+    Content search must locate a file by what is inside it, not by its name, and
+    leave the user positioned on the match. The information panel must describe
+    the entry currently hovered — the wrong entry's details is a subtle bug,
+    since the panel still looks right.
+
+    Tabs are checked as a pair of operations that must undo each other: opening
+    a tab roots it at the current directory, and closing it returns to the
+    directory the previous tab was showing.
 
 scenarios:
   - name: uppercase S content search finds the matching file

--- a/test/e2e/thirdparty/yazi/selection_matrix.atago.yaml
+++ b/test/e2e/thirdparty/yazi/selection_matrix.atago.yaml
@@ -2,6 +2,19 @@ version: "1"
 
 suite:
   name: yazi (third-party terminal file manager) / selection matrix
+  description: |
+    One rule, checked against every combination that could break it: an
+    operation acts on what is selected, not on what the cursor is pointing at.
+
+    Select an entry, move the cursor somewhere else, then copy, move, or delete
+    — and the selected entry must be the one affected, while the entry now under
+    the cursor must be left alone. Acting on the hovered file instead is the
+    failure mode that quietly destroys the wrong data.
+
+    The matrix runs that rule across files and directories, single entries and
+    visual-mode ranges, and copy, move, and permanent delete — with spaced names
+    included, since a path that splits on a space turns one operation into
+    several wrong ones.
 
 scenarios:
   - name: space-selected file is moved even when the cursor moves away

--- a/test/e2e/thirdparty/yazi/yazi.atago.yaml
+++ b/test/e2e/thirdparty/yazi/yazi.atago.yaml
@@ -2,13 +2,25 @@ version: "1"
 
 suite:
   name: yazi (third-party terminal file manager)
+  description: |
+    [yazi](https://yazi-rs.github.io/) is a file manager, so every keystroke is
+    a potential file operation. A test that only checked the screen would pass
+    on a version that draws a successful copy it never performed — and on a file
+    manager, that class of bug destroys data.
 
-# yazi is not just "a screen that appears": its core contract is that real file
-# operations are driven from a TUI with typed inputs, modal keybindings, live
-# filtering, and shell-wrapper cwd handoff. These scenarios therefore pin both
-# the rendered terminal UI and the actual filesystem effects under the scenario
-# workdir. Install: see .github/workflows/thirdparty.yml for the pinned CI
-# version.
+    So both are asserted throughout: what the terminal displays, and what
+    actually happened on disk afterwards.
+
+    This suite covers the core interactions — hidden files staying hidden until
+    toggled, live filtering narrowing the list, creating files and directories,
+    renaming exactly one entry and nothing else, yank/paste and cut/paste
+    between directories, and permanent deletion including the case where the
+    confirmation is declined and the file must survive.
+
+    The remaining yazi suites break out selection semantics, entry arguments,
+    navigation and tabs, search, and hardlinks and overwrites.
+
+# Install: see .github/workflows/thirdparty.yml for the pinned CI version.
 scenarios:
   - name: version prints a semantic version banner
     only:


### PR DESCRIPTION
## Summary

The [Real-world CLIs](https://nao1215.github.io/atago/real-world/) pages are the most-read generated output this project publishes, and until now every one of them opened with a suite name and a file path before dropping straight into Given/When/Then. The narrative explaining what the suite guarantees existed — as a file-top YAML comment in nearly every spec — but a comment never reaches the generated page.

This fills in `suite.description` (added in #295) for all 58 third-party suites and regenerates the 38 published pages. Only grafana had one before.

## Changes

- `test/e2e/thirdparty/**/*.atago.yaml`: a `description:` on every suite, written from what each spec actually asserts.
- `doc/e2e/*.md`: all 38 third-party pages regenerated.

Each description says what the tool is, what the suite guarantees about it, and — where it is the interesting part — why the guarantee is stated the way it is. The webhook suite explains that a declined trigger is asserted by the *absence* of the command's effect rather than by a status code; the yazi selection matrix explains that acting on the hovered entry instead of the selected one is the failure mode that destroys the wrong data; the openssl suite explains why a generated key is proven by signing with it rather than by checking that a file appeared.

## Design Decisions

Suite level only. Scenario names across these suites are already behavior sentences ("invalid JSON input fails loudly and keeps stdout clean"), so a scenario description would mostly restate them. Where a scenario genuinely needs background, `scenario.description` remains available for that one scenario; blanketing several hundred of them would be the low-quality filler this field is meant to avoid.

Comments were not simply promoted into descriptions. The existing file-top comments mix public intent with maintenance detail — install steps, port allocation, CI provenance, "gate: only where X is installed". The public half moved into `description`, the maintenance half stayed a comment. That split is the reason the field exists rather than a comment-harvesting feature, and this PR is the first large-scale application of it.

Scope stops at `test/e2e/thirdparty`. The suites under `test/e2e/tools` are a different case: mimixbox alone is 540 one-applet suites whose names (`mimixbox makemime`) and identical `--help` contracts leave nothing for a description to add that would not be boilerplate. If descriptions are wanted there, they should be judged suite by suite, not applied by sweep.

## Limitations

Descriptions are prose, and prose can drift from the assertions it describes. That already happened once in review on this feature: the grafana description claimed a datasource was read back when the spec only creates one (fixed in #295). Nothing mechanical guards against it — the same way nothing guards a scenario name that stops matching its steps. Each description here was written against the spec's actual steps and assertions rather than from its comment alone, but a reviewer's eye is the only check.

Six of the seven yazi suites had no comment to work from, so their descriptions were written by reading their scenarios; they deserve the closest review.