### PR TITLE
fix(report): show a difference the terminal would hide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- A failure whose two sides differ only in invisible characters now quotes both.
+  A byte-exact `equals` mismatch between `shared\n` and `shared\r\n` printed the
+  same word twice, and the same happened for a trailing space or a tab against
+  spaces: the reader could see there was a difference but not what it was.
+  Ordinary differences keep their plain, copy-pasteable form.
 - A `file:` assertion is no longer satisfied by a directory. `exists: true`
   passed for a tool that produced a directory where a file was expected, and
   `executable: true` passed on any directory, since every directory carries the

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 418 scenarios
+74 suites · 421 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -137,7 +137,7 @@
   - [explain describes every matcher of a composed stream assertion](#scenario-explain-describes-every-matcher-of-a-composed-stream-assertion)
   - [explain names the line a line-scoped matcher inspects](#scenario-explain-names-the-line-a-line-scoped-matcher-inspects)
   - [explain describes file not_contains and executable matchers](#scenario-explain-describes-file-not_contains-and-executable-matchers)
-- [atago self-hosting / file equals and equals_file byte-equality (#155)](#atago-self-hosting--file-equals-and-equals_file-byte-equality-155) — 7 scenarios
+- [atago self-hosting / file equals and equals_file byte-equality (#155)](#atago-self-hosting--file-equals-and-equals_file-byte-equality-155) — 10 scenarios
   - [equals_file passes for two byte-identical files](#scenario-equals_file-passes-for-two-byte-identical-files)
   - [equals matches an inline literal byte-for-byte](#scenario-equals-matches-an-inline-literal-byte-for-byte)
   - [equals_file fails the inner spec when the two files differ by one byte](#scenario-equals_file-fails-the-inner-spec-when-the-two-files-differ-by-one-byte)
@@ -145,6 +145,9 @@
   - [a file assertion is not satisfied by a directory](#scenario-a-file-assertion-is-not-satisfied-by-a-directory)
   - [an executable assertion is not satisfied by a directory](#scenario-an-executable-assertion-is-not-satisfied-by-a-directory)
   - [a real file still satisfies both matchers](#scenario-a-real-file-still-satisfies-both-matchers)
+  - [an invisible difference is quoted in the failure output](#scenario-an-invisible-difference-is-quoted-in-the-failure-output)
+  - [a trailing space difference is quoted too](#scenario-a-trailing-space-difference-is-quoted-too)
+  - [an ordinary difference keeps its plain form](#scenario-an-ordinary-difference-keeps-its-plain-form)
 - [atago self-hosting / fixture from (copy committed testdata)](#atago-self-hosting--fixture-from-copy-committed-testdata) — 2 scenarios
   - [a committed binary blob is copied verbatim into the workdir](#scenario-a-committed-binary-blob-is-copied-verbatim-into-the-workdir)
   - [copying from a missing source errors the scenario](#scenario-copying-from-a-missing-source-errors-the-scenario)
@@ -3021,6 +3024,84 @@ ${atago} run ok.atago.yaml
 #### Then
 - exit code is `0`
 - stdout contains `PASSED`
+### Scenario: an invisible difference is quoted in the failure output
+#### Given
+- Fixture file `crlf.atago.yaml` is created.
+#### Inputs
+_Fixture `crlf.atago.yaml`:_
+```text
+version: "1"
+suite: {name: crlf}
+scenarios:
+  - name: the file ends with CRLF, the expectation with LF
+    steps:
+      - fixture:
+          file: a.txt
+          base64: c2hhcmVkDQo=
+      - run: {command: echo hi}
+      - assert:
+          file:
+            path: a.txt
+            equals: "shared\n"
+```
+#### When
+```shell
+${atago} run crlf.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `"shared\n"`, `"shared\r\n"`
+### Scenario: a trailing space difference is quoted too
+#### Given
+- Fixture file `spaces.atago.yaml` is created.
+#### Inputs
+_Fixture `spaces.atago.yaml`:_
+```text
+version: "1"
+suite: {name: spaces}
+scenarios:
+  - name: the output carries trailing spaces
+    steps:
+      - run:
+          shell: true
+          command: "printf 'value  '"
+      - assert:
+          stdout:
+            equals: "value"
+```
+#### When
+```shell
+${atago} run spaces.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `"value  "`
+### Scenario: an ordinary difference keeps its plain form
+#### Given
+- Fixture file `plain.atago.yaml` is created.
+#### Inputs
+_Fixture `plain.atago.yaml`:_
+```text
+version: "1"
+suite: {name: plain}
+scenarios:
+  - name: the texts really are different
+    steps:
+      - run:
+          shell: true
+          command: "printf 'actual text'"
+      - assert:
+          stdout:
+            equals: "expected text"
+```
+#### When
+```shell
+${atago} run plain.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `expected text`, `actual text`
+- stdout does not contain `"actual text"`
 ## atago self-hosting / fixture from (copy committed testdata)
 Source: `test/e2e/atago/fixture_from.atago.yaml`
 ### Scenario: a committed binary blob is copied verbatim into the workdir

--- a/internal/report/console.go
+++ b/internal/report/console.go
@@ -83,11 +83,12 @@ func writeDetail(b *strings.Builder, color bool, suite, specPath string, sc *eng
 				if diff := checkDiff(ck); diff != "" {
 					fmt.Fprintf(b, "\nDiff (-expected +actual):\n%s\n", indent(colorizeDiff(color, diff)))
 				} else {
-					if ck.Expected != "" {
-						fmt.Fprintf(b, "\nExpected:\n%s\n", indent(ck.Expected))
+					expected, actual := visiblePair(ck.Expected, ck.Actual)
+					if expected != "" {
+						fmt.Fprintf(b, "\nExpected:\n%s\n", indent(expected))
 					}
-					if ck.Actual != "" {
-						fmt.Fprintf(b, "\nActual:\n%s\n", indent(ck.Actual))
+					if actual != "" {
+						fmt.Fprintf(b, "\nActual:\n%s\n", indent(actual))
 					}
 				}
 				if ck.Hint != "" {
@@ -216,11 +217,12 @@ func writeSuiteSteps(b *strings.Builder, color bool, suite, label string, steps 
 			if diff := checkDiff(ck); diff != "" {
 				fmt.Fprintf(b, "\nDiff (-expected +actual):\n%s\n", indent(colorizeDiff(color, diff)))
 			} else {
-				if ck.Expected != "" {
-					fmt.Fprintf(b, "\nExpected:\n%s\n", indent(ck.Expected))
+				expected, actual := visiblePair(ck.Expected, ck.Actual)
+				if expected != "" {
+					fmt.Fprintf(b, "\nExpected:\n%s\n", indent(expected))
 				}
-				if ck.Actual != "" {
-					fmt.Fprintf(b, "\nActual:\n%s\n", indent(ck.Actual))
+				if actual != "" {
+					fmt.Fprintf(b, "\nActual:\n%s\n", indent(actual))
 				}
 			}
 			if ck.Hint != "" {

--- a/internal/report/diff.go
+++ b/internal/report/diff.go
@@ -2,6 +2,7 @@ package report
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/nao1215/atago/internal/assert"
@@ -265,4 +266,33 @@ func colorizeDiff(on bool, diff string) string {
 		}
 	}
 	return strings.Join(lines, "\n")
+}
+
+// visiblePair returns the Expected/Actual pair to print in the compact form,
+// escaping both when they differ only in characters a terminal does not show.
+// A file `equals` failure between "shared\n" and "shared\r\n" printed the same
+// two words twice — the reader could see there was a difference but not what it
+// was — and the same happens for a tab against spaces or a trailing blank.
+// Quoting is applied to BOTH sides so they stay comparable, and only when the
+// plain rendering would be indistinguishable, so the ordinary failure keeps its
+// unquoted, copy-pasteable form.
+func visiblePair(expected, actual string) (string, string) {
+	if expected == "" || actual == "" || expected == actual {
+		return expected, actual
+	}
+	if stripInvisible(expected) != stripInvisible(actual) {
+		return expected, actual
+	}
+	return strconv.Quote(expected), strconv.Quote(actual)
+}
+
+// stripInvisible removes the characters whose presence a terminal does not
+// reveal: carriage returns, tabs, and whitespace at the end of a line or of the
+// text. Two payloads that are equal after this differ only invisibly.
+func stripInvisible(s string) string {
+	lines := strings.Split(strings.ReplaceAll(s, "\r", ""), "\n")
+	for i, ln := range lines {
+		lines[i] = strings.TrimRight(strings.ReplaceAll(ln, "\t", " "), " ")
+	}
+	return strings.TrimRight(strings.Join(lines, "\n"), "\n")
 }

--- a/internal/report/diff_test.go
+++ b/internal/report/diff_test.go
@@ -257,3 +257,69 @@ func TestUnifiedDiff_ZeroCountHunkHeader(t *testing.T) {
 		t.Errorf("both-no-newline sides not both annotated:\n%s", got)
 	}
 }
+
+// TestVisiblePair_EscapesOnlyInvisibleDifferences pins the rendering rule for
+// the compact Expected/Actual block: when the two payloads differ only in
+// characters a terminal does not show, both are quoted so the difference is
+// readable; an ordinary difference keeps its plain, copy-pasteable form.
+func TestVisiblePair_EscapesOnlyInvisibleDifferences(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name                     string
+		expected, actual         string
+		wantExpected, wantActual string
+	}{
+		{
+			name:         "crlf against lf",
+			expected:     "shared\n",
+			actual:       "shared\r\n",
+			wantExpected: `"shared\n"`,
+			wantActual:   `"shared\r\n"`,
+		},
+		{
+			name:         "trailing spaces",
+			expected:     "value",
+			actual:       "value  ",
+			wantExpected: `"value"`,
+			wantActual:   `"value  "`,
+		},
+		{
+			name:         "tab against spaces",
+			expected:     "a\tb",
+			actual:       "a b",
+			wantExpected: `"a\tb"`,
+			wantActual:   `"a b"`,
+		},
+		{
+			name:         "a visible difference is left alone",
+			expected:     "expected text",
+			actual:       "actual text",
+			wantExpected: "expected text",
+			wantActual:   "actual text",
+		},
+		{
+			name:         "identical strings are left alone",
+			expected:     "same",
+			actual:       "same",
+			wantExpected: "same",
+			wantActual:   "same",
+		},
+		{
+			name:         "an empty side is left alone",
+			expected:     "",
+			actual:       "something",
+			wantExpected: "",
+			wantActual:   "something",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotExpected, gotActual := visiblePair(tt.expected, tt.actual)
+			if gotExpected != tt.wantExpected || gotActual != tt.wantActual {
+				t.Errorf("visiblePair(%q, %q) = (%q, %q), want (%q, %q)",
+					tt.expected, tt.actual, gotExpected, gotActual, tt.wantExpected, tt.wantActual)
+			}
+		})
+	}
+}

--- a/internal/report/junit.go
+++ b/internal/report/junit.go
@@ -161,11 +161,12 @@ func detailText(sc *engine.ScenarioResult) string {
 			if diff := checkDiff(ck); diff != "" {
 				fmt.Fprintf(&b, "Diff (-expected +actual):\n%s\n", diff)
 			} else {
-				if ck.Expected != "" {
-					fmt.Fprintf(&b, "Expected: %s\n", ck.Expected)
+				expected, actual := visiblePair(ck.Expected, ck.Actual)
+				if expected != "" {
+					fmt.Fprintf(&b, "Expected: %s\n", expected)
 				}
-				if ck.Actual != "" {
-					fmt.Fprintf(&b, "Actual: %s\n", ck.Actual)
+				if actual != "" {
+					fmt.Fprintf(&b, "Actual: %s\n", actual)
 				}
 			}
 			if ck.Hint != "" {

--- a/test/e2e/atago/file_equals.atago.yaml
+++ b/test/e2e/atago/file_equals.atago.yaml
@@ -169,3 +169,85 @@ scenarios:
           exit_code: 0
           stdout:
             contains: PASSED
+
+  # A byte-exact comparison that fails on a carriage return printed the same two
+  # words twice: the reader could see there was a difference but not what it
+  # was. When the two sides differ only in characters a terminal does not show,
+  # both are quoted.
+  - name: an invisible difference is quoted in the failure output
+    steps:
+      - fixture:
+          file: crlf.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: crlf}
+            scenarios:
+              - name: the file ends with CRLF, the expectation with LF
+                steps:
+                  - fixture:
+                      file: a.txt
+                      base64: c2hhcmVkDQo=
+                  - run: {command: echo hi}
+                  - assert:
+                      file:
+                        path: a.txt
+                        equals: "shared\n"
+      - run:
+          command: ${atago} run crlf.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - '"shared\n"'
+              - '"shared\r\n"'
+
+  - name: a trailing space difference is quoted too
+    steps:
+      - fixture:
+          file: spaces.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: spaces}
+            scenarios:
+              - name: the output carries trailing spaces
+                steps:
+                  - run:
+                      shell: true
+                      command: "printf 'value  '"
+                  - assert:
+                      stdout:
+                        equals: "value"
+      - run:
+          command: ${atago} run spaces.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains: '"value  "'
+
+  - name: an ordinary difference keeps its plain form
+    steps:
+      - fixture:
+          file: plain.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: plain}
+            scenarios:
+              - name: the texts really are different
+                steps:
+                  - run:
+                      shell: true
+                      command: "printf 'actual text'"
+                  - assert:
+                      stdout:
+                        equals: "expected text"
+      - run:
+          command: ${atago} run plain.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "expected text"
+              - "actual text"
+      - assert:
+          stdout:
+            not_contains: '"actual text"'


### PR DESCRIPTION
A byte-exact comparison that failed on a carriage return printed `Expected: shared` and `Actual: shared`. The reader can see that there is a difference and cannot see what it is. The same happens for a trailing space, or a tab against spaces. A multi-line payload escapes this because it renders as a unified diff, but a single-line one — the common case for `equals` — falls back to the compact Expected/Actual block.

When the two sides differ only in characters a terminal does not show, both are now quoted, so the `\r`, the `\t`, or the trailing blank is visible. Only that case is quoted: an ordinary difference keeps its plain, copy-pasteable form, and the rule applies to both sides so they stay comparable. The console and the junit failure body share the helper.

This came out of a real CI failure in this repository: the git suite's clone comparison broke on Windows because of `core.autocrlf`, and the report gave no way to see why.

Tests: table-driven cases for CRLF, trailing spaces, tab-versus-spaces, a visible difference, identical strings, and an empty side; self-hosted E2E that runs nested specs and asserts the quoted rendering appears for the invisible cases and does not for the ordinary one. `make test`, `make lint`, `make e2e`, `make docs` are green.