### PR TITLE
fix(doc): describe every matcher an assertion sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `atago doc` and `atago explain` now describe every matcher an assertion sets
+  instead of the first one. A stream assertion that combines `contains` with
+  `not_contains`, `matches`, or `not_matches` enforces all of them at run time,
+  but the generated page advertised only the first — publishing a weaker
+  contract than the suite guards. A `line: N` selector is named too, so a
+  matcher scoped to one line no longer reads as one pinning the whole stream.
+- `file:` assertions using `not_contains` or `executable` rendered as "the file
+  is checked" in generated docs and `explain` output, hiding what the scenario
+  guarantees. Both matchers now have their own phrasing.
+
 ## [0.14.0] - 2026-07-26
 
 A minor release about the specs as documentation. A spec has always described

--- a/doc/e2e/aqua.md
+++ b/doc/e2e/aqua.md
@@ -190,7 +190,7 @@ aqua --config aqua.yaml exec -- mytool
 #### Then
 - after `aqua --config aqua.yaml install`:
   - exit code is `0`
-  - file `.aqua/pkgs/http/127.0.0.1:18595/mytool/mytool` is checked
+  - file `.aqua/pkgs/http/127.0.0.1:18595/mytool/mytool` is executable
 - after `aqua --config aqua.yaml which mytool`:
   - exit code is `0`
   - stdout contains `.aqua/pkgs/http/127.0.0.1:18595/mytool/mytool`

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -2040,8 +2040,8 @@ ${atago} doc matchers.atago.yaml
 ```
 #### Then
 - exit code is `0`
-- stdout contains `stdout contains `hello`, does not contain `goodbye``, `stdout line `2` equals an exact value`, `file `install.sh` is executable`, `file `install.sh` does not contain `rm -rf /``
-- stdout does not contain ``install.sh` is checked`
+- stdout contains `stdout contains `, `, does not contain `, `stdout line `, ` equals an exact value`, ` is executable`, ` does not contain `
+- stdout does not contain ` is checked`
 ### Scenario: a spec whose matchers doc renders still runs green
 _skipped on Windows_
 #### Given

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 395 scenarios
+74 suites · 399 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -78,13 +78,14 @@
   - [record, compare green, then a mutation names the changed paths](#scenario-record-compare-green-then-a-mutation-names-the-changed-paths)
   - [recursive matchers and ignore globs walk the tree](#scenario-recursive-matchers-and-ignore-globs-walk-the-tree)
   - [combining snapshot with matchers is a load-time error](#scenario-combining-snapshot-with-matchers-is-a-load-time-error)
-- [atago self-hosting / doc](#atago-self-hosting--doc) — 6 scenarios
+- [atago self-hosting / doc](#atago-self-hosting--doc) — 7 scenarios
   - [doc generates Markdown to a file](#scenario-doc-generates-markdown-to-a-file)
   - [doc writes Markdown to stdout without --out](#scenario-doc-writes-markdown-to-stdout-without---out)
   - [doc emits a summary, table of contents, and input previews](#scenario-doc-emits-a-summary-table-of-contents-and-input-previews)
   - [doc --split-by-spec writes one file per spec and an index](#scenario-doc---split-by-spec-writes-one-file-per-spec-and-an-index)
   - [doc --split-by-spec requires --out-dir](#scenario-doc---split-by-spec-requires---out-dir)
   - [doc renders suite and scenario descriptions verbatim](#scenario-doc-renders-suite-and-scenario-descriptions-verbatim)
+  - [doc renders every matcher an assertion sets](#scenario-doc-renders-every-matcher-an-assertion-sets)
 - [atago self-hosting / duration assertion](#atago-self-hosting--duration-assertion) — 4 scenarios
   - [a fast step passes a generous upper bound](#scenario-a-fast-step-passes-a-generous-upper-bound)
   - [an impossible bound fails and shows the measured duration](#scenario-an-impossible-bound-fails-and-shows-the-measured-duration)
@@ -123,8 +124,11 @@
   - [a signal exit composes with the in matcher alongside normal codes](#scenario-a-signal-exit-composes-with-the-in-matcher-alongside-normal-codes)
   - [a missing command is 127 under the shell](#scenario-a-missing-command-is-127-under-the-shell)
   - [POSIX exit codes wrap modulo 256](#scenario-posix-exit-codes-wrap-modulo-256)
-- [atago self-hosting / explain](#atago-self-hosting--explain) — 1 scenario
+- [atago self-hosting / explain](#atago-self-hosting--explain) — 4 scenarios
   - [explain summarizes a spec without running it](#scenario-explain-summarizes-a-spec-without-running-it)
+  - [explain describes every matcher of a composed stream assertion](#scenario-explain-describes-every-matcher-of-a-composed-stream-assertion)
+  - [explain names the line a line-scoped matcher inspects](#scenario-explain-names-the-line-a-line-scoped-matcher-inspects)
+  - [explain describes file not_contains and executable matchers](#scenario-explain-describes-file-not_contains-and-executable-matchers)
 - [atago self-hosting / file equals and equals_file byte-equality (#155)](#atago-self-hosting--file-equals-and-equals_file-byte-equality-155) — 4 scenarios
   - [equals_file passes for two byte-identical files](#scenario-equals_file-passes-for-two-byte-identical-files)
   - [equals matches an inline literal byte-for-byte](#scenario-equals-matches-an-inline-literal-byte-for-byte)
@@ -1108,7 +1112,7 @@ ${atago} run --ci --report json --filter alpha inner.atago.yaml
 #### Then
 - exit code is `0`
 - stdout at `$.suites[0].scenarios` has length 1
-- stdout contains `"alpha"`
+- stdout contains `"alpha"`, does not contain `"beta"`, `"gamma"`
 ### Scenario: filter is OR across a comma-separated list
 #### Given
 - Fixture file `inner.atago.yaml` is created.
@@ -1135,7 +1139,7 @@ ${atago} run --ci --report json --filter alpha,beta inner.atago.yaml
 #### Then
 - exit code is `0`
 - stdout at `$.suites[0].scenarios` has length 2
-- stdout contains `"alpha"`, `"beta"`
+- stdout contains `"alpha"`, `"beta"`, does not contain `"gamma"`
 ### Scenario: tag selects scenarios carrying the tag
 #### Given
 - Fixture file `inner.atago.yaml` is created.
@@ -1162,7 +1166,7 @@ ${atago} run --ci --report json --tag fast inner.atago.yaml
 #### Then
 - exit code is `0`
 - stdout at `$.suites[0].scenarios` has length 2
-- stdout contains `"alpha"`, `"gamma"`
+- stdout contains `"alpha"`, `"gamma"`, does not contain `"beta"`
 ### Scenario: a repeated tag flag is OR
 #### Given
 - Fixture file `inner.atago.yaml` is created.
@@ -1215,7 +1219,7 @@ ${atago} run --ci --report json --skip-tag slow inner.atago.yaml
 #### Then
 - exit code is `0`
 - stdout at `$.suites[0].scenarios` has length 1
-- stdout contains `"alpha"`
+- stdout contains `"alpha"`, does not contain `"beta"`, `"gamma"`
 ### Scenario: tag and skip-tag compose as selected minus skipped
 #### Given
 - Fixture file `inner.atago.yaml` is created.
@@ -1242,7 +1246,7 @@ ${atago} run --ci --report json --tag fast --skip-tag slow inner.atago.yaml
 #### Then
 - exit code is `0`
 - stdout at `$.suites[0].scenarios` has length 1
-- stdout contains `"alpha"`
+- stdout contains `"alpha"`, does not contain `"gamma"`
 ### Scenario: an empty filter selection fails under --ci with a substring hint
 #### Given
 - Fixture file `inner.atago.yaml` is created.
@@ -1295,7 +1299,7 @@ ${atago} run --ci --report json --tag no_such_tag inner.atago.yaml
 ```
 #### Then
 - exit code is `3`
-- stderr contains `no scenarios matched`, `--tag "no_such_tag"`, `match tags exactly`, `atago list`
+- stderr contains `no scenarios matched`, `--tag "no_such_tag"`, `match tags exactly`, `atago list`, does not contain `case-sensitive substring`
 ### Scenario: without --ci an empty selection only warns and still exits zero
 #### Given
 - Fixture file `inner.atago.yaml` is created.
@@ -2001,6 +2005,47 @@ ${atago} run described.atago.yaml
 - after `${atago} run described.atago.yaml`:
   - exit code is `0`
   - stdout contains `1 passed`
+### Scenario: doc renders every matcher an assertion sets
+#### Given
+- Fixture file `matchers.atago.yaml` is created.
+#### Inputs
+_Fixture `matchers.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: matchers
+scenarios:
+  - name: composed stream
+    steps:
+      - run:
+          command: echo hello
+      - assert:
+          stdout:
+            contains: hello
+            not_contains: goodbye
+  - name: line scoped
+    steps:
+      - run:
+          shell: true
+          command: printf 'one\ntwo\n'
+      - assert:
+          stdout:
+            line: 2
+… (truncated, 17 more lines)
+```
+#### When
+```shell
+${atago} doc matchers.atago.yaml
+${atago} run matchers.atago.yaml
+```
+#### Then
+- after `${atago} doc matchers.atago.yaml`:
+  - exit code is `0`
+  - stdout contains `stdout contains `hello`, does not contain `goodbye``, `stdout line `2` equals an exact value`, `file `install.sh` is executable`, `file `install.sh` does not contain `rm -rf /``
+  - stdout does not contain ``install.sh` is checked`
+- after `${atago} run matchers.atago.yaml`:
+  - exit code is `0`
+  - stdout contains `3 passed`
 ## atago self-hosting / duration assertion
 Source: `test/e2e/atago/duration.atago.yaml`
 ### Scenario: a fast step passes a generous upper bound
@@ -2164,7 +2209,7 @@ ${atago} snapshot update no-such-spec.atago.yaml
 ```
 #### Then
 - exit code is `3`
-- stderr contains `atago snapshot update: cannot access`
+- stderr contains `atago snapshot update: cannot access`, does not contain `atago run:`
 ### Scenario: a json assertion on malformed input fails cleanly, without a crash
 #### Given
 - Fixture file `bad.atago.yaml` is created.
@@ -2229,7 +2274,7 @@ alpha
 beta
 ```
 #### Then
-- file `data.txt` is checked
+- file `data.txt` does not contain `gamma`
 ### Scenario: not_contains fails when the substring is present
 #### Given
 - Fixture file `inner.atago.yaml` is created.
@@ -2516,6 +2561,117 @@ ${atago} explain target.atago.yaml
 #### Then
 - exit code is `0`
 - stdout contains `Suite: sample`, `Scenario: list as json`, `Commands:`, `Network policy:`
+### Scenario: explain describes every matcher of a composed stream assertion
+#### Given
+- Fixture file `composed.atago.yaml` is created.
+- Fixture file `broken.atago.yaml` is created.
+#### Inputs
+_Fixture `composed.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: composed
+scenarios:
+  - name: guards both directions
+    steps:
+      - run:
+          command: echo hello
+      - assert:
+          stdout:
+            contains: hello
+            not_contains: goodbye
+            matches: "^hel"
+```
+_Fixture `broken.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: composed
+scenarios:
+  - name: guards both directions
+    steps:
+      - run:
+          shell: true
+          command: printf 'hello goodbye\n'
+      - assert:
+          stdout:
+            contains: hello
+            not_contains: goodbye
+```
+#### When
+```shell
+${atago} explain composed.atago.yaml
+${atago} run broken.atago.yaml
+```
+#### Then
+- after `${atago} explain composed.atago.yaml`:
+  - exit code is `0`
+  - stdout contains `stdout contains "hello", does not contain "goodbye", matches /^hel/`
+- after `${atago} run broken.atago.yaml`:
+  - exit code is `1`
+  - stdout contains `does not contain`
+### Scenario: explain names the line a line-scoped matcher inspects
+#### Given
+- Fixture file `lined.atago.yaml` is created.
+#### Inputs
+_Fixture `lined.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: lined
+scenarios:
+  - name: second line only
+    steps:
+      - run:
+          shell: true
+          command: printf 'one\ntwo\n'
+      - assert:
+          stdout:
+            line: 2
+            equals: two
+```
+#### When
+```shell
+${atago} explain lined.atago.yaml
+```
+#### Then
+- exit code is `0`
+- stdout contains `stdout line 2 equals exact text`
+### Scenario: explain describes file not_contains and executable matchers
+#### Given
+- Fixture file `filematch.atago.yaml` is created.
+#### Inputs
+_Fixture `filematch.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: filematch
+scenarios:
+  - name: no secret leaked
+    steps:
+      - fixture:
+          file: out.txt
+          content: "public\n"
+      - run:
+          command: echo hi
+      - assert:
+          file:
+            path: out.txt
+            not_contains: "secret-token"
+  - name: installer stays executable
+    steps:
+      - fixture:
+          file: install.sh
+          content: "#!/bin/sh\n"
+… (truncated, 7 more lines)
+```
+#### When
+```shell
+${atago} explain filematch.atago.yaml
+```
+#### Then
+- exit code is `0`
+- stdout contains `file "out.txt" does not contain "secret-token"`, `file "install.sh" is executable`
 ## atago self-hosting / file equals and equals_file byte-equality (#155)
 Source: `test/e2e/atago/file_equals.atago.yaml`
 ### Scenario: equals_file passes for two byte-identical files
@@ -2672,8 +2828,8 @@ _Fixture `data.txt`:_
 plain
 ```
 #### Then
-- file `run.sh` is checked
-- file `data.txt` is checked
+- file `run.sh` is executable
+- file `data.txt` is not executable
 ### Scenario: fixture.mtime pins the modification time
 #### Given
 - Fixture file `stamped.txt` is created.
@@ -3601,16 +3757,16 @@ Source: `test/e2e/atago/line.atago.yaml`
 printf '[\n  {"id":1}\n]\n'
 ```
 #### Then
-- stdout equals an exact value
-- stdout contains `"id":1`
-- stdout equals an exact value
+- stdout line `1` equals an exact value
+- stdout line `2` contains `"id":1`
+- stdout line `3` equals an exact value
 ### Scenario: a trailing newline does not add a phantom final line
 #### When
 ```shell
 printf 'only-line\n'
 ```
 #### Then
-- stdout equals an exact value
+- stdout line `1` equals an exact value
 ### Scenario: an out-of-range line fails the inner spec
 #### Given
 - Fixture file `oor.atago.yaml` is created.
@@ -3720,7 +3876,7 @@ printf 'north\r\nsouth\r\n'
 printf 'header\r\npayload\r\n'
 ```
 #### Then
-- stdout equals an exact value
+- stdout line `2` equals an exact value
 ### Scenario: json parses a CRLF-formatted document
 #### When
 ```shell
@@ -4460,28 +4616,28 @@ Source: `test/e2e/atago/multi_matcher.atago.yaml`
 echo "hello world"
 ```
 #### Then
-- stdout contains `hello`
+- stdout contains `hello`, does not contain `goodbye`
 ### Scenario: matches and not_matches hold together
 #### When
 ```shell
 echo "release 1.2.3"
 ```
 #### Then
-- stdout matches `/[0-9]+\.[0-9]+\.[0-9]+/`
+- stdout matches `/[0-9]+\.[0-9]+\.[0-9]+/`, does not match `/(?i)error/`
 ### Scenario: all four text matchers compose
 #### When
 ```shell
 echo "Alice and Bob"
 ```
 #### Then
-- stdout contains `Alice`, `Bob`
+- stdout contains `Alice`, `Bob`, does not contain `Carol`, matches `/A.+e/`, does not match `/Dave/`
 ### Scenario: a combined matcher composes with a line selector
 #### When
 ```shell
 printf 'first line\nsecond line\n'
 ```
 #### Then
-- stdout contains `second`
+- stdout line `2` contains `second`, does not contain `first`
 ### Scenario: a failing member fails the inner spec and names the offender
 #### Given
 - Fixture file `inner.atago.yaml` is created.
@@ -4507,7 +4663,7 @@ ${atago} run inner.atago.yaml
 ```
 #### Then
 - exit code is `1`
-- stdout contains `goodbye`
+- stdout contains `goodbye`, does not contain `internal error`
 ### Scenario: mixing a whole-stream matcher with a text matcher is a load error
 #### Given
 - Fixture file `bad.atago.yaml` is created.
