### PR TITLE
fix(changes): track symlinks in the workdir delta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ and this project follows [Semantic Versioning](https://semver.org/).
 - `file:` assertions using `not_contains` or `executable` rendered as "the file
   is checked" in generated docs and `explain` output, hiding what the scenario
   guarantees. Both matchers now have their own phrasing.
+- `changes:` now tracks symlinks. Only regular files were scanned, so a step
+  that planted a link — an installer wiring `bin/tool`, a release that swaps a
+  `current` pointer — passed `created: []`, reporting "nothing happened" for a
+  run that added a path. A link is compared by the target it names: planting one
+  is a creation, retargeting it is a modification, removing it is a deletion,
+  and a dangling link stays visible. Writing through a link is still a
+  modification of the target file, and the delta never resolves a link, so a
+  cycle or a target outside the workdir is not followed.
 
 ## [0.14.0] - 2026-07-26
 

--- a/doc/cookbook.md
+++ b/doc/cookbook.md
@@ -1215,6 +1215,34 @@ scenarios:
             contains: link.txt      # reported under the name it was given
 ```
 
+A link the command itself creates is part of the workdir delta, so `changes:`
+pins it like any other path — including the negative case, where `created: []`
+proves the run planted no link at all:
+
+```yaml
+version: "1"
+suite:
+  name: install links
+
+scenarios:
+  - name: the installer links bin/tool and touches nothing else
+    skip:
+      os: windows
+    steps:
+      - run:
+          command: mytool install
+      - assert:
+          exit_code: 0
+          changes:
+            created: [bin/tool]   # the symlink itself, by the path it was given
+            modified: []
+            deleted: []
+```
+
+A symlink is compared by the target it names, never by the content behind it:
+retargeting a link is a modification, and writing through a link is a
+modification of the target file, not of the link.
+
 Full spec: [files_and_fixtures](../examples/files_and_fixtures.atago.yaml)
 
 ## Test freshness logic with fixture timestamps

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 400 scenarios
+74 suites · 406 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -28,7 +28,7 @@
   - [manifest surfaces the browser-runner configuration](#scenario-manifest-surfaces-the-browser-runner-configuration)
   - [an upload action without a file fails validation (exit 2)](#scenario-an-upload-action-without-a-file-fails-validation-exit-2)
   - [a download action without a click selector fails validation (exit 2)](#scenario-a-download-action-without-a-click-selector-fails-validation-exit-2)
-- [atago self-hosting / changes (workdir delta assertions)](#atago-self-hosting--changes-workdir-delta-assertions) — 12 scenarios
+- [atago self-hosting / changes (workdir delta assertions)](#atago-self-hosting--changes-workdir-delta-assertions) — 18 scenarios
   - [a generator touches exactly the files it should (POSIX)](#scenario-a-generator-touches-exactly-the-files-it-should-posix)
   - [an unexpected creation breaks the exact contract (POSIX)](#scenario-an-unexpected-creation-breaks-the-exact-contract-posix)
   - [stdout_to counts as created, and modified nothing holds (portable)](#scenario-stdout_to-counts-as-created-and-modified-nothing-holds-portable)
@@ -41,6 +41,12 @@
   - [a stray file outside the doublestar prefix breaks the exact contract (POSIX)](#scenario-a-stray-file-outside-the-doublestar-prefix-breaks-the-exact-contract-posix)
   - [a doublestar glob matches a nested redirect target (portable)](#scenario-a-doublestar-glob-matches-a-nested-redirect-target-portable)
   - [a doublestar prefix covers both redirect streams (portable)](#scenario-a-doublestar-prefix-covers-both-redirect-streams-portable)
+  - [creating a symlink is a creation](#scenario-creating-a-symlink-is-a-creation)
+  - [an exhaustive created list catches an unexpected symlink](#scenario-an-exhaustive-created-list-catches-an-unexpected-symlink)
+  - [retargeting a symlink is a modification](#scenario-retargeting-a-symlink-is-a-modification)
+  - [writing through a symlink modifies the target only](#scenario-writing-through-a-symlink-modifies-the-target-only)
+  - [removing a symlink is a deletion](#scenario-removing-a-symlink-is-a-deletion)
+  - [a dangling symlink is still a creation](#scenario-a-dangling-symlink-is-still-a-creation)
 - [atago self-hosting / CLI scenario selection](#atago-self-hosting--cli-scenario-selection) — 9 scenarios
   - [filter selects by a name substring](#scenario-filter-selects-by-a-name-substring)
   - [filter is OR across a comma-separated list](#scenario-filter-is-or-across-a-comma-separated-list)
@@ -1085,6 +1091,115 @@ echo out
 #### Generated artifacts
 - `logs/out.txt`
 - `logs/err.txt`
+### Scenario: creating a symlink is a creation
+_skipped on Windows_
+#### Given
+- Fixture file `real.txt` is created.
+#### Inputs
+_Fixture `real.txt`:_
+```text
+payload
+```
+#### When
+```shell
+ln -s real.txt link.txt
+```
+#### Then
+- exit code is `0`
+- the step changed exactly created `link.txt`, modified nothing, deleted nothing
+### Scenario: an exhaustive created list catches an unexpected symlink
+_skipped on Windows_
+#### Given
+- Fixture file `check.atago.yaml` is created.
+#### Inputs
+_Fixture `check.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: inner
+scenarios:
+  - name: claims to create nothing
+    steps:
+      - run:
+          shell: true
+          command: ln -s /etc/passwd sneaky
+      - assert:
+          exit_code: 0
+          changes:
+            created: []
+```
+#### When
+```shell
+${atago} run check.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `unexpected created file`
+### Scenario: retargeting a symlink is a modification
+_skipped on Windows_
+#### Given
+- Fixture file `v1.txt` is created.
+- Fixture file `v2.txt` is created.
+- Fixture file `current` is created.
+#### Inputs
+_Fixture `v1.txt`:_
+```text
+one
+```
+_Fixture `v2.txt`:_
+```text
+two
+```
+#### When
+```shell
+ln -sfn v2.txt current
+```
+#### Then
+- exit code is `0`
+- the step changed exactly created nothing, modified `current`, deleted nothing
+### Scenario: writing through a symlink modifies the target only
+_skipped on Windows_
+#### Given
+- Fixture file `real.txt` is created.
+- Fixture file `link.txt` is created.
+#### Inputs
+_Fixture `real.txt`:_
+```text
+before
+```
+#### When
+```shell
+printf 'after\n' > link.txt
+```
+#### Then
+- exit code is `0`
+- the step changed exactly created nothing, modified `real.txt`, deleted nothing
+### Scenario: removing a symlink is a deletion
+_skipped on Windows_
+#### Given
+- Fixture file `real.txt` is created.
+- Fixture file `link.txt` is created.
+#### Inputs
+_Fixture `real.txt`:_
+```text
+payload
+```
+#### When
+```shell
+rm link.txt
+```
+#### Then
+- exit code is `0`
+- the step changed exactly created nothing, modified nothing, deleted `link.txt`
+### Scenario: a dangling symlink is still a creation
+_skipped on Windows_
+#### When
+```shell
+ln -s no/such/target dangling
+```
+#### Then
+- exit code is `0`
+- the step changed exactly created `dangling`, modified nothing, deleted nothing
 ## atago self-hosting / CLI scenario selection
 Source: `test/e2e/atago/cli_selection.atago.yaml`
 ### Scenario: filter selects by a name substring

--- a/internal/fsdelta/fsdelta.go
+++ b/internal/fsdelta/fsdelta.go
@@ -14,10 +14,11 @@ import (
 	"sort"
 )
 
-// Snapshot maps a regular file's forward-slash path (relative to the scanned
-// root) to a hex-encoded SHA-256 of its content. Directories and symlinks are
-// not tracked: a rename is delete+create in v1, and an empty directory is not a
-// "file" the assertion reasons about.
+// Snapshot maps a tracked path (forward-slash, relative to the scanned root) to
+// a content fingerprint: a hex-encoded SHA-256 for a regular file, and a
+// symlinkPrefix-tagged target for a symlink. Directories are not tracked — an
+// empty directory is not a "file" the assertion reasons about — and a rename is
+// delete+create.
 type Snapshot map[string]string
 
 // unreadableSentinel marks a regular file that exists but could not be read
@@ -29,6 +30,16 @@ type Snapshot map[string]string
 // unreadable in the other reports as modified, because content equality cannot
 // be established across that readability boundary.
 const unreadableSentinel = "unreadable"
+
+// symlinkPrefix tags a symlink's fingerprint, which is the link target rather
+// than the content behind it. Tracking symlinks keeps `created: []` honest: a
+// step that plants a link — an installer wiring bin/tool, a tool that swaps a
+// "current" pointer — used to slip past an exhaustive changes assertion because
+// only regular files were scanned. Comparing targets (not the resolved content)
+// makes a retargeted link a modification, keeps a dangling link visible, and
+// avoids following a link out of the workdir or around a cycle. The prefix ends
+// in ':' so it can never collide with a 64-char hex digest.
+const symlinkPrefix = "symlink:"
 
 // Scan walks root and hashes every regular file, keyed by its forward-slash
 // path relative to root. It is best-effort about individual files: one that
@@ -47,12 +58,27 @@ func Scan(root string) (Snapshot, error) {
 			}
 			return nil
 		}
