### PR TITLE
fix(rerun): name the recorded failures a rerun could not run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- `--rerun-failed` now names the recorded failures it could not run. When a
+  scenario was renamed or deleted while still broken, the rerun quietly reported
+  fewer scenarios than were recorded, which reads as "the rest are fixed" — the
+  all-gone case already warned, but the partial case, where the miscount is
+  easiest to miss, did not. The entries are still kept in the ledger for the
+  next rerun.
 - `image: similar_to` now falls back to the scenario workdir when no committed
   baseline sits next to the spec. Comparing two images the run itself produced —
   the two ends of an encoder round trip, the before and after of an in-place

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 413 scenarios
+74 suites · 415 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -346,10 +346,12 @@
   - [TAP report is a numbered TAP 13 stream with ok / not ok points](#scenario-tap-report-is-a-numbered-tap-13-stream-with-ok--not-ok-points)
   - [failure artifacts are written and referenced in the JSON report](#scenario-failure-artifacts-are-written-and-referenced-in-the-json-report)
   - [a multi-line snapshot failure renders a unified diff with hunks](#scenario-a-multi-line-snapshot-failure-renders-a-unified-diff-with-hunks)
-- [atago self-hosting / rerun-failed](#atago-self-hosting--rerun-failed) — 3 scenarios
+- [atago self-hosting / rerun-failed](#atago-self-hosting--rerun-failed) — 5 scenarios
   - [a failing run is recorded and rerun-failed selects only it](#scenario-a-failing-run-is-recorded-and-rerun-failed-selects-only-it)
   - [rerun-failed with nothing recorded is a no-op success](#scenario-rerun-failed-with-nothing-recorded-is-a-no-op-success)
   - [rerun-failed with a filter preserves the still-failing scenarios it did not run](#scenario-rerun-failed-with-a-filter-preserves-the-still-failing-scenarios-it-did-not-run)
+  - [rerun-failed names the recorded failures that no longer match](#scenario-rerun-failed-names-the-recorded-failures-that-no-longer-match)
+  - [rerun-failed stays quiet when every recorded failure still exists](#scenario-rerun-failed-stays-quiet-when-every-recorded-failure-still-exists)
 - [atago self-hosting / retry until](#atago-self-hosting--retry-until) — 3 scenarios
   - [retry polls until the condition becomes true](#scenario-retry-polls-until-the-condition-becomes-true)
   - [retry fails the inner spec when until never holds](#scenario-retry-fails-the-inner-spec-when-until-never-holds)
@@ -6248,6 +6250,83 @@ ${atago} run --rerun-failed --filter red-a two.atago.yaml
 - after `${atago} run --rerun-failed --filter red-a two.atago.yaml`:
   - exit code is `1`
   - file `.atago/last-failed.json` contains `red-a`, `red-b`
+### Scenario: rerun-failed names the recorded failures that no longer match
+#### Given
+- Fixture file `two.atago.yaml` is created.
+- Fixture file `two.atago.yaml` is created.
+#### Inputs
+_Fixture `two.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: two
+scenarios:
+  - name: red-a
+    steps:
+      - run: {shell: true, command: "exit 1"}
+      - assert: {exit_code: 0}
+  - name: red-b
+    steps:
+      - run: {shell: true, command: "exit 1"}
+      - assert: {exit_code: 0}
+```
+_Fixture `two.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: two
+scenarios:
+  - name: red-a-renamed
+    steps:
+      - run: {shell: true, command: "exit 1"}
+      - assert: {exit_code: 0}
+  - name: red-b
+    steps:
+      - run: {shell: true, command: "exit 1"}
+      - assert: {exit_code: 0}
+```
+#### When
+```shell
+${atago} run two.atago.yaml
+${atago} run --rerun-failed two.atago.yaml
+```
+#### Then
+- after `${atago} run two.atago.yaml`:
+  - exit code is `1`
+- after `${atago} run --rerun-failed two.atago.yaml`:
+  - exit code is `1`
+  - stderr contains `1 recorded failing scenario did not match`, `red-a`
+  - file `.atago/last-failed.json` contains `red-a`, `red-b`
+### Scenario: rerun-failed stays quiet when every recorded failure still exists
+#### Given
+- Fixture file `two.atago.yaml` is created.
+#### Inputs
+_Fixture `two.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: two
+scenarios:
+  - name: red-a
+    steps:
+      - run: {shell: true, command: "exit 1"}
+      - assert: {exit_code: 0}
+  - name: red-b
+    steps:
+      - run: {shell: true, command: "exit 1"}
+      - assert: {exit_code: 0}
+```
+#### When
+```shell
+${atago} run two.atago.yaml
+${atago} run --rerun-failed two.atago.yaml
+```
+#### Then
+- after `${atago} run two.atago.yaml`:
+  - exit code is `1`
+- after `${atago} run --rerun-failed two.atago.yaml`:
+  - exit code is `1`
+  - stderr does not contain `did not match the current specs`
 ## atago self-hosting / retry until
 Source: `test/e2e/atago/retry.atago.yaml`
 ### Scenario: retry polls until the condition becomes true

--- a/internal/cli/features_test.go
+++ b/internal/cli/features_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
+	"sort"
 	"strings"
 	"testing"
 
@@ -451,6 +453,84 @@ func TestRerunFailed_NoMatchKeepsStateAndWarns(t *testing.T) {
 		}
 		if len(st.Failed) != 1 || st.Failed[0].Scenario != "fails" {
 			t.Errorf("recorded failures = %+v, want the original 'fails' preserved", st.Failed)
+		}
+	})
+}
+
+// TestRerunFailed_PartialMatchWarnsAboutTheRest covers the quiet half of the
+// case above: when only SOME recorded failures still exist, the rerun reports
+// fewer scenarios than were recorded, which reads as "the others are fixed".
+// The unmatched entries survive in the ledger, so the run must say which ones
+// it did not verify.
+func TestRerunFailed_PartialMatchWarnsAboutTheRest(t *testing.T) {
+	const spec = `version: "1"
+suite:
+  name: rerun
+scenarios:
+  - name: fails
+    steps:
+      - run: {shell: true, command: "exit 1"}
+      - assert: {exit_code: 0}
+  - name: also-fails
+    steps:
+      - run: {shell: true, command: "exit 1"}
+      - assert: {exit_code: 0}
+`
+	dir := t.TempDir()
+	writeSpec(t, dir, "s.atago.yaml", spec)
+	withWorkdir(t, dir, func() {
+		var out, errb bytes.Buffer
+		if got := Main([]string{"run", "."}, &out, &errb); got != ExitFailures {
+			t.Fatalf("first run exit = %d, want %d (stderr=%s)", got, ExitFailures, errb.String())
+		}
+		// One of the two recorded failures is renamed while still broken.
+		writeSpec(t, dir, "s.atago.yaml", strings.ReplaceAll(spec, "name: fails\n", "name: fails-renamed\n"))
+
+		out.Reset()
+		errb.Reset()
+		if got := Main([]string{"run", "--rerun-failed", "."}, &out, &errb); got != ExitFailures {
+			t.Fatalf("rerun exit = %d, want %d (stderr=%s)", got, ExitFailures, errb.String())
+		}
+		if !strings.Contains(errb.String(), "1 recorded failing scenario did not match") {
+			t.Errorf("stderr = %q, want a warning naming the unmatched recorded failure", errb.String())
+		}
+		if !strings.Contains(errb.String(), "s.atago.yaml / fails") {
+			t.Errorf("stderr = %q, want the unmatched scenario named", errb.String())
+		}
+		// The unmatched entry is still recorded for the next rerun.
+		st, err := loadRerunState()
+		if err != nil {
+			t.Fatalf("rerun state unreadable: %v", err)
+		}
+		var names []string
+		for _, e := range st.Failed {
+			names = append(names, e.Scenario)
+		}
+		sort.Strings(names)
+		want := []string{"also-fails", "fails"}
+		if !reflect.DeepEqual(names, want) {
+			t.Errorf("recorded failures = %v, want %v", names, want)
+		}
+	})
+}
+
+// TestRerunFailed_FullMatchIsQuiet pins that the warning is about a real
+// mismatch: when every recorded failure still exists, nothing extra is printed.
+func TestRerunFailed_FullMatchIsQuiet(t *testing.T) {
+	dir := t.TempDir()
+	writeSpec(t, dir, "s.atago.yaml", twoScenarioSpec)
+	withWorkdir(t, dir, func() {
+		var out, errb bytes.Buffer
+		if got := Main([]string{"run", "."}, &out, &errb); got != ExitFailures {
+			t.Fatalf("first run exit = %d, want %d (stderr=%s)", got, ExitFailures, errb.String())
+		}
+		out.Reset()
+		errb.Reset()
+		if got := Main([]string{"run", "--rerun-failed", "."}, &out, &errb); got != ExitFailures {
+			t.Fatalf("rerun exit = %d, want %d (stderr=%s)", got, ExitFailures, errb.String())
+		}
+		if strings.Contains(errb.String(), "did not match the current specs") {
+			t.Errorf("stderr = %q, want no mismatch warning when every recorded failure ran", errb.String())
 		}
 	})
 }

--- a/internal/cli/rerun.go
+++ b/internal/cli/rerun.go
@@ -299,18 +299,63 @@ func applyRerunSelection(label string, stderr io.Writer, paths []string, eng *en
 // so a write error is a warning, not a fatal exit; an UNREADABLE ledger is
 // never overwritten, so recorded failures a newer atago wrote survive a plain
 // run by an older one.
-func updateRerunLedger(label string, stderr io.Writer, results []*engine.SuiteResult, ranScenarios int) {
-	prior, perr := loadRerunState()
-	if perr != nil {
-		fmt.Fprintf(stderr, label+": cannot read %s; leaving it untouched: %v\n", rerunStatePath(), perr)
+// warnUnmatchedRerunEntries reports recorded failures that this --rerun-failed
+// run did not execute, which happens when a scenario was renamed or deleted
+// while still broken. The ledger keeps those entries, but silence is the wrong
+// answer: a rerun that shows "1 scenario" where two were recorded reads as
+// "the other one is fixed". The all-gone case is handled by the caller (it
+// verified nothing and exits non-zero); a partial mismatch stays a warning
+// because the entry survives for the next rerun.
+func warnUnmatchedRerunEntries(label string, stderr io.Writer, results []*engine.SuiteResult) {
+	prior, err := loadRerunState()
+	if err != nil || len(prior.Failed) == 0 {
 		return
 	}
-	executed := make(map[string]bool, ranScenarios)
+	executed := executedScenarioIDs(results)
+	var unmatched []failedEntry
+	for _, e := range prior.Failed {
+		if !executed[canonicalScenarioID(e.SpecPath, e.Scenario)] {
+			unmatched = append(unmatched, e)
+		}
+	}
+	if len(unmatched) == 0 {
+		return
+	}
+	names := make([]string, 0, len(unmatched))
+	for _, e := range unmatched {
+		names = append(names, fmt.Sprintf("%s / %s", e.SpecPath, e.Scenario))
+	}
+	sort.Strings(names)
+	fmt.Fprintf(stderr, "%s: warning: %s did not match the current specs (renamed or removed?) and was not rerun: %s; kept in %s for the next --rerun-failed\n",
+		label, pluralScenarios(len(unmatched)), strings.Join(names, ", "), rerunStatePath())
+}
+
+// pluralScenarios renders a recorded-failure count with the right noun.
+func pluralScenarios(n int) string {
+	if n == 1 {
+		return "1 recorded failing scenario"
+	}
+	return fmt.Sprintf("%d recorded failing scenarios", n)
+}
+
+// executedScenarioIDs is the set of scenarios a run actually executed.
+func executedScenarioIDs(results []*engine.SuiteResult) map[string]bool {
+	executed := map[string]bool{}
 	for _, r := range results {
 		for _, sc := range r.Scenarios {
 			executed[canonicalScenarioID(r.SpecPath, sc.Name)] = true
 		}
 	}
+	return executed
+}
+
+func updateRerunLedger(label string, stderr io.Writer, results []*engine.SuiteResult) {
+	prior, perr := loadRerunState()
+	if perr != nil {
+		fmt.Fprintf(stderr, label+": cannot read %s; leaving it untouched: %v\n", rerunStatePath(), perr)
+		return
+	}
+	executed := executedScenarioIDs(results)
 	var preserved []failedEntry
 	for _, e := range prior.Failed {
 		if !executed[canonicalScenarioID(e.SpecPath, e.Scenario)] {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -315,7 +315,14 @@ func finishRun(opts *runOptions, suiteResults []*engine.SuiteResult, loadErrs []
 	// and when a --rerun-failed matched nothing (its unmapped failures must
 	// survive).
 	if len(results) > 0 && !rerunMatchedNothing {
-		updateRerunLedger(opts.label, opts.stderr, results, ranScenarios)
+		// A --rerun-failed that matched only SOME of the recorded failures is the
+		// quiet version of the case above: the run reports fewer scenarios than
+		// were recorded, which reads as "the others are fixed". Say so before the
+		// ledger is rewritten, while the prior entries are still readable.
+		if opts.rerunFailed && !opts.selectionActive() {
+			warnUnmatchedRerunEntries(opts.label, opts.stderr, results)
+		}
+		updateRerunLedger(opts.label, opts.stderr, results)
 	}
 
 	// Every spec failed to load, or an interrupt skipped every suite before it

--- a/test/e2e/atago/rerun.atago.yaml
+++ b/test/e2e/atago/rerun.atago.yaml
@@ -101,3 +101,85 @@ scenarios:
           file:
             path: .atago/last-failed.json
             contains: [red-a, red-b]
+
+  # Renaming one broken scenario while fixing another leaves the rerun with
+  # fewer scenarios than were recorded, which reads as "the rest are fixed".
+  # The run has to say which recorded failure it did not verify.
+  - name: rerun-failed names the recorded failures that no longer match
+    steps:
+      - fixture:
+          file: two.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: two
+            scenarios:
+              - name: red-a
+                steps:
+                  - run: {shell: true, command: "exit 1"}
+                  - assert: {exit_code: 0}
+              - name: red-b
+                steps:
+                  - run: {shell: true, command: "exit 1"}
+                  - assert: {exit_code: 0}
+      - run:
+          command: ${atago} run two.atago.yaml
+      - assert:
+          exit_code: 1
+      # red-a is renamed while still broken; red-b keeps its name.
+      - fixture:
+          file: two.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: two
+            scenarios:
+              - name: red-a-renamed
+                steps:
+                  - run: {shell: true, command: "exit 1"}
+                  - assert: {exit_code: 0}
+              - name: red-b
+                steps:
+                  - run: {shell: true, command: "exit 1"}
+                  - assert: {exit_code: 0}
+      - run:
+          command: ${atago} run --rerun-failed two.atago.yaml
+      - assert:
+          exit_code: 1
+          stderr:
+            contains:
+              - "1 recorded failing scenario did not match"
+              - "red-a"
+      # The unmatched entry is kept, so the next rerun can still find it.
+      - assert:
+          file:
+            path: .atago/last-failed.json
+            contains: [red-a, red-b]
+
+  - name: rerun-failed stays quiet when every recorded failure still exists
+    steps:
+      - fixture:
+          file: two.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: two
+            scenarios:
+              - name: red-a
+                steps:
+                  - run: {shell: true, command: "exit 1"}
+                  - assert: {exit_code: 0}
+              - name: red-b
+                steps:
+                  - run: {shell: true, command: "exit 1"}
+                  - assert: {exit_code: 0}
+      - run:
+          command: ${atago} run two.atago.yaml
+      - assert:
+          exit_code: 1
+      - run:
+          command: ${atago} run --rerun-failed two.atago.yaml
+      - assert:
+          exit_code: 1
+          stderr:
+            not_contains: "did not match the current specs"


### PR DESCRIPTION
Renaming or deleting a scenario while it is still broken makes `--rerun-failed` run fewer scenarios than were recorded. The ledger already preserves the unmatched entries, but nothing told the user: the run reported "1 scenario" where two were recorded, which reads as "the other one is fixed".

The all-gone case was already handled — it warns loudly and refuses to exit green, because it verified nothing. The partial case was silent, and that is the one where the miscount is easiest to miss, because the run still looks like it did its job. It now names each recorded failure that did not match and says the entries are kept for the next rerun.

The exit code is deliberately unchanged for the partial case: something was verified, and the unmatched entries survive in `.atago/last-failed.json`, so the next rerun still finds them. An active `--filter`/`--tag` suppresses the warning, matching the existing rule that the user's own selection is not a rename.

Tests: cli tests for the partial mismatch (warning text, the named scenario, both entries still recorded) and for the quiet path when every recorded failure still exists; self-hosted E2E in `test/e2e/atago/rerun.atago.yaml` covering both through a real `atago run`. `make test`, `make lint`, `make docs` are green.