### PR TITLE
fix(assert): stop a directory from satisfying a file assertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- A `file:` assertion is no longer satisfied by a directory. `exists: true`
+  passed for a tool that produced a directory where a file was expected, and
+  `executable: true` passed on any directory, since every directory carries the
+  execute bit — two false passes in exactly the case the assertion exists to
+  catch. Both now fail and say the path is a directory, pointing at `dir:`.
+  atago's own image suite had one of these sloppy assertions, now corrected.
 - `--rerun-failed` now names the recorded failures it could not run. When a
   scenario was renamed or deleted while still broken, the rerun quietly reported
   fewer scenarios than were recorded, which reads as "the rest are fixed" — the

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 415 scenarios
+74 suites · 418 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -137,11 +137,14 @@
   - [explain describes every matcher of a composed stream assertion](#scenario-explain-describes-every-matcher-of-a-composed-stream-assertion)
   - [explain names the line a line-scoped matcher inspects](#scenario-explain-names-the-line-a-line-scoped-matcher-inspects)
   - [explain describes file not_contains and executable matchers](#scenario-explain-describes-file-not_contains-and-executable-matchers)
-- [atago self-hosting / file equals and equals_file byte-equality (#155)](#atago-self-hosting--file-equals-and-equals_file-byte-equality-155) — 4 scenarios
+- [atago self-hosting / file equals and equals_file byte-equality (#155)](#atago-self-hosting--file-equals-and-equals_file-byte-equality-155) — 7 scenarios
   - [equals_file passes for two byte-identical files](#scenario-equals_file-passes-for-two-byte-identical-files)
   - [equals matches an inline literal byte-for-byte](#scenario-equals-matches-an-inline-literal-byte-for-byte)
   - [equals_file fails the inner spec when the two files differ by one byte](#scenario-equals_file-fails-the-inner-spec-when-the-two-files-differ-by-one-byte)
   - [equals_file is byte-exact — a CRLF vs LF difference fails](#scenario-equals_file-is-byte-exact--a-crlf-vs-lf-difference-fails)
+  - [a file assertion is not satisfied by a directory](#scenario-a-file-assertion-is-not-satisfied-by-a-directory)
+  - [an executable assertion is not satisfied by a directory](#scenario-an-executable-assertion-is-not-satisfied-by-a-directory)
+  - [a real file still satisfies both matchers](#scenario-a-real-file-still-satisfies-both-matchers)
 - [atago self-hosting / fixture from (copy committed testdata)](#atago-self-hosting--fixture-from-copy-committed-testdata) — 2 scenarios
   - [a committed binary blob is copied verbatim into the workdir](#scenario-a-committed-binary-blob-is-copied-verbatim-into-the-workdir)
   - [copying from a missing source errors the scenario](#scenario-copying-from-a-missing-source-errors-the-scenario)
@@ -2940,6 +2943,84 @@ ${atago} run crlf.atago.yaml
 #### Then
 - exit code is `1`
 - stdout contains `not byte-identical`
+### Scenario: a file assertion is not satisfied by a directory
+#### Given
+- Fixture file `mistaken.atago.yaml` is created.
+#### Inputs
+_Fixture `mistaken.atago.yaml`:_
+```text
+version: "1"
+suite: {name: mistaken}
+scenarios:
+  - name: out is a directory, not the expected file
+    steps:
+      - run: {shell: true, command: "mkdir out"}
+      - assert:
+          file:
+            path: out
+            exists: true
+```
+#### When
+```shell
+${atago} run mistaken.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `exists but is a directory`, `use a dir: assertion`
+### Scenario: an executable assertion is not satisfied by a directory
+_skipped on Windows_
+#### Given
+- Fixture file `execdir.atago.yaml` is created.
+#### Inputs
+_Fixture `execdir.atago.yaml`:_
+```text
+version: "1"
+suite: {name: execdir}
+scenarios:
+  - name: a directory is not an executable
+    steps:
+      - run: {shell: true, command: "mkdir bin"}
+      - assert:
+          file:
+            path: bin
+            executable: true
+```
+#### When
+```shell
+${atago} run execdir.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `is a directory, not an executable file`
+### Scenario: a real file still satisfies both matchers
+_skipped on Windows_
+#### Given
+- Fixture file `ok.atago.yaml` is created.
+#### Inputs
+_Fixture `ok.atago.yaml`:_
+```text
+version: "1"
+suite: {name: ok}
+scenarios:
+  - name: a real executable file
+    steps:
+      - fixture:
+          file: tool.sh
+          content: "#!/bin/sh\n"
+          mode: "0755"
+      - run: {command: echo hi}
+      - assert:
+          file: {path: tool.sh, exists: true}
+      - assert:
+          file: {path: tool.sh, executable: true}
+```
+#### When
+```shell
+${atago} run ok.atago.yaml
+```
+#### Then
+- exit code is `0`
+- stdout contains `PASSED`
 ## atago self-hosting / fixture from (copy committed testdata)
 Source: `test/e2e/atago/fixture_from.atago.yaml`
 ### Scenario: a committed binary blob is copied verbatim into the workdir
@@ -3468,15 +3549,13 @@ cat arts/*/*/*image.metadata.json
 - after `${atago} run --report json --artifacts-dir arts diff.atago.yaml`:
   - exit code is `1`
   - stdout contains `"artifacts"`
-  - file `arts` exists
+  - dir `arts` exists
 - after `ls arts/*/*/`:
   - exit code is `0`
   - stdout contains `image.actual.png`, `image.baseline.png`, `image.diff.png`, `image.metadata.json`
 - after `cat arts/*/*/*image.metadata.json`:
   - exit code is `0`
   - stdout at `$.diff_generated` equals `true`
-#### Generated artifacts
-- `arts`
 ### Scenario: a similar_to baseline resolves in the scenario workdir
 #### Given
 - Fixture file `roundtrip.atago.yaml` is created.

--- a/internal/assert/assert_test.go
+++ b/internal/assert/assert_test.go
@@ -1571,6 +1571,43 @@ func TestCheckFile_Executable(t *testing.T) {
 	}
 }
 
+// TestCheckFile_DirectoryIsNotAFile pins that a directory never satisfies a
+// file assertion. `exists: true` used to pass for a tool that produced a
+// directory where a file was expected, and `executable: true` used to pass on
+// any directory, since every directory carries the execute bit — two false
+// passes in exactly the case the assertion exists to catch.
+func TestCheckFile_DirectoryIsNotAFile(t *testing.T) {
+	t.Parallel()
+	wd := t.TempDir()
+	if err := os.Mkdir(filepath.Join(wd, "out"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cr := checkFileOK(t, wd, &spec.FileAssert{Path: "out", Exists: boolp(true)})
+	if cr.OK {
+		t.Error("exists:true on a directory must fail")
+	}
+	if !strings.Contains(cr.Hint, "is a directory") {
+		t.Errorf("Hint = %q, want it to say the path is a directory", cr.Hint)
+	}
+
+	cr = checkFileOK(t, wd, &spec.FileAssert{Path: "out", Executable: boolp(true)})
+	if cr.OK {
+		t.Error("executable:true on a directory must fail")
+	}
+	if !strings.Contains(cr.Hint, "is a directory") {
+		t.Errorf("Hint = %q, want it to say the path is a directory", cr.Hint)
+	}
+
+	// A real file is unaffected.
+	if err := os.WriteFile(filepath.Join(wd, "real.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if cr := checkFileOK(t, wd, &spec.FileAssert{Path: "real.txt", Exists: boolp(true)}); !cr.OK {
+		t.Errorf("exists:true on a regular file must still pass: %+v", cr)
+	}
+}
+
 func TestExistenceAndExecutabilityWords(t *testing.T) {
 	t.Parallel()
 	if existence(true) != "exist" || existence(false) != "not exist" {

--- a/internal/assert/file.go
+++ b/internal/assert/file.go
@@ -44,7 +44,7 @@ func checkFile(f *spec.FileAssert, env Env) (out *CheckResult) {
 	switch {
 	case f.Exists != nil:
 		desc := fmt.Sprintf("assert file %q exists: %t", f.Path, *f.Exists)
-		_, err := os.Stat(path)
+		info, err := os.Stat(path)
 		// Only a genuine "not exist" result participates in exists:true/false.
 		// Permission, I/O, and other stat failures are surfaced as an error so
 		// users do not debug a "missing file" that is really unreadable (#39).
@@ -54,6 +54,17 @@ func checkFile(f *spec.FileAssert, env Env) (out *CheckResult) {
 				Expected: fmt.Sprintf("stat-able file %q", f.Path),
 				Actual:   err.Error(),
 				Hint:     fmt.Sprintf("could not stat file %q: %v", f.Path, err),
+			}
+		}
+		// A directory is not the file this assertion is about. Counting it as one
+		// made `exists: true` pass for a tool that produced a directory where a
+		// file was expected — the assertion's whole job is to catch that.
+		if err == nil && info.IsDir() {
+			return &CheckResult{
+				Desc:     desc,
+				Expected: fmt.Sprintf("file %q exists=%t", f.Path, *f.Exists),
+				Actual:   fmt.Sprintf("%q is a directory", f.Path),
+				Hint:     fmt.Sprintf("%q exists but is a directory, not a file; use a dir: assertion for it", f.Path),
 			}
 		}
 		exists := err == nil
@@ -109,8 +120,19 @@ func checkFile(f *spec.FileAssert, env Env) (out *CheckResult) {
 				Hint:     fmt.Sprintf("could not stat file %q", f.Path),
 			}
 		}
-		isExec := info.Mode().Perm()&0o111 != 0
 		desc := fmt.Sprintf("assert file %q executable: %t", f.Path, *f.Executable)
+		// Every directory carries the execute bit, so reading it as "this is an
+		// executable" turned a tool that produced a directory into a passing
+		// executable check.
+		if info.IsDir() {
+			return &CheckResult{
+				Desc:     desc,
+				Expected: fmt.Sprintf("file %q executable=%t", f.Path, *f.Executable),
+				Actual:   fmt.Sprintf("%q is a directory", f.Path),
+				Hint:     fmt.Sprintf("%q is a directory, not an executable file; a directory's execute bit means it can be entered", f.Path),
+			}
+		}
+		isExec := info.Mode().Perm()&0o111 != 0
 		if isExec == *f.Executable {
 			return pass(desc)
 		}

--- a/internal/spec/assert.go
+++ b/internal/spec/assert.go
@@ -355,15 +355,20 @@ func (l *StringList) UnmarshalYAML(unmarshal func(any) error) error {
 // the point is to prove two files are byte-identical (matching the `dir`
 // snapshot hashing semantics), which `cmp` cannot express portably.
 type FileAssert struct {
-	Path        string     `yaml:"path"`
+	Path string `yaml:"path"`
+	// Exists asserts a FILE is (or is not) at the path. A directory there fails
+	// either way and points at DirAssert: counting one as a file let a tool that
+	// produced a directory satisfy the assertion meant to catch exactly that.
 	Exists      *bool      `yaml:"exists,omitempty"`
 	Contains    StringList `yaml:"contains,omitempty"`
 	NotContains StringList `yaml:"not_contains,omitempty"`
-	Executable  *bool      `yaml:"executable,omitempty"`
-	Equals      *string    `yaml:"equals,omitempty"`
-	EqualsFile  *string    `yaml:"equals_file,omitempty"`
-	JSON        JSONChecks `yaml:"json,omitempty"`
-	Snapshot    string     `yaml:"snapshot,omitempty"`
+	// Executable asserts the POSIX execute bit. A directory fails: every
+	// directory has that bit, and it means "can be entered", not "is a program".
+	Executable *bool      `yaml:"executable,omitempty"`
+	Equals     *string    `yaml:"equals,omitempty"`
+	EqualsFile *string    `yaml:"equals_file,omitempty"`
+	JSON       JSONChecks `yaml:"json,omitempty"`
+	Snapshot   string     `yaml:"snapshot,omitempty"`
 
 	// Text is a store-only selector (#158): when true, `store` captures the
 	// whole file content verbatim instead of extracting a value via a json path.

--- a/schema/atago.schema.json
+++ b/schema/atago.schema.json
@@ -2234,7 +2234,7 @@
         },
         "exists": {
           "type": "boolean",
-          "description": "Asserts the file exists (`true`) or is absent (`false`)."
+          "description": "Asserts the file exists (`true`) or is absent (`false`). A directory at that path is not a file: it fails either way and points at the `dir:` assertion."
         },
         "contains": {
           "$ref": "#/$defs/stringOrList",
@@ -2246,7 +2246,7 @@
         },
         "executable": {
           "type": "boolean",
-          "description": "Asserts whether the file has an executable bit set (POSIX)."
+          "description": "Asserts whether the file has an executable bit set (POSIX). A directory fails: every directory carries the execute bit, which means \"can be entered\", not \"is a program\"."
         },
         "equals": {
           "type": "string",

--- a/test/e2e/atago/file_equals.atago.yaml
+++ b/test/e2e/atago/file_equals.atago.yaml
@@ -89,3 +89,83 @@ scenarios:
           exit_code: 1
           stdout:
             contains: "not byte-identical"
+
+  # A directory is not a file. Both of these used to pass: `exists: true`
+  # because stat succeeds on a directory, and `executable: true` because every
+  # directory carries the execute bit — so a tool that produced a directory
+  # where a file was expected satisfied the assertion meant to catch that.
+  - name: a file assertion is not satisfied by a directory
+    steps:
+      - fixture:
+          file: mistaken.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: mistaken}
+            scenarios:
+              - name: out is a directory, not the expected file
+                steps:
+                  - run: {shell: true, command: "mkdir out"}
+                  - assert:
+                      file:
+                        path: out
+                        exists: true
+      - run:
+          command: ${atago} run mistaken.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "exists but is a directory"
+              - "use a dir: assertion"
+
+  - name: an executable assertion is not satisfied by a directory
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: execdir.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: execdir}
+            scenarios:
+              - name: a directory is not an executable
+                steps:
+                  - run: {shell: true, command: "mkdir bin"}
+                  - assert:
+                      file:
+                        path: bin
+                        executable: true
+      - run:
+          command: ${atago} run execdir.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains: "is a directory, not an executable file"
+
+  - name: a real file still satisfies both matchers
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: ok.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: ok}
+            scenarios:
+              - name: a real executable file
+                steps:
+                  - fixture:
+                      file: tool.sh
+                      content: "#!/bin/sh\n"
+                      mode: "0755"
+                  - run: {command: echo hi}
+                  - assert:
+                      file: {path: tool.sh, exists: true}
+                  - assert:
+                      file: {path: tool.sh, executable: true}
+      - run:
+          command: ${atago} run ok.atago.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: PASSED

--- a/test/e2e/atago/image.atago.yaml
+++ b/test/e2e/atago/image.atago.yaml
@@ -126,7 +126,7 @@ scenarios:
             contains: "\"artifacts\""
       # The actual, baseline, and a deterministic diff heatmap are all preserved.
       - assert:
-          file:
+          dir:
             path: arts
             exists: true
       - run:


### PR DESCRIPTION
`file: {exists: true}` passed when the path held a directory, because `stat` succeeds on one. `file: {executable: true}` passed on any directory, because every directory carries the execute bit. Both are false passes in exactly the situation the assertion exists to catch — a tool that wrote a directory where a file was expected, or an "the installer produced an executable" check that a plain directory satisfies.

Both now fail and name what is actually at the path, pointing at the `dir:` assertion. `exists: false` keeps its verdict (a directory was never "absent"), it just explains itself now instead of reporting a bare `exists=true`. This is the mirror image of the recent `dir:` fix that reports a file sitting where a directory was expected.

The change immediately caught a sloppy assertion in atago's own suite: the image suite asserted `file: {path: arts, exists: true}` for an artifacts directory. That is corrected to `dir:` here, and it is the only such assertion in the repository.

Tests: unit coverage for both matchers against a directory, and for a regular file still passing; self-hosted E2E that runs nested specs asserting on a directory (both matchers) and on a real executable file. `make test`, `make lint`, `make e2e`, `make docs` are green, and the third-party suites show no new failures.