### PR TITLE
test(git): pin the branching, diff, and failure contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- The git third-party suite gains a second spec covering what a script leans on:
+  `diff --exit-code` as a status contract, the exact `--porcelain` status codes,
+  a fast-forward merge and a real conflict, stash and patch round trips proven
+  byte for byte, `.gitignore` keeping a file out of the index, a local clone
+  reproducing the same commit, content-addressed identity for two identical
+  commits, and the documented failures (no repository, duplicate tag, nothing
+  staged) with their own exit codes.
 - Third-party suite for zstd: compression round trips proven byte for byte with
   `equals_file` (including an empty file and one full of NUL bytes), the input
   kept unless `--rm` is asked for, an existing archive never silently

--- a/doc/e2e/git.md
+++ b/doc/e2e/git.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-3 suites · 8 scenarios
+4 suites · 20 scenarios
 ## Contents
 - [git + changes (a staged blob touches exactly index + one object)](#git--changes-a-staged-blob-touches-exactly-index--one-object) — 2 scenarios
   - [staging one file creates the index and a single loose object (POSIX)](#scenario-staging-one-file-creates-the-index-and-a-single-loose-object-posix)
@@ -13,6 +13,19 @@
   - [checking out a missing ref fails with an explanation (v9.9.9)](#scenario-checking-out-a-missing-ref-fails-with-an-explanation-v999)
 - [git + sandbox_home (global config in an isolated HOME)](#git--sandbox_home-global-config-in-an-isolated-home) — 1 scenario
   - [global user.name is written under the sandbox home and read back (POSIX)](#scenario-global-username-is-written-under-the-sandbox-home-and-read-back-posix)
+- [git (branching, diffs, and failure contracts)](#git-branching-diffs-and-failure-contracts) — 12 scenarios
+  - [diff --exit-code reports difference through the exit status](#scenario-diff---exit-code-reports-difference-through-the-exit-status)
+  - [status --porcelain spells each state exactly](#scenario-status---porcelain-spells-each-state-exactly)
+  - [a diverged branch fast-forwards into the base](#scenario-a-diverged-branch-fast-forwards-into-the-base)
+  - [a conflicting merge stops with markers and a non-zero status](#scenario-a-conflicting-merge-stops-with-markers-and-a-non-zero-status)
+  - [stash and pop restore the working tree byte for byte](#scenario-stash-and-pop-restore-the-working-tree-byte-for-byte)
+  - [a diff applied back restores the discarded change](#scenario-a-diff-applied-back-restores-the-discarded-change)
+  - [an ignored file is never staged](#scenario-an-ignored-file-is-never-staged)
+  - [a local clone reproduces the same commit](#scenario-a-local-clone-reproduces-the-same-commit)
+  - [committing with nothing staged fails and creates no commit](#scenario-committing-with-nothing-staged-fails-and-creates-no-commit)
+  - [a duplicate tag is refused and the original is untouched](#scenario-a-duplicate-tag-is-refused-and-the-original-is-untouched)
+  - [git outside a repository fails with its own exit code](#scenario-git-outside-a-repository-fails-with-its-own-exit-code)
+  - [identical commits made twice hash the same](#scenario-identical-commits-made-twice-hash-the-same)
 ## git + changes (a staged blob touches exactly index + one object)
 `git add` is documented as writing a blob and updating the index. This suite
 holds git to that literally: after initializing a repository, staging one
@@ -173,3 +186,396 @@ git config --global user.name
 - after `git config --global user.name`:
   - exit code is `0`
   - stdout equals an exact value
+## git (branching, diffs, and failure contracts)
+The second half of the git suite: the parts of git a script actually leans
+on, driven as state transitions rather than single commands.
+
+A branch is created, diverged, merged fast-forward, and then merged into a
+real conflict; a stash and an `apply`ed patch are proven to restore the file
+byte for byte; `--porcelain` and `diff --exit-code` are pinned as the
+machine contracts they are; and each documented failure — no repository, a
+duplicate tag, nothing staged, a conflicted merge — is pinned to its own
+exit code with the message that explains it. Every command uses git's own
+`-C`/`-c` flags, so no shell is involved except where a redirect is the
+thing under test.
+
+Source: `test/e2e/thirdparty/git/workflow.atago.yaml`
+### Scenario: diff --exit-code reports difference through the exit status
+#### Given
+- Fixture file `repo/a.txt` is created.
+- Fixture file `repo/a.txt` is created.
+#### Inputs
+_Fixture `repo/a.txt`:_
+```text
+one
+```
+_Fixture `repo/a.txt`:_
+```text
+one
+two
+```
+#### When
+```shell
+git init -q repo
+git -C repo add a.txt
+git -C repo -c user.name=atago -c user.email=atago@example.com commit -q -m first
+git -C repo diff --exit-code
+git -C repo diff --exit-code
+```
+#### Then
+- after `git -C repo -c user.name=atago -c user.email=atago@example.com commit -q -m first`:
+  - exit code is `0`
+- after `git -C repo diff --exit-code`:
+  - exit code is `0`
+  - stdout is empty
+- after `git -C repo diff --exit-code`:
+  - exit code is `1`
+  - stdout contains `diff --git a/a.txt b/a.txt`, `+two`
+### Scenario: status --porcelain spells each state exactly
+#### Given
+- Fixture file `repo/tracked.txt` is created.
+- Fixture file `repo/tracked.txt` is created.
+- Fixture file `repo/untracked.txt` is created.
+- Fixture file `repo/staged.txt` is created.
+#### Inputs
+_Fixture `repo/tracked.txt`:_
+```text
+v1
+```
+_Fixture `repo/tracked.txt`:_
+```text
+v2
+```
+_Fixture `repo/untracked.txt`:_
+```text
+new
+```
+_Fixture `repo/staged.txt`:_
+```text
+staged
+```
+#### When
+```shell
+git init -q repo
+git -C repo add tracked.txt
+git -C repo -c user.name=atago -c user.email=atago@example.com commit -q -m first
+git -C repo add staged.txt
+git -C repo status --porcelain
+```
+#### Then
+- after `git -C repo -c user.name=atago -c user.email=atago@example.com commit -q -m first`:
+  - exit code is `0`
+- after `git -C repo add staged.txt`:
+  - exit code is `0`
+- after `git -C repo status --porcelain`:
+  - exit code is `0`
+  - stdout line `1` equals an exact value
+  - stdout line `2` equals an exact value
+  - stdout line `3` equals an exact value
+### Scenario: a diverged branch fast-forwards into the base
+#### Given
+- Fixture file `repo/a.txt` is created.
+- Fixture file `repo/b.txt` is created.
+#### Inputs
+_Fixture `repo/a.txt`:_
+```text
+base
+```
+_Fixture `repo/b.txt`:_
+```text
+feature
+```
+#### When
+```shell
+git init -q -b main repo
+git -C repo add a.txt
+git -C repo -c user.name=atago -c user.email=atago@example.com commit -q -m base
+git -C repo checkout -q -b feature
+git -C repo add b.txt
+git -C repo -c user.name=atago -c user.email=atago@example.com commit -q -m feature
+git -C repo checkout -q main
+git -C repo merge --ff-only feature
+git -C repo rev-parse main
+# capture ${main_head} from stdout
+git -C repo rev-parse feature
+```
+#### Then
+- after `git -C repo checkout -q -b feature`:
+  - exit code is `0`
+- after `git -C repo merge --ff-only feature`:
+  - exit code is `0`
+- after `git -C repo rev-parse feature`:
+  - exit code is `0`
+  - stdout contains `${main_head}`
+  - file `repo/b.txt` contains `feature`
+### Scenario: a conflicting merge stops with markers and a non-zero status
+#### Given
+- Fixture file `repo/a.txt` is created.
+- Fixture file `repo/a.txt` is created.
+- Fixture file `repo/a.txt` is created.
+#### Inputs
+_Fixture `repo/a.txt`:_
+```text
+base
+```
+_Fixture `repo/a.txt`:_
+```text
+from other
+```
+_Fixture `repo/a.txt`:_
+```text
+from main
+```
+#### When
+```shell
+git init -q -b main repo
+git -C repo add a.txt
+git -C repo -c user.name=atago -c user.email=atago@example.com commit -q -m base
+git -C repo checkout -q -b other
+git -C repo add a.txt
+git -C repo -c user.name=atago -c user.email=atago@example.com commit -q -m other
+git -C repo checkout -q main
+git -C repo add a.txt
+git -C repo -c user.name=atago -c user.email=atago@example.com commit -q -m main
+git -C repo -c user.name=atago -c user.email=atago@example.com merge other
+git -C repo status --porcelain
+```
+#### Then
+- after `git -C repo -c user.name=atago -c user.email=atago@example.com merge other`:
+  - exit code is `1`
+  - stdout contains `CONFLICT`
+  - file `repo/a.txt` contains `<<<<<<<`, `from main`, `from other`, `>>>>>>>`
+- after `git -C repo status --porcelain`:
+  - stdout contains `UU a.txt`
+### Scenario: stash and pop restore the working tree byte for byte
+_skipped on Windows_
+#### Given
+- Fixture file `repo/a.txt` is created.
+- Fixture file `repo/a.txt` is created.
+#### Inputs
+_Fixture `repo/a.txt`:_
+```text
+committed
+```
+_Fixture `repo/a.txt`:_
+```text
+work in progress	tab and trailing space 
+```
+#### When
+```shell
+git init -q repo
+git -C repo add a.txt
+git -C repo -c user.name=atago -c user.email=atago@example.com commit -q -m first
+cp repo/a.txt expected.txt
+git -C repo -c user.name=atago -c user.email=atago@example.com stash
+git -C repo status --porcelain
+git -C repo stash pop
+```
+#### Then
+- after `git -C repo -c user.name=atago -c user.email=atago@example.com stash`:
+  - exit code is `0`
+  - file `repo/a.txt` equals exact bytes
+- after `git -C repo status --porcelain`:
+  - stdout is empty
+- after `git -C repo stash pop`:
+  - exit code is `0`
+  - file `repo/a.txt` is byte-identical to `expected.txt`
+### Scenario: a diff applied back restores the discarded change
+_skipped on Windows_
+#### Given
+- Fixture file `repo/a.txt` is created.
+- Fixture file `repo/a.txt` is created.
+#### Inputs
+_Fixture `repo/a.txt`:_
+```text
+line1
+```
+_Fixture `repo/a.txt`:_
+```text
+line1
+line2
+```
+#### When
+```shell
+git init -q repo
+git -C repo add a.txt
+git -C repo -c user.name=atago -c user.email=atago@example.com commit -q -m first
+cp repo/a.txt expected.txt
+git -C repo diff > change.patch
+git -C repo checkout -- a.txt
+git -C repo apply ../change.patch
+```
+#### Then
+- after `git -C repo diff > change.patch`:
+  - exit code is `0`
+  - file `change.patch` contains `+line2`
+- after `git -C repo checkout -- a.txt`:
+  - exit code is `0`
+  - file `repo/a.txt` equals exact bytes
+- after `git -C repo apply ../change.patch`:
+  - exit code is `0`
+  - file `repo/a.txt` is byte-identical to `expected.txt`
+### Scenario: an ignored file is never staged
+#### Given
+- Fixture file `repo/.gitignore` is created.
+- Fixture file `repo/keep.txt` is created.
+- Fixture file `repo/debug.log` is created.
+- Fixture file `repo/build/out.bin` is created.
+#### Inputs
+_Fixture `repo/.gitignore`:_
+```text
+*.log
+build/
+```
+_Fixture `repo/keep.txt`:_
+```text
+keep
+```
+_Fixture `repo/debug.log`:_
+```text
+noise
+```
+_Fixture `repo/build/out.bin`:_
+```text
+artifact
+```
+#### When
+```shell
+git init -q repo
+git -C repo add .
+git -C repo status --porcelain
+git -C repo check-ignore -v debug.log
+```
+#### Then
+- after `git -C repo add .`:
+  - exit code is `0`
+- after `git -C repo status --porcelain`:
+  - exit code is `0`
+  - stdout contains `A  .gitignore`, `A  keep.txt`
+  - stdout does not contain `debug.log`, `build/out.bin`
+- after `git -C repo check-ignore -v debug.log`:
+  - exit code is `0`
+  - stdout contains `*.log`
+### Scenario: a local clone reproduces the same commit
+#### Given
+- Fixture file `origin/a.txt` is created.
+#### Inputs
+_Fixture `origin/a.txt`:_
+```text
+shared
+```
+#### When
+```shell
+git init -q origin
+git -C origin add a.txt
+git -C origin -c user.name=atago -c user.email=atago@example.com commit -q -m shared
+git -C origin rev-parse HEAD
+# capture ${origin_head} from stdout
+git clone -q origin copy
+git -C copy rev-parse HEAD
+```
+#### Then
+- after `git clone -q origin copy`:
+  - exit code is `0`
+- after `git -C copy rev-parse HEAD`:
+  - exit code is `0`
+  - stdout contains `${origin_head}`
+  - file `copy/a.txt` equals exact bytes
+### Scenario: committing with nothing staged fails and creates no commit
+#### Given
+- Fixture file `repo/a.txt` is created.
+#### Inputs
+_Fixture `repo/a.txt`:_
+```text
+one
+```
+#### When
+```shell
+git init -q repo
+git -C repo add a.txt
+git -C repo -c user.name=atago -c user.email=atago@example.com commit -q -m first
+git -C repo rev-parse HEAD
+# capture ${head_before} from stdout
+git -C repo -c user.name=atago -c user.email=atago@example.com commit -m "empty"
+git -C repo rev-parse HEAD
+```
+#### Then
+- after `git -C repo -c user.name=atago -c user.email=atago@example.com commit -q -m first`:
+  - exit code is `0`
+- after `git -C repo -c user.name=atago -c user.email=atago@example.com commit -m "empty"`:
+  - exit code is `1`
+  - stdout contains `nothing to commit`
+- after `git -C repo rev-parse HEAD`:
+  - exit code is `0`
+  - stdout contains `${head_before}`
+### Scenario: a duplicate tag is refused and the original is untouched
+#### Given
+- Fixture file `repo/a.txt` is created.
+#### Inputs
+_Fixture `repo/a.txt`:_
+```text
+one
+```
+#### When
+```shell
+git init -q repo
+git -C repo add a.txt
+git -C repo -c user.name=atago -c user.email=atago@example.com commit -q -m first
+git -C repo tag v1
+git -C repo tag v1
+git -C repo tag --list
+```
+#### Then
+- after `git -C repo tag v1`:
+  - exit code is `0`
+- after `git -C repo tag v1`:
+  - exit code is `128`
+  - stderr contains `already exists`
+- after `git -C repo tag --list`:
+  - exit code is `0`
+  - stdout equals an exact value
+#### Expected output
+_expected stdout:_
+```text
+v1
+```
+### Scenario: git outside a repository fails with its own exit code
+#### When
+```shell
+git status
+```
+#### Then
+- exit code is `128`
+- stdout is empty
+- stderr contains `not a git repository`
+### Scenario: identical commits made twice hash the same
+#### Given
+- Fixture file `one/a.txt` is created.
+- Fixture file `two/a.txt` is created.
+- Environment variables are set: GIT_AUTHOR_DATE, GIT_COMMITTER_DATE.
+- Environment variables are set: GIT_AUTHOR_DATE, GIT_COMMITTER_DATE.
+#### Inputs
+_Fixture `one/a.txt`:_
+```text
+same bytes
+```
+_Fixture `two/a.txt`:_
+```text
+same bytes
+```
+#### When
+```shell
+git init -q one
+git init -q two
+git -C one add a.txt
+git -C two add a.txt
+git -C one -c user.name=atago -c user.email=atago@example.com commit -q -m same
+git -C two -c user.name=atago -c user.email=atago@example.com commit -q -m same
+git -C one rev-parse HEAD
+# capture ${one_head} from stdout
+git -C two rev-parse HEAD
+```
+#### Then
+- after `git -C two rev-parse HEAD`:
+  - exit code is `0`
+  - stdout contains `${one_head}`

--- a/doc/e2e/git.md
+++ b/doc/e2e/git.md
@@ -471,11 +471,11 @@ git -C origin add a.txt
 git -C origin -c user.name=atago -c user.email=atago@example.com commit -q -m shared
 git -C origin rev-parse HEAD
 # capture ${origin_head} from stdout
-git clone -q origin copy
+git -c core.autocrlf=false clone -q origin copy
 git -C copy rev-parse HEAD
 ```
 #### Then
-- after `git clone -q origin copy`:
+- after `git -c core.autocrlf=false clone -q origin copy`:
   - exit code is `0`
 - after `git -C copy rev-parse HEAD`:
   - exit code is `0`

--- a/doc/real-world.md
+++ b/doc/real-world.md
@@ -22,7 +22,7 @@ Third-party programs ([test/e2e/thirdparty/](../test/e2e/thirdparty/)). atago ru
 
 | Program | Feature | License | Specs | Docs |
 |---------|---------|---------|-------|------|
-| [git](https://git-scm.com/) | Version control — runs in CI on all three OSes. | GPL-2.0 | [specs](../test/e2e/thirdparty/git) | [docs](e2e/git.md) |
+| [git](https://git-scm.com/) | Version control — runs in CI on all three OSes: init/add/commit and status, plus `diff --exit-code` as a status contract, exact `--porcelain` codes, a fast-forward merge and a real conflict, stash and patch round trips proven byte for byte, `.gitignore` keeping a file out of the index, a local clone reproducing the same commit, and the documented failures (no repository, duplicate tag, nothing staged). | GPL-2.0 | [specs](../test/e2e/thirdparty/git) | [docs](e2e/git.md) |
 | [jq](https://jqlang.org/) | JSON processor: stdin-driven filters, --arg injection, and its documented exit-code contract (1 for -e false, 3 for a bad program, parse failures). | MIT | [specs](../test/e2e/thirdparty/jq) | [docs](e2e/jq.md) |
 | [fzf](https://github.com/junegunn/fzf) | Interactive fuzzy finder driven inside a real pseudo-terminal: expect/send sessions type queries, multi-select, and abort (exit 130); --filter pins the non-TTY contract. | MIT | [specs](../test/e2e/thirdparty/fzf) | [docs](e2e/fzf.md) |
 | [gum](https://github.com/charmbracelet/gum) | Shell-script UI toolkit: non-interactive stdout contracts (`version-check`, `join`, `table`, `log`) plus TTY prompts and pickers (`choose`, `filter`, `confirm`, `input`, `file`, `pager`) driven over a real terminal. | MIT | [specs](../test/e2e/thirdparty/gum) | [docs](e2e/gum.md) |

--- a/test/e2e/thirdparty/git/workflow.atago.yaml
+++ b/test/e2e/thirdparty/git/workflow.atago.yaml
@@ -357,8 +357,11 @@ scenarios:
           from:
             stdout:
               trim: true
+      # core.autocrlf=false keeps the checkout byte-exact on Windows, where git
+      # would otherwise rewrite LF to CRLF and make the comparison below about
+      # the platform rather than about the clone.
       - run:
-          command: git clone -q origin copy
+          command: git -c core.autocrlf=false clone -q origin copy
       - assert:
           exit_code: 0
       - run:

--- a/test/e2e/thirdparty/git/workflow.atago.yaml
+++ b/test/e2e/thirdparty/git/workflow.atago.yaml
@@ -1,0 +1,491 @@
+version: "1"
+
+suite:
+  name: git (branching, diffs, and failure contracts)
+  description: |
+    The second half of the git suite: the parts of git a script actually leans
+    on, driven as state transitions rather than single commands.
+
+    A branch is created, diverged, merged fast-forward, and then merged into a
+    real conflict; a stash and an `apply`ed patch are proven to restore the file
+    byte for byte; `--porcelain` and `diff --exit-code` are pinned as the
+    machine contracts they are; and each documented failure — no repository, a
+    duplicate tag, nothing staged, a conflicted merge — is pinned to its own
+    exit code with the message that explains it. Every command uses git's own
+    `-C`/`-c` flags, so no shell is involved except where a redirect is the
+    thing under test.
+scenarios:
+  # `git diff --exit-code` is git's answer to terraform's detailed exit code: it
+  # reports "is there a difference" through the status, which is what a CI gate
+  # branches on.
+  - name: diff --exit-code reports difference through the exit status
+    steps:
+      - fixture:
+          file: repo/a.txt
+          content: "one\n"
+      - run:
+          command: git init -q repo
+      - run:
+          command: git -C repo add a.txt
+      - run:
+          command: git -C repo -c user.name=atago -c user.email=atago@example.com commit -q -m first
+      - assert:
+          exit_code: 0
+      # Nothing changed since the commit: exit 0 and no diff text.
+      - run:
+          command: git -C repo diff --exit-code
+      - assert:
+          exit_code: 0
+          stdout:
+            empty: true
+      - fixture:
+          file: repo/a.txt
+          content: "one\ntwo\n"
+      # Now there is a difference: exit 1, and the patch names the file.
+      - run:
+          command: git -C repo diff --exit-code
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "diff --git a/a.txt b/a.txt"
+              - "+two"
+
+  # --porcelain is the machine-readable status format, so its exact bytes are
+  # the contract — not a substring of the human output.
+  - name: status --porcelain spells each state exactly
+    steps:
+      - fixture:
+          file: repo/tracked.txt
+          content: "v1\n"
+      - run:
+          command: git init -q repo
+      - run:
+          command: git -C repo add tracked.txt
+      - run:
+          command: git -C repo -c user.name=atago -c user.email=atago@example.com commit -q -m first
+      - assert:
+          exit_code: 0
+      # An untracked file, a modified tracked file, and a staged addition each
+      # get their own two-letter code.
+      - fixture:
+          file: repo/tracked.txt
+          content: "v2\n"
+      - fixture:
+          file: repo/untracked.txt
+          content: "new\n"
+      - fixture:
+          file: repo/staged.txt
+          content: "staged\n"
+      - run:
+          command: git -C repo add staged.txt
+      - assert:
+          exit_code: 0
+      - run:
+          command: git -C repo status --porcelain
+      - assert:
+          exit_code: 0
+          # git orders the staged entry first; each line is pinned exactly, so a
+          # change in the two-letter status codes breaks this.
+          stdout:
+            line: 1
+            equals: "A  staged.txt"
+      - assert:
+          stdout:
+            line: 2
+            equals: " M tracked.txt"
+      - assert:
+          stdout:
+            line: 3
+            equals: "?? untracked.txt"
+
+  # A branch that only adds commits merges without a merge commit, and the two
+  # refs end up at the same object — the observable definition of fast-forward.
+  - name: a diverged branch fast-forwards into the base
+    steps:
+      - fixture:
+          file: repo/a.txt
+          content: "base\n"
+      - run:
+          command: git init -q -b main repo
+      - run:
+          command: git -C repo add a.txt
+      - run:
+          command: git -C repo -c user.name=atago -c user.email=atago@example.com commit -q -m base
+      - run:
+          command: git -C repo checkout -q -b feature
+      - assert:
+          exit_code: 0
+      - fixture:
+          file: repo/b.txt
+          content: "feature\n"
+      - run:
+          command: git -C repo add b.txt
+      - run:
+          command: git -C repo -c user.name=atago -c user.email=atago@example.com commit -q -m feature
+      - run:
+          command: git -C repo checkout -q main
+      - run:
+          command: git -C repo merge --ff-only feature
+      - assert:
+          exit_code: 0
+      # Both refs now name the same commit.
+      - run:
+          command: git -C repo rev-parse main
+      - store:
+          name: main_head
+          from:
+            stdout:
+              trim: true
+      - run:
+          command: git -C repo rev-parse feature
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: ${main_head}
+      # The merged file is present in the working tree.
+      - assert:
+          file:
+            path: repo/b.txt
+            contains: feature
+
+  # The failure half of merging: both sides edited the same line, so git stops
+  # with a conflict, marks the file, and leaves the merge in progress.
+  - name: a conflicting merge stops with markers and a non-zero status
+    steps:
+      - fixture:
+          file: repo/a.txt
+          content: "base\n"
+      - run:
+          command: git init -q -b main repo
+      - run:
+          command: git -C repo add a.txt
+      - run:
+          command: git -C repo -c user.name=atago -c user.email=atago@example.com commit -q -m base
+      - run:
+          command: git -C repo checkout -q -b other
+      - fixture:
+          file: repo/a.txt
+          content: "from other\n"
+      - run:
+          command: git -C repo add a.txt
+      - run:
+          command: git -C repo -c user.name=atago -c user.email=atago@example.com commit -q -m other
+      - run:
+          command: git -C repo checkout -q main
+      - fixture:
+          file: repo/a.txt
+          content: "from main\n"
+      - run:
+          command: git -C repo add a.txt
+      - run:
+          command: git -C repo -c user.name=atago -c user.email=atago@example.com commit -q -m main
+      - run:
+          command: git -C repo -c user.name=atago -c user.email=atago@example.com merge other
+      - assert:
+          exit_code: 1
+          stdout:
+            contains: CONFLICT
+      # The conflict is written into the file, and status marks it unmerged.
+      - assert:
+          file:
+            path: repo/a.txt
+            contains:
+              - "<<<<<<<"
+              - "from main"
+              - "from other"
+              - ">>>>>>>"
+      - run:
+          command: git -C repo status --porcelain
+      - assert:
+          stdout:
+            contains: "UU a.txt"   # both sides modified: unmerged
+
+  # stash is a round trip: the working tree goes back to the committed state and
+  # then returns to exactly the bytes that were stashed.
+  - name: stash and pop restore the working tree byte for byte
+    # Uses cp and a shell redirect to keep a byte-exact copy, so POSIX only.
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: repo/a.txt
+          content: "committed\n"
+      - run:
+          command: git init -q repo
+      - run:
+          command: git -C repo add a.txt
+      - run:
+          command: git -C repo -c user.name=atago -c user.email=atago@example.com commit -q -m first
+      - fixture:
+          file: repo/a.txt
+          content: "work in progress\ttab and trailing space \n"
+      # Keep a copy of the exact bytes for the round-trip comparison.
+      - run:
+          shell: true
+          command: cp repo/a.txt expected.txt
+      - run:
+          command: git -C repo -c user.name=atago -c user.email=atago@example.com stash
+      - assert:
+          exit_code: 0
+      # The tree is back to the committed content.
+      - assert:
+          file:
+            path: repo/a.txt
+            equals: "committed\n"
+      - run:
+          command: git -C repo status --porcelain
+      - assert:
+          stdout:
+            empty: true
+      - run:
+          command: git -C repo stash pop
+      - assert:
+          exit_code: 0
+      - assert:
+          # Byte for byte, including the tab and the trailing space.
+          file:
+            path: repo/a.txt
+            equals_file: expected.txt
+
+  # A patch is a serialization of a change: writing one out, discarding the
+  # change, and applying it back must restore the same bytes.
+  - name: a diff applied back restores the discarded change
+    # Uses cp and a shell redirect to keep a byte-exact copy, so POSIX only.
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: repo/a.txt
+          content: "line1\n"
+      - run:
+          command: git init -q repo
+      - run:
+          command: git -C repo add a.txt
+      - run:
+          command: git -C repo -c user.name=atago -c user.email=atago@example.com commit -q -m first
+      - fixture:
+          file: repo/a.txt
+          content: "line1\nline2\n"
+      - run:
+          shell: true
+          command: cp repo/a.txt expected.txt
+      - run:
+          shell: true
+          command: git -C repo diff > change.patch
+      - assert:
+          exit_code: 0
+          file:
+            path: change.patch
+            contains: "+line2"
+      # Discard the change, then apply the patch back.
+      - run:
+          command: git -C repo checkout -- a.txt
+      - assert:
+          exit_code: 0
+          file:
+            path: repo/a.txt
+            equals: "line1\n"
+      - run:
+          command: git -C repo apply ../change.patch
+      - assert:
+          exit_code: 0
+          file:
+            path: repo/a.txt
+            equals_file: expected.txt
+
+  # .gitignore is a negative-space contract: the ignored file must stay out of
+  # the index no matter that it sits in the tree.
+  - name: an ignored file is never staged
+    steps:
+      - fixture:
+          file: repo/.gitignore
+          content: "*.log\nbuild/\n"
+      - fixture:
+          file: repo/keep.txt
+          content: "keep\n"
+      - fixture:
+          file: repo/debug.log
+          content: "noise\n"
+      - fixture:
+          file: repo/build/out.bin
+          content: "artifact\n"
+      - run:
+          command: git init -q repo
+      - run:
+          command: git -C repo add .
+      - assert:
+          exit_code: 0
+      - run:
+          command: git -C repo status --porcelain
+      - assert:
+          exit_code: 0
+          stdout:
+            contains:
+              - "A  .gitignore"
+              - "A  keep.txt"
+      - assert:
+          stdout:
+            not_contains:
+              - "debug.log"
+              - "build/out.bin"
+      # Asking git directly: the ignored path is reported as ignored.
+      - run:
+          command: git -C repo check-ignore -v debug.log
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "*.log"
+
+  # A local clone must reproduce the source history exactly, which is the one
+  # thing a version control system cannot get wrong.
+  - name: a local clone reproduces the same commit
+    steps:
+      - fixture:
+          file: origin/a.txt
+          content: "shared\n"
+      - run:
+          command: git init -q origin
+      - run:
+          command: git -C origin add a.txt
+      - run:
+          command: git -C origin -c user.name=atago -c user.email=atago@example.com commit -q -m shared
+      - run:
+          command: git -C origin rev-parse HEAD
+      - store:
+          name: origin_head
+          from:
+            stdout:
+              trim: true
+      - run:
+          command: git clone -q origin copy
+      - assert:
+          exit_code: 0
+      - run:
+          command: git -C copy rev-parse HEAD
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: ${origin_head}
+      - assert:
+          file:
+            path: copy/a.txt
+            equals: "shared\n"
+
+  - name: committing with nothing staged fails and creates no commit
+    steps:
+      - fixture:
+          file: repo/a.txt
+          content: "one\n"
+      - run:
+          command: git init -q repo
+      - run:
+          command: git -C repo add a.txt
+      - run:
+          command: git -C repo -c user.name=atago -c user.email=atago@example.com commit -q -m first
+      - assert:
+          exit_code: 0
+      - run:
+          command: git -C repo rev-parse HEAD
+      - store:
+          name: head_before
+          from:
+            stdout:
+              trim: true
+      # Nothing has changed since that commit.
+      - run:
+          command: git -C repo -c user.name=atago -c user.email=atago@example.com commit -m "empty"
+      - assert:
+          exit_code: 1
+          stdout:
+            contains: "nothing to commit"
+      # The refusal left history exactly where it was.
+      - run:
+          command: git -C repo rev-parse HEAD
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: ${head_before}
+
+  - name: a duplicate tag is refused and the original is untouched
+    steps:
+      - fixture:
+          file: repo/a.txt
+          content: "one\n"
+      - run:
+          command: git init -q repo
+      - run:
+          command: git -C repo add a.txt
+      - run:
+          command: git -C repo -c user.name=atago -c user.email=atago@example.com commit -q -m first
+      - run:
+          command: git -C repo tag v1
+      - assert:
+          exit_code: 0
+      - run:
+          command: git -C repo tag v1
+      - assert:
+          exit_code: 128
+          stderr:
+            contains: already exists
+      # Exactly one tag survives, spelled exactly.
+      - run:
+          command: git -C repo tag --list
+      - assert:
+          exit_code: 0
+          stdout:
+            equals: "v1\n"
+
+  - name: git outside a repository fails with its own exit code
+    steps:
+      - run:
+          command: git status
+      - assert:
+          exit_code: 128
+          stdout:
+            empty: true
+          stderr:
+            contains: "not a git repository"
+
+  # Two commits with identical content, author, and dates must be the same
+  # object: git's identity is content-addressed, and that is what makes a clone
+  # verifiable.
+  - name: identical commits made twice hash the same
+    steps:
+      - fixture:
+          file: one/a.txt
+          content: "same bytes\n"
+      - fixture:
+          file: two/a.txt
+          content: "same bytes\n"
+      - run:
+          command: git init -q one
+      - run:
+          command: git init -q two
+      - run:
+          command: git -C one add a.txt
+      - run:
+          command: git -C two add a.txt
+      - run:
+          env:
+            GIT_AUTHOR_DATE: "2026-01-01T00:00:00Z"
+            GIT_COMMITTER_DATE: "2026-01-01T00:00:00Z"
+          command: git -C one -c user.name=atago -c user.email=atago@example.com commit -q -m same
+      - run:
+          env:
+            GIT_AUTHOR_DATE: "2026-01-01T00:00:00Z"
+            GIT_COMMITTER_DATE: "2026-01-01T00:00:00Z"
+          command: git -C two -c user.name=atago -c user.email=atago@example.com commit -q -m same
+      - run:
+          command: git -C one rev-parse HEAD
+      - store:
+          name: one_head
+          from:
+            stdout:
+              trim: true
+      - run:
+          command: git -C two rev-parse HEAD
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: ${one_head}


### PR DESCRIPTION
The git suite proved the basics — init, add, commit, status — and stopped there. This second spec covers the parts a script actually leans on, driven as state transitions rather than single commands.

`diff --exit-code` is pinned as the status contract a CI gate branches on (0 with empty stdout, then 1 with the patch naming the file). `--porcelain` is pinned by its exact two-letter codes, line by line, instead of a substring of the human output. A branch is diverged and fast-forwarded with both refs proven to name the same commit, then merged into a real conflict with the markers written into the file and the unmerged status code. Stash/pop and diff/apply are round trips checked with `equals_file`, using content that includes a tab and a trailing space so any normalization would break them. `.gitignore` is asserted as negative space (the ignored paths never reach the index, and `check-ignore` names the rule), a local clone must reproduce the source commit hash, and two identical commits made in separate repositories with pinned dates must hash the same — content addressing is the one thing a version control system cannot get wrong.

Each documented failure gets its own exit code: `git status` outside a repository (128, stdout empty), a duplicate tag (128, with the tag list proven unchanged), and a commit with nothing staged (1, with HEAD proven not to have moved).

Two scenarios use `cp` and a shell redirect to keep a byte-exact copy for comparison and are marked POSIX-only; the rest use git's own `-C`/`-c` flags. `make e2e`, `make lint`, `make docs` are green.