@@ -4556,7 +4712,7 @@ echo hello
 printf 'first\nsecond\n'
 ```
 #### Then
-- stdout does not equal an exact value
+- stdout line `2` does not equal an exact value
 ### Scenario: not_equals fails the inner spec when the text matches exactly
 #### Given
 - Fixture file `ne.atago.yaml` is created.
@@ -4903,7 +5059,7 @@ _skipped on Windows_
 '
 ```
 #### Then
-- rendered screen equals an exact value
+- rendered screen line `1` equals an exact value
 - rendered screen does not contain `loading`
 - stdout contains `loading`
 ### Scenario: a screen snapshot round-trips through update and compare
@@ -5229,7 +5385,7 @@ ${atago} run echo.atago.yaml
 #### Then
 - exit code is `0`
 - file `echo.atago.yaml` contains `- pty:`, `command: echo done`
-- file `echo.atago.yaml` is checked
+- file `echo.atago.yaml` does not contain `- send:`, `session:`
 - exit code is `0`
 - stdout contains `1 passed`
 ### Scenario: a prompt with regex metacharacters is escaped in the generated expect
@@ -5271,7 +5427,7 @@ ${atago} run sec.atago.yaml
 #### Then
 - exit code is `0`
 - file `sec.atago.yaml` contains `${env:ATAGO_SECRET_1}`
-- file `sec.atago.yaml` is checked
+- file `sec.atago.yaml` does not contain `hunter2`
 - after `${atago} run sec.atago.yaml`:
   - exit code is `0`
   - stdout contains `1 passed`
@@ -5587,8 +5743,8 @@ ${atago} run --report tap mixed.atago.yaml
 ```
 #### Then
 - exit code is `1`
-- stdout equals an exact value
-- stdout equals an exact value
+- stdout line `1` equals an exact value
+- stdout line `2` equals an exact value
 - stdout contains `ok 1 - sample / good`, `not ok 2 - sample / bad`
 ### Scenario: failure artifacts are written and referenced in the JSON report
 #### Given
@@ -6736,7 +6892,7 @@ ${atago} snapshot update uuid.atago.yaml
 ```
 #### Then
 - file `g.txt` contains `id=<uuid>`
-- file `g.txt` is checked
+- file `g.txt` does not contain `550e8400`
 ### Scenario: an ISO timestamp is masked in the golden
 #### Given
 - Fixture file `ts.atago.yaml` is created.
@@ -6777,7 +6933,7 @@ ${atago} snapshot update port.atago.yaml
 ```
 #### Then
 - file `g.txt` contains `127.0.0.1:<port>`
-- file `g.txt` is checked
+- file `g.txt` does not contain `54321`
 ### Scenario: the home directory is masked to a tilde in the golden
 #### Given
 - Fixture file `home.atago.yaml` is created.
@@ -7325,7 +7481,7 @@ printf 'αβγδ\n'
 printf 'ひらがな\nカタカナ\n漢字\n'
 ```
 #### Then
-- stdout equals an exact value
+- stdout line `2` equals an exact value
 ### Scenario: not_contains a multibyte needle that is absent
 #### When
 ```shell
@@ -7360,7 +7516,7 @@ printf 'noeol'
 printf 'body\n\n'
 ```
 #### Then
-- stdout equals an exact value
+- stdout line `2` equals an exact value
 ### Scenario: contains treats a needle with regex metacharacters literally
 #### When
 ```shell
@@ -7402,21 +7558,21 @@ printf '[{"id":1}]\n'
 seq 1 100
 ```
 #### Then
-- stdout equals an exact value
+- stdout line `100` equals an exact value
 ### Scenario: a line selector composes with contains
 #### When
 ```shell
 printf 'alpha\nbeta-gamma\n'
 ```
 #### Then
-- stdout contains `gamma`
+- stdout line `2` contains `gamma`
 ### Scenario: a line selector composes with a regex
 #### When
 ```shell
 printf 'k=1\nk=2\n'
 ```
 #### Then
-- stdout matches `/^k=[0-9]$/`
+- stdout line `2` matches `/^k=[0-9]$/`
 ### Scenario: stderr carries the same matcher semantics as stdout
 #### When
 ```shell

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 399 scenarios
+74 suites · 400 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -78,7 +78,7 @@
   - [record, compare green, then a mutation names the changed paths](#scenario-record-compare-green-then-a-mutation-names-the-changed-paths)
   - [recursive matchers and ignore globs walk the tree](#scenario-recursive-matchers-and-ignore-globs-walk-the-tree)
   - [combining snapshot with matchers is a load-time error](#scenario-combining-snapshot-with-matchers-is-a-load-time-error)
-- [atago self-hosting / doc](#atago-self-hosting--doc) — 7 scenarios
+- [atago self-hosting / doc](#atago-self-hosting--doc) — 8 scenarios
   - [doc generates Markdown to a file](#scenario-doc-generates-markdown-to-a-file)
   - [doc writes Markdown to stdout without --out](#scenario-doc-writes-markdown-to-stdout-without---out)
   - [doc emits a summary, table of contents, and input previews](#scenario-doc-emits-a-summary-table-of-contents-and-input-previews)
@@ -86,6 +86,7 @@
   - [doc --split-by-spec requires --out-dir](#scenario-doc---split-by-spec-requires---out-dir)
   - [doc renders suite and scenario descriptions verbatim](#scenario-doc-renders-suite-and-scenario-descriptions-verbatim)
   - [doc renders every matcher an assertion sets](#scenario-doc-renders-every-matcher-an-assertion-sets)
+  - [a spec whose matchers doc renders still runs green](#scenario-a-spec-whose-matchers-doc-renders-still-runs-green)
 - [atago self-hosting / duration assertion](#atago-self-hosting--duration-assertion) — 4 scenarios
   - [a fast step passes a generous upper bound](#scenario-a-fast-step-passes-a-generous-upper-bound)
   - [an impossible bound fails and shows the measured duration](#scenario-an-impossible-bound-fails-and-shows-the-measured-duration)
@@ -2036,16 +2037,47 @@ scenarios:
 #### When
 ```shell
 ${atago} doc matchers.atago.yaml
+```
+#### Then
+- exit code is `0`
+- stdout contains `stdout contains `hello`, does not contain `goodbye``, `stdout line `2` equals an exact value`, `file `install.sh` is executable`, `file `install.sh` does not contain `rm -rf /``
+- stdout does not contain ``install.sh` is checked`
+### Scenario: a spec whose matchers doc renders still runs green
+_skipped on Windows_
+#### Given
+- Fixture file `matchers.atago.yaml` is created.
+#### Inputs
+_Fixture `matchers.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: matchers
+scenarios:
+  - name: composed stream
+    steps:
+      - run:
+          command: echo hello
+      - assert:
+          stdout:
+            contains: hello
+            not_contains: goodbye
+  - name: line scoped
+    steps:
+      - run:
+          shell: true
+          command: printf 'one\ntwo\n'
+      - assert:
+          stdout:
+            line: 2
+… (truncated, 17 more lines)
+```
+#### When
+```shell
 ${atago} run matchers.atago.yaml
 ```
 #### Then
-- after `${atago} doc matchers.atago.yaml`:
-  - exit code is `0`
-  - stdout contains `stdout contains `hello`, does not contain `goodbye``, `stdout line `2` equals an exact value`, `file `install.sh` is executable`, `file `install.sh` does not contain `rm -rf /``
-  - stdout does not contain ``install.sh` is checked`
-- after `${atago} run matchers.atago.yaml`:
-  - exit code is `0`
-  - stdout contains `3 passed`
+- exit code is `0`
+- stdout contains `3 passed`
 ## atago self-hosting / duration assertion
 Source: `test/e2e/atago/duration.atago.yaml`
 ### Scenario: a fast step passes a generous upper bound

--- a/doc/e2e/fzf.md
+++ b/doc/e2e/fzf.md
@@ -83,7 +83,7 @@ _only when `fzf --version` succeeds · skipped on Windows_
 #### Then
 - exit code is `0`
 - file `pick.txt` contains `cherry`
-- file `pick.txt` is checked
+- file `pick.txt` does not contain `banana`
 ### Scenario: multi-select accepts several lines at once
 _only when `fzf --version` succeeds · skipped on Windows_
 #### When

--- a/doc/e2e/iso8583tool.md
+++ b/doc/e2e/iso8583tool.md
@@ -498,7 +498,7 @@ iso8583tool view $ISO_EXAMPLES/basei/0110-auth-response.hex --no-color
 ```
 #### Then
 - exit code is `0`
-- stdout is not empty
+- stdout line `1` is not empty
 - stdout contains `Processing Code`
 - stdout matches `/F3.*: 000000/`
 ### Scenario: matches the filtered view for F4
@@ -2467,8 +2467,8 @@ iso8583tool redact $ISO_EXAMPLES/basei/0100-auth-request.hex --format text --col
 ```
 #### Then
 - exit code is `0`
-- stdout contains `MTI:`
-- stdout contains `F2 =`
+- stdout line `1` contains `MTI:`
+- stdout line `2` contains `F2 =`
 ### Scenario: reads from stdin for a Slack-safe pipe
 #### When
 ```shell

--- a/doc/e2e/jq.md
+++ b/doc/e2e/jq.md
@@ -206,5 +206,5 @@ jq -c '.n * 2'
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
-- stdout equals an exact value
+- stdout line `1` equals an exact value
+- stdout line `2` equals an exact value

--- a/doc/e2e/kustomize.md
+++ b/doc/e2e/kustomize.md
@@ -99,7 +99,7 @@ kustomize edit fix
 - exit code is `0`
 - the step changed exactly created nothing, modified `kustomization.yaml`, deleted nothing
 - file `kustomization.yaml` contains `labels:`
-- file `kustomization.yaml` is checked
+- file `kustomization.yaml` does not contain `commonLabels:`
 ### Scenario: edit without a kustomization file fails
 _only when `kustomize version` succeeds_
 #### When

--- a/doc/e2e/mimixbox.md
+++ b/doc/e2e/mimixbox.md
@@ -2085,8 +2085,8 @@ ar rc lib.a a.txt b.txt && ar t lib.a
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
-- stdout equals an exact value
+- stdout line `1` equals an exact value
+- stdout line `2` equals an exact value
 ### Scenario: extracts a member
 #### Given
 - Fixture file `a.txt` is created.
@@ -2457,8 +2457,8 @@ rpm -qpl sample.rpm
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
-- stdout equals an exact value
+- stdout line `1` equals an exact value
+- stdout line `2` equals an exact value
 ### Scenario: extracts the payload with rpm2cpio
 #### Given
 - Fixture file `sample.rpm` is created.
@@ -3802,7 +3802,7 @@ diff a b
 ```
 #### Then
 - exit code is `1`
-- stdout equals an exact value
+- stdout line `1` equals an exact value
 ### Scenario: is silent and succeeds for identical files
 #### Given
 - Fixture file `a` is created.
@@ -4002,8 +4002,8 @@ printf '1\n2\n3\n' | sed '2d'
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
-- stdout equals an exact value
+- stdout line `1` equals an exact value
+- stdout line `2` equals an exact value
 ### Scenario: prints a single line with -n
 #### When
 ```shell
@@ -4265,7 +4265,7 @@ xz --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: xz/`
+- stdout line `1` matches `/^Usage: xz/`
 - stdout contains `Examples:`, `Exit status:`, `  xz `
 ### Scenario: unxz --help exposes the documented sections
 #### When
@@ -4274,7 +4274,7 @@ unxz --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: unxz/`
+- stdout line `1` matches `/^Usage: unxz/`
 - stdout contains `Examples:`, `Exit status:`, `  unxz `
 ### Scenario: xzcat --help exposes the documented sections
 #### When
@@ -4283,7 +4283,7 @@ xzcat --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: xzcat/`
+- stdout line `1` matches `/^Usage: xzcat/`
 - stdout contains `Examples:`, `Exit status:`, `  xzcat `
 ### Scenario: lzma --help exposes the documented sections
 #### When
@@ -4292,7 +4292,7 @@ lzma --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: lzma/`
+- stdout line `1` matches `/^Usage: lzma/`
 - stdout contains `Examples:`, `Exit status:`, `  lzma `
 ### Scenario: unlzma --help exposes the documented sections
 #### When
@@ -4301,7 +4301,7 @@ unlzma --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: unlzma/`
+- stdout line `1` matches `/^Usage: unlzma/`
 - stdout contains `Examples:`, `Exit status:`, `  unlzma `
 ### Scenario: lzcat --help exposes the documented sections
 #### When
@@ -4310,7 +4310,7 @@ lzcat --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: lzcat/`
+- stdout line `1` matches `/^Usage: lzcat/`
 - stdout contains `Examples:`, `Exit status:`, `  lzcat `
 ### Scenario: lzop --help exposes the documented sections
 #### When
@@ -4319,7 +4319,7 @@ lzop --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: lzop/`
+- stdout line `1` matches `/^Usage: lzop/`
 - stdout contains `Examples:`, `Exit status:`, `  lzop `
 ### Scenario: unlzop --help exposes the documented sections
 #### When
@@ -4328,7 +4328,7 @@ unlzop --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: unlzop/`
+- stdout line `1` matches `/^Usage: unlzop/`
 - stdout contains `Examples:`, `Exit status:`, `  unlzop `
 ### Scenario: lzopcat --help exposes the documented sections
 #### When
@@ -4337,7 +4337,7 @@ lzopcat --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: lzopcat/`
+- stdout line `1` matches `/^Usage: lzopcat/`
 - stdout contains `Examples:`, `Exit status:`, `  lzopcat `
 ### Scenario: zcat --help exposes the documented sections
 #### When
@@ -4346,7 +4346,7 @@ zcat --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: zcat/`
+- stdout line `1` matches `/^Usage: zcat/`
 - stdout contains `Examples:`, `Exit status:`, `  zcat `
 ### Scenario: bzcat --help exposes the documented sections
 #### When
@@ -4355,7 +4355,7 @@ bzcat --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: bzcat/`
+- stdout line `1` matches `/^Usage: bzcat/`
 - stdout contains `Examples:`, `Exit status:`, `  bzcat `
 ### Scenario: unit --help exposes the documented sections
 #### When
@@ -4364,7 +4364,7 @@ unit --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: unit/`
+- stdout line `1` matches `/^Usage: unit/`
 - stdout contains `Examples:`, `Exit status:`, `  unit `
 ## mimixbox --help exit-status contract
 Source: `test/e2e/tools/mimixbox/embedded/help_exit_status.atago.yaml`
@@ -4375,7 +4375,7 @@ ash --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: ash/`
+- stdout line `1` matches `/^Usage: ash/`
 - stdout contains `Exit status:`
 ### Scenario: bash --help exposes the documented sections
 #### When
@@ -4384,7 +4384,7 @@ bash --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: bash/`
+- stdout line `1` matches `/^Usage: bash/`
 - stdout contains `Exit status:`
 ### Scenario: bc --help exposes the documented sections
 #### When
@@ -4393,7 +4393,7 @@ bc --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: bc/`
+- stdout line `1` matches `/^Usage: bc/`
 - stdout contains `Exit status:`
 ### Scenario: busybox --help exposes the documented sections
 #### When
@@ -4402,7 +4402,7 @@ busybox --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: busybox/`
+- stdout line `1` matches `/^Usage: busybox/`
 - stdout contains `Exit status:`
 ### Scenario: cttyhack --help exposes the documented sections
 #### When
@@ -4411,7 +4411,7 @@ cttyhack --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: cttyhack/`
+- stdout line `1` matches `/^Usage: cttyhack/`
 - stdout contains `Exit status:`
 ### Scenario: dc --help exposes the documented sections
 #### When
@@ -4420,7 +4420,7 @@ dc --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: dc/`
+- stdout line `1` matches `/^Usage: dc/`
 - stdout contains `Exit status:`
 ### Scenario: ed --help exposes the documented sections
 #### When
@@ -4429,7 +4429,7 @@ ed --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: ed/`
+- stdout line `1` matches `/^Usage: ed/`
 - stdout contains `Exit status:`
 ### Scenario: hd --help exposes the documented sections
 #### When
@@ -4438,7 +4438,7 @@ hd --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: hd/`
+- stdout line `1` matches `/^Usage: hd/`
 - stdout contains `Exit status:`
 ### Scenario: hexdump --help exposes the documented sections
 #### When
