### PR TITLE
fix(assert): resolve a similar_to baseline in the scenario workdir too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- `image: similar_to` now falls back to the scenario workdir when no committed
+  baseline sits next to the spec. Comparing two images the run itself produced —
+  the two ends of an encoder round trip, the before and after of an in-place
+  edit — failed with "could not read baseline image" unless the spec spelled out
+  `${workdir}/...`. A committed golden still wins, so no existing baseline
+  changes meaning, and the workdir path is confined to the scenario like every
+  other runtime path. The failure message now names both places it looked.
+
 - `atago doc` and `atago explain` now describe every matcher an assertion sets
   instead of the first one. A stream assertion that combines `contains` with
   `not_contains`, `matches`, or `not_matches` enforces all of them at run time,

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 410 scenarios
+74 suites · 413 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -167,11 +167,14 @@
 - [atago self-hosting / http runner](#atago-self-hosting--http-runner) — 2 scenarios
   - [a denied host is a security policy violation (exit 6)](#scenario-a-denied-host-is-a-security-policy-violation-exit-6)
   - [an http step with an undeclared runner fails validation (exit 2)](#scenario-an-http-step-with-an-undeclared-runner-fails-validation-exit-2)
-- [atago self-hosting / image](#atago-self-hosting--image) — 4 scenarios
+- [atago self-hosting / image](#atago-self-hosting--image) — 7 scenarios
   - [format, dimension and alpha assertions pass on a PNG](#scenario-format-dimension-and-alpha-assertions-pass-on-a-png)
   - [a pixel comparison against an identical baseline passes](#scenario-a-pixel-comparison-against-an-identical-baseline-passes)
   - [a wrong dimension assertion fails with a clear diff](#scenario-a-wrong-dimension-assertion-fails-with-a-clear-diff)
   - [a failing similar_to writes visual diff artifacts](#scenario-a-failing-similar_to-writes-visual-diff-artifacts)
+  - [a similar_to baseline resolves in the scenario workdir](#scenario-a-similar_to-baseline-resolves-in-the-scenario-workdir)
+  - [a workdir baseline still fails when the images differ](#scenario-a-workdir-baseline-still-fails-when-the-images-differ)
+  - [a baseline that exists nowhere names both places it was looked for](#scenario-a-baseline-that-exists-nowhere-names-both-places-it-was-looked-for)
 - [atago self-hosting / init](#atago-self-hosting--init) — 3 scenarios
   - [init scaffolds a runnable spec](#scenario-init-scaffolds-a-runnable-spec)
   - [init emits a resolvable schema header for editor completion](#scenario-init-emits-a-resolvable-schema-header-for-editor-completion)
@@ -3472,6 +3475,98 @@ cat arts/*/*/*image.metadata.json
   - stdout at `$.diff_generated` equals `true`
 #### Generated artifacts
 - `arts`
+### Scenario: a similar_to baseline resolves in the scenario workdir
+#### Given
+- Fixture file `roundtrip.atago.yaml` is created.
+#### Inputs
+_Fixture `roundtrip.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: a copy of the output matches it pixel for pixel
+    steps:
+      - fixture:
+          file: source.png
+          base64: iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAIAAABLbSncAAAAGUlEQVR4nGJJSUlhwAaYsIoOWglAAAAA///xaAE/jf0lQAAAAABJRU5ErkJggg==
+      - run:
+          shell: true
+          command: cp source.png restored.png
+      - assert:
+          exit_code: 0
+          image:
+            path: restored.png
+            similar_to: source.png
+```
+#### When
+```shell
+${atago} run roundtrip.atago.yaml
+```
+#### Then
+- exit code is `0`
+- stdout contains `PASSED`
+### Scenario: a workdir baseline still fails when the images differ
+#### Given
+- Fixture file `differ.atago.yaml` is created.
+#### Inputs
+_Fixture `differ.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: a different image is not the baseline
+    steps:
+      - fixture:
+          file: source.png
+          base64: iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAAFUlEQVR4nGL5z4AATAxEcQABAAD//zRtAQqfxpGAAAAAAElFTkSuQmCC
+      - fixture:
+          file: other.png
+          base64: iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAAGElEQVR4nGJhYPjPAANMDEgANwcQAAD//zJvAQo6fkx6AAAAAElFTkSuQmCC
+      - run:
+          command: echo compared
+      - assert:
+          image:
+            path: other.png
+            similar_to: source.png
+```
+#### When
+```shell
+${atago} run differ.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `FAILED`
+### Scenario: a baseline that exists nowhere names both places it was looked for
+#### Given
+- Fixture file `missing.atago.yaml` is created.
+#### Inputs
+_Fixture `missing.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: the baseline was never produced
+    steps:
+      - fixture:
+          file: out.png
+          base64: iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAAFUlEQVR4nGL5z4AATAxEcQABAAD//zRtAQqfxpGAAAAAAElFTkSuQmCC
+      - run:
+          command: echo compared
+      - assert:
+          image:
+            path: out.png
+            similar_to: never-written.png
+```
+#### When
+```shell
+${atago} run missing.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `could not read baseline image`, `scenario workdir`
 ## atago self-hosting / init
 Source: `test/e2e/atago/init.atago.yaml`
 ### Scenario: init scaffolds a runnable spec

--- a/internal/assert/image.go
+++ b/internal/assert/image.go
@@ -22,12 +22,14 @@ import (
 	_ "golang.org/x/image/tiff"
 	_ "golang.org/x/image/webp"
 
+	"github.com/nao1215/atago/internal/security"
 	"github.com/nao1215/atago/internal/spec"
 )
 
 // checkImage evaluates an image assertion. Every constraint set on
 // the assertion must hold. Relative paths resolve against the scenario workdir;
-// a relative similar_to baseline resolves against the spec file's directory.
+// a relative similar_to baseline resolves against the spec file's directory,
+// falling back to the scenario workdir when no committed baseline is there.
 func checkImage(im *spec.ImageAssert, env Env) *CheckResult {
 	path := im.Path
 	if !filepath.IsAbs(path) {
@@ -182,6 +184,38 @@ func checkImageAlpha(im *spec.ImageAssert, img image.Image) *CheckResult {
 	}
 }
 
+// readBaselineImage loads the baseline a `similar_to` comparison runs against.
+// A committed golden lives next to the spec, so the spec directory is tried
+// first and that stays the meaning of an existing baseline path. When no such
+// file exists, the scenario workdir is tried too: comparing two images the run
+// itself produced — the round trip of an encoder, the before and after of an
+// in-place edit — is the other half of what pixel comparison is for, and it was
+// impossible to express because the workdir was never consulted. An absolute
+// path is used verbatim.
+func readBaselineImage(baseline string, env Env) ([]byte, error) {
+	if filepath.IsAbs(baseline) {
+		return os.ReadFile(baseline) //nolint:gosec // path is the user-declared baseline
+	}
+	specPath := filepath.Join(env.SpecDir, baseline)
+	data, err := os.ReadFile(specPath) //nolint:gosec // path is the user-declared baseline
+	if err == nil || env.Workdir == "" {
+		return data, err
+	}
+	// The workdir fallback is confined to the workdir the same way every other
+	// runtime path is, so a baseline cannot reach outside the scenario.
+	workPath, resolveErr := security.ResolveWorkdirPath("assert.image.similar_to", env.Workdir, baseline)
+	if resolveErr != nil {
+		return nil, resolveErr
+	}
+	workData, workErr := os.ReadFile(workPath) //nolint:gosec // path is confined to the workdir
+	if workErr != nil {
+		// Report the spec-directory miss: a committed baseline is the common
+		// case, and its path is the one the author most likely mistyped.
+		return nil, err
+	}
+	return workData, nil
+}
+
 // checkImageSimilarTo decodes both the asserted image and the baseline and
 // compares their pixels. The normalized mean per-pixel difference must be at or
 // below MaxDiff (default 0, an exact match). On failure it attaches review
@@ -212,18 +246,15 @@ func checkImageSimilarTo(im *spec.ImageAssert, data []byte, env Env) *CheckResul
 	meta.ActualFormat = detectImageFormat(data)
 	meta.ActualDimensions = dimStr(got)
 
-	basePath := im.SimilarTo
-	if !filepath.IsAbs(basePath) {
-		basePath = filepath.Join(env.SpecDir, im.SimilarTo)
-	}
-	baseData, err := os.ReadFile(basePath) //nolint:gosec // path is the user-declared baseline
+	baseData, err := readBaselineImage(im.SimilarTo, env)
 	if err != nil {
 		meta.Reason = "baseline image could not be read"
 		cr := &CheckResult{
 			Desc:     desc,
 			Expected: fmt.Sprintf("readable baseline image %q", im.SimilarTo),
 			Actual:   err.Error(),
-			Hint:     fmt.Sprintf("could not read baseline image %q", im.SimilarTo),
+			Hint: fmt.Sprintf("could not read baseline image %q; looked for a committed baseline next to the spec and for a file of that name in the scenario workdir",
+				im.SimilarTo),
 		}
 		return attachImageArtifacts(cr, meta, data, nil)
 	}

--- a/internal/assert/image.go
+++ b/internal/assert/image.go
@@ -3,10 +3,12 @@ package assert
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"image"
 	"image/color"
 	"image/png"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -198,7 +200,11 @@ func readBaselineImage(baseline string, env Env) ([]byte, error) {
 	}
 	specPath := filepath.Join(env.SpecDir, baseline)
 	data, err := os.ReadFile(specPath) //nolint:gosec // path is the user-declared baseline
-	if err == nil || env.Workdir == "" {
+	// Only a missing committed baseline falls through. A golden that exists but
+	// cannot be read (permissions, a directory in its place) is an error worth
+	// reporting, not a reason to silently compare against a same-named workdir
+	// file.
+	if err == nil || env.Workdir == "" || !errors.Is(err, fs.ErrNotExist) {
 		return data, err
 	}
 	// The workdir fallback is confined to the workdir the same way every other

--- a/internal/assert/image_test.go
+++ b/internal/assert/image_test.go
@@ -254,6 +254,63 @@ func TestCheckImage_Conjunctive(t *testing.T) {
 	}
 }
 
+// TestCheckImage_SimilarToWorkdirBaseline covers the comparison a run produces
+// both sides of: an encoder round trip, where neither image is a committed
+// golden. The workdir was never consulted, so the assertion failed with "could
+// not read baseline image" and the round-trip check could not be written at all.
+func TestCheckImage_SimilarToWorkdirBaseline(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	specDir := t.TempDir()
+	base := makePNG(t, 12, 12, color.RGBA{9, 9, 9, 255})
+	writeImage(t, dir, "source.png", base)
+	writeImage(t, dir, "restored.png", base)
+	writeImage(t, dir, "other.png", makePNG(t, 12, 12, color.RGBA{200, 0, 0, 255}))
+
+	env := Env{Workdir: dir, SpecDir: specDir}
+
+	got := Check(&spec.Assert{Image: &spec.ImageAssert{Path: "restored.png", SimilarTo: "source.png"}}, nil, env)
+	if !got.OK {
+		t.Errorf("a baseline produced by the run should resolve in the workdir: %s", got.Hint)
+	}
+
+	// The fallback must not weaken the comparison itself.
+	got = Check(&spec.Assert{Image: &spec.ImageAssert{Path: "other.png", SimilarTo: "source.png"}}, nil, env)
+	if got.OK {
+		t.Error("a different image must still fail against a workdir baseline")
+	}
+
+	// A committed golden still wins: the spec directory is consulted first, so an
+	// unrelated workdir file of the same name cannot shadow it.
+	writeImage(t, specDir, "source.png", makePNG(t, 12, 12, color.RGBA{255, 255, 255, 255}))
+	got = Check(&spec.Assert{Image: &spec.ImageAssert{Path: "restored.png", SimilarTo: "source.png"}}, nil, env)
+	if got.OK {
+		t.Error("the committed baseline next to the spec must take precedence over the workdir file")
+	}
+}
+
+// TestCheckImage_SimilarToEscapingWorkdir pins that the workdir fallback cannot
+// be used to read an image outside the scenario directory.
+func TestCheckImage_SimilarToEscapingWorkdir(t *testing.T) {
+	t.Parallel()
+	outside := t.TempDir()
+	dir := filepath.Join(outside, "work")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	base := makePNG(t, 8, 8, color.RGBA{1, 2, 3, 255})
+	writeImage(t, dir, "out.png", base)
+	// The image sits one level above the workdir, so only a traversal reaches it.
+	writeImage(t, outside, "secret.png", base)
+
+	got := Check(&spec.Assert{
+		Image: &spec.ImageAssert{Path: "out.png", SimilarTo: "../secret.png"},
+	}, nil, Env{Workdir: dir, SpecDir: t.TempDir()})
+	if got.OK {
+		t.Error("a baseline path escaping the workdir must not resolve")
+	}
+}
+
 func TestCheckImage_SimilarToAbsolutePath(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/assert/image_test.go
+++ b/internal/assert/image_test.go
@@ -289,6 +289,29 @@ func TestCheckImage_SimilarToWorkdirBaseline(t *testing.T) {
 	}
 }
 
+// TestCheckImage_SimilarToUnreadableGoldenDoesNotFallBack pins that only a
+// MISSING committed baseline falls through to the workdir. A golden that exists
+// but cannot be read must be reported, not quietly replaced by a same-named
+// workdir file that would make the comparison pass against the wrong image.
+func TestCheckImage_SimilarToUnreadableGoldenDoesNotFallBack(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	specDir := t.TempDir()
+	base := makePNG(t, 8, 8, color.RGBA{7, 7, 7, 255})
+	writeImage(t, dir, "out.png", base)
+	writeImage(t, dir, "baseline.png", base)
+	// A directory where the golden should be: it exists, so it is not ErrNotExist.
+	if err := os.Mkdir(filepath.Join(specDir, "baseline.png"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := Check(&spec.Assert{Image: &spec.ImageAssert{Path: "out.png", SimilarTo: "baseline.png"}},
+		nil, Env{Workdir: dir, SpecDir: specDir})
+	if got.OK {
+		t.Error("an unreadable committed baseline must fail rather than fall back to the workdir")
+	}
+}
+
 // TestCheckImage_SimilarToEscapingWorkdir pins that the workdir fallback cannot
 // be used to read an image outside the scenario directory.
 func TestCheckImage_SimilarToEscapingWorkdir(t *testing.T) {

--- a/internal/spec/assert.go
+++ b/internal/spec/assert.go
@@ -213,8 +213,10 @@ type ImageAssert struct {
 	Alpha *bool `yaml:"alpha,omitempty"`
 	// SimilarTo compares the decoded pixels against a baseline image. A relative
 	// path resolves against the spec file's directory (like a committed
-	// snapshot); use an absolute or ${workdir}-prefixed path to compare against
-	// another generated file. Both images must share dimensions.
+	// snapshot); when no file is there, it resolves against the scenario workdir
+	// instead, so two images the run produced — the two ends of a round trip —
+	// compare with a plain relative name. An absolute path is used as given.
+	// Both images must share dimensions.
 	SimilarTo string `yaml:"similar_to,omitempty"`
 	// MaxDiff is the maximum allowed normalized mean per-pixel difference (0..1)
 	// for SimilarTo. It defaults to 0 (an exact pixel match); lossy formats need a

--- a/schema/atago.schema.json
+++ b/schema/atago.schema.json
@@ -2380,7 +2380,7 @@
         "similar_to": {
           "type": "string",
           "minLength": 1,
-          "description": "Baseline image to compare decoded pixels against. A relative path resolves against the spec file's directory; both images must share dimensions."
+          "description": "Baseline image to compare decoded pixels against. A relative path resolves against the spec file's directory (a committed golden), falling back to the scenario workdir when no such file is there — which is how two images the run itself produced, such as the two ends of an encoder round trip, are compared. Both images must share dimensions."
         },
         "max_diff": {
           "type": "number",

--- a/test/e2e/atago/image.atago.yaml
+++ b/test/e2e/atago/image.atago.yaml
@@ -150,3 +150,94 @@ scenarios:
             json:
               path: $.diff_generated
               equals: true
+
+  # Comparing two images the run itself produced — the two ends of an encoder
+  # round trip — needs no committed golden. The baseline resolves in the
+  # scenario workdir, so the natural relative name works.
+  - name: a similar_to baseline resolves in the scenario workdir
+    steps:
+      - fixture:
+          file: roundtrip.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: sample
+            scenarios:
+              - name: a copy of the output matches it pixel for pixel
+                steps:
+                  - fixture:
+                      file: source.png
+                      base64: iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAIAAABLbSncAAAAGUlEQVR4nGJJSUlhwAaYsIoOWglAAAAA///xaAE/jf0lQAAAAABJRU5ErkJggg==
+                  - run:
+                      shell: true
+                      command: cp source.png restored.png
+                  - assert:
+                      exit_code: 0
+                      image:
+                        path: restored.png
+                        similar_to: source.png
+      - run:
+          command: ${atago} run roundtrip.atago.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: PASSED
+
+  - name: a workdir baseline still fails when the images differ
+    steps:
+      - fixture:
+          file: differ.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: sample
+            scenarios:
+              - name: a different image is not the baseline
+                steps:
+                  - fixture:
+                      file: source.png
+                      base64: iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAAFUlEQVR4nGL5z4AATAxEcQABAAD//zRtAQqfxpGAAAAAAElFTkSuQmCC
+                  - fixture:
+                      file: other.png
+                      base64: iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAAGElEQVR4nGJhYPjPAANMDEgANwcQAAD//zJvAQo6fkx6AAAAAElFTkSuQmCC
+                  - run:
+                      command: echo compared
+                  - assert:
+                      image:
+                        path: other.png
+                        similar_to: source.png
+      - run:
+          command: ${atago} run differ.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains: FAILED
+
+  - name: a baseline that exists nowhere names both places it was looked for
+    steps:
+      - fixture:
+          file: missing.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: sample
+            scenarios:
+              - name: the baseline was never produced
+                steps:
+                  - fixture:
+                      file: out.png
+                      base64: iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAAFUlEQVR4nGL5z4AATAxEcQABAAD//zRtAQqfxpGAAAAAAElFTkSuQmCC
+                  - run:
+                      command: echo compared
+                  - assert:
+                      image:
+                        path: out.png
+                        similar_to: never-written.png
+      - run:
+          command: ${atago} run missing.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "could not read baseline image"
+              - "scenario workdir"


### PR DESCRIPTION
Pixel comparison has two uses. One is against a committed golden that lives next to the spec. The other is between two images the run itself produced — the two ends of an encoder round trip, the before and after of an in-place edit — and that one did not work: a relative `similar_to` resolved against the spec directory and nowhere else, so the assertion failed with "could not read baseline image". The workaround is an absolute `${workdir}/...` path, which is exactly how the self-hosted image suite had to be written.

The spec directory is still consulted first, so every existing baseline keeps its meaning and a workdir file of the same name cannot shadow a committed golden. The workdir fallback goes through the same confinement every other runtime path uses, so a baseline cannot traverse out of the scenario. The failure message now names both places it looked instead of just saying the file could not be read.

Tests: unit tests for a matching and a differing workdir baseline, for the committed golden taking precedence over a same-named workdir file, and for a `../` traversal being rejected; self-hosted E2E covering the round-trip comparison written the natural way, the differing case still failing, and the message when the baseline exists in neither place. `make test`, `make lint`, `make docs` are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `image: similar_to` now looks for relative baseline images in the scenario workdir when no committed baseline is available.
  * Baseline path access remains confined to the scenario workdir.
  * Failure messages now identify both locations checked when a baseline is missing.

* **Documentation**
  * Updated image assertion guidance to describe baseline lookup behavior and requirements.

* **Tests**
  * Added coverage for workdir baselines, mismatched images, missing baselines, and unsafe paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->