### PR TITLE
fix(assert): find PDF metadata inside a compressed object stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- `pdf: metadata:` now finds the Info dictionary when the producer stores it in
+  a compressed object stream, which every PDF 1.5+ writer does by default —
+  Ghostscript 10, LaTeX, Word. Only the raw bytes were scanned, so a metadata
+  assertion reported "field not present" for an ordinary modern PDF while page
+  count and text extraction (which already go through the decompressed streams)
+  worked. A value stored in the clear still wins over one repeated in a stream.
 - A JSON `null` is now spelled `null` in matcher subjects and failure messages
   instead of Go's `<nil>`. The Go-ism made a message about someone else's
   document read as a message about atago's implementation, and left `matches`

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 423 scenarios
+74 suites · 425 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -304,9 +304,11 @@
   - [a dir assert addresses a nested tree and child by forward-slash path](#scenario-a-dir-assert-addresses-a-nested-tree-and-child-by-forward-slash-path)
   - [equals_file compares two files addressed by forward-slash paths](#scenario-equals_file-compares-two-files-addressed-by-forward-slash-paths)
   - [a redirect path may not escape the workdir via a nested traversal](#scenario-a-redirect-path-may-not-escape-the-workdir-via-a-nested-traversal)
-- [atago self-hosting / pdf assertion](#atago-self-hosting--pdf-assertion) — 2 scenarios
+- [atago self-hosting / pdf assertion](#atago-self-hosting--pdf-assertion) — 4 scenarios
   - [pdf assertions cover page count, metadata, and text](#scenario-pdf-assertions-cover-page-count-metadata-and-text)
   - [a non-pdf file fails the pdf target](#scenario-a-non-pdf-file-fails-the-pdf-target)
+  - [metadata is found inside a compressed object stream](#scenario-metadata-is-found-inside-a-compressed-object-stream)
+  - [a wrong expectation still fails against compressed metadata](#scenario-a-wrong-expectation-still-fails-against-compressed-metadata)
 - [atago self-hosting / pty](#atago-self-hosting--pty) — 8 scenarios
   - [a pty step sees a terminal where a run step sees a pipe](#scenario-a-pty-step-sees-a-terminal-where-a-run-step-sees-a-pipe)
   - [a never-matching expect fails with the pattern in the block](#scenario-a-never-matching-expect-fails-with-the-pattern-in-the-block)
@@ -5488,6 +5490,63 @@ ${atago} version
 ```
 #### Then
 - exit code is `0`
+### Scenario: metadata is found inside a compressed object stream
+#### Given
+- Fixture file `objstm.atago.yaml` is created.
+#### Inputs
+_Fixture `objstm.atago.yaml`:_
+```text
+version: "1"
+suite: {name: objstm}
+scenarios:
+  - name: the title lives in a Flate-compressed object stream
+    steps:
+      - fixture:
+          file: compressed.pdf
+          base64: JVBERi0xLjUKMSAwIG9iago8PCAvVHlwZSAvUGFnZSA+PgplbmRvYmoKMiAwIG9iago8PCAvVHlwZSAvT2JqU3RtIC9OIDEgL0ZpcnN0IDAgL0ZpbHRlciAvRmxhdGVEZWNvZGUgL0xlbmd0aCA1MCA+PgpzdHJlYW0KeJyzsdEPySzJSdVwzs8tKEotLk5NUQALaOo7lpZk5BdpBJcUpSbmKkB4mnZ2AMDhEaAKZW5kc3RyZWFtCmVuZG9iagp0cmFpbGVyCjw8IC9Sb290IDEgMCBSID4+CiUlRU9GCg==
+      - run: {command: echo produced}
+      - assert:
+          pdf:
+            path: compressed.pdf
+            metadata:
+              title: Compressed Title
+              author: Stream Author
+```
+#### When
+```shell
+${atago} run objstm.atago.yaml
+```
+#### Then
+- exit code is `0`
+- stdout contains `PASSED`
+### Scenario: a wrong expectation still fails against compressed metadata
+#### Given
+- Fixture file `wrongmeta.atago.yaml` is created.
+#### Inputs
+_Fixture `wrongmeta.atago.yaml`:_
+```text
+version: "1"
+suite: {name: wrongmeta}
+scenarios:
+  - name: the title is not what the spec claims
+    steps:
+      - fixture:
+          file: compressed.pdf
+          base64: JVBERi0xLjUKMSAwIG9iago8PCAvVHlwZSAvUGFnZSA+PgplbmRvYmoKMiAwIG9iago8PCAvVHlwZSAvT2JqU3RtIC9OIDEgL0ZpcnN0IDAgL0ZpbHRlciAvRmxhdGVEZWNvZGUgL0xlbmd0aCA1MCA+PgpzdHJlYW0KeJyzsdEPySzJSdVwzs8tKEotLk5NUQALaOo7lpZk5BdpBJcUpSbmKkB4mnZ2AMDhEaAKZW5kc3RyZWFtCmVuZG9iagp0cmFpbGVyCjw8IC9Sb290IDEgMCBSID4+CiUlRU9GCg==
+      - run: {command: echo produced}
+      - assert:
+          pdf:
+            path: compressed.pdf
+            metadata:
+              title: Not This Title
+```
+#### When
+```shell
+${atago} run wrongmeta.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `Compressed Title`
 ## atago self-hosting / pty
 Source: `test/e2e/atago/pty.atago.yaml`
 ### Scenario: a pty step sees a terminal where a run step sees a pipe

--- a/internal/assert/pdf.go
+++ b/internal/assert/pdf.go
@@ -137,6 +137,9 @@ var (
 	rePageObj = regexp.MustCompile(`/Type\s*/Page(?:[^s]|$)`)
 	reCount   = regexp.MustCompile(`/Count\s+(\d+)`)
 	reStream  = regexp.MustCompile(`(?s)stream\r?\n(.*?)\r?\nendstream`)
+	// /Type /ObjStm marks a stream that holds document objects (PDF 1.5+), which
+	// is where a modern writer puts the Info dictionary.
+	reObjStm = regexp.MustCompile(`/Type\s*/ObjStm`)
 	// A metadata value is either a "(…)" literal string or a "<…>" hex string.
 	reMetaItem = regexp.MustCompile(`/(Title|Author|Subject|Keywords|Creator|Producer)\s*[(<]`)
 	// A text operand is a "(…)" literal string or a "<…>" hex string (ISO 32000
@@ -166,13 +169,19 @@ func parsePDF(data []byte) pdfDoc {
 	// objects — including the Info dictionary — into a compressed object stream,
 	// so metadata has to be looked for inside them too.
 	var text strings.Builder
-	var decodedStreams [][]byte
-	for _, m := range reStream.FindAllSubmatch(data, -1) {
-		raw := m[1]
+	var objectStreams [][]byte
+	for _, loc := range reStream.FindAllSubmatchIndex(data, -1) {
+		raw := data[loc[2]:loc[3]]
 		decoded := raw
 		if inflated, err := inflate(raw); err == nil {
 			decoded = inflated
-			decodedStreams = append(decodedStreams, decoded)
+			// Only a stream that declares /Type /ObjStm holds document objects.
+			// Any other decompressed stream is page content, where a literal
+			// "/Title(...)" drawn on the page would otherwise be mistaken for
+			// the document's metadata.
+			if isObjectStream(data, loc[0]) {
+				objectStreams = append(objectStreams, decoded)
+			}
 		}
 		for _, lit := range reTextOp.FindAll(decoded, -1) {
 			text.WriteString(decodePDFString(lit))
@@ -186,10 +195,25 @@ func parsePDF(data []byte) pdfDoc {
 	// clear); anything still missing is looked for in the decompressed object
 	// streams, which is where Ghostscript 10, LaTeX, and Word put it.
 	readMetadata(doc.metadata, data, false)
-	for _, decoded := range decodedStreams {
+	for _, decoded := range objectStreams {
 		readMetadata(doc.metadata, decoded, true)
 	}
 	return doc
+}
+
+// objStmWindow is how far back from a `stream` keyword the object's dictionary
+// is looked for. A dictionary is a short header; a window keeps the scan cheap
+// and cannot wander into the previous object's payload for any realistic PDF.
+const objStmWindow = 512
+
+// isObjectStream reports whether the stream starting at streamAt is declared as
+// an object stream by the dictionary that precedes it.
+func isObjectStream(data []byte, streamAt int) bool {
+	start := streamAt - objStmWindow
+	if start < 0 {
+		start = 0
+	}
+	return reObjStm.Match(data[start:streamAt])
 }
 
 // readMetadata pulls the known Info fields out of buf into meta. When keepFirst

--- a/internal/assert/pdf.go
+++ b/internal/assert/pdf.go
@@ -161,13 +161,18 @@ func parsePDF(data []byte) pdfDoc {
 	}
 
 	// Content-stream text: decode every stream (raw + zlib/Flate) and pull the
-	// parenthesized string literals that feed the text-showing operators.
+	// parenthesized string literals that feed the text-showing operators. The
+	// decoded streams are kept: since PDF 1.5 a writer may pack the document's
+	// objects — including the Info dictionary — into a compressed object stream,
+	// so metadata has to be looked for inside them too.
 	var text strings.Builder
+	var decodedStreams [][]byte
 	for _, m := range reStream.FindAllSubmatch(data, -1) {
 		raw := m[1]
 		decoded := raw
 		if inflated, err := inflate(raw); err == nil {
 			decoded = inflated
+			decodedStreams = append(decodedStreams, decoded)
 		}
 		for _, lit := range reTextOp.FindAll(decoded, -1) {
 			text.WriteString(decodePDFString(lit))
@@ -176,15 +181,33 @@ func parsePDF(data []byte) pdfDoc {
 	}
 	doc.text = strings.TrimSpace(text.String())
 
-	// Info metadata: read the parenthesized value after each known field name.
-	for _, loc := range reMetaItem.FindAllSubmatchIndex(data, -1) {
-		field := strings.ToLower(string(data[loc[2]:loc[3]]))
-		// loc[1] is just past the opening delimiter ("(" or "<") of the value.
-		if val, ok := readPDFStringOrHex(data, loc[1]-1); ok {
-			doc.metadata[field] = val
-		}
+	// Info metadata: read the value after each known field name. The raw bytes
+	// come first (a PDF 1.4-style writer leaves the Info dictionary in the
+	// clear); anything still missing is looked for in the decompressed object
+	// streams, which is where Ghostscript 10, LaTeX, and Word put it.
+	readMetadata(doc.metadata, data, false)
+	for _, decoded := range decodedStreams {
+		readMetadata(doc.metadata, decoded, true)
 	}
 	return doc
+}
+
+// readMetadata pulls the known Info fields out of buf into meta. When keepFirst
+// is set, a field already found is not overwritten, so the uncompressed document
+// trailer keeps precedence over whatever a stream repeats.
+func readMetadata(meta map[string]string, buf []byte, keepFirst bool) {
+	for _, loc := range reMetaItem.FindAllSubmatchIndex(buf, -1) {
+		field := strings.ToLower(string(buf[loc[2]:loc[3]]))
+		if keepFirst {
+			if _, ok := meta[field]; ok {
+				continue
+			}
+		}
+		// loc[1] is just past the opening delimiter ("(" or "<") of the value.
+		if val, ok := readPDFStringOrHex(buf, loc[1]-1); ok {
+			meta[field] = val
+		}
+	}
 }
 
 // maxPDFStreamBytes caps how many bytes a single FlateDecode stream may inflate

--- a/internal/assert/pdf_test.go
+++ b/internal/assert/pdf_test.go
@@ -5,6 +5,7 @@ import (
 	"compress/zlib"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/nao1215/atago/internal/spec"
@@ -323,7 +324,7 @@ func TestParsePDF_UncompressedMetadataWins(t *testing.T) {
 	}
 	var pdf bytes.Buffer
 	pdf.WriteString("%PDF-1.5\n1 0 obj\n<< /Type /Page >>\nendobj\n")
-	pdf.WriteString("2 0 obj\n<< /Filter /FlateDecode >>\nstream\n")
+	pdf.WriteString("2 0 obj\n<< /Type /ObjStm /Filter /FlateDecode >>\nstream\n")
 	pdf.Write(buf.Bytes())
 	pdf.WriteString("\nendstream\nendobj\n")
 	pdf.WriteString("3 0 obj\n<< /Title (From The Trailer) >>\nendobj\ntrailer\n<< /Info 3 0 R >>\n%%EOF\n")
@@ -331,5 +332,35 @@ func TestParsePDF_UncompressedMetadataWins(t *testing.T) {
 	doc := parsePDF(pdf.Bytes())
 	if got := doc.metadata["title"]; got != "From The Trailer" {
 		t.Errorf("title = %q, want the uncompressed value", got)
+	}
+}
+
+
+// TestParsePDF_PageContentIsNotMetadata pins that only a declared object stream
+// can supply metadata: a page whose drawn text happens to contain "/Title(...)"
+// must not be mistaken for the document's Info dictionary.
+func TestParsePDF_PageContentIsNotMetadata(t *testing.T) {
+	t.Parallel()
+	payload := []byte("BT (/Title(Drawn On The Page)) Tj ET")
+	var buf bytes.Buffer
+	zw := zlib.NewWriter(&buf)
+	if _, err := zw.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	var pdf bytes.Buffer
+	pdf.WriteString("%PDF-1.5\n1 0 obj\n<< /Type /Page /Contents 2 0 R >>\nendobj\n")
+	pdf.WriteString("2 0 obj\n<< /Filter /FlateDecode >>\nstream\n")
+	pdf.Write(buf.Bytes())
+	pdf.WriteString("\nendstream\nendobj\ntrailer\n<< /Root 1 0 R >>\n%%EOF\n")
+
+	doc := parsePDF(pdf.Bytes())
+	if got, ok := doc.metadata["title"]; ok {
+		t.Errorf("title = %q, want no metadata from a page content stream", got)
+	}
+	if !strings.Contains(doc.text, "Drawn On The Page") {
+		t.Errorf("text = %q, want the drawn text to still be extracted", doc.text)
 	}
 }

--- a/internal/assert/pdf_test.go
+++ b/internal/assert/pdf_test.go
@@ -274,3 +274,62 @@ func TestDecodePDFString_Escapes(t *testing.T) {
 		}
 	}
 }
+
+// TestParsePDF_MetadataInsideObjectStream pins that Info metadata is found when
+// the producer packs it into a compressed object stream, which every PDF 1.5+
+// writer does by default — Ghostscript 10, LaTeX, Word. The parser only scanned
+// the raw bytes, so `metadata:` reported "field not present" for a perfectly
+// ordinary PDF while page count and text (which go through the decompressed
+// streams) worked.
+func TestParsePDF_MetadataInsideObjectStream(t *testing.T) {
+	t.Parallel()
+	payload := []byte("<</Title(Compressed Title)/Author(Stream Author)>>")
+	var buf bytes.Buffer
+	zw := zlib.NewWriter(&buf)
+	if _, err := zw.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	var pdf bytes.Buffer
+	pdf.WriteString("%PDF-1.5\n1 0 obj\n<< /Type /Page >>\nendobj\n")
+	pdf.WriteString("2 0 obj\n<< /Type /ObjStm /Filter /FlateDecode >>\nstream\n")
+	pdf.Write(buf.Bytes())
+	pdf.WriteString("\nendstream\nendobj\ntrailer\n<< /Root 1 0 R >>\n%%EOF\n")
+
+	doc := parsePDF(pdf.Bytes())
+	if got := doc.metadata["title"]; got != "Compressed Title" {
+		t.Errorf("title = %q, want %q", got, "Compressed Title")
+	}
+	if got := doc.metadata["author"]; got != "Stream Author" {
+		t.Errorf("author = %q, want %q", got, "Stream Author")
+	}
+}
+
+// TestParsePDF_UncompressedMetadataWins pins the precedence: a value in the
+// clear (the classic trailer layout) is not overwritten by whatever a stream
+// happens to repeat.
+func TestParsePDF_UncompressedMetadataWins(t *testing.T) {
+	t.Parallel()
+	payload := []byte("<</Title(From The Stream)>>")
+	var buf bytes.Buffer
+	zw := zlib.NewWriter(&buf)
+	if _, err := zw.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	var pdf bytes.Buffer
+	pdf.WriteString("%PDF-1.5\n1 0 obj\n<< /Type /Page >>\nendobj\n")
+	pdf.WriteString("2 0 obj\n<< /Filter /FlateDecode >>\nstream\n")
+	pdf.Write(buf.Bytes())
+	pdf.WriteString("\nendstream\nendobj\n")
+	pdf.WriteString("3 0 obj\n<< /Title (From The Trailer) >>\nendobj\ntrailer\n<< /Info 3 0 R >>\n%%EOF\n")
+
+	doc := parsePDF(pdf.Bytes())
+	if got := doc.metadata["title"]; got != "From The Trailer" {
+		t.Errorf("title = %q, want the uncompressed value", got)
+	}
+}

--- a/internal/assert/pdf_test.go
+++ b/internal/assert/pdf_test.go
@@ -335,7 +335,6 @@ func TestParsePDF_UncompressedMetadataWins(t *testing.T) {
 	}
 }
 
-
 // TestParsePDF_PageContentIsNotMetadata pins that only a declared object stream
 // can supply metadata: a page whose drawn text happens to contain "/Title(...)"
 // must not be mistaken for the document's Info dictionary.

--- a/schema/atago.schema.json
+++ b/schema/atago.schema.json
@@ -1944,7 +1944,7 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "Maps an Info-dictionary field (title, author, subject, keywords, creator, producer; case-insensitive) to a substring its value must contain."
+          "description": "Maps an Info-dictionary field (title, author, subject, keywords, creator, producer; case-insensitive) to a substring its value must contain. The field is read whether the producer leaves the Info dictionary in the clear or packs it into a compressed object stream (PDF 1.5+)."
         },
         "text": {
           "$ref": "#/$defs/stream",

--- a/test/e2e/atago/pdf.atago.yaml
+++ b/test/e2e/atago/pdf.atago.yaml
@@ -57,3 +57,60 @@ scenarios:
           command: ${atago} version
       - assert:
           exit_code: 0
+
+  # Any PDF 1.5+ writer — Ghostscript 10, LaTeX, Word — packs the Info
+  # dictionary into a compressed object stream. The parser only read the raw
+  # bytes, so a metadata assertion reported "field not present" for a perfectly
+  # ordinary PDF while page count and text extraction worked.
+  - name: metadata is found inside a compressed object stream
+    steps:
+      - fixture:
+          file: objstm.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: objstm}
+            scenarios:
+              - name: the title lives in a Flate-compressed object stream
+                steps:
+                  - fixture:
+                      file: compressed.pdf
+                      base64: JVBERi0xLjUKMSAwIG9iago8PCAvVHlwZSAvUGFnZSA+PgplbmRvYmoKMiAwIG9iago8PCAvVHlwZSAvT2JqU3RtIC9OIDEgL0ZpcnN0IDAgL0ZpbHRlciAvRmxhdGVEZWNvZGUgL0xlbmd0aCA1MCA+PgpzdHJlYW0KeJyzsdEPySzJSdVwzs8tKEotLk5NUQALaOo7lpZk5BdpBJcUpSbmKkB4mnZ2AMDhEaAKZW5kc3RyZWFtCmVuZG9iagp0cmFpbGVyCjw8IC9Sb290IDEgMCBSID4+CiUlRU9GCg==
+                  - run: {command: echo produced}
+                  - assert:
+                      pdf:
+                        path: compressed.pdf
+                        metadata:
+                          title: Compressed Title
+                          author: Stream Author
+      - run:
+          command: ${atago} run objstm.atago.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: PASSED
+
+  - name: a wrong expectation still fails against compressed metadata
+    steps:
+      - fixture:
+          file: wrongmeta.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: wrongmeta}
+            scenarios:
+              - name: the title is not what the spec claims
+                steps:
+                  - fixture:
+                      file: compressed.pdf
+                      base64: JVBERi0xLjUKMSAwIG9iago8PCAvVHlwZSAvUGFnZSA+PgplbmRvYmoKMiAwIG9iago8PCAvVHlwZSAvT2JqU3RtIC9OIDEgL0ZpcnN0IDAgL0ZpbHRlciAvRmxhdGVEZWNvZGUgL0xlbmd0aCA1MCA+PgpzdHJlYW0KeJyzsdEPySzJSdVwzs8tKEotLk5NUQALaOo7lpZk5BdpBJcUpSbmKkB4mnZ2AMDhEaAKZW5kc3RyZWFtCmVuZG9iagp0cmFpbGVyCjw8IC9Sb290IDEgMCBSID4+CiUlRU9GCg==
+                  - run: {command: echo produced}
+                  - assert:
+                      pdf:
+                        path: compressed.pdf
+                        metadata:
+                          title: Not This Title
+      - run:
+          command: ${atago} run wrongmeta.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains: "Compressed Title"


### PR DESCRIPTION
Since PDF 1.5 a writer may pack the document's objects — including the Info dictionary — into a Flate-compressed object stream, and every current writer does it by default: Ghostscript 10, LaTeX, Word. The parser scanned only the raw bytes for the Info fields, so `pdf: metadata:` reported "field not present" for a perfectly ordinary PDF, while `pages:` and `text:` worked because those already read the decompressed streams.

The decompressed streams are now searched for metadata as well. A value stored in the clear keeps precedence over one repeated inside a stream, so the classic PDF 1.4 layout behaves exactly as before.

This came out of writing a spec against Ghostscript: `gs -sDEVICE=pdfwrite` with a `DOCINFO pdfmark` produces a PDF whose title atago could not see, and the only way to make the assertion pass was to force `-dCompatibilityLevel=1.4` — which tests the workaround rather than the tool.

Tests: unit coverage for a title and author inside a compressed object stream, and for the uncompressed value winning when both exist; self-hosted E2E with a committed base64 fixture PDF (hand-built, no third-party asset) covering the passing assertion and a wrong expectation that must still fail with the real value shown. `make test`, `make lint`, `make docs` are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PDF metadata extraction for documents that store Info data in compressed object streams.
  * Preserved metadata from uncompressed document sections when duplicate values are present.
* **Documentation**
  * Clarified that PDF metadata can be read from both standard and compressed formats.
* **Tests**
  * Added coverage for compressed metadata extraction and incorrect metadata assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->