@@ -4447,7 +4447,7 @@ hexdump --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: hexdump/`
+- stdout line `1` matches `/^Usage: hexdump/`
 - stdout contains `Exit status:`
 ### Scenario: hush --help exposes the documented sections
 #### When
@@ -4456,7 +4456,7 @@ hush --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: hush/`
+- stdout line `1` matches `/^Usage: hush/`
 - stdout contains `Exit status:`
 ### Scenario: iostat --help exposes the documented sections
 #### When
@@ -4465,7 +4465,7 @@ iostat --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: iostat/`
+- stdout line `1` matches `/^Usage: iostat/`
 - stdout contains `Exit status:`
 ### Scenario: ipcs --help exposes the documented sections
 #### When
@@ -4474,7 +4474,7 @@ ipcs --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: ipcs/`
+- stdout line `1` matches `/^Usage: ipcs/`
 - stdout contains `Exit status:`
 ### Scenario: last --help exposes the documented sections
 #### When
@@ -4483,7 +4483,7 @@ last --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: last/`
+- stdout line `1` matches `/^Usage: last/`
 - stdout contains `Exit status:`
 ### Scenario: less --help exposes the documented sections
 #### When
@@ -4492,7 +4492,7 @@ less --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: less/`
+- stdout line `1` matches `/^Usage: less/`
 - stdout contains `Exit status:`
 ### Scenario: lsblk --help exposes the documented sections
 #### When
@@ -4501,7 +4501,7 @@ lsblk --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: lsblk/`
+- stdout line `1` matches `/^Usage: lsblk/`
 - stdout contains `Exit status:`
 ### Scenario: lspci --help exposes the documented sections
 #### When
@@ -4510,7 +4510,7 @@ lspci --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: lspci/`
+- stdout line `1` matches `/^Usage: lspci/`
 - stdout contains `Exit status:`
 ### Scenario: lsusb --help exposes the documented sections
 #### When
@@ -4519,7 +4519,7 @@ lsusb --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: lsusb/`
+- stdout line `1` matches `/^Usage: lsusb/`
 - stdout contains `Exit status:`
 ### Scenario: mbsh --help exposes the documented sections
 #### When
@@ -4528,7 +4528,7 @@ mbsh --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: mbsh/`
+- stdout line `1` matches `/^Usage: mbsh/`
 - stdout contains `Exit status:`
 ### Scenario: minips --help exposes the documented sections
 #### When
@@ -4537,7 +4537,7 @@ minips --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: minips/`
+- stdout line `1` matches `/^Usage: minips/`
 - stdout contains `Exit status:`
 ### Scenario: more --help exposes the documented sections
 #### When
@@ -4546,7 +4546,7 @@ more --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: more/`
+- stdout line `1` matches `/^Usage: more/`
 - stdout contains `Exit status:`
 ### Scenario: mpstat --help exposes the documented sections
 #### When
@@ -4555,7 +4555,7 @@ mpstat --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: mpstat/`
+- stdout line `1` matches `/^Usage: mpstat/`
 - stdout contains `Exit status:`
 ### Scenario: nmeter --help exposes the documented sections
 #### When
@@ -4564,7 +4564,7 @@ nmeter --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: nmeter/`
+- stdout line `1` matches `/^Usage: nmeter/`
 - stdout contains `Exit status:`
 ### Scenario: pipe_progress --help exposes the documented sections
 #### When
@@ -4573,7 +4573,7 @@ pipe_progress --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: pipe_progress/`
+- stdout line `1` matches `/^Usage: pipe_progress/`
 - stdout contains `Exit status:`
 ### Scenario: powertop --help exposes the documented sections
 #### When
@@ -4582,7 +4582,7 @@ powertop --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: powertop/`
+- stdout line `1` matches `/^Usage: powertop/`
 - stdout contains `Exit status:`
 ### Scenario: ps --help exposes the documented sections
 #### When
@@ -4591,7 +4591,7 @@ ps --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: ps/`
+- stdout line `1` matches `/^Usage: ps/`
 - stdout contains `Exit status:`
 ### Scenario: pstree --help exposes the documented sections
 #### When
@@ -4600,7 +4600,7 @@ pstree --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: pstree/`
+- stdout line `1` matches `/^Usage: pstree/`
 - stdout contains `Exit status:`
 ### Scenario: sh --help exposes the documented sections
 #### When
@@ -4609,7 +4609,7 @@ sh --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: sh/`
+- stdout line `1` matches `/^Usage: sh/`
 - stdout contains `Exit status:`
 ### Scenario: smemcap --help exposes the documented sections
 #### When
@@ -4618,7 +4618,7 @@ smemcap --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: smemcap/`
+- stdout line `1` matches `/^Usage: smemcap/`
 - stdout contains `Exit status:`
 ### Scenario: top --help exposes the documented sections
 #### When
@@ -4627,7 +4627,7 @@ top --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: top/`
+- stdout line `1` matches `/^Usage: top/`
 - stdout contains `Exit status:`
 ### Scenario: uptime --help exposes the documented sections
 #### When
@@ -4636,7 +4636,7 @@ uptime --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: uptime/`
+- stdout line `1` matches `/^Usage: uptime/`
 - stdout contains `Exit status:`
 ### Scenario: users --help exposes the documented sections
 #### When
@@ -4645,7 +4645,7 @@ users --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: users/`
+- stdout line `1` matches `/^Usage: users/`
 - stdout contains `Exit status:`
 ### Scenario: uudecode --help exposes the documented sections
 #### When
@@ -4654,7 +4654,7 @@ uudecode --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: uudecode/`
+- stdout line `1` matches `/^Usage: uudecode/`
 - stdout contains `Exit status:`
 ### Scenario: uuencode --help exposes the documented sections
 #### When
@@ -4663,7 +4663,7 @@ uuencode --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: uuencode/`
+- stdout line `1` matches `/^Usage: uuencode/`
 - stdout contains `Exit status:`
 ### Scenario: vi --help exposes the documented sections
 #### When
@@ -4672,7 +4672,7 @@ vi --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: vi/`
+- stdout line `1` matches `/^Usage: vi/`
 - stdout contains `Exit status:`
 ### Scenario: vmstat --help exposes the documented sections
 #### When
@@ -4681,7 +4681,7 @@ vmstat --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: vmstat/`
+- stdout line `1` matches `/^Usage: vmstat/`
 - stdout contains `Exit status:`
 ### Scenario: w --help exposes the documented sections
 #### When
@@ -4690,7 +4690,7 @@ w --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: w/`
+- stdout line `1` matches `/^Usage: w/`
 - stdout contains `Exit status:`
 ### Scenario: wall --help exposes the documented sections
 #### When
@@ -4699,7 +4699,7 @@ wall --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: wall/`
+- stdout line `1` matches `/^Usage: wall/`
 - stdout contains `Exit status:`
 ## mimixbox embedded --help helpers
 Source: `test/e2e/tools/mimixbox/embedded/help_helpers_embedded.atago.yaml`
@@ -4808,7 +4808,7 @@ acpid --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: acpid/`
+- stdout line `1` matches `/^Usage: acpid/`
 - stdout contains `Notes:`
 ### Scenario: brctl --help exposes the documented sections
 #### When
@@ -4817,7 +4817,7 @@ brctl --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: brctl/`
+- stdout line `1` matches `/^Usage: brctl/`
 - stdout contains `Notes:`
 ### Scenario: crond --help exposes the documented sections
 #### When
@@ -4826,7 +4826,7 @@ crond --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: crond/`
+- stdout line `1` matches `/^Usage: crond/`
 - stdout contains `Notes:`
 ### Scenario: ifenslave --help exposes the documented sections
 #### When
@@ -4835,7 +4835,7 @@ ifenslave --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: ifenslave/`
+- stdout line `1` matches `/^Usage: ifenslave/`
 - stdout contains `Notes:`
 ### Scenario: mkfs.reiser --help exposes the documented sections
 #### When
@@ -4844,7 +4844,7 @@ mkfs.reiser --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: mkfs\.reiser/`
+- stdout line `1` matches `/^Usage: mkfs\.reiser/`
 - stdout contains `Notes:`
 ### Scenario: nbd-client --help exposes the documented sections
 #### When
@@ -4853,7 +4853,7 @@ nbd-client --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: nbd\-client/`
+- stdout line `1` matches `/^Usage: nbd\-client/`
 - stdout contains `Notes:`
 ### Scenario: ssl_server --help exposes the documented sections
 #### When
@@ -4862,7 +4862,7 @@ ssl_server --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: ssl_server/`
+- stdout line `1` matches `/^Usage: ssl_server/`
 - stdout contains `Notes:`
 ### Scenario: tunctl --help exposes the documented sections
 #### When
@@ -4871,7 +4871,7 @@ tunctl --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: tunctl/`
+- stdout line `1` matches `/^Usage: tunctl/`
 - stdout contains `Notes:`
 ### Scenario: vconfig --help exposes the documented sections
 #### When
@@ -4880,7 +4880,7 @@ vconfig --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: vconfig/`
+- stdout line `1` matches `/^Usage: vconfig/`
 - stdout contains `Notes:`
 ### Scenario: zcip --help exposes the documented sections
 #### When
@@ -4889,7 +4889,7 @@ zcip --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: zcip/`
+- stdout line `1` matches `/^Usage: zcip/`
 - stdout contains `Notes:`
 ### Scenario: [ --help exposes the documented sections
 #### When
@@ -4898,7 +4898,7 @@ env [ --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: \[/`
+- stdout line `1` matches `/^Usage: \[/`
 - stdout contains `Notes:`
 ### Scenario: [[ --help exposes the documented sections
 #### When