-		if d.IsDir() || !d.Type().IsRegular() {
+		if d.IsDir() || (!d.Type().IsRegular() && d.Type()&fs.ModeSymlink == 0) {
 			return nil
 		}
 		rel, rerr := filepath.Rel(root, path)
 		if rerr != nil {
 			return nil //nolint:nilerr // an un-relativizable path is skipped, not fatal
+		}
+		if d.Type()&fs.ModeSymlink != 0 {
+			target, lerr := os.Readlink(path)
+			if lerr != nil {
+				if os.IsNotExist(lerr) {
+					// Raced away between walk and readlink; genuinely absent.
+					return nil
+				}
+				// The link exists but its target cannot be read: keep it visible
+				// to created/deleted rather than dropping it.
+				snap[filepath.ToSlash(rel)] = symlinkPrefix + unreadableSentinel
+				return nil
+			}
+			snap[filepath.ToSlash(rel)] = symlinkPrefix + filepath.ToSlash(target)
+			return nil
 		}
 		sum, herr := hashFile(path)
 		if herr != nil {

--- a/internal/fsdelta/fsdelta_test.go
+++ b/internal/fsdelta/fsdelta_test.go
@@ -118,9 +118,13 @@ func TestScan_MissingRootReturnsEmpty(t *testing.T) {
 	}
 }
 
-// TestScan_SkipsSymlinks proves symlinks are not tracked (only regular files
-// are), so a symlink cannot be mistaken for a created/modified content file.
-func TestScan_SkipsSymlinks(t *testing.T) {
+// TestScan_TracksSymlinksByTarget proves a symlink is tracked by the target it
+// names, not by the content behind it: a step that plants a link has to show up
+// in `created:` instead of slipping past an exhaustive assertion, and the
+// fingerprint must not be the target file's digest (that would report the link
+// and its target as the same content, and would follow a link out of the
+// workdir).
+func TestScan_TracksSymlinksByTarget(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink creation is restricted on Windows")
@@ -137,11 +141,105 @@ func TestScan_SkipsSymlinks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Scan: %v", err)
 	}
-	if _, ok := snap["link.txt"]; ok {
-		t.Errorf("symlink should not be tracked, snapshot = %v", snap)
+	got, ok := snap["link.txt"]
+	if !ok {
+		t.Fatalf("symlink should be tracked, snapshot = %v", snap)
 	}
-	if _, ok := snap["real.txt"]; !ok {
-		t.Errorf("regular file should be tracked, snapshot = %v", snap)
+	if want := "symlink:" + filepath.ToSlash(target); got != want {
+		t.Errorf("symlink fingerprint = %q, want %q", got, want)
+	}
+	real, ok := snap["real.txt"]
+	if !ok {
+		t.Fatalf("regular file should be tracked, snapshot = %v", snap)
+	}
+	if real == got {
+		t.Errorf("symlink and its target share a fingerprint %q", got)
+	}
+}
+
+// TestDiff_SymlinkLifecycle drives a symlink through create, retarget, and
+// delete. Retargeting is a modification because the observable thing a symlink
+// carries is where it points.
+func TestDiff_SymlinkLifecycle(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is restricted on Windows")
+	}
+	root := t.TempDir()
+	write(t, root, "v1.txt", "one")
+	write(t, root, "v2.txt", "two")
+	link := filepath.Join(root, "current")
+
+	empty, err := Scan(root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if err := os.Symlink("v1.txt", link); err != nil {
+		t.Fatal(err)
+	}
+	created, err := Scan(root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if d := Diff(empty, created); !reflect.DeepEqual(d.Created, []string{"current"}) {
+		t.Errorf("creating a symlink: Created = %v, want [current]", d.Created)
+	}
+
+	if err := os.Remove(link); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("v2.txt", link); err != nil {
+		t.Fatal(err)
+	}
+	retargeted, err := Scan(root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	d := Diff(created, retargeted)
+	if !reflect.DeepEqual(d.Modified, []string{"current"}) {
+		t.Errorf("retargeting a symlink: Modified = %v, want [current]", d.Modified)
+	}
+	if len(d.Created) != 0 || len(d.Deleted) != 0 {
+		t.Errorf("retargeting a symlink: Created = %v, Deleted = %v, want both empty", d.Created, d.Deleted)
+	}
+
+	if err := os.Remove(link); err != nil {
+		t.Fatal(err)
+	}
+	removed, err := Scan(root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if d := Diff(retargeted, removed); !reflect.DeepEqual(d.Deleted, []string{"current"}) {
+		t.Errorf("removing a symlink: Deleted = %v, want [current]", d.Deleted)
+	}
+}
+
+// TestDiff_SymlinkContentChangeIsNotALinkChange pins that writing through a
+// symlink is a modification of the target file, not of the link: the link still
+// points where it did.
+func TestDiff_SymlinkContentChangeIsNotALinkChange(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is restricted on Windows")
+	}
+	root := t.TempDir()
+	write(t, root, "real.txt", "before")
+	if err := os.Symlink("real.txt", filepath.Join(root, "link")); err != nil {
+		t.Fatal(err)
+	}
+	pre, err := Scan(root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	write(t, root, "real.txt", "after")
+	post, err := Scan(root)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	d := Diff(pre, post)
+	if !reflect.DeepEqual(d.Modified, []string{"real.txt"}) {
+		t.Errorf("Modified = %v, want [real.txt]", d.Modified)
 	}
 }
 
@@ -323,7 +421,8 @@ func TestDiff_FileReplacedByDirectoryAndReverse(t *testing.T) {
 
 // TestScan_BrokenAndCyclicSymlinksNoCrash proves Scan never follows a symlink
 // into a crash or infinite loop: a dangling link and a self-referential cyclic
-// link are both skipped (only regular files are tracked), leaving the real file.
+// link are both recorded by the target they name, which is exactly why they are
+// safe to track — the target is read, never resolved.
 func TestScan_BrokenAndCyclicSymlinksNoCrash(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS == "windows" {
@@ -345,8 +444,8 @@ func TestScan_BrokenAndCyclicSymlinksNoCrash(t *testing.T) {
 		t.Errorf("regular file should be tracked, snapshot = %v", keys(snap))
 	}
 	for _, link := range []string{"broken", "loop"} {
-		if _, ok := snap[link]; ok {
-			t.Errorf("symlink %q should not be tracked, snapshot = %v", link, keys(snap))
+		if _, ok := snap[link]; !ok {
+			t.Errorf("symlink %q should be tracked, snapshot = %v", link, keys(snap))
 		}
 	}
 }

--- a/schema/atago.schema.json
+++ b/schema/atago.schema.json
@@ -1858,7 +1858,7 @@
     "changesAssert": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Pins the exact workdir delta of the immediately preceding run/pty step (#70): which files it created, modified, and deleted. Each set field is EXHAUSTIVE in both directions (every observed path must match an entry, every entry must match a path), so `modified: []` asserts \"modified nothing\". An omitted field is unconstrained. Entries are workdir-relative doublestar globs, always /-separated: a single `*` stays within one path segment while `**` crosses `/` at any depth (`site/**` covers the whole tree, `dist/**/*.css` composes with a suffix). A backslash escapes a literal metacharacter (`\\[`, `\\?`, `\\*`) — `a\\[1\\].txt` matches the file `a[1].txt`; the escape is portable because entries are always /-separated.",
+      "description": "Pins the exact workdir delta of the immediately preceding run/pty step (#70): which files it created, modified, and deleted. Each set field is EXHAUSTIVE in both directions (every observed path must match an entry, every entry must match a path), so `modified: []` asserts \"modified nothing\". An omitted field is unconstrained. Regular files and symlinks are tracked; directories are not (an empty directory is not a file the delta reasons about). A symlink is compared by the target it names, so planting one is a creation, retargeting it is a modification, and a dangling link is still visible. Entries are workdir-relative doublestar globs, always /-separated: a single `*` stays within one path segment while `**` crosses `/` at any depth (`site/**` covers the whole tree, `dist/**/*.css` composes with a suffix). A backslash escapes a literal metacharacter (`\\[`, `\\?`, `\\*`) — `a\\[1\\].txt` matches the file `a[1].txt`; the escape is portable because entries are always /-separated.",
       "minProperties": 1,
       "properties": {
         "created": {
@@ -1867,7 +1867,7 @@
         },
         "modified": {
           "$ref": "#/$defs/changesEntries",
-          "description": "Exhaustive list of paths the step modified (content-based, not mtime). `[]` asserts \"modified nothing\"."
+          "description": "Exhaustive list of paths the step modified (content-based, not mtime; for a symlink, a change of target). `[]` asserts \"modified nothing\"."
         },
         "deleted": {
           "$ref": "#/$defs/changesEntries",

--- a/test/e2e/atago/changes.atago.yaml
+++ b/test/e2e/atago/changes.atago.yaml
@@ -282,3 +282,133 @@ scenarios:
               - "logs/**"
             modified: []
             deleted: []
+
+  # A symlink is part of the workdir delta. Before this was tracked, a step that
+  # planted a link slipped past `created: []` entirely — the assertion reported
+  # "nothing happened" for a run that wired up a new path.
+  - name: creating a symlink is a creation
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: real.txt
+          content: "payload\n"
+      - run:
+          shell: true
+          command: ln -s real.txt link.txt
+      - assert:
+          exit_code: 0
+          changes:
+            created: [link.txt]
+            modified: []
+            deleted: []
+
+  - name: an exhaustive created list catches an unexpected symlink
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: check.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: inner
+            scenarios:
+              - name: claims to create nothing
+                steps:
+                  - run:
+                      shell: true
+                      command: ln -s /etc/passwd sneaky
+                  - assert:
+                      exit_code: 0
+                      changes:
+                        created: []
+      - run:
+          command: ${atago} run check.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains: "unexpected created file"
+
+  # A symlink is compared by the target it names, so retargeting it is a
+  # modification even though no file content changed.
+  - name: retargeting a symlink is a modification
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: v1.txt
+          content: "one\n"
+      - fixture:
+          file: v2.txt
+          content: "two\n"
+      - fixture:
+          file: current
+          symlink: v1.txt
+      - run:
+          shell: true
+          command: ln -sfn v2.txt current
+      - assert:
+          exit_code: 0
+          changes:
+            created: []
+            modified: [current]
+            deleted: []
+
+  # Writing through a link changes the target file, not the link: the link still
+  # points where it did.
+  - name: writing through a symlink modifies the target only
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: real.txt
+          content: "before\n"
+      - fixture:
+          file: link.txt
+          symlink: real.txt
+      - run:
+          shell: true
+          command: printf 'after\n' > link.txt
+      - assert:
+          exit_code: 0
+          changes:
+            created: []
+            modified: [real.txt]
+            deleted: []
+
+  - name: removing a symlink is a deletion
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: real.txt
+          content: "payload\n"
+      - fixture:
+          file: link.txt
+          symlink: real.txt
+      - run:
+          shell: true
+          command: rm link.txt
+      - assert:
+          exit_code: 0
+          changes:
+            created: []
+            modified: []
+            deleted: [link.txt]
+
+  # A dangling link names a target that does not exist. It is still an
+  # observable creation: the delta reads the target, it never resolves it.
+  - name: a dangling symlink is still a creation
+    skip:
+      os: windows
+    steps:
+      - run:
+          shell: true
+          command: ln -s no/such/target dangling
+      - assert:
+          exit_code: 0
+          changes:
+            created: [dangling]
+            modified: []
+            deleted: []


### PR DESCRIPTION
`changes:` scanned regular files only, so a step that created a symlink was invisible to it: a spec asserting `created: []` passed even though the run planted a new path. For an assertion whose whole value is being exhaustive in both directions, that is the worst possible failure mode — it reports "this run changed nothing" for a run that changed something. The cases are ordinary ones: an installer linking `bin/tool`, a release swapping a `current` pointer, a tool that leaves a compatibility link behind.

A symlink is now recorded by the target it names, with a tagged fingerprint that cannot collide with a content digest. Planting a link is a creation, retargeting it is a modification, removing it is a deletion, and a dangling link stays visible. The target is read and never resolved, so the scan still refuses to follow a link out of the workdir or around a cycle, and writing through a link is still a modification of the target file rather than of the link.

This changes what an existing spec observes: a scenario whose command creates a symlink and asserts `created: []` will now fail, which is the point. Nothing else moves — directories are still untracked, and the comparison is still content-based rather than mtime-based.

Tests: fsdelta unit tests for the create/retarget/delete lifecycle, the target-not-content fingerprint, and write-through; the broken/cyclic-link test now asserts both links are tracked instead of skipped. Self-hosted E2E in `test/e2e/atago/changes.atago.yaml` covers each verb and the negative case where a spec claiming `created: []` while planting a link fails. `make test`, `make lint`, `make e2e`, `make docs` are green, and the third-party suites show no new failures.