### PR TITLE
fix(assert): name the difference when a value mismatch is invisible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ and this project follows [Semantic Versioning](https://semver.org/).
 - `file:` assertions using `not_contains` or `executable` rendered as "the file
   is checked" in generated docs and `explain` output, hiding what the scenario
   guarantees. Both matchers now have their own phrasing.
+- A failing `json: equals` now names the difference. Both sides were rendered
+  bare, so a type or whitespace mismatch printed the same text twice — the
+  boolean `true` against the string `"true"` read as "expected true, got true",
+  and `" x "` against `"x"` hid the spaces. Strings are quoted and `null` is
+  named; numbers and booleans stay bare.
+- A `dir:` assertion on a path that holds a file reported a bare
+  `exists=false`, which reads as "nothing is there". It now says the path
+  exists as a regular file (or symlink, socket, …) and points at `file:`.
 - `changes:` now tracks symlinks. Only regular files were scanned, so a step
   that planted a link — an installer wiring `bin/tool`, a release that swaps a
   `current` pointer — passed `created: []`, reporting "nothing happened" for a

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 406 scenarios
+74 suites · 410 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -73,13 +73,14 @@
   - [an unsupported defaults field is a load-time error (exit 2)](#scenario-an-unsupported-defaults-field-is-a-load-time-error-exit-2)
   - [defaults.run.env merges per key and a step env wins the collisions](#scenario-defaultsrunenv-merges-per-key-and-a-step-env-wins-the-collisions)
   - [a step opts out of defaults.run.shell with an explicit shell false](#scenario-a-step-opts-out-of-defaultsrunshell-with-an-explicit-shell-false)
-- [atago self-hosting / dir assertion](#atago-self-hosting--dir-assertion) — 6 scenarios
+- [atago self-hosting / dir assertion](#atago-self-hosting--dir-assertion) — 7 scenarios
   - [directory/tree assertions cover a multi-file generator](#scenario-directorytree-assertions-cover-a-multi-file-generator)
   - [a missing directory can be asserted absent](#scenario-a-missing-directory-can-be-asserted-absent)
   - [a dangling symlink is a present directory entry (membership uses Lstat)](#scenario-a-dangling-symlink-is-a-present-directory-entry-membership-uses-lstat)
   - [a failed dir assert lists what the directory actually holds](#scenario-a-failed-dir-assert-lists-what-the-directory-actually-holds)
   - [a failed count assert lists the entries it counted](#scenario-a-failed-count-assert-lists-the-entries-it-counted)
   - [a failed recursive assert lists the walked tree](#scenario-a-failed-recursive-assert-lists-the-walked-tree)
+  - [a dir assertion on a file path says the path is a file](#scenario-a-dir-assertion-on-a-file-path-says-the-path-is-a-file)
 - [atago self-hosting / recursive dir asserts + tree snapshots](#atago-self-hosting--recursive-dir-asserts--tree-snapshots) — 3 scenarios
   - [record, compare green, then a mutation names the changed paths](#scenario-record-compare-green-then-a-mutation-names-the-changed-paths)
   - [recursive matchers and ignore globs walk the tree](#scenario-recursive-matchers-and-ignore-globs-walk-the-tree)
@@ -201,7 +202,7 @@
   - [a json list fails the inner spec when one listed path mismatches](#scenario-a-json-list-fails-the-inner-spec-when-one-listed-path-mismatches)
   - [a stdout json list against a JSON-producing command](#scenario-a-stdout-json-list-against-a-json-producing-command)
   - [a yaml list asserts several paths on one document](#scenario-a-yaml-list-asserts-several-paths-on-one-document)
-- [atago self-hosting / json matcher boundary values](#atago-self-hosting--json-matcher-boundary-values) — 9 scenarios
+- [atago self-hosting / json matcher boundary values](#atago-self-hosting--json-matcher-boundary-values) — 12 scenarios
   - [an array element is addressable by index](#scenario-an-array-element-is-addressable-by-index)
   - [a top-level array reports its length](#scenario-a-top-level-array-reports-its-length)
   - [an empty array has length zero](#scenario-an-empty-array-has-length-zero)
@@ -211,6 +212,9 @@
   - [a string carrying a quote compares equal](#scenario-a-string-carrying-a-quote-compares-equal)
   - [a deeply nested path resolves](#scenario-a-deeply-nested-path-resolves)
   - [a path that selects nothing fails with a clear message](#scenario-a-path-that-selects-nothing-fails-with-a-clear-message)
+  - [a type mismatch failure distinguishes a string from a boolean](#scenario-a-type-mismatch-failure-distinguishes-a-string-from-a-boolean)
+  - [a whitespace-only mismatch shows the surrounding spaces](#scenario-a-whitespace-only-mismatch-shows-the-surrounding-spaces)
+  - [a numeric mismatch stays unquoted](#scenario-a-numeric-mismatch-stays-unquoted)
 - [atago self-hosting / line selector](#atago-self-hosting--line-selector) — 3 scenarios
   - [line selector narrows stdout to a single 1-based line](#scenario-line-selector-narrows-stdout-to-a-single-1-based-line)
   - [a trailing newline does not add a phantom final line](#scenario-a-trailing-newline-does-not-add-a-phantom-final-line)
@@ -1835,6 +1839,31 @@ ${atago} run walked.atago.yaml
 #### Then
 - exit code is `1`
 - stdout contains `assets/app.css`, `index.html`
+### Scenario: a dir assertion on a file path says the path is a file
+#### Given
+- Fixture file `mistaken.atago.yaml` is created.
+#### Inputs
+_Fixture `mistaken.atago.yaml`:_
+```text
+version: "1"
+suite: {name: mistaken}
+scenarios:
+  - name: out is a file, not a directory
+    steps:
+      - fixture: {file: out, content: "report\n"}
+      - run: {command: echo built}
+      - assert:
+          dir:
+            path: out
+            exists: true
+```
+#### When
+```shell
+${atago} run mistaken.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `exists but is a regular file`, `use a file: assertion`
 ## atago self-hosting / recursive dir asserts + tree snapshots
 Source: `test/e2e/atago/dir_tree.atago.yaml`
 ### Scenario: record, compare green, then a mutation names the changed paths
@@ -3896,6 +3925,70 @@ ${atago} run nopath.atago.yaml
 #### Then
 - exit code is `1`
 - stdout contains `selected no value`
+### Scenario: a type mismatch failure distinguishes a string from a boolean
+#### Given
+- Fixture file `typed.atago.yaml` is created.
+#### Inputs
+_Fixture `typed.atago.yaml`:_
+```text
+version: "1"
+suite: {name: typed}
+scenarios:
+  - name: string spelling of a boolean
+    steps:
+      - run: {shell: true, command: 'printf ''{"b":true}'''}
+      - assert: {stdout: {json: [{path: "$.b", equals: "true"}]}}
+```
+#### When
+```shell
+${atago} run typed.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `$.b == "true"`, `$.b = true`
+### Scenario: a whitespace-only mismatch shows the surrounding spaces
+#### Given
+- Fixture file `spaced.atago.yaml` is created.
+#### Inputs
+_Fixture `spaced.atago.yaml`:_
+```text
+version: "1"
+suite: {name: spaced}
+scenarios:
+  - name: padded value
+    steps:
+      - run: {shell: true, command: 'printf ''{"v":" x "}'''}
+      - assert: {stdout: {json: [{path: "$.v", equals: "x"}]}}
+```
+#### When
+```shell
+${atago} run spaced.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `$.v = " x "`
+### Scenario: a numeric mismatch stays unquoted
+#### Given
+- Fixture file `nums.atago.yaml` is created.
+#### Inputs
+_Fixture `nums.atago.yaml`:_
+```text
+version: "1"
+suite: {name: nums}
+scenarios:
+  - name: off by one
+    steps:
+      - run: {shell: true, command: 'printf ''{"n":2}'''}
+      - assert: {stdout: {json: [{path: "$.n", equals: 1}]}}
+```
+#### When
+```shell
+${atago} run nums.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `$.n == 1`, `$.n = 2`
+- stdout does not contain `"2"`
 ## atago self-hosting / line selector
 Source: `test/e2e/atago/line.atago.yaml`
 ### Scenario: line selector narrows stdout to a single 1-based line

--- a/internal/assert/assert_test.go
+++ b/internal/assert/assert_test.go
@@ -1481,7 +1481,7 @@ func TestDirStatActual(t *testing.T) {
 	if got := dirStatActual(nil, os.ErrNotExist); got != os.ErrNotExist.Error() {
 		t.Errorf("err branch = %q", got)
 	}
-	// A regular file's FileInfo → "not a directory".
+	// A regular file's FileInfo → "not a directory", naming what it is instead.
 	f := filepath.Join(t.TempDir(), "x")
 	if err := os.WriteFile(f, []byte("y"), 0o600); err != nil {
 		t.Fatal(err)
@@ -1490,7 +1490,7 @@ func TestDirStatActual(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := dirStatActual(info, nil); got != "not a directory" {
+	if got := dirStatActual(info, nil); got != "not a directory (regular file)" {
 		t.Errorf("not-a-dir branch = %q", got)
 	}
 }
@@ -2214,5 +2214,89 @@ func TestCheck_JSON_BoolNotEqualStringSpelling(t *testing.T) {
 	got = Check(&spec.Assert{Stdout: &spec.StreamAssert{JSON: spec.JSONChecks{{Path: "$.b", Equals: true}}}}, res, Env{})
 	if !got.OK {
 		t.Errorf("JSON boolean true did not equal true (%s)", got.Hint)
+	}
+}
+
+// TestCheck_JSONEquals_MismatchNamesTheDifference pins that a failing equals
+// says which value it saw. Rendering both sides bare made a type or whitespace
+// mismatch print the same text twice — "expected true, got true" for a boolean
+// against the string "true", and "expected x, got  x " with the spaces
+// invisible — so the report gave the author nothing to act on.
+func TestCheck_JSONEquals_MismatchNamesTheDifference(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		stdout   string
+		want     any
+		expected string
+		actual   string
+	}{
+		{
+			name:     "string expected against a boolean",
+			stdout:   `{"v":true}`,
+			want:     "true",
+			expected: `$.v == "true"`,
+			actual:   `$.v = true`,
+		},
+		{
+			name:     "surrounding whitespace stays visible",
+			stdout:   `{"v":" x "}`,
+			want:     "x",
+			expected: `$.v == "x"`,
+			actual:   `$.v = " x "`,
+		},
+		{
+			name:     "null actual is named",
+			stdout:   `{"v":null}`,
+			want:     "none",
+			expected: `$.v == "none"`,
+			actual:   `$.v = null`,
+		},
+		{
+			name:     "numbers stay bare",
+			stdout:   `{"v":2}`,
+			want:     1,
+			expected: `$.v == 1`,
+			actual:   `$.v = 2`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			res := &runner.Result{Stdout: []byte(tt.stdout)}
+			got := Check(&spec.Assert{Stdout: &spec.StreamAssert{JSON: spec.JSONChecks{{Path: "$.v", Equals: tt.want}}}}, res, Env{})
+			if got.OK {
+				t.Fatalf("assertion unexpectedly passed")
+			}
+			if got.Expected != tt.expected {
+				t.Errorf("Expected = %q, want %q", got.Expected, tt.expected)
+			}
+			if got.Actual != tt.actual {
+				t.Errorf("Actual = %q, want %q", got.Actual, tt.actual)
+			}
+		})
+	}
+}
+
+// TestCheck_DirExists_OnAFilePathSaysSo pins the hint for the confusing case: a
+// path that exists as a file reported a bare "exists=false", which reads as
+// "nothing is there" and sends the author looking for output that is sitting
+// exactly where they asked, as a file.
+func TestCheck_DirExists_OnAFilePathSaysSo(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "out"), []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	yes := true
+	got := Check(&spec.Assert{Dir: &spec.DirAssert{Path: "out", Exists: &yes}}, &runner.Result{}, Env{Workdir: dir})
+	if got.OK {
+		t.Fatalf("dir assertion on a file unexpectedly passed")
+	}
+	if !strings.Contains(got.Hint, "exists but is a regular file") {
+		t.Errorf("Hint = %q, want it to say the path is a regular file", got.Hint)
+	}
+	if !strings.Contains(got.Actual, "regular file") {
+		t.Errorf("Actual = %q, want it to name the kind of entry", got.Actual)
 	}
 }

--- a/internal/assert/dir.go
+++ b/internal/assert/dir.go
@@ -78,11 +78,20 @@ func checkDirExists(d *spec.DirAssert, info os.FileInfo, statErr error) *CheckRe
 	if exists == *d.Exists {
 		return nil
 	}
+	// A path that exists but is not a directory is the confusing case: a bare
+	// "exists=false" reads as "nothing is there" and sends the author looking for
+	// a missing output that is in fact sitting right where they asked, as a file.
+	actual := fmt.Sprintf("exists=%t", exists)
+	hint := fmt.Sprintf("expected directory %q to %s", d.Path, existence(*d.Exists))
+	if statErr == nil && !info.IsDir() {
+		actual = fmt.Sprintf("exists=%t (%q is a %s, not a directory)", exists, d.Path, fileKind(info))
+		hint = fmt.Sprintf("%q exists but is a %s; use a file: assertion for it", d.Path, fileKind(info))
+	}
 	return &CheckResult{
 		Desc:     desc,
 		Expected: fmt.Sprintf("directory %q exists=%t", d.Path, *d.Exists),
-		Actual:   fmt.Sprintf("exists=%t", exists),
-		Hint:     fmt.Sprintf("expected directory %q to %s", d.Path, existence(*d.Exists)),
+		Actual:   actual,
+		Hint:     hint,
 	}
 }
 
@@ -242,8 +251,28 @@ func dirStatActual(info os.FileInfo, err error) string {
 	case err != nil:
 		return err.Error()
 	case !info.IsDir():
-		return "not a directory"
+		return "not a directory (" + fileKind(info) + ")"
 	default:
 		return "directory"
+	}
+}
+
+// fileKind names what a non-directory path actually is, so a failure can say
+// "regular file" instead of leaving the author to guess why a directory
+// assertion reports the path as absent.
+func fileKind(info os.FileInfo) string {
+	switch mode := info.Mode(); {
+	case mode.IsRegular():
+		return "regular file"
+	case mode&os.ModeSymlink != 0:
+		return "symlink"
+	case mode&os.ModeNamedPipe != 0:
+		return "named pipe"
+	case mode&os.ModeSocket != 0:
+		return "socket"
+	case mode&os.ModeDevice != 0:
+		return "device"
+	default:
+		return "non-directory entry"
 	}
 }

--- a/internal/assert/jsonmatch.go
+++ b/internal/assert/jsonmatch.go
@@ -159,7 +159,7 @@ func jsonCompare(desc, path string, nodes []any, op string, want float64) *Check
 		return &CheckResult{
 			Desc:     desc,
 			Expected: fmt.Sprintf("%s is a number %s %v", path, opSymbol(op), want),
-			Actual:   fmt.Sprintf("%s = %v", path, node),
+			Actual:   fmt.Sprintf("%s = %s", path, displayValue(node)),
 			Hint:     fmt.Sprintf("value at %s is not numeric, so it cannot be compared with %s", path, op),
 		}
 	}
@@ -181,8 +181,8 @@ func jsonCompare(desc, path string, nodes []any, op string, want float64) *Check
 	return &CheckResult{
 		Desc:     d,
 		Expected: fmt.Sprintf("%s %s %v", path, opSymbol(op), want),
-		Actual:   fmt.Sprintf("%s = %s", path, renderNode(node)),
-		Hint:     fmt.Sprintf("value at %s (%s) is not %s %v", path, renderNode(node), op, want),
+		Actual:   fmt.Sprintf("%s = %s", path, displayValue(node)),
+		Hint:     fmt.Sprintf("value at %s (%s) is not %s %v", path, displayValue(node), op, want),
 	}
 }
 
@@ -240,15 +240,32 @@ func jsonEquals(desc, path string, nodes []any, want any) *CheckResult {
 	if cr != nil {
 		return cr
 	}
-	d := fmt.Sprintf("%s == %v", desc, want)
+	d := fmt.Sprintf("%s == %s", desc, displayValue(want))
 	if valuesEqual(node, want) {
 		return pass(d)
 	}
 	return &CheckResult{
 		Desc:     d,
-		Expected: fmt.Sprintf("%s == %v", path, want),
-		Actual:   fmt.Sprintf("%s = %s", path, renderNode(node)),
-		Hint:     fmt.Sprintf("value at %s did not equal %v", path, want),
+		Expected: fmt.Sprintf("%s == %s", path, displayValue(want)),
+		Actual:   fmt.Sprintf("%s = %s", path, displayValue(node)),
+		Hint:     fmt.Sprintf("value at %s did not equal %s", path, displayValue(want)),
+	}
+}
+
+// displayValue renders a JSON value for a failure message so two values that
+// differ only in type or in surrounding whitespace do not print identically.
+// The string "true" shows as `"true"` next to the boolean true, and " x " keeps
+// its spaces visible — without quoting, a mismatch report read as "expected x,
+// got x". Numbers, booleans, and null stay bare so the common case reads as the
+// JSON the tool emitted.
+func displayValue(v any) string {
+	switch t := v.(type) {
+	case string:
+		return strconv.Quote(t)
+	case nil:
+		return "null"
+	default:
+		return renderNode(v)
 	}
 }
 

--- a/test/e2e/atago/dir.atago.yaml
+++ b/test/e2e/atago/dir.atago.yaml
@@ -134,3 +134,31 @@ scenarios:
             contains:
               - "assets/app.css"
               - "index.html"
+
+  # Asserting a directory at a path that holds a file used to report a bare
+  # "exists=false", which reads as "nothing is there" and hides the real
+  # problem: the output is exactly where it was asked for, as a file.
+  - name: a dir assertion on a file path says the path is a file
+    steps:
+      - fixture:
+          file: mistaken.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: mistaken}
+            scenarios:
+              - name: out is a file, not a directory
+                steps:
+                  - fixture: {file: out, content: "report\n"}
+                  - run: {command: echo built}
+                  - assert:
+                      dir:
+                        path: out
+                        exists: true
+      - run:
+          command: ${atago} run mistaken.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - 'exists but is a regular file'
+              - 'use a file: assertion'

--- a/test/e2e/atago/json_matcher_edges.atago.yaml
+++ b/test/e2e/atago/json_matcher_edges.atago.yaml
@@ -114,3 +114,68 @@ scenarios:
           exit_code: 1
           stdout:
             contains: "selected no value"
+
+  # A failing equals has to say which value it saw. Rendering both sides bare
+  # printed the same text twice for a type mismatch — "expected true, got true"
+  # for a boolean against the string "true" — which tells the author nothing.
+  - name: a type mismatch failure distinguishes a string from a boolean
+    steps:
+      - fixture:
+          file: typed.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: typed}
+            scenarios:
+              - name: string spelling of a boolean
+                steps:
+                  - run: {shell: true, command: 'printf ''{"b":true}'''}
+                  - assert: {stdout: {json: [{path: "$.b", equals: "true"}]}}
+      - run: {command: "${atago} run typed.atago.yaml"}
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - '$.b == "true"'
+              - "$.b = true"
+
+  # Whitespace differences are invisible unless the value is quoted.
+  - name: a whitespace-only mismatch shows the surrounding spaces
+    steps:
+      - fixture:
+          file: spaced.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: spaced}
+            scenarios:
+              - name: padded value
+                steps:
+                  - run: {shell: true, command: 'printf ''{"v":" x "}'''}
+                  - assert: {stdout: {json: [{path: "$.v", equals: "x"}]}}
+      - run: {command: "${atago} run spaced.atago.yaml"}
+      - assert:
+          exit_code: 1
+          stdout:
+            contains: '$.v = " x "'
+
+  - name: a numeric mismatch stays unquoted
+    steps:
+      - fixture:
+          file: nums.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: nums}
+            scenarios:
+              - name: off by one
+                steps:
+                  - run: {shell: true, command: 'printf ''{"n":2}'''}
+                  - assert: {stdout: {json: [{path: "$.n", equals: 1}]}}
+      - run: {command: "${atago} run nums.atago.yaml"}
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "$.n == 1"
+              - "$.n = 2"
+      - assert:
+          stdout:
+            not_contains: '"2"'


### PR DESCRIPTION
Two failure messages left the author with nothing to act on.

A failing `json: equals` rendered both the expected and the actual value bare, so a mismatch that is purely about type or whitespace printed the same text on both lines. Asserting the string `"true"` against the boolean `true` reported `Expected: $.b == true` / `Actual: $.b = true`, and asserting `"x"` against `" x "` hid the spaces completely. Strings are now quoted and `null` is named, while numbers and booleans stay bare so the ordinary numeric mismatch still reads as the JSON the tool emitted.

A `dir:` assertion against a path that holds a file reported `exists=false`. That reads as "nothing is there", when the truth is the opposite: the output is sitting exactly where the spec asked for it, as a file. The failure now says the path exists as a regular file (or symlink, named pipe, socket, device) and points at the `file:` assertion.

Only failure text changes — no verdict moves, and passing assertions are untouched.

Tests: table-driven cases in `internal/assert` for the four `equals` renderings and for the dir-on-a-file hint, plus self-hosted E2E in `json_matcher_edges.atago.yaml` and `dir.atago.yaml` that pin the rendered failure text through a real `atago run`. `make test`, `make lint`, `make docs` are green.