@@ -4907,7 +4907,7 @@ env [[ --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: \[\[/`
+- stdout line `1` matches `/^Usage: \[\[/`
 - stdout contains `Notes:`
 ## mimixbox structured --help sections
 Source: `test/e2e/tools/mimixbox/embedded/help_structured_sections.atago.yaml`
@@ -4918,7 +4918,7 @@ ln --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: ln/`
+- stdout line `1` matches `/^Usage: ln/`
 - stdout contains `Examples:`, `Exit status:`, `  ln `
 ### Scenario: log-collect --help exposes the documented sections
 #### When
@@ -4927,7 +4927,7 @@ log-collect --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: log\-collect/`
+- stdout line `1` matches `/^Usage: log\-collect/`
 - stdout contains `Examples:`, `Exit status:`, `  log-collect `
 ### Scenario: logname --help exposes the documented sections
 #### When
@@ -4936,7 +4936,7 @@ logname --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: logname/`
+- stdout line `1` matches `/^Usage: logname/`
 - stdout contains `Examples:`, `Exit status:`, `  logname `
 ### Scenario: md5sum --help exposes the documented sections
 #### When
@@ -4945,7 +4945,7 @@ md5sum --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: md5sum/`
+- stdout line `1` matches `/^Usage: md5sum/`
 - stdout contains `Examples:`, `Exit status:`, `  md5sum `
 ### Scenario: mkdir --help exposes the documented sections
 #### When
@@ -4954,7 +4954,7 @@ mkdir --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: mkdir/`
+- stdout line `1` matches `/^Usage: mkdir/`
 - stdout contains `Examples:`, `Exit status:`, `  mkdir `
 ### Scenario: mkfifo --help exposes the documented sections
 #### When
@@ -4963,7 +4963,7 @@ mkfifo --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: mkfifo/`
+- stdout line `1` matches `/^Usage: mkfifo/`
 - stdout contains `Examples:`, `Exit status:`, `  mkfifo `
 ### Scenario: mknod --help exposes the documented sections
 #### When
@@ -4972,7 +4972,7 @@ mknod --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: mknod/`
+- stdout line `1` matches `/^Usage: mknod/`
 - stdout contains `Examples:`, `Exit status:`, `  mknod `
 ### Scenario: mktemp --help exposes the documented sections
 #### When
@@ -4981,7 +4981,7 @@ mktemp --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: mktemp/`
+- stdout line `1` matches `/^Usage: mktemp/`
 - stdout contains `Examples:`, `Exit status:`, `  mktemp `
 ### Scenario: mountpoint --help exposes the documented sections
 #### When
@@ -4990,7 +4990,7 @@ mountpoint --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: mountpoint/`
+- stdout line `1` matches `/^Usage: mountpoint/`
 - stdout contains `Examples:`, `Exit status:`, `  mountpoint `
 ### Scenario: mv --help exposes the documented sections
 #### When
@@ -4999,7 +4999,7 @@ mv --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: mv/`
+- stdout line `1` matches `/^Usage: mv/`
 - stdout contains `Examples:`, `Exit status:`, `  mv `
 ### Scenario: nc --help exposes the documented sections
 #### When
@@ -5008,7 +5008,7 @@ nc --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: nc/`
+- stdout line `1` matches `/^Usage: nc/`
 - stdout contains `Examples:`, `Exit status:`, `  nc `
 ### Scenario: netcat --help exposes the documented sections
 #### When
@@ -5017,7 +5017,7 @@ netcat --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: netcat/`
+- stdout line `1` matches `/^Usage: netcat/`
 - stdout contains `Examples:`, `Exit status:`, `  netcat `
 ### Scenario: nl --help exposes the documented sections
 #### When
@@ -5026,7 +5026,7 @@ nl --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: nl/`
+- stdout line `1` matches `/^Usage: nl/`
 - stdout contains `Examples:`, `Exit status:`, `  nl `
 ### Scenario: nohup --help exposes the documented sections
 #### When
@@ -5035,7 +5035,7 @@ nohup --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: nohup/`
+- stdout line `1` matches `/^Usage: nohup/`
 - stdout contains `Examples:`, `Exit status:`, `  nohup `
 ### Scenario: nproc --help exposes the documented sections
 #### When
@@ -5044,7 +5044,7 @@ nproc --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: nproc/`
+- stdout line `1` matches `/^Usage: nproc/`
 - stdout contains `Examples:`, `Exit status:`, `  nproc `
 ### Scenario: nyancat --help exposes the documented sections
 #### When
@@ -5053,7 +5053,7 @@ nyancat --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: nyancat/`
+- stdout line `1` matches `/^Usage: nyancat/`
 - stdout contains `Examples:`, `Exit status:`, `  nyancat `
 ### Scenario: od --help exposes the documented sections
 #### When
@@ -5062,7 +5062,7 @@ od --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: od/`
+- stdout line `1` matches `/^Usage: od/`
 - stdout contains `Examples:`, `Exit status:`, `  od `
 ### Scenario: paste --help exposes the documented sections
 #### When
@@ -5071,7 +5071,7 @@ paste --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: paste/`
+- stdout line `1` matches `/^Usage: paste/`
 - stdout contains `Examples:`, `Exit status:`, `  paste `
 ### Scenario: patch --help exposes the documented sections
 #### When
@@ -5080,7 +5080,7 @@ patch --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: patch/`
+- stdout line `1` matches `/^Usage: patch/`
 - stdout contains `Examples:`, `Exit status:`, `  patch `
 ### Scenario: path --help exposes the documented sections
 #### When
@@ -5089,7 +5089,7 @@ path --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: path/`
+- stdout line `1` matches `/^Usage: path/`
 - stdout contains `Examples:`, `Exit status:`, `  path `
 ### Scenario: pidof --help exposes the documented sections
 #### When
@@ -5098,7 +5098,7 @@ pidof --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: pidof/`
+- stdout line `1` matches `/^Usage: pidof/`
 - stdout contains `Examples:`, `Exit status:`, `  pidof `
 ### Scenario: ping --help exposes the documented sections
 #### When
@@ -5107,7 +5107,7 @@ ping --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: ping/`
+- stdout line `1` matches `/^Usage: ping/`
 - stdout contains `Examples:`, `Exit status:`, `  ping `
 ### Scenario: posixer --help exposes the documented sections
 #### When
@@ -5116,7 +5116,7 @@ posixer --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: posixer/`
+- stdout line `1` matches `/^Usage: posixer/`
 - stdout contains `Examples:`, `Exit status:`, `  posixer `
 ### Scenario: poweroff --help exposes the documented sections
 #### When
@@ -5125,7 +5125,7 @@ poweroff --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: poweroff/`
+- stdout line `1` matches `/^Usage: poweroff/`
 - stdout contains `Examples:`, `Exit status:`, `  poweroff `
 ### Scenario: printenv --help exposes the documented sections
 #### When
@@ -5134,7 +5134,7 @@ printenv --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: printenv/`
+- stdout line `1` matches `/^Usage: printenv/`
 - stdout contains `Examples:`, `Exit status:`, `  printenv `
 ### Scenario: pwcrack --help exposes the documented sections
 #### When
@@ -5143,7 +5143,7 @@ pwcrack --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: pwcrack/`
+- stdout line `1` matches `/^Usage: pwcrack/`
 - stdout contains `Examples:`, `Exit status:`, `  pwcrack `
 ### Scenario: pwgen --help exposes the documented sections
 #### When
@@ -5152,7 +5152,7 @@ pwgen --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: pwgen/`
+- stdout line `1` matches `/^Usage: pwgen/`
 - stdout contains `Examples:`, `Exit status:`, `  pwgen `
 ### Scenario: pwscore --help exposes the documented sections
 #### When
@@ -5161,7 +5161,7 @@ pwscore --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: pwscore/`
+- stdout line `1` matches `/^Usage: pwscore/`
 - stdout contains `Examples:`, `Exit status:`, `  pwscore `
 ### Scenario: readlink --help exposes the documented sections
 #### When
@@ -5170,7 +5170,7 @@ readlink --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: readlink/`
+- stdout line `1` matches `/^Usage: readlink/`
 - stdout contains `Examples:`, `Exit status:`, `  readlink `
 ### Scenario: realpath --help exposes the documented sections
 #### When
@@ -5179,7 +5179,7 @@ realpath --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: realpath/`
+- stdout line `1` matches `/^Usage: realpath/`
 - stdout contains `Examples:`, `Exit status:`, `  realpath `
 ### Scenario: reboot --help exposes the documented sections
 #### When
@@ -5188,7 +5188,7 @@ reboot --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: reboot/`
+- stdout line `1` matches `/^Usage: reboot/`
 - stdout contains `Examples:`, `Exit status:`, `  reboot `
 ### Scenario: remove-shell --help exposes the documented sections
 #### When
@@ -5197,7 +5197,7 @@ remove-shell --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: remove\-shell/`
+- stdout line `1` matches `/^Usage: remove\-shell/`
 - stdout contains `Examples:`, `Exit status:`, `  remove-shell `
 ### Scenario: reset --help exposes the documented sections
 #### When
@@ -5206,7 +5206,7 @@ reset --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: reset/`
+- stdout line `1` matches `/^Usage: reset/`
 - stdout contains `Examples:`, `Exit status:`, `  reset `
 ### Scenario: resize --help exposes the documented sections
 #### When
@@ -5215,7 +5215,7 @@ resize --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: resize/`
+- stdout line `1` matches `/^Usage: resize/`
 - stdout contains `Examples:`, `Exit status:`, `  resize `
 ### Scenario: rev --help exposes the documented sections
 #### When
@@ -5224,7 +5224,7 @@ rev --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: rev/`
+- stdout line `1` matches `/^Usage: rev/`
 - stdout contains `Examples:`, `Exit status:`, `  rev `
 ### Scenario: rm --help exposes the documented sections
 #### When
@@ -5233,7 +5233,7 @@ rm --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: rm/`
+- stdout line `1` matches `/^Usage: rm/`
 - stdout contains `Examples:`, `Exit status:`, `  rm `
 ### Scenario: rmdir --help exposes the documented sections
 #### When
@@ -5242,7 +5242,7 @@ rmdir --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: rmdir/`
+- stdout line `1` matches `/^Usage: rmdir/`
 - stdout contains `Examples:`, `Exit status:`, `  rmdir `
 ### Scenario: rpm --help exposes the documented sections
 #### When
@@ -5251,7 +5251,7 @@ rpm --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: rpm/`
+- stdout line `1` matches `/^Usage: rpm/`
 - stdout contains `Examples:`, `Exit status:`, `  rpm `
 ### Scenario: rpm2cpio --help exposes the documented sections
 #### When
@@ -5260,7 +5260,7 @@ rpm2cpio --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: rpm2cpio/`
+- stdout line `1` matches `/^Usage: rpm2cpio/`
 - stdout contains `Examples:`, `Exit status:`, `  rpm2cpio `
 ### Scenario: sddf --help exposes the documented sections
 #### When
@@ -5269,7 +5269,7 @@ sddf --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: sddf/`
+- stdout line `1` matches `/^Usage: sddf/`
 - stdout contains `Examples:`, `Exit status:`, `  sddf `
 ### Scenario: sed --help exposes the documented sections
 #### When
@@ -5278,7 +5278,7 @@ sed --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: sed/`
+- stdout line `1` matches `/^Usage: sed/`
 - stdout contains `Examples:`, `Exit status:`, `  sed `
 ### Scenario: seq --help exposes the documented sections
 #### When
@@ -5287,7 +5287,7 @@ seq --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: seq/`
+- stdout line `1` matches `/^Usage: seq/`
 - stdout contains `Examples:`, `Exit status:`, `  seq `
 ### Scenario: serial --help exposes the documented sections
 #### When
@@ -5296,7 +5296,7 @@ serial --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: serial/`
+- stdout line `1` matches `/^Usage: serial/`
 - stdout contains `Examples:`, `Exit status:`, `  serial `
 ### Scenario: sha1sum --help exposes the documented sections
 #### When
@@ -5305,7 +5305,7 @@ sha1sum --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: sha1sum/`
+- stdout line `1` matches `/^Usage: sha1sum/`
 - stdout contains `Examples:`, `Exit status:`, `  sha1sum `
 ### Scenario: sha256sum --help exposes the documented sections
 #### When
@@ -5314,7 +5314,7 @@ sha256sum --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: sha256sum/`
+- stdout line `1` matches `/^Usage: sha256sum/`
 - stdout contains `Examples:`, `Exit status:`, `  sha256sum `
 ### Scenario: sha384sum --help exposes the documented sections
 #### When
@@ -5323,7 +5323,7 @@ sha384sum --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: sha384sum/`
+- stdout line `1` matches `/^Usage: sha384sum/`
 - stdout contains `Examples:`, `Exit status:`, `  sha384sum `
 ### Scenario: sha3sum --help exposes the documented sections
 #### When
@@ -5332,7 +5332,7 @@ sha3sum --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: sha3sum/`
+- stdout line `1` matches `/^Usage: sha3sum/`
 - stdout contains `Examples:`, `Exit status:`, `  sha3sum `
 ### Scenario: sha512sum --help exposes the documented sections
 #### When
@@ -5341,7 +5341,7 @@ sha512sum --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: sha512sum/`
+- stdout line `1` matches `/^Usage: sha512sum/`
 - stdout contains `Examples:`, `Exit status:`, `  sha512sum `
 ### Scenario: shred --help exposes the documented sections
 #### When
@@ -5350,7 +5350,7 @@ shred --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: shred/`
+- stdout line `1` matches `/^Usage: shred/`
 - stdout contains `Examples:`, `Exit status:`, `  shred `
 ### Scenario: shuf --help exposes the documented sections
 #### When
@@ -5359,7 +5359,7 @@ shuf --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: shuf/`
+- stdout line `1` matches `/^Usage: shuf/`
 - stdout contains `Examples:`, `Exit status:`, `  shuf `
 ### Scenario: sl --help exposes the documented sections
 #### When
@@ -5368,7 +5368,7 @@ sl --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: sl/`
+- stdout line `1` matches `/^Usage: sl/`
 - stdout contains `Examples:`, `Exit status:`, `  sl `
 ### Scenario: sleep --help exposes the documented sections
 #### When
@@ -5377,7 +5377,7 @@ sleep --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: sleep/`
+- stdout line `1` matches `/^Usage: sleep/`
 - stdout contains `Examples:`, `Exit status:`, `  sleep `
 ### Scenario: sort --help exposes the documented sections
 #### When
@@ -5386,7 +5386,7 @@ sort --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: sort/`
+- stdout line `1` matches `/^Usage: sort/`
 - stdout contains `Examples:`, `Exit status:`, `  sort `
 ### Scenario: speaker --help exposes the documented sections
 #### When
@@ -5395,7 +5395,7 @@ speaker --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: speaker/`
+- stdout line `1` matches `/^Usage: speaker/`
 - stdout contains `Examples:`, `Exit status:`, `  speaker `
 ### Scenario: split --help exposes the documented sections
 #### When
@@ -5404,7 +5404,7 @@ split --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: split/`
+- stdout line `1` matches `/^Usage: split/`
 - stdout contains `Examples:`, `Exit status:`, `  split `
 ### Scenario: stat --help exposes the documented sections
 #### When
@@ -5413,7 +5413,7 @@ stat --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: stat/`
+- stdout line `1` matches `/^Usage: stat/`
 - stdout contains `Examples:`, `Exit status:`, `  stat `
 ### Scenario: strings --help exposes the documented sections
 #### When
@@ -5422,7 +5422,7 @@ strings --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: strings/`
+- stdout line `1` matches `/^Usage: strings/`
 - stdout contains `Examples:`, `Exit status:`, `  strings `
 ### Scenario: sync --help exposes the documented sections
 #### When
@@ -5431,7 +5431,7 @@ sync --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: sync/`
+- stdout line `1` matches `/^Usage: sync/`
 - stdout contains `Examples:`, `Exit status:`, `  sync `
 ### Scenario: tac --help exposes the documented sections
 #### When
@@ -5440,7 +5440,7 @@ tac --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: tac/`
+- stdout line `1` matches `/^Usage: tac/`
 - stdout contains `Examples:`, `Exit status:`, `  tac `
 ### Scenario: tar --help exposes the documented sections
 #### When
@@ -5449,7 +5449,7 @@ tar --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: tar/`
+- stdout line `1` matches `/^Usage: tar/`
 - stdout contains `Examples:`, `Exit status:`, `  tar `
 ### Scenario: tee --help exposes the documented sections
 #### When
@@ -5458,7 +5458,7 @@ tee --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: tee/`
+- stdout line `1` matches `/^Usage: tee/`
 - stdout contains `Examples:`, `Exit status:`, `  tee `
 ### Scenario: timeout --help exposes the documented sections
 #### When
@@ -5467,7 +5467,7 @@ timeout --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: timeout/`
+- stdout line `1` matches `/^Usage: timeout/`
 - stdout contains `Examples:`, `Exit status:`, `  timeout `
 ### Scenario: touch --help exposes the documented sections
 #### When
@@ -5476,7 +5476,7 @@ touch --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: touch/`
+- stdout line `1` matches `/^Usage: touch/`
 - stdout contains `Examples:`, `Exit status:`, `  touch `
 ### Scenario: tr --help exposes the documented sections
 #### When
@@ -5485,7 +5485,7 @@ tr --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: tr/`
+- stdout line `1` matches `/^Usage: tr/`
 - stdout contains `Examples:`, `Exit status:`, `  tr `
 ### Scenario: truncate --help exposes the documented sections
 #### When
@@ -5494,7 +5494,7 @@ truncate --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: truncate/`
+- stdout line `1` matches `/^Usage: truncate/`
 - stdout contains `Examples:`, `Exit status:`, `  truncate `
 ### Scenario: tty --help exposes the documented sections
 #### When
@@ -5503,7 +5503,7 @@ tty --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: tty/`
+- stdout line `1` matches `/^Usage: tty/`
 - stdout contains `Examples:`, `Exit status:`, `  tty `
 ### Scenario: uname --help exposes the documented sections
 #### When
@@ -5512,7 +5512,7 @@ uname --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: uname/`
+- stdout line `1` matches `/^Usage: uname/`
 - stdout contains `Examples:`, `Exit status:`, `  uname `
 ### Scenario: uncompress --help exposes the documented sections
 #### When
@@ -5521,7 +5521,7 @@ uncompress --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: uncompress/`
+- stdout line `1` matches `/^Usage: uncompress/`
 - stdout contains `Examples:`, `Exit status:`, `  uncompress `
 ### Scenario: unexpand --help exposes the documented sections
 #### When
@@ -5530,7 +5530,7 @@ unexpand --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: unexpand/`
+- stdout line `1` matches `/^Usage: unexpand/`
 - stdout contains `Examples:`, `Exit status:`, `  unexpand `
 ### Scenario: uniq --help exposes the documented sections
 #### When
@@ -5539,7 +5539,7 @@ uniq --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: uniq/`
+- stdout line `1` matches `/^Usage: uniq/`
 - stdout contains `Examples:`, `Exit status:`, `  uniq `
 ### Scenario: unix2dos --help exposes the documented sections
 #### When
@@ -5548,7 +5548,7 @@ unix2dos --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: unix2dos/`
+- stdout line `1` matches `/^Usage: unix2dos/`
 - stdout contains `Examples:`, `Exit status:`, `  unix2dos `
 ### Scenario: unlink --help exposes the documented sections
 #### When
@@ -5557,7 +5557,7 @@ unlink --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: unlink/`
+- stdout line `1` matches `/^Usage: unlink/`
 - stdout contains `Examples:`, `Exit status:`, `  unlink `
 ### Scenario: unshadow --help exposes the documented sections
 #### When
@@ -5566,7 +5566,7 @@ unshadow --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: unshadow/`
+- stdout line `1` matches `/^Usage: unshadow/`
 - stdout contains `Examples:`, `Exit status:`, `  unshadow `
 ### Scenario: unzip --help exposes the documented sections
 #### When
@@ -5575,7 +5575,7 @@ unzip --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: unzip/`
+- stdout line `1` matches `/^Usage: unzip/`
 - stdout contains `Examples:`, `Exit status:`, `  unzip `
 ### Scenario: uuidgen --help exposes the documented sections
 #### When
@@ -5584,7 +5584,7 @@ uuidgen --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: uuidgen/`
+- stdout line `1` matches `/^Usage: uuidgen/`
 - stdout contains `Examples:`, `Exit status:`, `  uuidgen `
 ### Scenario: valid-shell --help exposes the documented sections
 #### When
@@ -5593,7 +5593,7 @@ valid-shell --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: valid\-shell/`
+- stdout line `1` matches `/^Usage: valid\-shell/`
 - stdout contains `Examples:`, `Exit status:`, `  valid-shell `
 ### Scenario: watch --help exposes the documented sections
 #### When
@@ -5602,7 +5602,7 @@ watch --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: watch/`
+- stdout line `1` matches `/^Usage: watch/`
 - stdout contains `Examples:`, `Exit status:`, `  watch `
 ### Scenario: wc --help exposes the documented sections
 #### When
@@ -5611,7 +5611,7 @@ wc --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: wc/`
+- stdout line `1` matches `/^Usage: wc/`
 - stdout contains `Examples:`, `Exit status:`, `  wc `
 ### Scenario: which --help exposes the documented sections
 #### When
@@ -5620,7 +5620,7 @@ which --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: which/`
+- stdout line `1` matches `/^Usage: which/`
 - stdout contains `Examples:`, `Exit status:`, `  which `
 ### Scenario: who --help exposes the documented sections
 #### When
@@ -5629,7 +5629,7 @@ who --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: who/`
+- stdout line `1` matches `/^Usage: who/`
 - stdout contains `Examples:`, `Exit status:`, `  who `
 ### Scenario: whoami --help exposes the documented sections
 #### When
@@ -5638,7 +5638,7 @@ whoami --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: whoami/`
+- stdout line `1` matches `/^Usage: whoami/`
 - stdout contains `Examples:`, `Exit status:`, `  whoami `
 ### Scenario: whris --help exposes the documented sections
 #### When
@@ -5647,7 +5647,7 @@ whris --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: whris/`
+- stdout line `1` matches `/^Usage: whris/`
 - stdout contains `Examples:`, `Exit status:`, `  whris `
 ### Scenario: xargs --help exposes the documented sections
 #### When
@@ -5656,7 +5656,7 @@ xargs --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: xargs/`
+- stdout line `1` matches `/^Usage: xargs/`
 - stdout contains `Examples:`, `Exit status:`, `  xargs `
 ### Scenario: xxd --help exposes the documented sections
 #### When
@@ -5665,7 +5665,7 @@ xxd --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: xxd/`
+- stdout line `1` matches `/^Usage: xxd/`
 - stdout contains `Examples:`, `Exit status:`, `  xxd `
 ### Scenario: yes --help exposes the documented sections
 #### When
@@ -5674,7 +5674,7 @@ yes --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: yes/`
+- stdout line `1` matches `/^Usage: yes/`
 - stdout contains `Examples:`, `Exit status:`, `  yes `
 ### Scenario: zip --help exposes the documented sections
 #### When
@@ -5683,7 +5683,7 @@ zip --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: zip/`
+- stdout line `1` matches `/^Usage: zip/`
 - stdout contains `Examples:`, `Exit status:`, `  zip `
 ### Scenario: zip-pwcrack --help exposes the documented sections
 #### When
@@ -5692,7 +5692,7 @@ zip-pwcrack --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: zip\-pwcrack/`
+- stdout line `1` matches `/^Usage: zip\-pwcrack/`
 - stdout contains `Examples:`, `Exit status:`, `  zip-pwcrack `
 ### Scenario: true --help exposes the documented sections
 #### When
@@ -5701,7 +5701,7 @@ env true --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: true/`
+- stdout line `1` matches `/^Usage: true/`
 - stdout contains `Examples:`, `Exit status:`, `  true `
 ### Scenario: test --help exposes the documented sections
 #### When
@@ -5710,7 +5710,7 @@ env test --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: test/`
+- stdout line `1` matches `/^Usage: test/`
 - stdout contains `Examples:`, `Exit status:`, `  test `
 ### Scenario: printf --help exposes the documented sections
 #### When
@@ -5719,7 +5719,7 @@ env printf --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: printf/`
+- stdout line `1` matches `/^Usage: printf/`
 - stdout contains `Examples:`, `Exit status:`, `  printf `
 ### Scenario: pwd --help exposes the documented sections
 #### When
@@ -5728,7 +5728,7 @@ env pwd --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: pwd/`
+- stdout line `1` matches `/^Usage: pwd/`
 - stdout contains `Examples:`, `Exit status:`, `  pwd `
 ## mimixbox structured --help sections (2)
 Source: `test/e2e/tools/mimixbox/embedded/help_structured_sections_2.atago.yaml`
@@ -5739,7 +5739,7 @@ add-shell --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: add\-shell/`
+- stdout line `1` matches `/^Usage: add\-shell/`
 - stdout contains `Examples:`, `Exit status:`, `  add-shell `
 ### Scenario: ar --help exposes the documented sections
 #### When
@@ -5748,7 +5748,7 @@ ar --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: ar/`
+- stdout line `1` matches `/^Usage: ar/`
 - stdout contains `Examples:`, `Exit status:`, `  ar `
 ### Scenario: arch --help exposes the documented sections
 #### When
@@ -5757,7 +5757,7 @@ arch --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: arch/`
+- stdout line `1` matches `/^Usage: arch/`
 - stdout contains `Examples:`, `Exit status:`, `  arch `
 ### Scenario: awk --help exposes the documented sections
 #### When
@@ -5766,7 +5766,7 @@ awk --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: awk/`
+- stdout line `1` matches `/^Usage: awk/`
 - stdout contains `Examples:`, `Exit status:`, `  awk `
 ### Scenario: banner --help exposes the documented sections
 #### When
@@ -5775,7 +5775,7 @@ banner --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: banner/`
+- stdout line `1` matches `/^Usage: banner/`
 - stdout contains `Examples:`, `Exit status:`, `  banner `
 ### Scenario: base32 --help exposes the documented sections
 #### When
@@ -5784,7 +5784,7 @@ base32 --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: base32/`
+- stdout line `1` matches `/^Usage: base32/`
 - stdout contains `Examples:`, `Exit status:`, `  base32 `
 ### Scenario: base64 --help exposes the documented sections
 #### When
@@ -5793,7 +5793,7 @@ base64 --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: base64/`
+- stdout line `1` matches `/^Usage: base64/`
 - stdout contains `Examples:`, `Exit status:`, `  base64 `
 ### Scenario: basename --help exposes the documented sections
 #### When
@@ -5802,7 +5802,7 @@ basename --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: basename/`
+- stdout line `1` matches `/^Usage: basename/`
 - stdout contains `Examples:`, `Exit status:`, `  basename `
 ### Scenario: bunzip2 --help exposes the documented sections
 #### When
@@ -5811,7 +5811,7 @@ bunzip2 --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: bunzip2/`
+- stdout line `1` matches `/^Usage: bunzip2/`
 - stdout contains `Examples:`, `Exit status:`, `  bunzip2 `
 ### Scenario: cal --help exposes the documented sections
 #### When
@@ -5820,7 +5820,7 @@ cal --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: cal/`
+- stdout line `1` matches `/^Usage: cal/`
 - stdout contains `Examples:`, `Exit status:`, `  cal `
 ### Scenario: cat --help exposes the documented sections
 #### When
@@ -5829,7 +5829,7 @@ cat --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: cat/`
+- stdout line `1` matches `/^Usage: cat/`
 - stdout contains `Examples:`, `Exit status:`, `  cat `
 ### Scenario: chgrp --help exposes the documented sections
 #### When
@@ -5838,7 +5838,7 @@ chgrp --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: chgrp/`
+- stdout line `1` matches `/^Usage: chgrp/`
 - stdout contains `Examples:`, `Exit status:`, `  chgrp `
 ### Scenario: chmod --help exposes the documented sections
 #### When
@@ -5847,7 +5847,7 @@ chmod --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: chmod/`
+- stdout line `1` matches `/^Usage: chmod/`
 - stdout contains `Examples:`, `Exit status:`, `  chmod `
 ### Scenario: chown --help exposes the documented sections
 #### When
@@ -5856,7 +5856,7 @@ chown --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: chown/`
+- stdout line `1` matches `/^Usage: chown/`
 - stdout contains `Examples:`, `Exit status:`, `  chown `
 ### Scenario: cksum --help exposes the documented sections
 #### When
@@ -5865,7 +5865,7 @@ cksum --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: cksum/`
+- stdout line `1` matches `/^Usage: cksum/`
 - stdout contains `Examples:`, `Exit status:`, `  cksum `
 ### Scenario: clear --help exposes the documented sections
 #### When
@@ -5874,7 +5874,7 @@ clear --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: clear/`
+- stdout line `1` matches `/^Usage: clear/`
 - stdout contains `Examples:`, `Exit status:`, `  clear `
 ### Scenario: cmatrix --help exposes the documented sections
 #### When
@@ -5883,7 +5883,7 @@ cmatrix --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: cmatrix/`
+- stdout line `1` matches `/^Usage: cmatrix/`
 - stdout contains `Examples:`, `Exit status:`, `  cmatrix `
 ### Scenario: cmp --help exposes the documented sections
 #### When
@@ -5892,7 +5892,7 @@ cmp --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: cmp/`
+- stdout line `1` matches `/^Usage: cmp/`
 - stdout contains `Examples:`, `Exit status:`, `  cmp `
 ### Scenario: comm --help exposes the documented sections
 #### When
@@ -5901,7 +5901,7 @@ comm --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: comm/`
+- stdout line `1` matches `/^Usage: comm/`
 - stdout contains `Examples:`, `Exit status:`, `  comm `
 ### Scenario: compress --help exposes the documented sections
 #### When
@@ -5910,7 +5910,7 @@ compress --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: compress/`
+- stdout line `1` matches `/^Usage: compress/`
 - stdout contains `Examples:`, `Exit status:`, `  compress `
 ### Scenario: cowsay --help exposes the documented sections
 #### When
@@ -5919,7 +5919,7 @@ cowsay --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: cowsay/`
+- stdout line `1` matches `/^Usage: cowsay/`
 - stdout contains `Examples:`, `Exit status:`, `  cowsay `
 ### Scenario: cowthink --help exposes the documented sections
 #### When
@@ -5928,7 +5928,7 @@ cowthink --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: cowthink/`
+- stdout line `1` matches `/^Usage: cowthink/`
 - stdout contains `Examples:`, `Exit status:`, `  cowthink `
 ### Scenario: cpio --help exposes the documented sections
 #### When
@@ -5937,7 +5937,7 @@ cpio --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: cpio/`
+- stdout line `1` matches `/^Usage: cpio/`
 - stdout contains `Examples:`, `Exit status:`, `  cpio `
 ### Scenario: cut --help exposes the documented sections
 #### When
@@ -5946,7 +5946,7 @@ cut --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: cut/`
+- stdout line `1` matches `/^Usage: cut/`
 - stdout contains `Examples:`, `Exit status:`, `  cut `
 ### Scenario: date --help exposes the documented sections
 #### When
@@ -5955,7 +5955,7 @@ date --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: date/`
+- stdout line `1` matches `/^Usage: date/`
 - stdout contains `Examples:`, `Exit status:`, `  date `
 ### Scenario: dd --help exposes the documented sections
 #### When
@@ -5964,7 +5964,7 @@ dd --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: dd/`
+- stdout line `1` matches `/^Usage: dd/`
 - stdout contains `Examples:`, `Exit status:`, `  dd `
 ### Scenario: df --help exposes the documented sections
 #### When
@@ -5973,7 +5973,7 @@ df --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: df/`
+- stdout line `1` matches `/^Usage: df/`
 - stdout contains `Examples:`, `Exit status:`, `  df `
 ### Scenario: diff --help exposes the documented sections
 #### When
@@ -5982,7 +5982,7 @@ diff --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: diff/`
+- stdout line `1` matches `/^Usage: diff/`
 - stdout contains `Examples:`, `Exit status:`, `  diff `
 ### Scenario: dirname --help exposes the documented sections
 #### When
@@ -5991,7 +5991,7 @@ dirname --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: dirname/`
+- stdout line `1` matches `/^Usage: dirname/`
 - stdout contains `Examples:`, `Exit status:`, `  dirname `
 ### Scenario: dos2unix --help exposes the documented sections
 #### When
@@ -6000,7 +6000,7 @@ dos2unix --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: dos2unix/`
+- stdout line `1` matches `/^Usage: dos2unix/`
 - stdout contains `Examples:`, `Exit status:`, `  dos2unix `
 ### Scenario: du --help exposes the documented sections
 #### When
@@ -6009,7 +6009,7 @@ du --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: du/`
+- stdout line `1` matches `/^Usage: du/`
 - stdout contains `Examples:`, `Exit status:`, `  du `
 ### Scenario: egrep --help exposes the documented sections
 #### When
@@ -6018,7 +6018,7 @@ egrep --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: egrep/`
+- stdout line `1` matches `/^Usage: egrep/`
 - stdout contains `Examples:`, `Exit status:`, `  egrep `
 ### Scenario: env --help exposes the documented sections
 #### When
@@ -6027,7 +6027,7 @@ env --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: env/`
+- stdout line `1` matches `/^Usage: env/`
 - stdout contains `Examples:`, `Exit status:`, `  env `
 ### Scenario: expand --help exposes the documented sections
 #### When
@@ -6036,7 +6036,7 @@ expand --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: expand/`
+- stdout line `1` matches `/^Usage: expand/`
 - stdout contains `Examples:`, `Exit status:`, `  expand `
 ### Scenario: expr --help exposes the documented sections
 #### When
@@ -6045,7 +6045,7 @@ expr --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: expr/`
+- stdout line `1` matches `/^Usage: expr/`
 - stdout contains `Examples:`, `Exit status:`, `  expr `
 ### Scenario: fakemovie --help exposes the documented sections
 #### When
@@ -6054,7 +6054,7 @@ fakemovie --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: fakemovie/`
+- stdout line `1` matches `/^Usage: fakemovie/`
 - stdout contains `Examples:`, `Exit status:`, `  fakemovie `
 ### Scenario: fgrep --help exposes the documented sections
 #### When
@@ -6063,7 +6063,7 @@ fgrep --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: fgrep/`
+- stdout line `1` matches `/^Usage: fgrep/`
 - stdout contains `Examples:`, `Exit status:`, `  fgrep `
 ### Scenario: fmt --help exposes the documented sections
 #### When
@@ -6072,7 +6072,7 @@ fmt --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: fmt/`
+- stdout line `1` matches `/^Usage: fmt/`
 - stdout contains `Examples:`, `Exit status:`, `  fmt `
 ### Scenario: fold --help exposes the documented sections
 #### When
@@ -6081,7 +6081,7 @@ fold --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: fold/`
+- stdout line `1` matches `/^Usage: fold/`
 - stdout contains `Examples:`, `Exit status:`, `  fold `
 ### Scenario: fortune --help exposes the documented sections
 #### When
@@ -6090,7 +6090,7 @@ fortune --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: fortune/`
+- stdout line `1` matches `/^Usage: fortune/`
 - stdout contains `Examples:`, `Exit status:`, `  fortune `
 ### Scenario: free --help exposes the documented sections
 #### When
@@ -6099,7 +6099,7 @@ free --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: free/`
+- stdout line `1` matches `/^Usage: free/`
 - stdout contains `Examples:`, `Exit status:`, `  free `
 ### Scenario: ghrdc --help exposes the documented sections
 #### When
@@ -6108,7 +6108,7 @@ ghrdc --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: ghrdc/`
+- stdout line `1` matches `/^Usage: ghrdc/`
 - stdout contains `Examples:`, `Exit status:`, `  ghrdc `
 ### Scenario: grep --help exposes the documented sections
 #### When
@@ -6117,7 +6117,7 @@ grep --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: grep/`
+- stdout line `1` matches `/^Usage: grep/`
 - stdout contains `Examples:`, `Exit status:`, `  grep `
 ### Scenario: groups --help exposes the documented sections
 #### When
@@ -6126,7 +6126,7 @@ groups --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: groups/`
+- stdout line `1` matches `/^Usage: groups/`
 - stdout contains `Examples:`, `Exit status:`, `  groups `
 ### Scenario: gunzip --help exposes the documented sections
 #### When
@@ -6135,7 +6135,7 @@ gunzip --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: gunzip/`
+- stdout line `1` matches `/^Usage: gunzip/`
 - stdout contains `Examples:`, `Exit status:`, `  gunzip `
 ### Scenario: gzip --help exposes the documented sections
 #### When
@@ -6144,7 +6144,7 @@ gzip --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: gzip/`
+- stdout line `1` matches `/^Usage: gzip/`
 - stdout contains `Examples:`, `Exit status:`, `  gzip `
 ### Scenario: halt --help exposes the documented sections
 #### When
@@ -6153,7 +6153,7 @@ halt --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: halt/`
+- stdout line `1` matches `/^Usage: halt/`
 - stdout contains `Examples:`, `Exit status:`, `  halt `
 ### Scenario: head --help exposes the documented sections
 #### When
@@ -6162,7 +6162,7 @@ head --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: head/`
+- stdout line `1` matches `/^Usage: head/`
 - stdout contains `Examples:`, `Exit status:`, `  head `
 ### Scenario: hostid --help exposes the documented sections
 #### When
@@ -6171,7 +6171,7 @@ hostid --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: hostid/`
+- stdout line `1` matches `/^Usage: hostid/`
 - stdout contains `Examples:`, `Exit status:`, `  hostid `
 ### Scenario: hostname --help exposes the documented sections
 #### When
@@ -6180,7 +6180,7 @@ hostname --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: hostname/`
+- stdout line `1` matches `/^Usage: hostname/`
 - stdout contains `Examples:`, `Exit status:`, `  hostname `
 ### Scenario: http-status-code --help exposes the documented sections
 #### When
@@ -6189,7 +6189,7 @@ http-status-code --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: http\-status\-code/`
+- stdout line `1` matches `/^Usage: http\-status\-code/`
 - stdout contains `Examples:`, `Exit status:`, `  http-status-code `
 ### Scenario: id --help exposes the documented sections
 #### When
@@ -6198,7 +6198,7 @@ id --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: id/`
+- stdout line `1` matches `/^Usage: id/`
 - stdout contains `Examples:`, `Exit status:`, `  id `
 ### Scenario: install --help exposes the documented sections
 #### When
@@ -6207,7 +6207,7 @@ install --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: install/`
+- stdout line `1` matches `/^Usage: install/`
 - stdout contains `Examples:`, `Exit status:`, `  install `
 ### Scenario: ischroot --help exposes the documented sections
 #### When
@@ -6216,7 +6216,7 @@ ischroot --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: ischroot/`
+- stdout line `1` matches `/^Usage: ischroot/`
 - stdout contains `Examples:`, `Exit status:`, `  ischroot `
 ### Scenario: killall --help exposes the documented sections
 #### When
@@ -6225,7 +6225,7 @@ killall --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: killall/`
+- stdout line `1` matches `/^Usage: killall/`
 - stdout contains `Examples:`, `Exit status:`, `  killall `
 ### Scenario: lifegame --help exposes the documented sections
 #### When
@@ -6234,7 +6234,7 @@ lifegame --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: lifegame/`
+- stdout line `1` matches `/^Usage: lifegame/`
 - stdout contains `Examples:`, `Exit status:`, `  lifegame `
 ### Scenario: link --help exposes the documented sections
 #### When
@@ -6243,7 +6243,7 @@ link --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: link/`
+- stdout line `1` matches `/^Usage: link/`
 - stdout contains `Examples:`, `Exit status:`, `  link `
 ### Scenario: echo --help exposes the documented sections
 #### When
@@ -6252,7 +6252,7 @@ env echo --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: echo/`
+- stdout line `1` matches `/^Usage: echo/`
 - stdout contains `Examples:`, `Exit status:`, `  echo `
 ### Scenario: false --help exposes the documented sections
 #### When
@@ -6261,7 +6261,7 @@ env false --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: false/`
+- stdout line `1` matches `/^Usage: false/`
 - stdout contains `Examples:`, `Exit status:`, `  false `
 ### Scenario: kill --help exposes the documented sections
 #### When
@@ -6270,7 +6270,7 @@ env kill --help
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^Usage: kill/`
+- stdout line `1` matches `/^Usage: kill/`
 - stdout contains `Examples:`, `Exit status:`, `  kill `
 ## mimixbox i2cdetect
 Source: `test/e2e/tools/mimixbox/embedded/i2cdetect.atago.yaml`
@@ -7518,7 +7518,7 @@ ls --sort=size ${workdir}/ls_gnu
 #### Then
 - after `ls --sort=size ${workdir}/ls_gnu`:
   - exit code is `0`
-  - stdout equals an exact value
+  - stdout line `1` equals an exact value
 ### Scenario: lists directories first with --group-directories-first
 #### When
 ```shell
@@ -7536,7 +7536,7 @@ ls --group-directories-first ${workdir}/ls_gnu
 #### Then
 - after `ls --group-directories-first ${workdir}/ls_gnu`:
   - exit code is `0`
-  - stdout equals an exact value
+  - stdout line `1` equals an exact value
 ### Scenario: drops matches with --ignore
 #### When
 ```shell
@@ -8756,7 +8756,7 @@ grep -A1 MATCH ${workdir}/grep_gnu/groups.txt
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
+- stdout line `3` equals an exact value
 ### Scenario: searches only included files with --include
 #### When
 ```shell
@@ -9360,8 +9360,8 @@ init -t inittab
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
-- stdout equals an exact value
+- stdout line `1` equals an exact value
+- stdout line `2` equals an exact value
 ### Scenario: fails on a missing inittab
 #### When
 ```shell
@@ -9515,8 +9515,8 @@ run-parts parts
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
-- stdout equals an exact value
+- stdout line `1` equals an exact value
+- stdout line `2` equals an exact value
 ### Scenario: requires a directory
 #### When
 ```shell
@@ -9532,7 +9532,7 @@ Source: `test/e2e/tools/mimixbox/loginutils/runlevel.atago.yaml`
 runlevel
 ```
 #### Then
-- stdout matches `/.+/`
+- stdout line `1` matches `/.+/`
 ## mimixbox start-stop-daemon
 Source: `test/e2e/tools/mimixbox/loginutils/start-stop-daemon.atago.yaml`
 ### Scenario: describes itself with --help
@@ -10975,8 +10975,8 @@ logread sys.log
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
-- stdout equals an exact value
+- stdout line `1` equals an exact value
+- stdout line `2` equals an exact value
 ### Scenario: fails when no readable log is found
 #### When
 ```shell
@@ -11012,8 +11012,8 @@ lsof -p $$
 ```
 #### Then
 - exit code is `0`
-- stdout contains `COMMAND`
-- stdout contains `NAME`
+- stdout line `1` contains `COMMAND`
+- stdout line `1` contains `NAME`
 ## mimixbox minips
 Source: `test/e2e/tools/mimixbox/procps/minips.atago.yaml`
 ### Scenario: prints the PID/USER/COMMAND header
@@ -11023,7 +11023,7 @@ minips
 ```
 #### Then
 - exit code is `0`
-- stdout contains `COMMAND`
+- stdout line `1` contains `COMMAND`
 ### Scenario: lists processes
 #### When
 ```shell
@@ -11139,7 +11139,7 @@ ps
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
+- stdout line `1` equals an exact value
 ### Scenario: lists running processes
 #### When
 ```shell
@@ -11227,7 +11227,7 @@ top -bn1
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^top -/`
+- stdout line `1` matches `/^top -/`
 ### Scenario: prints the tasks line
 #### When
 ```shell
@@ -11290,7 +11290,7 @@ vmstat
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^[ 0-9]+$/`
+- stdout line `3` matches `/^[ 0-9]+$/`
 ## mimixbox chpst
 Source: `test/e2e/tools/mimixbox/runit/chpst.atago.yaml`
 ### Scenario: loads an environment directory
@@ -11483,8 +11483,8 @@ cat log/current
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
-- stdout equals an exact value
+- stdout line `1` equals an exact value
+- stdout line `2` equals an exact value
 ### Scenario: requires a directory
 #### Inputs
 _stdin for `svlogd`:_
@@ -12484,13 +12484,13 @@ df --output=source,fstype,size,used,avail,pcent,target
 ```
 #### Then
 - exit code is `0`
-- stdout contains `Filesystem`
-- stdout contains `Type`
-- stdout contains `Size`
-- stdout contains `Used`
-- stdout contains `Avail`
-- stdout contains `Use%`
-- stdout contains `Mounted on`
+- stdout line `1` contains `Filesystem`
+- stdout line `1` contains `Type`
+- stdout line `1` contains `Size`
+- stdout line `1` contains `Used`
+- stdout line `1` contains `Avail`
+- stdout line `1` contains `Use%`
+- stdout line `1` contains `Mounted on`
 ### Scenario: --output honors a reordered field list
 #### When
 ```shell
@@ -12498,7 +12498,7 @@ df --output=target,source
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/Mounted on.*Filesystem.*/`
+- stdout line `1` matches `/Mounted on.*Filesystem.*/`
 ### Scenario: --output rejects an unknown field
 #### When
 ```shell
@@ -12530,7 +12530,7 @@ df --type=tmpfs --output=fstype,target
 ```
 #### Then
 - exit code is `0`
-- stdout contains `Type`
+- stdout line `1` contains `Type`
 ### Scenario: --type is repeatable
 #### When
 ```shell
@@ -12538,7 +12538,7 @@ df -t tmpfs -t ext4 --output=fstype
 ```
 #### Then
 - exit code is `0`
-- stdout contains `Type`
+- stdout line `1` contains `Type`
 ### Scenario: --block-size labels the block-size in the classic header
 #### When
 ```shell
@@ -12546,7 +12546,7 @@ df --block-size=1M
 ```
 #### Then
 - exit code is `0`
-- stdout contains `1048576-blocks`
+- stdout line `1` contains `1048576-blocks`
 ### Scenario: --block-size rejects an invalid size
 #### When
 ```shell
@@ -12671,8 +12671,8 @@ mkdir -p sub/deep && head -c 1000 /dev/zero > a.txt && head -c 2000 /dev/zero > 
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
-- stdout equals an exact value
+- stdout line `1` equals an exact value
+- stdout line `2` equals an exact value
 ### Scenario: prints only the operand total with --max-depth=0
 #### When
 ```shell
@@ -13396,7 +13396,7 @@ mimixbox --list --filter=cat
 #### Then
 - exit code is `0`
 - stdout contains `cat`
-- stdout contains `cat`
+- stdout line `1` contains `cat`
 ### Scenario: --list --subsystem=textutils includes cat and excludes ls
 #### When
 ```shell
@@ -13813,7 +13813,7 @@ printf --help
 #### Then
 - exit code is `0`
 - stdout contains `Examples:`
-- stdout matches `/^Usage: printf/`
+- stdout line `1` matches `/^Usage: printf/`
 ### Scenario: prints the version banner for a leading --version
 #### When
 ```shell
@@ -15203,10 +15203,10 @@ comm --output-delimiter=, ${workdir}/comm_gnu/a.txt ${workdir}/comm_gnu/b.txt
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
-- stdout equals an exact value
-- stdout equals an exact value
-- stdout equals an exact value
+- stdout line `1` equals an exact value
+- stdout line `2` equals an exact value
+- stdout line `3` equals an exact value
+- stdout line `4` equals an exact value
 ### Scenario: read and write NUL-terminated records with -z
 #### Given
 - Fixture file `comm_gnu/za.txt` is created.

--- a/doc/e2e/openssl.md
+++ b/doc/e2e/openssl.md
@@ -142,7 +142,7 @@ openssl enc -d -aes-256-cbc -pbkdf2 -pass pass:wrong-password -in secret.enc -ou
 - after `openssl enc -aes-256-cbc -pbkdf2 -pass pass:correct-horse -in secret.txt -out secret.enc`:
   - exit code is `0`
   - file `secret.enc` exists
-  - file `secret.enc` is checked
+  - file `secret.enc` does not contain `attack at dawn`
 - after `openssl enc -d -aes-256-cbc -pbkdf2 -pass pass:correct-horse -in secret.enc -out roundtrip.txt`:
   - exit code is `0`
   - file `roundtrip.txt` contains `attack at dawn`

--- a/doc/e2e/sqlite3.md
+++ b/doc/e2e/sqlite3.md
@@ -101,8 +101,8 @@ sqlite3 -csv app.db "SELECT * FROM u ORDER BY id;"
 #### Then
 - after `sqlite3 -csv app.db "SELECT * FROM u ORDER BY id;"`:
   - exit code is `0`
-  - stdout equals an exact value
-  - stdout equals an exact value
+  - stdout line `1` equals an exact value
+  - stdout line `2` equals an exact value
 ### Scenario: .dump emits SQL that rebuilds an identical database
 #### When
 ```shell

--- a/doc/e2e/sqly.md
+++ b/doc/e2e/sqly.md
@@ -691,9 +691,9 @@ sqly user.csv
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
-- stdout equals an exact value
-- stdout equals an exact value
+- stdout line `1` equals an exact value
+- stdout line `2` equals an exact value
+- stdout line `3` equals an exact value
 - stderr contains `Change output mode`
 ### Scenario: runs a multiline WITH (CTE) query
 #### Given
@@ -928,7 +928,7 @@ sqly u.csv
 - exit code is `1`
 - stdout contains `affected`
 - stderr does not contain `Saved`
-- file `u.csv` is checked
+- file `u.csv` does not contain `BROKEN`
 ### Scenario: does not run .dump after an earlier failure
 #### Given
 - Fixture file `u.csv` is created.
@@ -1321,7 +1321,7 @@ sqly --csv --sql "SELECT user_name, position FROM user INNER JOIN identifier ON 
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
+- stdout line `1` equals an exact value
 - stdout contains `booker12`
 ### Scenario: writes JSON results to the given path with --output
 #### Given
@@ -1355,7 +1355,7 @@ sqly --sql "SELECT user_name FROM user ORDER BY identifier LIMIT 1" user.csv --c
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
+- stdout line `1` equals an exact value
 - stdout contains `booker12`
 ### Scenario: fails fast on an unknown flag after the file path
 #### Given
@@ -1594,7 +1594,7 @@ sqly --compare --compare-format text zebra.csv ant.csv
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
+- stdout line `1` equals an exact value
 ### Scenario: reverses left and right when the inputs are swapped
 #### Given
 - Fixture file `zebra.csv` is created.
@@ -1616,7 +1616,7 @@ sqly --compare --compare-format text ant.csv zebra.csv
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
+- stdout line `1` equals an exact value
 ### Scenario: keeps the keyed diff correct on a larger input
 #### Given
 - Fixture file `big1.csv` is created.
@@ -1697,7 +1697,7 @@ sqly --csv --sql "SELECT p.name, p.price, s.quantity, ROUND(p.price * s.quantity
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
+- stdout line `1` equals an exact value
 - stdout contains `Laptop`, `2999.97`
 ## sqly empty command arguments
 Source: `test/e2e/tools/sqly/empty_args.atago.yaml`
@@ -1723,7 +1723,7 @@ sqly u.csv
 - exit code is `1`
 - stdout contains `affected`
 - stderr contains `.save requires`
-- file `u.csv` is checked
+- file `u.csv` does not contain `EMPTY`
 ### Scenario: rejects .dump with an empty destination
 #### Given
 - Fixture file `user.csv` is created.
@@ -1777,7 +1777,7 @@ sqly --excel --output out.xlsx --sql "SELECT * FROM user LIMIT 1" user.csv
 - exit code is `0`
 - stderr contains `output mode=excel`
 - file `out.xlsx` exists
-- file `out.xlsx` is checked
+- file `out.xlsx` is not executable
 #### Generated artifacts
 - `out.xlsx`
 ### Scenario: writes a non-executable .xlsx with the .dump command
@@ -1802,7 +1802,7 @@ sqly user.csv
 - exit code is `0`
 - stderr contains `mode=excel`
 - file `dump.xlsx` exists
-- file `dump.xlsx` is checked
+- file `dump.xlsx` is not executable
 #### Generated artifacts
 - `dump.xlsx`
 ## sqly export format inference
@@ -1843,7 +1843,7 @@ sqly --sql "SELECT user_name FROM user ORDER BY identifier LIMIT 1" user.csv --o
 - exit code is `0`
 - stderr contains `output mode=ndjson`
 - file `result.ndjson.gz` exists
-- file `result.ndjson.gz` is checked
+- file `result.ndjson.gz` does not contain `booker12`
 #### Generated artifacts
 - `result.ndjson.gz`
 ### Scenario: re-imports a gzip-compressed csv it wrote
@@ -1864,8 +1864,8 @@ sqly --csv --sql "SELECT user_name FROM result LIMIT 1" result.csv.gz
 #### Then
 - after `sqly --csv --sql "SELECT user_name FROM result LIMIT 1" result.csv.gz`:
   - exit code is `0`
-  - stdout equals an exact value
-  - stdout equals an exact value
+  - stdout line `1` equals an exact value
+  - stdout line `2` equals an exact value
 ### Scenario: writes the CSV fallback to an unknown extension path without rewriting it
 #### Given
 - Fixture file `user.csv` is created.
@@ -2404,7 +2404,7 @@ sqly --json user.csv
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
+- stdout line `1` equals an exact value
 ### Scenario: .import imports a quoted path containing a space as one argument
 #### Given
 - Fixture file `sqly_e2e space.csv` is created.
@@ -2467,7 +2467,7 @@ sqly user.csv
 - exit code is `0`
 - stderr contains `mode=tsv`
 - file `out.tsv` contains `user_name	identifier`
-- file `out.tsv` is checked
+- file `out.tsv` does not contain `user_name,identifier`
 ## sqly hermetic environment
 Source: `test/e2e/tools/sqly/hermetic.atago.yaml`
 ### Scenario: runs with HOME inside the sandbox
@@ -2584,7 +2584,7 @@ sqly --inspect user.csv
 #### Then
 - after `sqly --inspect user.csv`:
   - exit code is `0`
-  - stdout equals an exact value
+  - stdout line `1` equals an exact value
   - stdout contains `"name": "user"`
 ### Scenario: runs batch mode and warns when a history write fails after startup
 #### Given
@@ -2817,7 +2817,7 @@ sqly --inspect user.csv
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
+- stdout line `1` equals an exact value
 - stdout contains `"name": "user"`, `"row_count": 3`, `"user_name"`
 ### Scenario: maps every table from a multi-table ACH file to its source
 #### Given
@@ -2850,7 +2850,7 @@ sqly --inspect ins
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
+- stdout line `1` equals an exact value
 - stdout contains `"name": "a"`, `"name": "b"`
 - stderr does not contain `Successfully imported`
 ### Scenario: fails with a clear error when no input is given
@@ -3007,7 +3007,7 @@ sqly --csv --sql "SELECT user_name FROM user" user.csv
 ```
 #### Then
 - after `sqly --csv --sql "SELECT COUNT(*) AS c FROM user" user.csv`:
-  - stdout equals an exact value
+  - stdout line `2` equals an exact value
 - after `sqly --csv --sql "SELECT user_name FROM user" user.csv`:
   - stdout contains `booker12`, `jenkins46`, `grey07`
 ### Scenario: WHERE 1=1 returns all rows and WHERE 1=0 returns none
@@ -3028,7 +3028,7 @@ sqly --json --sql "SELECT user_name FROM user WHERE 1=0" user.csv
 ```
 #### Then
 - after `sqly --csv --sql "SELECT COUNT(*) AS c FROM user WHERE 1=1" user.csv`:
-  - stdout equals an exact value
+  - stdout line `2` equals an exact value
 - after `sqly --json --sql "SELECT user_name FROM user WHERE 1=0" user.csv`:
   - stdout equals an exact value
 ### Scenario: ORDER BY preserves the row multiset
@@ -3048,7 +3048,7 @@ sqly --csv --sql "SELECT user_name FROM user ORDER BY user_name DESC" user.csv
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
+- stdout line `2` equals an exact value
 - stdout contains `grey07`, `booker12`
 ### Scenario: csv and ndjson yield the same rows
 #### Given
@@ -3066,8 +3066,8 @@ grey07,3
 sqly --ndjson --sql "SELECT user_name FROM user ORDER BY identifier" user.csv
 ```
 #### Then
-- stdout equals an exact value
-- stdout equals an exact value
+- stdout line `1` equals an exact value
+- stdout line `3` equals an exact value
 ### Scenario: CSV dump reimported yields identical data
 #### Given
 - Fixture file `user.csv` is created.
@@ -3091,9 +3091,9 @@ sqly --csv --sql "SELECT * FROM rt ORDER BY identifier" rt.csv
 #### Then
 - after `sqly --csv --sql "SELECT * FROM rt ORDER BY identifier" rt.csv`:
   - exit code is `0`
-  - stdout equals an exact value
-  - stdout equals an exact value
-  - stdout equals an exact value
+  - stdout line `1` equals an exact value
+  - stdout line `2` equals an exact value
+  - stdout line `4` equals an exact value
 ## sqly .mode banner routing
 Source: `test/e2e/tools/sqly/mode_banner.atago.yaml`
 ### Scenario: keeps stdout pure JSON after .mode json
@@ -3116,7 +3116,7 @@ sqly user.csv
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
+- stdout line `1` equals an exact value
 - stdout does not contain `Change output mode`
 - stderr contains `Change output mode from table to json`
 ### Scenario: keeps stdout pure NDJSON after .mode ndjson
@@ -3139,7 +3139,7 @@ sqly user.csv
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
+- stdout line `1` equals an exact value
 - stdout does not contain `Change output mode`
 - stderr contains `Change output mode from table to ndjson`
 ### Scenario: reports the typed mode by name and emits typed output after .mode json-typed
@@ -3184,7 +3184,7 @@ sqly --json --sql "SELECT user_name, identifier FROM user ORDER BY identifier LI
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
+- stdout line `1` equals an exact value
 - stdout contains `{"user_name":"booker12","identifier":"1"}`
 - stdout contains `{"user_name":"jenkins46","identifier":"2"}`
 ### Scenario: --json prints [] for an empty result
@@ -3220,8 +3220,8 @@ sqly --ndjson --sql "SELECT user_name, identifier FROM user ORDER BY identifier 
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
-- stdout equals an exact value
+- stdout line `1` equals an exact value
+- stdout line `2` equals an exact value
 ### Scenario: --ndjson prints nothing for an empty result
 #### Given
 - Fixture file `user.csv` is created.
@@ -3254,8 +3254,8 @@ sqly --csv --sql "SELECT user_name, identifier FROM user ORDER BY identifier LIM
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
-- stdout equals an exact value
+- stdout line `1` equals an exact value
+- stdout line `2` equals an exact value
 ## sqly --output requires --sql
 Source: `test/e2e/tools/sqly/output_requires_sql.atago.yaml`
 ### Scenario: rejects --output with no query
@@ -3394,7 +3394,7 @@ sqly --csv --sql "SELECT COUNT(*) AS c FROM user" user.parquet
   - file `user.parquet` exists
 - after `sqly --csv --sql "SELECT COUNT(*) AS c FROM user" user.parquet`:
   - exit code is `0`
-  - stdout equals an exact value
+  - stdout line `2` equals an exact value
 #### Generated artifacts
 - `user.parquet`
 ### Scenario: appends the .parquet extension
@@ -3500,7 +3500,7 @@ sqly --csv --sql "SELECT COUNT(*) AS c FROM user" a/b/c/d/e/f/g/h/i/j/k/user.csv
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
+- stdout line `2` equals an exact value
 ### Scenario: imports a file whose name literally contains ..%2f
 #### Given
 - Fixture file `..%2fuser.csv` is created.
@@ -3798,7 +3798,7 @@ sqly --csv --sql "SELECT user_name FROM user ORDER BY identifier LIMIT 1" user.c
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
+- stdout line `2` equals an exact value
 ### Scenario: queries a Parquet file
 #### Given
 - Fixture file `products.parquet` is created.
@@ -3808,7 +3808,7 @@ sqly --csv --sql "SELECT name FROM products ORDER BY CAST(price AS REAL) DESC LI
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
+- stdout line `2` equals an exact value
 ### Scenario: joins a compressed CSV with a plain CSV
 #### Given
 - Fixture file `user.csv.gz` is created.
@@ -3844,9 +3844,9 @@ smith79,3,Jamie,Smith
 sqly --csv --sql "SELECT user_name, identifier FROM user LIMIT 2" user.csv
 ```
 #### Then
-- stdout equals an exact value
-- stdout equals an exact value
-- stdout equals an exact value
+- stdout line `1` equals an exact value
+- stdout line `2` equals an exact value
+- stdout line `3` equals an exact value
 ### Scenario: renders JSON with --json
 #### Given
 - Fixture file `user.csv` is created.
@@ -3880,8 +3880,8 @@ smith79,3,Jamie,Smith
 sqly --ndjson --sql "SELECT user_name, identifier FROM user LIMIT 2" user.csv
 ```
 #### Then
-- stdout equals an exact value
-- stdout equals an exact value
+- stdout line `1` equals an exact value
+- stdout line `2` equals an exact value
 ### Scenario: renders a markdown table with --markdown
 #### Given
 - Fixture file `user.csv` is created.
@@ -3898,7 +3898,7 @@ smith79,3,Jamie,Smith
 sqly --markdown --sql "SELECT user_name, identifier FROM user LIMIT 2" user.csv
 ```
 #### Then
-- stdout equals an exact value
+- stdout line `1` equals an exact value
 - stdout contains `| booker12 | 1 |`
 ### Scenario: renders LTSV with --ltsv
 #### Given
@@ -3916,7 +3916,7 @@ smith79,3,Jamie,Smith
 sqly --ltsv --sql "SELECT user_name, identifier FROM user LIMIT 1" user.csv
 ```
 #### Then
-- stdout equals an exact value
+- stdout line `1` equals an exact value
 ### Scenario: writes CSV to the path given by --output
 #### Given
 - Fixture file `user.csv` is created.
@@ -4125,7 +4125,7 @@ sqly --sql "UPDATE user SET first_name = 'Rachelle' WHERE identifier = 1" --save
 - exit code is `0`
 - stdout contains `affected`
 - stderr contains `Saved user to`
-- file `user.csv` is checked
+- file `user.csv` does not contain `Rachelle`
 - file `out/user.csv` contains `Rachelle`
 ### Scenario: rejects --save without --force
 #### Given
@@ -4145,7 +4145,7 @@ sqly --sql "UPDATE user SET identifier = identifier + 100" --save user.csv
 #### Then
 - exit code is `1`
 - stderr contains `force`
-- file `user.csv` is checked
+- file `user.csv` does not contain `101`
 ### Scenario: rejects a schema-changing statement under --save-dir before writing anything
 #### Given
 - Fixture file `user.csv` is created.
@@ -4389,7 +4389,7 @@ sqly --sql "UPDATE u SET first_name = 'CHANGED' WHERE identifier = 1" u.csv --sa
 - exit code is `0`
 - stdout contains `affected`
 - stderr contains `Saved u to`
-- file `u.csv` is checked
+- file `u.csv` does not contain `CHANGED`
 - file `out/u.csv` contains `CHANGED`
 ### Scenario: refuses --save without --force
 #### Given
@@ -4408,7 +4408,7 @@ sqly --sql "UPDATE u SET first_name = 'X'" u.csv --save
 #### Then
 - exit code is `1`
 - stderr contains `--force`
-- file `u.csv` is checked
+- file `u.csv` does not contain `X,`
 ### Scenario: overwrites the source in place with --save --force
 #### Given
 - Fixture file `u.csv` is created.
@@ -4445,7 +4445,7 @@ sqly --csv --sql "SELECT COUNT(*) AS c FROM u" u.csv
 #### Then
 - after `sqly --csv --sql "SELECT COUNT(*) AS c FROM u" u.csv`:
   - exit code is `0`
-  - stdout equals an exact value
+  - stdout line `2` equals an exact value
 ### Scenario: preserves gzip compression on in-place save
 #### Given
 - Fixture file `c.csv.gz` is created.
@@ -4457,7 +4457,7 @@ sqly --csv --sql "SELECT first_name FROM c WHERE identifier = 1" c.csv.gz
 #### Then
 - after `sqly --csv --sql "SELECT first_name FROM c WHERE identifier = 1" c.csv.gz`:
   - exit code is `0`
-  - stdout equals an exact value
+  - stdout line `2` equals an exact value
 ### Scenario: saves via the .save command in batch mode
 #### Given
 - Fixture file `u.csv` is created.
@@ -5097,9 +5097,9 @@ sqly --stdin csv --csv --sql "SELECT name FROM stdin ORDER BY id"
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
-- stdout equals an exact value
-- stdout equals an exact value
+- stdout line `1` equals an exact value
+- stdout line `2` equals an exact value
+- stdout line `3` equals an exact value
 ### Scenario: queries piped TSV data
 #### Inputs
 _stdin for `sqly`:_
@@ -5721,7 +5721,7 @@ sqly --csv --sql "SELECT 'a,b' AS c"
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
+- stdout line `2` equals an exact value
 ### Scenario: quotes a CSV value containing a double quote
 #### When
 ```shell
@@ -5729,7 +5729,7 @@ sqly --csv --sql "SELECT 'a' || char(34) || 'b' AS c"
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
+- stdout line `2` equals an exact value
 ### Scenario: rejects an LTSV value containing a tab
 #### When
 ```shell
@@ -5769,7 +5769,7 @@ sqly --csv --sql "/* note */ SELECT 1 AS x"
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
+- stdout line `2` equals an exact value
 ### Scenario: accepts PRAGMA in direct --sql
 #### Given
 - Fixture file `user.csv` is created.
@@ -5904,7 +5904,7 @@ sqly --csv --sql "SELECT COUNT(*) AS n FROM empty" empty.json
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
+- stdout line `2` equals an exact value
 ### Scenario: imports an empty JSONL file as a zero-row table
 #### Given
 - Fixture file `empty.jsonl` is created.
@@ -5914,7 +5914,7 @@ sqly --csv --sql "SELECT COUNT(*) AS n FROM empty" empty.jsonl
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
+- stdout line `2` equals an exact value
 ### Scenario: rejects an --output path ending with a slash
 #### Given
 - Fixture file `user.csv` is created.
@@ -6430,7 +6430,7 @@ sqly --csv --sql "SELECT COUNT(*) AS c FROM stdin" /dev/stdin
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
+- stdout line `2` equals an exact value
 ### Scenario: imports /proc/self/fd/0 as CSV
 _only on Linux_
 #### Inputs
@@ -6447,7 +6447,7 @@ sqly --csv --sql "SELECT COUNT(*) AS c FROM sheet_0" /proc/self/fd/0
 ```
 #### Then
 - exit code is `0`
-- stdout equals an exact value
+- stdout line `2` equals an exact value
 ### Scenario: rejects --output to a multi-compressed ACH destination
 #### Given
 - Fixture file `user.csv` is created.

--- a/doc/e2e/ssh-keygen.md
+++ b/doc/e2e/ssh-keygen.md
@@ -35,7 +35,7 @@ ssh-keygen -t ed25519 -N '' -f key -C test@atago
 - file `key` exists
 - file `key.pub` exists
 - file `key.pub` contains `ssh-ed25519`
-- file `key.pub` is checked
+- file `key.pub` is not executable
 #### Generated artifacts
 - `key`
 - `key.pub`

--- a/doc/e2e/yazi.md
+++ b/doc/e2e/yazi.md
@@ -1123,7 +1123,7 @@ inside
 # interactive (pty): yazi --cwd-file ${workdir}/cwd.txt .
 ```
 #### Then
-- file `cwd.txt` is checked
+- file `cwd.txt` does not contain `/sub`
 ### Scenario: right arrow enters a spaced directory before choosing a file
 _only when `yazi --version` succeeds · skipped on Windows_
 #### Given
@@ -2453,7 +2453,7 @@ _only when `yazi --version` succeeds · skipped on Windows_
 ```
 #### Then
 - exit code is `0`
-- file `cwd.txt` is checked
+- file `cwd.txt` does not contain `a-dir`
 ### Scenario: tabs preserve per-tab cwd and q writes the active tab cwd
 _only when `yazi --version` succeeds · skipped on Windows_
 #### Given

--- a/internal/assertdesc/describe.go
+++ b/internal/assertdesc/describe.go
@@ -119,10 +119,12 @@ func DescribeStream(s *spec.StreamAssert, style StreamStyle) string {
 	if s.Snapshot != "" {
 		parts = append(parts, "matches snapshot "+style.Snapshot(s.Snapshot))
 	}
-	if len(parts) == 0 {
-		return style.NoMatcher
+	desc := style.NoMatcher
+	if len(parts) > 0 {
+		desc = strings.Join(parts, ", ")
 	}
-	desc := strings.Join(parts, ", ")
+	// The line scope is part of what the assertion looks at, so it is named even
+	// when no matcher survived — the reader still learns which line is in play.
 	if s.Line != nil && style.Line != nil {
 		return style.Line(*s.Line) + " " + desc
 	}

--- a/internal/assertdesc/describe.go
+++ b/internal/assertdesc/describe.go
@@ -74,37 +74,59 @@ type StreamStyle struct {
 	JSON      JSONStyle
 	YAML      JSONStyle
 	Snapshot  func(string) string
+	Line      func(int) string
 	NoMatcher string
 }
 
+// DescribeStream renders every matcher a stream assertion sets, not just the
+// first one: the text matchers compose (contains + not_contains + matches +
+// not_matches all have to hold), so describing one of them would publish a
+// weaker contract than the run enforces. A `line: N` selector is rendered as a
+// prefix because it narrows what every matcher sees.
 func DescribeStream(s *spec.StreamAssert, style StreamStyle) string {
-	switch {
-	case s.Empty != nil:
+	var parts []string
+	if s.Empty != nil {
 		if *s.Empty {
-			return "is empty"
+			parts = append(parts, "is empty")
+		} else {
+			parts = append(parts, "is not empty")
 		}
-		return "is not empty"
-	case s.Contains != nil:
-		return "contains " + style.List(s.Contains)
-	case s.NotContains != nil:
-		return "does not contain " + style.List(s.NotContains)
-	case s.Matches != nil:
-		return "matches " + style.Regex(*s.Matches)
-	case s.NotMatches != nil:
-		return "does not match " + style.Regex(*s.NotMatches)
-	case s.Equals != nil:
-		return style.Equals
-	case s.NotEquals != nil:
-		return style.NotEquals
-	case len(s.JSON) > 0:
-		return DescribeJSONChecks(s.JSON, style.JSON)
-	case len(s.YAML) > 0:
-		return DescribeJSONChecks(s.YAML, style.YAML)
-	case s.Snapshot != "":
-		return "matches snapshot " + style.Snapshot(s.Snapshot)
-	default:
+	}
+	if s.Contains != nil {
+		parts = append(parts, "contains "+style.List(s.Contains))
+	}
+	if s.NotContains != nil {
+		parts = append(parts, "does not contain "+style.List(s.NotContains))
+	}
+	if s.Matches != nil {
+		parts = append(parts, "matches "+style.Regex(*s.Matches))
+	}
+	if s.NotMatches != nil {
+		parts = append(parts, "does not match "+style.Regex(*s.NotMatches))
+	}
+	if s.Equals != nil {
+		parts = append(parts, style.Equals)
+	}
+	if s.NotEquals != nil {
+		parts = append(parts, style.NotEquals)
+	}
+	if len(s.JSON) > 0 {
+		parts = append(parts, DescribeJSONChecks(s.JSON, style.JSON))
+	}
+	if len(s.YAML) > 0 {
+		parts = append(parts, DescribeJSONChecks(s.YAML, style.YAML))
+	}
+	if s.Snapshot != "" {
+		parts = append(parts, "matches snapshot "+style.Snapshot(s.Snapshot))
+	}
+	if len(parts) == 0 {
 		return style.NoMatcher
 	}
+	desc := strings.Join(parts, ", ")
+	if s.Line != nil && style.Line != nil {
+		return style.Line(*s.Line) + " " + desc
+	}
+	return desc
 }
 
 type FileStyle struct {
@@ -116,6 +138,10 @@ type FileStyle struct {
 	ExactBytes string
 }
 
+// DescribeFile renders the single matcher a file assertion sets. Every matcher
+// the loader accepts has a case here: one that fell through to Checked would
+// publish "the file is checked" for an assertion that actually pins content or
+// permissions.
 func DescribeFile(f *spec.FileAssert, style FileStyle) string {
 	switch {
 	case f.Exists != nil:
@@ -125,6 +151,13 @@ func DescribeFile(f *spec.FileAssert, style FileStyle) string {
 		return style.Path(f.Path) + " does not exist"
 	case f.Contains != nil:
 		return style.Path(f.Path) + " contains " + style.List(f.Contains)
+	case f.NotContains != nil:
+		return style.Path(f.Path) + " does not contain " + style.List(f.NotContains)
+	case f.Executable != nil:
+		if *f.Executable {
+			return style.Path(f.Path) + " is executable"
+		}
+		return style.Path(f.Path) + " is not executable"
 	case f.Equals != nil:
 		return style.Path(f.Path) + " " + style.ExactBytes
 	case f.EqualsFile != nil:

--- a/internal/assertdesc/describe_test.go
+++ b/internal/assertdesc/describe_test.go
@@ -85,6 +85,104 @@ func TestDescribeStreamAndFile(t *testing.T) {
 	}
 }
 
+// TestDescribeStreamComposedMatchers pins that every matcher a stream assertion
+// sets is described. The text matchers compose at run time (all of them must
+// hold), so describing only the first one published a weaker contract than the
+// run enforces: `contains` + `not_contains` read as a bare `contains`.
+func TestDescribeStreamComposedMatchers(t *testing.T) {
+	t.Parallel()
+	style := StreamStyle{
+		List:      func(ss spec.StringList) string { return fmt.Sprint([]string(ss)) },
+		Regex:     func(s string) string { return "/" + s + "/" },
+		Equals:    "equals exact text",
+		NotEquals: "does not equal exact text",
+		Snapshot:  func(s string) string { return s },
+		Line:      func(n int) string { return fmt.Sprintf("line %d", n) },
+		NoMatcher: "(no matcher)",
+	}
+	tests := []struct {
+		name string
+		s    *spec.StreamAssert
+		want string
+	}{
+		{
+			name: "contains and not_contains",
+			s:    &spec.StreamAssert{Contains: spec.StringList{"ok"}, NotContains: spec.StringList{"panic"}},
+			want: "contains [ok], does not contain [panic]",
+		},
+		{
+			name: "contains and matches and not_matches",
+			s: &spec.StreamAssert{
+				Contains:   spec.StringList{"ok"},
+				Matches:    strptr("^ok"),
+				NotMatches: strptr("error"),
+			},
+			want: "contains [ok], matches /^ok/, does not match /error/",
+		},
+		{
+			name: "line selector prefixes the matcher",
+			s:    &spec.StreamAssert{Line: intptr(2), Equals: strptr("two")},
+			want: "line 2 equals exact text",
+		},
+		{
+			name: "line selector with composed matchers",
+			s:    &spec.StreamAssert{Line: intptr(3), Contains: spec.StringList{"a"}, NotContains: spec.StringList{"b"}},
+			want: "line 3 contains [a], does not contain [b]",
+		},
+		{
+			name: "no matcher",
+			s:    &spec.StreamAssert{},
+			want: "(no matcher)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := DescribeStream(tt.s, style); got != tt.want {
+				t.Fatalf("DescribeStream() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDescribeFileEveryMatcher pins that each matcher the loader accepts on a
+// file assertion has its own phrasing. not_contains and executable used to fall
+// through to the Checked fallback, so `atago doc` and `atago explain` published
+// "the file is checked" for an assertion that pins content or the exec bit.
+func TestDescribeFileEveryMatcher(t *testing.T) {
+	t.Parallel()
+	style := FileStyle{
+		Path:       func(s string) string { return "[" + s + "]" },
+		List:       func(ss spec.StringList) string { return fmt.Sprint([]string(ss)) },
+		Snapshot:   func(s string) string { return "<" + s + ">" },
+		Checked:    func(s string) string { return "checked " + s },
+		ExactBytes: "equals exact bytes",
+	}
+	tests := []struct {
+		name string
+		f    *spec.FileAssert
+		want string
+	}{
+		{"exists", &spec.FileAssert{Path: "a", Exists: boolptr(true)}, "[a] exists"},
+		{"not exists", &spec.FileAssert{Path: "a", Exists: boolptr(false)}, "[a] does not exist"},
+		{"contains", &spec.FileAssert{Path: "a", Contains: spec.StringList{"x"}}, "[a] contains [x]"},
+		{"not_contains", &spec.FileAssert{Path: "a", NotContains: spec.StringList{"secret"}}, "[a] does not contain [secret]"},
+		{"executable", &spec.FileAssert{Path: "a", Executable: boolptr(true)}, "[a] is executable"},
+		{"not executable", &spec.FileAssert{Path: "a", Executable: boolptr(false)}, "[a] is not executable"},
+		{"equals", &spec.FileAssert{Path: "a", Equals: strptr("x")}, "[a] equals exact bytes"},
+		{"equals_file", &spec.FileAssert{Path: "a", EqualsFile: strptr("b")}, "[a] is byte-identical to [b]"},
+		{"snapshot", &spec.FileAssert{Path: "a", Snapshot: "s"}, "[a] matches snapshot <s>"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := DescribeFile(tt.f, style); got != tt.want {
+				t.Fatalf("DescribeFile() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDescribeChangesMockImageDirAndPDF(t *testing.T) {
 	t.Parallel()
 	if got := DescribeChanges(&spec.ChangesAssert{

--- a/internal/assertdesc/describe_test.go
+++ b/internal/assertdesc/describe_test.go
@@ -134,6 +134,11 @@ func TestDescribeStreamComposedMatchers(t *testing.T) {
 			s:    &spec.StreamAssert{},
 			want: "(no matcher)",
 		},
+		{
+			name: "line selector survives a matcher-less assertion",
+			s:    &spec.StreamAssert{Line: intptr(4)},
+			want: "line 4 (no matcher)",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/docgen/describe.go
+++ b/internal/docgen/describe.go
@@ -48,6 +48,7 @@ var docgenStreamStyle = assertdesc.StreamStyle{
 	JSON:      docgenJSONStyle,
 	YAML:      docgenYAMLStyle,
 	Snapshot:  markdown.Code,
+	Line:      func(n int) string { return "line " + markdown.Code(fmt.Sprint(n)) },
 	NoMatcher: "is checked",
 }
 

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -443,6 +443,7 @@ var explainStreamStyle = assertdesc.StreamStyle{
 	JSON:      explainJSONStyle,
 	YAML:      explainYAMLStyle,
 	Snapshot:  func(s string) string { return s },
+	Line:      func(n int) string { return fmt.Sprintf("line %d", n) },
 	NoMatcher: "(no matcher)",
 }
 

--- a/test/e2e/atago/doc.atago.yaml
+++ b/test/e2e/atago/doc.atago.yaml
@@ -243,14 +243,19 @@ scenarios:
       - assert:
           exit_code: 0
           stdout:
+            # The needles avoid the backticks the page puts around each matcher
+            # argument: a needle carrying them would land inside a code span in
+            # this suite's own generated page and render as a malformed one.
             contains:
-              - "stdout contains `hello`, does not contain `goodbye`"
-              - "stdout line `2` equals an exact value"
-              - "file `install.sh` is executable"
-              - "file `install.sh` does not contain `rm -rf /`"
+              - "stdout contains "
+              - ", does not contain "
+              - "stdout line "
+              - " equals an exact value"
+              - " is executable"
+              - " does not contain "
       - assert:
           stdout:
-            not_contains: "`install.sh` is checked"
+            not_contains: " is checked"
 
   # The documented spec is the one that runs: it still passes as written. The
   # executable matcher needs a POSIX exec bit, so this half is POSIX-only while

--- a/test/e2e/atago/doc.atago.yaml
+++ b/test/e2e/atago/doc.atago.yaml
@@ -251,7 +251,54 @@ scenarios:
       - assert:
           stdout:
             not_contains: "`install.sh` is checked"
-      # The documented spec is the one that runs: it still passes as written.
+
+  # The documented spec is the one that runs: it still passes as written. The
+  # executable matcher needs a POSIX exec bit, so this half is POSIX-only while
+  # the rendering above stays portable.
+  - name: a spec whose matchers doc renders still runs green
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: matchers.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: matchers
+            scenarios:
+              - name: composed stream
+                steps:
+                  - run:
+                      command: echo hello
+                  - assert:
+                      stdout:
+                        contains: hello
+                        not_contains: goodbye
+              - name: line scoped
+                steps:
+                  - run:
+                      shell: true
+                      command: printf 'one\ntwo\n'
+                  - assert:
+                      stdout:
+                        line: 2
+                        equals: two
+              - name: file matchers
+                steps:
+                  - fixture:
+                      file: install.sh
+                      content: "#!/bin/sh\n"
+                      mode: "0755"
+                  - run:
+                      command: echo hi
+                  - assert:
+                      file:
+                        path: install.sh
+                        executable: true
+                  - assert:
+                      file:
+                        path: install.sh
+                        not_contains: "rm -rf /"
       - run:
           command: ${atago} run matchers.atago.yaml
       - assert:

--- a/test/e2e/atago/doc.atago.yaml
+++ b/test/e2e/atago/doc.atago.yaml
@@ -191,3 +191,70 @@ scenarios:
           exit_code: 0
           stdout:
             contains: "1 passed"
+
+  # Generated docs are published as the contract a suite guarantees, so every
+  # matcher an assertion sets has to appear. A composed stream assertion used to
+  # render as its first matcher alone, and file not_contains/executable rendered
+  # as a bare "is checked".
+  - name: doc renders every matcher an assertion sets
+    steps:
+      - fixture:
+          file: matchers.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: matchers
+            scenarios:
+              - name: composed stream
+                steps:
+                  - run:
+                      command: echo hello
+                  - assert:
+                      stdout:
+                        contains: hello
+                        not_contains: goodbye
+              - name: line scoped
+                steps:
+                  - run:
+                      shell: true
+                      command: printf 'one\ntwo\n'
+                  - assert:
+                      stdout:
+                        line: 2
+                        equals: two
+              - name: file matchers
+                steps:
+                  - fixture:
+                      file: install.sh
+                      content: "#!/bin/sh\n"
+                      mode: "0755"
+                  - run:
+                      command: echo hi
+                  - assert:
+                      file:
+                        path: install.sh
+                        executable: true
+                  - assert:
+                      file:
+                        path: install.sh
+                        not_contains: "rm -rf /"
+      - run:
+          command: ${atago} doc matchers.atago.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            contains:
+              - "stdout contains `hello`, does not contain `goodbye`"
+              - "stdout line `2` equals an exact value"
+              - "file `install.sh` is executable"
+              - "file `install.sh` does not contain `rm -rf /`"
+      - assert:
+          stdout:
+            not_contains: "`install.sh` is checked"
+      # The documented spec is the one that runs: it still passes as written.
+      - run:
+          command: ${atago} run matchers.atago.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "3 passed"

--- a/test/e2e/atago/explain.atago.yaml
+++ b/test/e2e/atago/explain.atago.yaml
@@ -31,3 +31,126 @@ scenarios:
               - "Scenario: list as json"
               - "Commands:"
               - "Network policy:"
+
+  # explain must describe every matcher an assertion sets. The text matchers
+  # compose at run time, so summarizing only the first one advertises a weaker
+  # contract than the run enforces.
+  - name: explain describes every matcher of a composed stream assertion
+    steps:
+      - fixture:
+          file: composed.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: composed
+            scenarios:
+              - name: guards both directions
+                steps:
+                  - run:
+                      command: echo hello
+                  - assert:
+                      stdout:
+                        contains: hello
+                        not_contains: goodbye
+                        matches: "^hel"
+      - run:
+          command: ${atago} explain composed.atago.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: 'stdout contains "hello", does not contain "goodbye", matches /^hel/'
+      # The composed assertion really is enforced: dropping the forbidden text
+      # into stdout fails the run.
+      - fixture:
+          file: broken.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: composed
+            scenarios:
+              - name: guards both directions
+                steps:
+                  - run:
+                      shell: true
+                      command: printf 'hello goodbye\n'
+                  - assert:
+                      stdout:
+                        contains: hello
+                        not_contains: goodbye
+      - run:
+          command: ${atago} run broken.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains: does not contain
+
+  # A line: selector narrows what every matcher sees, so explain has to say
+  # which line is under test instead of implying the whole stream.
+  - name: explain names the line a line-scoped matcher inspects
+    steps:
+      - fixture:
+          file: lined.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: lined
+            scenarios:
+              - name: second line only
+                steps:
+                  - run:
+                      shell: true
+                      command: printf 'one\ntwo\n'
+                  - assert:
+                      stdout:
+                        line: 2
+                        equals: two
+      - run:
+          command: ${atago} explain lined.atago.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "stdout line 2 equals exact text"
+
+  # not_contains and executable are ordinary file matchers: explain used to
+  # report the bare path, which reads as "the file is checked" and hides what
+  # the scenario actually guarantees.
+  - name: explain describes file not_contains and executable matchers
+    steps:
+      - fixture:
+          file: filematch.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: filematch
+            scenarios:
+              - name: no secret leaked
+                steps:
+                  - fixture:
+                      file: out.txt
+                      content: "public\n"
+                  - run:
+                      command: echo hi
+                  - assert:
+                      file:
+                        path: out.txt
+                        not_contains: "secret-token"
+              - name: installer stays executable
+                steps:
+                  - fixture:
+                      file: install.sh
+                      content: "#!/bin/sh\n"
+                      mode: "0755"
+                  - run:
+                      command: echo hi
+                  - assert:
+                      file:
+                        path: install.sh
+                        executable: true
+      - run:
+          command: ${atago} explain filematch.atago.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            contains:
+              - 'file "out.txt" does not contain "secret-token"'
+              - 'file "install.sh" is executable'


### PR DESCRIPTION
`atago doc` and `atago explain` described a stream assertion by its first matcher only, and silently dropped a `line:` selector. The text matchers compose at run time — `contains` plus `not_contains` plus `matches` all have to hold — so a generated page advertised a weaker contract than the suite actually enforces, and a matcher scoped to one line read as one pinning the whole stream.

`file:` assertions had a related gap: `not_contains` and `executable` had no case in the describer and fell through to the "is checked" fallback, so a published page said nothing at all about a file whose content or exec bit is pinned. The regenerated `doc/e2e` pages in this PR show the effect — sqly's `file \`u.csv\` is checked` now reads `file \`u.csv\` does not contain \`BROKEN\``, and mimixbox's repeated `stdout equals an exact value` bullets now name the line each one inspects.

Descriptions now accumulate every matcher that is set, prefix the `line: N` scope, and cover every file matcher the loader accepts. Nothing about execution changes: this is the description layer shared by `doc` and `explain`, and the run-time checks already enforced all of these matchers.

Tests: table-driven regression tests in `internal/assertdesc` for composed stream matchers, the line prefix, and every file matcher; self-hosted E2E in `test/e2e/atago/doc.atago.yaml` and `explain.atago.yaml` that assert the rendered text, that the "is checked" fallback no longer appears for a file matcher, and that the documented spec still runs green. `make test`, `make lint`, `make docs`, and `make site` are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `atago doc` and `atago explain` now describe every matcher in composed assertions.
  * Line-scoped assertions identify the specific line being checked.
  * File assertions provide clearer descriptions for content and executable checks.

* **Documentation**
  * Expanded end-to-end scenarios with more precise output, file, permission, and negative-condition checks.
  * Added coverage for composed matcher and line-specific explanations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->