### PR TITLE
fix(assert): read a PDF stream that ends without a newline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- `pdf: text:` no longer loses everything after the first stream that ends
+  without a newline. ISO 32000 recommends an EOL before `endstream` but does not
+  require one, and Ghostscript omits it, so the scan ran past the true end of a
+  stream and swallowed the objects that followed: a two-page Ghostscript PDF
+  reported only its first page's words.
 - `pdf: metadata:` now finds the Info dictionary when the producer stores it in
   a compressed object stream, which every PDF 1.5+ writer does by default —
   Ghostscript 10, LaTeX, Word. Only the raw bytes were scanned, so a metadata

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 425 scenarios
+74 suites · 426 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -304,11 +304,12 @@
   - [a dir assert addresses a nested tree and child by forward-slash path](#scenario-a-dir-assert-addresses-a-nested-tree-and-child-by-forward-slash-path)
   - [equals_file compares two files addressed by forward-slash paths](#scenario-equals_file-compares-two-files-addressed-by-forward-slash-paths)
   - [a redirect path may not escape the workdir via a nested traversal](#scenario-a-redirect-path-may-not-escape-the-workdir-via-a-nested-traversal)
-- [atago self-hosting / pdf assertion](#atago-self-hosting--pdf-assertion) — 4 scenarios
+- [atago self-hosting / pdf assertion](#atago-self-hosting--pdf-assertion) — 5 scenarios
   - [pdf assertions cover page count, metadata, and text](#scenario-pdf-assertions-cover-page-count-metadata-and-text)
   - [a non-pdf file fails the pdf target](#scenario-a-non-pdf-file-fails-the-pdf-target)
   - [metadata is found inside a compressed object stream](#scenario-metadata-is-found-inside-a-compressed-object-stream)
   - [a wrong expectation still fails against compressed metadata](#scenario-a-wrong-expectation-still-fails-against-compressed-metadata)
+  - [a stream that ends without a newline does not swallow the next object](#scenario-a-stream-that-ends-without-a-newline-does-not-swallow-the-next-object)
 - [atago self-hosting / pty](#atago-self-hosting--pty) — 8 scenarios
   - [a pty step sees a terminal where a run step sees a pipe](#scenario-a-pty-step-sees-a-terminal-where-a-run-step-sees-a-pipe)
   - [a never-matching expect fails with the pattern in the block](#scenario-a-never-matching-expect-fails-with-the-pattern-in-the-block)
@@ -5547,6 +5548,39 @@ ${atago} run wrongmeta.atago.yaml
 #### Then
 - exit code is `1`
 - stdout contains `Compressed Title`
+### Scenario: a stream that ends without a newline does not swallow the next object
+#### Given
+- Fixture file `nonewline.atago.yaml` is created.
+#### Inputs
+_Fixture `nonewline.atago.yaml`:_
+```text
+version: "1"
+suite: {name: nonewline}
+scenarios:
+  - name: both pages contribute their text
+    steps:
+      - fixture:
+          file: two-pages.pdf
+          base64: JVBERi0xLjUKMSAwIG9iago8PCAvVHlwZSAvUGFnZSA+PgplbmRvYmoKMiAwIG9iago8PCAvRmlsdGVyIC9GbGF0ZURlY29kZSA+PgpzdHJlYW0KeJxzClHQcMssKi5RKEhMT1Uozy9KKdZUCMlScA0BAHn8CLNlbmRzdHJlYW0KZW5kb2JqCjMgMCBvYmoKPDwgL1R5cGUgL1BhZ2UgPj4KZW5kb2JqCjQgMCBvYmoKPDwgL0ZpbHRlciAvRmxhdGVEZWNvZGUgPj4Kc3RyZWFtCniccwpR0AhOTc7PS1EoSExPVSjPL0op1lQIyVJwDQEAgxUJBwplbmRzdHJlYW0KZW5kb2JqCnRyYWlsZXIKPDwgL1Jvb3QgMSAwIFIgPj4KJSVFT0YK
+      - run: {command: echo produced}
+      - assert:
+          pdf:
+            path: two-pages.pdf
+            pages: 2
+      - assert:
+          pdf:
+            path: two-pages.pdf
+            text:
+              contains: ["First 
+… (truncated)
+```
+#### When
+```shell
+${atago} run nonewline.atago.yaml
+```
+#### Then
+- exit code is `0`
+- stdout contains `PASSED`
 ## atago self-hosting / pty
 Source: `test/e2e/atago/pty.atago.yaml`
 ### Scenario: a pty step sees a terminal where a run step sees a pipe

--- a/internal/assert/pdf.go
+++ b/internal/assert/pdf.go
@@ -136,11 +136,15 @@ var (
 	// not match `/Type /Pages`). Whitespace between token parts is flexible.
 	rePageObj = regexp.MustCompile(`/Type\s*/Page(?:[^s]|$)`)
 	reCount   = regexp.MustCompile(`/Count\s+(\d+)`)
+	// A stream's payload starts just after the `stream` keyword and its EOL.
+	reStreamStart = regexp.MustCompile(`stream\r?\n`)
 	// The EOL before `endstream` is recommended by ISO 32000 but not required,
 	// and real producers (Ghostscript) omit it. Requiring it made the scan run
 	// past the true end of a stream and swallow the following objects, so a
 	// document's later pages contributed no text at all.
-	reStream = regexp.MustCompile(`(?s)stream\r?\n(.*?)\r?\n?endstream`)
+	reEndStream = regexp.MustCompile(`\r?\n?endstream`)
+	// A direct (non-indirect) stream length: authoritative when present.
+	reDirectLength = regexp.MustCompile(`/Length\s+(\d+)\s*(?:/|>>)`)
 	// /Type /ObjStm marks a stream that holds document objects (PDF 1.5+), which
 	// is where a modern writer puts the Info dictionary.
 	reObjStm = regexp.MustCompile(`/Type\s*/ObjStm`)
@@ -174,16 +178,15 @@ func parsePDF(data []byte) pdfDoc {
 	// so metadata has to be looked for inside them too.
 	var text strings.Builder
 	var objectStreams [][]byte
-	for _, loc := range reStream.FindAllSubmatchIndex(data, -1) {
-		raw := data[loc[2]:loc[3]]
-		decoded := raw
-		if inflated, err := inflate(raw); err == nil {
+	for _, st := range pdfStreams(data) {
+		decoded := st.payload
+		if inflated, err := inflate(st.payload); err == nil {
 			decoded = inflated
 			// Only a stream that declares /Type /ObjStm holds document objects.
 			// Any other decompressed stream is page content, where a literal
 			// "/Title(...)" drawn on the page would otherwise be mistaken for
 			// the document's metadata.
-			if isObjectStream(data, loc[0]) {
+			if reObjStm.Match(st.dict) {
 				objectStreams = append(objectStreams, decoded)
 			}
 		}
@@ -205,19 +208,67 @@ func parsePDF(data []byte) pdfDoc {
 	return doc
 }
 
-// objStmWindow is how far back from a `stream` keyword the object's dictionary
-// is looked for. A dictionary is a short header; a window keeps the scan cheap
-// and cannot wander into the previous object's payload for any realistic PDF.
-const objStmWindow = 512
+// dictWindow is how far back from a `stream` keyword the object's dictionary is
+// looked for. A dictionary is a short header; a window keeps the scan cheap and
+// cannot wander into the previous object's payload for any realistic PDF.
+const dictWindow = 512
 
-// isObjectStream reports whether the stream starting at streamAt is declared as
-// an object stream by the dictionary that precedes it.
-func isObjectStream(data []byte, streamAt int) bool {
-	start := streamAt - objStmWindow
-	if start < 0 {
-		start = 0
+// pdfStream is one stream object: its payload and the dictionary that declared
+// it (used to tell an object stream from page content).
+type pdfStream struct {
+	dict    []byte
+	payload []byte
+}
+
+// pdfStreams walks the file and returns every stream object. The payload's end
+// comes from the dictionary's /Length when that is a direct integer, which is
+// authoritative and survives a payload that happens to contain the bytes
+// "endstream"; otherwise — a producer that writes an indirect length, as
+// Ghostscript does for page content — it falls back to the next `endstream`
+// keyword. Scanning resumes past each stream, so the keyword search can never
+// start inside a payload it has already consumed.
+func pdfStreams(data []byte) []pdfStream {
+	var out []pdfStream
+	for pos := 0; pos < len(data); {
+		loc := reStreamStart.FindIndex(data[pos:])
+		if loc == nil {
+			break
+		}
+		keywordAt := pos + loc[0]
+		payloadAt := pos + loc[1]
+		dictFrom := keywordAt - dictWindow
+		if dictFrom < 0 {
+			dictFrom = 0
+		}
+		dict := data[dictFrom:keywordAt]
+
+		end, resume := streamEnd(data, dict, payloadAt)
+		if end < 0 {
+			break
+		}
+		out = append(out, pdfStream{dict: dict, payload: data[payloadAt:end]})
+		pos = resume
 	}
-	return reObjStm.Match(data[start:streamAt])
+	return out
+}
+
+// streamEnd returns where the payload starting at payloadAt ends and where the
+// scan should resume. It prefers the declared /Length, verifying that the
+// `endstream` keyword really follows, and falls back to the keyword search.
+// (-1, 0) means no terminator was found at all.
+func streamEnd(data, dict []byte, payloadAt int) (end, resume int) {
+	if m := reDirectLength.FindSubmatch(dict); m != nil {
+		if n, err := strconv.Atoi(string(m[1])); err == nil && n >= 0 && payloadAt+n <= len(data) {
+			if tail := reEndStream.FindIndex(data[payloadAt+n:]); tail != nil && tail[0] == 0 {
+				return payloadAt + n, payloadAt + n + tail[1]
+			}
+		}
+	}
+	tail := reEndStream.FindIndex(data[payloadAt:])
+	if tail == nil {
+		return -1, 0
+	}
+	return payloadAt + tail[0], payloadAt + tail[1]
 }
 
 // readMetadata pulls the known Info fields out of buf into meta. When keepFirst

--- a/internal/assert/pdf.go
+++ b/internal/assert/pdf.go
@@ -136,7 +136,11 @@ var (
 	// not match `/Type /Pages`). Whitespace between token parts is flexible.
 	rePageObj = regexp.MustCompile(`/Type\s*/Page(?:[^s]|$)`)
 	reCount   = regexp.MustCompile(`/Count\s+(\d+)`)
-	reStream  = regexp.MustCompile(`(?s)stream\r?\n(.*?)\r?\nendstream`)
+	// The EOL before `endstream` is recommended by ISO 32000 but not required,
+	// and real producers (Ghostscript) omit it. Requiring it made the scan run
+	// past the true end of a stream and swallow the following objects, so a
+	// document's later pages contributed no text at all.
+	reStream = regexp.MustCompile(`(?s)stream\r?\n(.*?)\r?\n?endstream`)
 	// /Type /ObjStm marks a stream that holds document objects (PDF 1.5+), which
 	// is where a modern writer puts the Info dictionary.
 	reObjStm = regexp.MustCompile(`/Type\s*/ObjStm`)

--- a/internal/assert/pdf_test.go
+++ b/internal/assert/pdf_test.go
@@ -363,3 +363,46 @@ func TestParsePDF_PageContentIsNotMetadata(t *testing.T) {
 		t.Errorf("text = %q, want the drawn text to still be extracted", doc.text)
 	}
 }
+
+// TestParsePDF_StreamWithoutTrailingNewline is a regression: ISO 32000
+// recommends an EOL before `endstream` but does not require one, and
+// Ghostscript omits it. Requiring the newline made the scan run past the true
+// end of a stream, swallow the objects that followed, and silently drop their
+// text — a two-page document reported only its first page's words.
+func TestParsePDF_StreamWithoutTrailingNewline(t *testing.T) {
+	t.Parallel()
+	deflate := func(payload string) []byte {
+		var buf bytes.Buffer
+		zw := zlib.NewWriter(&buf)
+		if _, err := zw.Write([]byte(payload)); err != nil {
+			t.Fatal(err)
+		}
+		if err := zw.Close(); err != nil {
+			t.Fatal(err)
+		}
+		return buf.Bytes()
+	}
+
+	var pdf bytes.Buffer
+	pdf.WriteString("%PDF-1.5\n")
+	pdf.WriteString("1 0 obj\n<< /Type /Page >>\nendobj\n")
+	// First page content: no EOL between the payload and `endstream`.
+	pdf.WriteString("2 0 obj\n<< /Filter /FlateDecode >>\nstream\n")
+	pdf.Write(deflate("BT (First page words) Tj ET"))
+	pdf.WriteString("endstream\nendobj\n")
+	pdf.WriteString("3 0 obj\n<< /Type /Page >>\nendobj\n")
+	pdf.WriteString("4 0 obj\n<< /Filter /FlateDecode >>\nstream\n")
+	pdf.Write(deflate("BT (Second page words) Tj ET"))
+	pdf.WriteString("\nendstream\nendobj\n")
+	pdf.WriteString("trailer\n<< /Root 1 0 R >>\n%%EOF\n")
+
+	doc := parsePDF(pdf.Bytes())
+	if doc.pages != 2 {
+		t.Errorf("pages = %d, want 2", doc.pages)
+	}
+	for _, want := range []string{"First page words", "Second page words"} {
+		if !strings.Contains(doc.text, want) {
+			t.Errorf("text = %q, want it to contain %q", doc.text, want)
+		}
+	}
+}

--- a/internal/assert/pdf_test.go
+++ b/internal/assert/pdf_test.go
@@ -3,6 +3,7 @@ package assert
 import (
 	"bytes"
 	"compress/zlib"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -401,6 +402,27 @@ func TestParsePDF_StreamWithoutTrailingNewline(t *testing.T) {
 		t.Errorf("pages = %d, want 2", doc.pages)
 	}
 	for _, want := range []string{"First page words", "Second page words"} {
+		if !strings.Contains(doc.text, want) {
+			t.Errorf("text = %q, want it to contain %q", doc.text, want)
+		}
+	}
+}
+
+// TestParsePDF_LengthWinsOverEndstreamInPayload pins that a declared /Length is
+// authoritative: a payload that itself contains the bytes "endstream" — drawn
+// text, or compressed data that happens to spell it — must not truncate the
+// stream.
+func TestParsePDF_LengthWinsOverEndstreamInPayload(t *testing.T) {
+	t.Parallel()
+	payload := "BT (endstream is drawn here) Tj ET BT (after the trap) Tj ET"
+	var pdf bytes.Buffer
+	pdf.WriteString("%PDF-1.4\n1 0 obj\n<< /Type /Page >>\nendobj\n")
+	fmt.Fprintf(&pdf, "2 0 obj\n<< /Length %d >>\nstream\n", len(payload))
+	pdf.WriteString(payload)
+	pdf.WriteString("\nendstream\nendobj\ntrailer\n<< /Root 1 0 R >>\n%%EOF\n")
+
+	doc := parsePDF(pdf.Bytes())
+	for _, want := range []string{"endstream is drawn here", "after the trap"} {
 		if !strings.Contains(doc.text, want) {
 			t.Errorf("text = %q, want it to contain %q", doc.text, want)
 		}

--- a/test/e2e/atago/pdf.atago.yaml
+++ b/test/e2e/atago/pdf.atago.yaml
@@ -114,3 +114,37 @@ scenarios:
           exit_code: 1
           stdout:
             contains: "Compressed Title"
+
+  # ISO 32000 recommends an EOL before `endstream` but does not require one, and
+  # Ghostscript omits it. Requiring it made the scan run past the true end of a
+  # stream and swallow the objects that followed, so a document reported only
+  # its first page's words while the later pages contributed nothing.
+  - name: a stream that ends without a newline does not swallow the next object
+    steps:
+      - fixture:
+          file: nonewline.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: nonewline}
+            scenarios:
+              - name: both pages contribute their text
+                steps:
+                  - fixture:
+                      file: two-pages.pdf
+                      base64: JVBERi0xLjUKMSAwIG9iago8PCAvVHlwZSAvUGFnZSA+PgplbmRvYmoKMiAwIG9iago8PCAvRmlsdGVyIC9GbGF0ZURlY29kZSA+PgpzdHJlYW0KeJxzClHQcMssKi5RKEhMT1Uozy9KKdZUCMlScA0BAHn8CLNlbmRzdHJlYW0KZW5kb2JqCjMgMCBvYmoKPDwgL1R5cGUgL1BhZ2UgPj4KZW5kb2JqCjQgMCBvYmoKPDwgL0ZpbHRlciAvRmxhdGVEZWNvZGUgPj4Kc3RyZWFtCniccwpR0AhOTc7PS1EoSExPVSjPL0op1lQIyVJwDQEAgxUJBwplbmRzdHJlYW0KZW5kb2JqCnRyYWlsZXIKPDwgL1Jvb3QgMSAwIFIgPj4KJSVFT0YK
+                  - run: {command: echo produced}
+                  - assert:
+                      pdf:
+                        path: two-pages.pdf
+                        pages: 2
+                  - assert:
+                      pdf:
+                        path: two-pages.pdf
+                        text:
+                          contains: ["First page words", "Second page words"]
+      - run:
+          command: ${atago} run nonewline.atago.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: PASSED


### PR DESCRIPTION
ISO 32000 recommends an EOL between a stream's data and `endstream` but does not require one, and Ghostscript omits it. The scanner required it, so it ran past the true end of the stream, swallowed every object up to the next newline-terminated `endstream`, and lost their content. The visible effect: a two-page Ghostscript PDF reported only its first page's words, and a merged document reported only the first source's — with no error to explain the absence.

Making the trailing newline optional pairs each stream with its own `endstream`. A stream that does terminate with a newline matches exactly as before, because the optional group still consumes it.

Found while writing a third-party spec against Ghostscript: `pdf: text: contains` passed for the first page and failed for the second, in a document where both pages plainly contained their text.

Tests: a unit test that builds a two-page PDF whose first stream ends without a newline and requires both pages to contribute text; self-hosted E2E over the same document as a committed base64 fixture (hand-built, no third-party asset). `make test`, `make lint`, `make docs` are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF text extraction for streams ending without a trailing newline.
  * Ensures subsequent PDF objects and pages are read correctly instead of being skipped.

* **Tests**
  * Added coverage for multi-page PDFs with streams that omit the recommended newline before `endstream`.
  * Added an end-to-end scenario verifying page counts and text from all pages.

* **Documentation**
  * Updated the changelog and end-to-end scenario documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->