### PR TITLE
fix(assert): spell a JSON null as null, not <nil>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- A JSON `null` is now spelled `null` in matcher subjects and failure messages
+  instead of Go's `<nil>`. The Go-ism made a message about someone else's
+  document read as a message about atago's implementation, and left `matches`
+  with nothing writable to match a null field against; the `store` path already
+  refused to leak it.
 - A failure whose two sides differ only in invisible characters now quotes both.
   A byte-exact `equals` mismatch between `shared\n` and `shared\r\n` printed the
   same word twice, and the same happened for a trailing space or a tab against

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 421 scenarios
+74 suites · 423 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -211,7 +211,7 @@
   - [a json list fails the inner spec when one listed path mismatches](#scenario-a-json-list-fails-the-inner-spec-when-one-listed-path-mismatches)
   - [a stdout json list against a JSON-producing command](#scenario-a-stdout-json-list-against-a-json-producing-command)
   - [a yaml list asserts several paths on one document](#scenario-a-yaml-list-asserts-several-paths-on-one-document)
-- [atago self-hosting / json matcher boundary values](#atago-self-hosting--json-matcher-boundary-values) — 12 scenarios
+- [atago self-hosting / json matcher boundary values](#atago-self-hosting--json-matcher-boundary-values) — 14 scenarios
   - [an array element is addressable by index](#scenario-an-array-element-is-addressable-by-index)
   - [a top-level array reports its length](#scenario-a-top-level-array-reports-its-length)
   - [an empty array has length zero](#scenario-an-empty-array-has-length-zero)
@@ -224,6 +224,8 @@
   - [a type mismatch failure distinguishes a string from a boolean](#scenario-a-type-mismatch-failure-distinguishes-a-string-from-a-boolean)
   - [a whitespace-only mismatch shows the surrounding spaces](#scenario-a-whitespace-only-mismatch-shows-the-surrounding-spaces)
   - [a numeric mismatch stays unquoted](#scenario-a-numeric-mismatch-stays-unquoted)
+  - [a null value is spelled null, not the Go zero value](#scenario-a-null-value-is-spelled-null-not-the-go-zero-value)
+  - [a failure against a null value names it as null](#scenario-a-failure-against-a-null-value-names-it-as-null)
 - [atago self-hosting / line selector](#atago-self-hosting--line-selector) — 3 scenarios
   - [line selector narrows stdout to a single 1-based line](#scenario-line-selector-narrows-stdout-to-a-single-1-based-line)
   - [a trailing newline does not add a phantom final line](#scenario-a-trailing-newline-does-not-add-a-phantom-final-line)
@@ -4246,6 +4248,35 @@ ${atago} run nums.atago.yaml
 - exit code is `1`
 - stdout contains `$.n == 1`, `$.n = 2`
 - stdout does not contain `"2"`
+### Scenario: a null value is spelled null, not the Go zero value
+#### When
+```shell
+printf '{"v": null}'
+```
+#### Then
+- stdout at `$.v` matches `/^null$/`
+### Scenario: a failure against a null value names it as null
+#### Given
+- Fixture file `nulled.atago.yaml` is created.
+#### Inputs
+_Fixture `nulled.atago.yaml`:_
+```text
+version: "1"
+suite: {name: nulled}
+scenarios:
+  - name: the field is null, the expectation is a string
+    steps:
+      - run: {shell: true, command: 'printf ''{"v": null}'''}
+      - assert: {stdout: {json: [{path: "$.v", equals: "something"}]}}
+```
+#### When
+```shell
+${atago} run nulled.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `$.v = null`
+- stdout does not contain `<nil>`
 ## atago self-hosting / line selector
 Source: `test/e2e/atago/line.atago.yaml`
 ### Scenario: line selector narrows stdout to a single 1-based line

--- a/internal/assert/assert_test.go
+++ b/internal/assert/assert_test.go
@@ -2315,6 +2315,34 @@ func TestCheck_JSONEquals_MismatchNamesTheDifference(t *testing.T) {
 	}
 }
 
+// TestCheck_JSON_NullRendersAsNull pins that a JSON null is spelled the way the
+// document spells it. Go prints nil as "<nil>", which turned a message about
+// someone else's JSON into a message about Go, and made `matches` impossible to
+// write against a null field. The store path already refused to leak it.
+func TestCheck_JSON_NullRendersAsNull(t *testing.T) {
+	t.Parallel()
+	res := &runner.Result{Stdout: []byte(`{"v":null}`)}
+
+	// The subject the regex sees is "null", so a spec can match on it.
+	got := Check(&spec.Assert{Stdout: &spec.StreamAssert{
+		JSON: spec.JSONChecks{{Path: "$.v", Matches: strp("^null$")}},
+	}}, res, Env{})
+	if !got.OK {
+		t.Errorf("matches ^null$ against a JSON null should pass: %s", got.Hint)
+	}
+
+	// And a failing comparison names it as null rather than as a Go value.
+	got = Check(&spec.Assert{Stdout: &spec.StreamAssert{
+		JSON: spec.JSONChecks{{Path: "$.v", Equals: "something"}},
+	}}, res, Env{})
+	if got.OK {
+		t.Fatal("a null value must not equal a string")
+	}
+	if !strings.Contains(got.Actual, "null") || strings.Contains(got.Actual, "<nil>") {
+		t.Errorf("Actual = %q, want it to spell the value null", got.Actual)
+	}
+}
+
 // TestCheck_DirExists_OnAFilePathSaysSo pins the hint for the confusing case: a
 // path that exists as a file reported a bare "exists=false", which reads as
 // "nothing is there" and sends the author looking for output that is sitting

--- a/internal/assert/jsonmatch.go
+++ b/internal/assert/jsonmatch.go
@@ -262,8 +262,6 @@ func displayValue(v any) string {
 	switch t := v.(type) {
 	case string:
 		return strconv.Quote(t)
-	case nil:
-		return "null"
 	default:
 		return renderNode(v)
 	}
@@ -281,6 +279,12 @@ func renderNode(v any) string {
 		return formatNum(t)
 	case float32:
 		return formatNum(float64(t))
+	case nil:
+		// A JSON null is nil in Go, and fmt prints that as "<nil>" — a Go-ism in
+		// a message about someone else's JSON, and a subject the `matches`
+		// matcher could never be written against. The store path already refuses
+		// to leak it; the matchers now spell it the way the document does.
+		return "null"
 	default:
 		return fmt.Sprintf("%v", v)
 	}

--- a/test/e2e/atago/json_matcher_edges.atago.yaml
+++ b/test/e2e/atago/json_matcher_edges.atago.yaml
@@ -179,3 +179,38 @@ scenarios:
       - assert:
           stdout:
             not_contains: '"2"'
+
+  # A JSON null is nil in Go, and Go prints that as "<nil>". Leaking that made
+  # the message about Go rather than about the document under test, and left the
+  # matches matcher with nothing writable to match against.
+  - name: a null value is spelled null, not the Go zero value
+    steps:
+      - run:
+          shell: true
+          command: "printf '{\"v\": null}'"
+      - assert:
+          stdout:
+            json:
+              - path: "$.v"
+                matches: "^null$"
+
+  - name: a failure against a null value names it as null
+    steps:
+      - fixture:
+          file: nulled.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: nulled}
+            scenarios:
+              - name: the field is null, the expectation is a string
+                steps:
+                  - run: {shell: true, command: 'printf ''{"v": null}'''}
+                  - assert: {stdout: {json: [{path: "$.v", equals: "something"}]}}
+      - run: {command: "${atago} run nulled.atago.yaml"}
+      - assert:
+          exit_code: 1
+          stdout:
+            contains: "$.v = null"
+      - assert:
+          stdout:
+            not_contains: "<nil>"


### PR DESCRIPTION
A JSON `null` decodes to `nil`, and `fmt` prints that as `<nil>`. Two consequences: a failure about someone else's document read as a message about atago's Go implementation (`$.v = <nil>`), and the `matches` matcher had nothing writable to aim at a null field, because `^null$` could never match a subject spelled `<nil>`.

The `store` path already treats this leak as a defect and refuses to capture `<nil>` ("would leak a Go-ism into a user-visible variable"). The matchers now agree and render a null the way the document spells it. As a side effect, `matches: "^null$"` becomes a usable way to assert that a field is null — which is otherwise inexpressible, since `equals: null` is indistinguishable from an unset matcher at the loader level (filed separately).

Tests: unit coverage for the matcher subject and for the failure text, which must contain `null` and must not contain `<nil>`; self-hosted E2E for both through a real `atago run`. `make test`, `make lint`, `make docs` are green.