### PR TITLE
refactor: make counted nouns agree, from one place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,15 @@ and this project follows [Semantic Versioning](https://semver.org/).
   behaviors. Inputs are synthesized with `xc:` canvases, so the suite carries no
   image assets.
 
+### Changed
+
+- Counted nouns in messages now agree with their number: "1 page" instead of
+  "1 pages", "1 entry" instead of "1 entries", "1 line" instead of
+  "1 line(s)", and `atago record` reports "1 file created" rather than
+  "1 file(s) created". Three packages had spelled this three different ways;
+  they now share one helper, so a reader never has to notice which part of
+  atago wrote a sentence.
+
 ### Fixed
 
 - `pdf: text:` no longer loses everything after the first stream that ends

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1761,7 +1761,7 @@ mkdir -p site/assets && printf '<html>' > site/index.html && printf '<html>' > s
 ```
 #### Then
 - exit code is `0`
-- dir `site` exists, contains `index.html`, contains `about.html`, contains `assets/app.css`, does not contain `secret.txt`, has 3 entries, has >= 1 entries, has <= 10 entries, matches glob `*.html`
+- dir `site` exists, contains `index.html`, contains `about.html`, contains `assets/app.css`, does not contain `secret.txt`, has 3 entries, has >= 1 entry, has <= 10 entries, matches glob `*.html`
 ### Scenario: a missing directory can be asserted absent
 #### Then
 - dir `never-created` does not exist
@@ -5476,7 +5476,7 @@ trailer
 … (truncated, 2 more lines)
 ```
 #### Then
-- pdf `report.pdf` 1 pages, >= 1 pages, <= 3 pages, author contains `atago`, title contains `Quarterly`, text contains `Hello atago report`
+- pdf `report.pdf` 1 page, >= 1 page, <= 3 pages, author contains `atago`, title contains `Quarterly`, text contains `Hello atago report`
 ### Scenario: a non-pdf file fails the pdf target
 #### Given
 - Fixture file `notpdf.txt` is created.

--- a/doc/e2e/career.md
+++ b/doc/e2e/career.md
@@ -108,7 +108,7 @@ head -c 4 cv.pdf
 #### Then
 - after `head -c 4 cv.pdf`:
   - stdout equals an exact value
-  - pdf `cv.pdf` >= 1 pages
+  - pdf `cv.pdf` >= 1 page
 ### Scenario: japanese-resume renders a PDF from a positional input
 #### When
 ```shell

--- a/doc/e2e/ghostscript.md
+++ b/doc/e2e/ghostscript.md
@@ -100,7 +100,7 @@ gs -q -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -dFirstPage=2 -dLastPage=2 -o second.p
   - pdf `whole.pdf` 2 pages
 - after `gs -q -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -dFirstPage=2 -dLastPage=2 -o second.pdf whole.pdf`:
   - exit code is `0`
-  - pdf `second.pdf` 1 pages
+  - pdf `second.pdf` 1 page
   - pdf `second.pdf` text contains `Second page marker`
   - pdf `second.pdf` text does not contain `First page marker`
 ### Scenario: merging two documents yields the sum of their pages
@@ -134,7 +134,7 @@ gs -q -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -o merged.pdf one.pdf two.pdf
 #### Then
 - after `gs -q -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -o one.pdf one.ps`:
   - exit code is `0`
-  - pdf `one.pdf` 1 pages
+  - pdf `one.pdf` 1 page
 - after `gs -q -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -o two.pdf two.ps`:
   - exit code is `0`
   - pdf `two.pdf` 2 pages
@@ -252,7 +252,7 @@ gs -q -dNOPAUSE -dBATCH -sDEVICE=pdfwrite -o out.pdf broken.ps
 #### Then
 - exit code is `1`
 - stderr contains `Unrecoverable error`
-- pdf `out.pdf` 1 pages
+- pdf `out.pdf` 1 page
 - pdf `out.pdf` text does not contain `this is not postscript`
 ### Scenario: an unknown device is refused
 _only when `gs --version` succeeds_

--- a/internal/assert/assert_test.go
+++ b/internal/assert/assert_test.go
@@ -1792,9 +1792,6 @@ func TestMockFilterLabelAndPlural(t *testing.T) {
 			t.Errorf("mockFilterLabel = %q, want %q", got, c.want)
 		}
 	}
-	if plural("request", 1) != "request" || plural("request", 0) != "requests" || plural("request", 2) != "requests" {
-		t.Error("plural wrong")
-	}
 	if summarizeRecords(nil) != "  (no requests recorded)" {
 		t.Error("empty summarizeRecords wrong")
 	}

--- a/internal/assert/dir.go
+++ b/internal/assert/dir.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/nao1215/atago/internal/plural"
 	"github.com/nao1215/atago/internal/security"
 	"github.com/nao1215/atago/internal/spec"
 )
@@ -141,13 +142,13 @@ func checkDirCounts(d *spec.DirAssert, dirPath string) *CheckResult {
 	}
 	n := len(entries)
 	if d.Count != nil && n != *d.Count {
-		return dirCountFailure(d, n, fmt.Sprintf("exactly %d entries", *d.Count), dirListing(dirPath))
+		return dirCountFailure(d, n, "exactly "+plural.Count(*d.Count, "entry", "entries"), dirListing(dirPath))
 	}
 	if d.MinCount != nil && n < *d.MinCount {
-		return dirCountFailure(d, n, fmt.Sprintf("at least %d entries", *d.MinCount), dirListing(dirPath))
+		return dirCountFailure(d, n, "at least "+plural.Count(*d.MinCount, "entry", "entries"), dirListing(dirPath))
 	}
 	if d.MaxCount != nil && n > *d.MaxCount {
-		return dirCountFailure(d, n, fmt.Sprintf("at most %d entries", *d.MaxCount), dirListing(dirPath))
+		return dirCountFailure(d, n, "at most "+plural.Count(*d.MaxCount, "entry", "entries"), dirListing(dirPath))
 	}
 	return nil
 }
@@ -157,17 +158,8 @@ func dirCountFailure(d *spec.DirAssert, got int, want, listing string) *CheckRes
 		Desc:     fmt.Sprintf("assert dir %q entry count", d.Path),
 		Expected: want,
 		Actual:   listing,
-		Hint:     fmt.Sprintf("directory %q has %s, expected %s", d.Path, pluralEntries(got), want),
+		Hint:     fmt.Sprintf("directory %q has %s, expected %s", d.Path, plural.Count(got, "entry", "entries"), want),
 	}
-}
-
-// pluralEntries renders an entry count with the right noun, so a failure reads
-// "has 1 entry" instead of "has 1 entries".
-func pluralEntries(n int) string {
-	if n == 1 {
-		return "1 entry"
-	}
-	return fmt.Sprintf("%d entries", n)
 }
 
 func checkDirGlob(d *spec.DirAssert, dirPath string) *CheckResult {

--- a/internal/assert/jsonmatch.go
+++ b/internal/assert/jsonmatch.go
@@ -12,6 +12,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/goccy/go-yaml"
+	"github.com/nao1215/atago/internal/plural"
 	"github.com/nao1215/atago/internal/spec"
 	"github.com/ohler55/ojg/jp"
 	"github.com/ohler55/ojg/oj"
@@ -351,8 +352,8 @@ func single(desc, path string, nodes []any) (any, *CheckResult) {
 		return nil, &CheckResult{
 			Desc:     desc,
 			Expected: fmt.Sprintf("a single value at %s", path),
-			Actual:   fmt.Sprintf("%d matches", len(nodes)),
-			Hint:     fmt.Sprintf("JSON path %s selected %d values; use a more specific path", path, len(nodes)),
+			Actual:   plural.Count(len(nodes), "match", "matches"),
+			Hint:     fmt.Sprintf("JSON path %s selected %s; use a more specific path", path, plural.Count(len(nodes), "value", "values")),
 		}
 	}
 }

--- a/internal/assert/mock.go
+++ b/internal/assert/mock.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/nao1215/atago/internal/plural"
 	"github.com/nao1215/atago/internal/runner/mock"
 	"github.com/nao1215/atago/internal/spec"
 )
@@ -35,11 +36,11 @@ func checkMock(m *spec.MockAssert, env Env) *CheckResult {
 
 	filter := mockFilterLabel(m)
 	if m.Count != nil {
-		desc := fmt.Sprintf("assert mock %q received %d %s", m.Name, *m.Count, plural("request", *m.Count))
+		desc := fmt.Sprintf("assert mock %q received %s", m.Name, plural.Count(*m.Count, "request", "requests"))
 		if len(matched) != *m.Count {
 			return &CheckResult{
 				Desc:     desc,
-				Expected: fmt.Sprintf("%d %s %s", *m.Count, plural("request", *m.Count), filter),
+				Expected: fmt.Sprintf("%s %s", plural.Count(*m.Count, "request", "requests"), filter),
 				Actual:   fmt.Sprintf("%d matching of %d recorded:\n%s", len(matched), len(records), summarizeRecords(records)),
 				Hint:     "the CLI under test did not send the expected number of matching requests",
 			}
@@ -72,7 +73,7 @@ func checkMock(m *spec.MockAssert, env Env) *CheckResult {
 		}
 	}
 	if m.Count != nil {
-		return pass(fmt.Sprintf("assert mock %q received %d %s", m.Name, *m.Count, plural("request", *m.Count)))
+		return pass(fmt.Sprintf("assert mock %q received %s", m.Name, plural.Count(*m.Count, "request", "requests")))
 	}
 	return pass(desc + " received a matching request")
 }
@@ -102,11 +103,4 @@ func summarizeRecords(records []mock.Record) string {
 		fmt.Fprintf(&b, "  %d: %s %s -> %d\n", i+1, r.Method, r.Path, r.Status)
 	}
 	return strings.TrimRight(b.String(), "\n")
-}
-
-func plural(word string, n int) string {
-	if n == 1 {
-		return word
-	}
-	return word + "s"
 }

--- a/internal/assert/pdf.go
+++ b/internal/assert/pdf.go
@@ -7,9 +7,11 @@ import (
 	"io"
 	"os"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
+	"github.com/nao1215/atago/internal/plural"
 	"github.com/nao1215/atago/internal/security"
 	"github.com/nao1215/atago/internal/spec"
 )
@@ -68,18 +70,18 @@ func checkPDFPages(p *spec.PDFAssert, doc pdfDoc) *CheckResult {
 		return &CheckResult{
 			Desc:     fmt.Sprintf("assert pdf %q page count", p.Path),
 			Expected: want,
-			Actual:   fmt.Sprintf("%d pages", n),
-			Hint:     fmt.Sprintf("PDF %q has %d pages, expected %s", p.Path, n, want),
+			Actual:   plural.Count(n, "page", "pages"),
+			Hint:     fmt.Sprintf("PDF %q has %s, expected %s", p.Path, plural.Count(n, "page", "pages"), want),
 		}
 	}
 	if p.Pages != nil && n != *p.Pages {
-		return fail(fmt.Sprintf("exactly %d pages", *p.Pages))
+		return fail("exactly " + plural.Count(*p.Pages, "page", "pages"))
 	}
 	if p.MinPages != nil && n < *p.MinPages {
-		return fail(fmt.Sprintf("at least %d pages", *p.MinPages))
+		return fail("at least " + plural.Count(*p.MinPages, "page", "pages"))
 	}
 	if p.MaxPages != nil && n > *p.MaxPages {
-		return fail(fmt.Sprintf("at most %d pages", *p.MaxPages))
+		return fail("at most " + plural.Count(*p.MaxPages, "page", "pages"))
 	}
 	return nil
 }
@@ -113,13 +115,7 @@ func sortedMetadataKeys(m map[string]string) []string {
 		keys = append(keys, k)
 	}
 	// Deterministic order so a failing metadata check is stable.
-	for i := 0; i < len(keys); i++ {
-		for j := i + 1; j < len(keys); j++ {
-			if keys[j] < keys[i] {
-				keys[i], keys[j] = keys[j], keys[i]
-			}
-		}
-	}
+	sort.Strings(keys)
 	return keys
 }
 

--- a/internal/assert/stream.go
+++ b/internal/assert/stream.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/nao1215/atago/internal/plural"
 	"github.com/nao1215/atago/internal/spec"
 )
 
@@ -42,7 +43,7 @@ func checkStream(name string, s *spec.StreamAssert, data []byte, hasData bool, e
 				Desc:     fmt.Sprintf("assert %s line %d", name, *s.Line),
 				Expected: fmt.Sprintf("%s to have a line %d", name, *s.Line),
 				Actual:   excerpt(got),
-				Hint:     fmt.Sprintf("%s has only %d line(s); line %d is out of range", name, countLines(got), *s.Line),
+				Hint:     fmt.Sprintf("%s has only %s; line %d is out of range", name, plural.Count(countLines(got), "line", "lines"), *s.Line),
 			}
 		}
 		got = line

--- a/internal/assertdesc/describe.go
+++ b/internal/assertdesc/describe.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/nao1215/atago/internal/plural"
 	"github.com/nao1215/atago/internal/spec"
 )
 
@@ -35,6 +36,15 @@ type JSONStyle struct {
 	Length  func(int) string
 	Compare func(string, any) string
 	Default string
+}
+
+// WithPrefix returns a copy of the style that renders the path differently —
+// the only thing that separates a YAML check from a JSON one. Copying the whole
+// struct field by field to change one function meant a field added later was
+// silently dropped from the copy.
+func (s JSONStyle) WithPrefix(prefix func(string) string) JSONStyle {
+	s.Prefix = prefix
+	return s
 }
 
 func DescribeJSONChecks(list spec.JSONChecks, style JSONStyle) string {
@@ -242,13 +252,13 @@ func DescribeDir(d *spec.DirAssert, style DirStyle) string {
 		parts = append(parts, "does not contain "+style.Item(c))
 	}
 	if d.Count != nil {
-		parts = append(parts, fmt.Sprintf("has %d entries", *d.Count))
+		parts = append(parts, "has "+plural.Count(*d.Count, "entry", "entries"))
 	}
 	if d.MinCount != nil {
-		parts = append(parts, fmt.Sprintf("has >= %d entries", *d.MinCount))
+		parts = append(parts, "has >= "+plural.Count(*d.MinCount, "entry", "entries"))
 	}
 	if d.MaxCount != nil {
-		parts = append(parts, fmt.Sprintf("has <= %d entries", *d.MaxCount))
+		parts = append(parts, "has <= "+plural.Count(*d.MaxCount, "entry", "entries"))
 	}
 	if d.Glob != "" {
 		parts = append(parts, "matches glob "+style.Token(d.Glob))
@@ -278,13 +288,13 @@ type PDFStyle struct {
 func DescribePDF(p *spec.PDFAssert, style PDFStyle) string {
 	var parts []string
 	if p.Pages != nil {
-		parts = append(parts, fmt.Sprintf("%d pages", *p.Pages))
+		parts = append(parts, plural.Count(*p.Pages, "page", "pages"))
 	}
 	if p.MinPages != nil {
-		parts = append(parts, fmt.Sprintf(">= %d pages", *p.MinPages))
+		parts = append(parts, ">= "+plural.Count(*p.MinPages, "page", "pages"))
 	}
 	if p.MaxPages != nil {
-		parts = append(parts, fmt.Sprintf("<= %d pages", *p.MaxPages))
+		parts = append(parts, "<= "+plural.Count(*p.MaxPages, "page", "pages"))
 	}
 	keys := make([]string, 0, len(p.Metadata))
 	for k := range p.Metadata {

--- a/internal/assertdesc/describe_test.go
+++ b/internal/assertdesc/describe_test.go
@@ -256,3 +256,34 @@ func strptr(s string) *string   { return &s }
 func intptr(n int) *int         { return &n }
 func boolptr(b bool) *bool      { return &b }
 func f64ptr(f float64) *float64 { return &f }
+
+// TestJSONStyle_WithPrefix pins that only the path prefix changes: the YAML
+// variant of a JSON style used to be a field-by-field copy, so a field added
+// later was silently dropped from it.
+func TestJSONStyle_WithPrefix(t *testing.T) {
+	t.Parallel()
+	base := JSONStyle{
+		Prefix:  func(path string) string { return "at " + path },
+		Equals:  func(v any) string { return fmt.Sprintf("== %v", v) },
+		Matches: func(s string) string { return "matches " + s },
+		Length:  func(n int) string { return fmt.Sprintf("length %d", n) },
+		Compare: func(op string, v any) string { return fmt.Sprintf("%s %v", op, v) },
+		Default: "checked",
+	}
+	yaml := base.WithPrefix(func(path string) string { return "YAML " + path })
+
+	checks := spec.JSONChecks{{Path: "$.n", Equals: 3}}
+	if got := DescribeJSONChecks(checks, base); got != "at $.n == 3" {
+		t.Errorf("base = %q", got)
+	}
+	if got := DescribeJSONChecks(checks, yaml); got != "YAML $.n == 3" {
+		t.Errorf("with prefix = %q, want only the prefix to change", got)
+	}
+	// The original is untouched: WithPrefix returns a copy.
+	if got := DescribeJSONChecks(checks, base); got != "at $.n == 3" {
+		t.Errorf("base after WithPrefix = %q, want it unchanged", got)
+	}
+	if yaml.Default != base.Default {
+		t.Errorf("Default = %q, want the base value %q carried over", yaml.Default, base.Default)
+	}
+}

--- a/internal/cli/record.go
+++ b/internal/cli/record.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nao1215/atago/internal/plural"
 	"github.com/nao1215/atago/internal/record"
 	runnercmd "github.com/nao1215/atago/internal/runner/cmd"
 	"github.com/nao1215/atago/internal/snapshot"
@@ -127,8 +128,10 @@ non-goal for now — write those steps by hand.
 		return ExitInternal
 	}
 
-	fmt.Fprintf(stderr, "recorded: exit %d, %d stdout line(s), %d file(s) created\n",
-		res.ExitCode, countLines(res.Stdout), len(created))
+	fmt.Fprintf(stderr, "recorded: exit %d, %s of stdout, %s created\n",
+		res.ExitCode,
+		plural.Count(countLines(res.Stdout), "line", "lines"),
+		plural.Count(len(created), "file", "files"))
 
 	if *out == "" {
 		fmt.Fprint(stdout, string(generated))

--- a/internal/docgen/describe.go
+++ b/internal/docgen/describe.go
@@ -31,14 +31,9 @@ var docgenJSONStyle = assertdesc.JSONStyle{
 	Default: "is checked",
 }
 
-var docgenYAMLStyle = assertdesc.JSONStyle{
-	Prefix:  func(path string) string { return "YAML at " + markdown.Code(path) },
-	Equals:  docgenJSONStyle.Equals,
-	Matches: docgenJSONStyle.Matches,
-	Length:  docgenJSONStyle.Length,
-	Compare: docgenJSONStyle.Compare,
-	Default: docgenJSONStyle.Default,
-}
+var docgenYAMLStyle = docgenJSONStyle.WithPrefix(func(path string) string {
+	return "YAML at " + markdown.Code(path)
+})
 
 var docgenStreamStyle = assertdesc.StreamStyle{
 	List:      codeList,

--- a/internal/docgen/docgen_test.go
+++ b/internal/docgen/docgen_test.go
@@ -639,12 +639,12 @@ func TestDescribeTarget_MatcherMatrix(t *testing.T) {
 		{"mock no route", &spec.Assert{Mock: &spec.MockAssert{Name: "api"}}, "mock `api` received a request"},
 		// dir constraints
 		{"dir", &spec.Assert{Dir: &spec.DirAssert{Path: "site", Exists: boolptr(true), Contains: []string{"index.html"}, NotContains: []string{"tmp"}, Count: intptr(3), MinCount: intptr(1), MaxCount: intptr(9), Glob: "*.html", Recursive: true, Snapshot: "tree.snap", Ignore: []string{"*.log"}}},
-			"dir `site` exists, contains `index.html`, does not contain `tmp`, has 3 entries, has >= 1 entries, has <= 9 entries, matches glob `*.html`, tree matches snapshot `tree.snap`, (recursive), ignoring *.log"},
+			"dir `site` exists, contains `index.html`, does not contain `tmp`, has 3 entries, has >= 1 entry, has <= 9 entries, matches glob `*.html`, tree matches snapshot `tree.snap`, (recursive), ignoring *.log"},
 		{"dir absent", &spec.Assert{Dir: &spec.DirAssert{Path: "gone", Exists: boolptr(false)}}, "dir `gone` does not exist"},
 		{"dir checked", &spec.Assert{Dir: &spec.DirAssert{Path: "d"}}, "dir `d` is checked"},
 		// pdf
 		{"pdf", &spec.Assert{PDF: &spec.PDFAssert{Path: "r.pdf", Pages: intptr(3), MinPages: intptr(1), MaxPages: intptr(9), Metadata: map[string]string{"title": "Q1", "author": "me"}, Text: &spec.StreamAssert{Contains: spec.StringList{"total"}}}},
-			"pdf `r.pdf` 3 pages, >= 1 pages, <= 9 pages, author contains `me`, title contains `Q1`, text contains `total`"},
+			"pdf `r.pdf` 3 pages, >= 1 page, <= 9 pages, author contains `me`, title contains `Q1`, text contains `total`"},
 		{"pdf checked", &spec.Assert{PDF: &spec.PDFAssert{Path: "e.pdf"}}, "pdf `e.pdf` is checked"},
 		// image min/max dims + no-alpha + similar
 		{"image", &spec.Assert{Image: &spec.ImageAssert{Path: "o.png", MinWidth: intptr(1), MaxWidth: intptr(2), MinHeight: intptr(3), MaxHeight: intptr(4), Alpha: boolptr(false), SimilarTo: "base.png"}},

--- a/internal/engine/store.go
+++ b/internal/engine/store.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ohler55/ojg/jp"
 	"github.com/ohler55/ojg/oj"
 
+	"github.com/nao1215/atago/internal/plural"
 	"github.com/nao1215/atago/internal/runner"
 	"github.com/nao1215/atago/internal/security"
 	"github.com/nao1215/atago/internal/spec"
@@ -128,7 +129,7 @@ func jsonValue(data []byte, path string) (string, error) {
 	}
 	nodes := expr.Get(v)
 	if len(nodes) != 1 {
-		return "", fmt.Errorf("JSON path %q selected %d values, want exactly 1", path, len(nodes))
+		return "", fmt.Errorf("JSON path %q selected %s, want exactly 1", path, plural.Count(len(nodes), "value", "values"))
 	}
 	// Why: a JSON null selects exactly one node whose Go value is nil, and
 	// fmt.Sprint(nil) yields the literal string "<nil>". Storing that would leak

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -426,14 +426,9 @@ var explainJSONStyle = assertdesc.JSONStyle{
 	Default: "",
 }
 
-var explainYAMLStyle = assertdesc.JSONStyle{
-	Prefix:  func(path string) string { return "YAML " + path },
-	Equals:  explainJSONStyle.Equals,
-	Matches: explainJSONStyle.Matches,
-	Length:  explainJSONStyle.Length,
-	Compare: explainJSONStyle.Compare,
-	Default: explainJSONStyle.Default,
-}
+var explainYAMLStyle = explainJSONStyle.WithPrefix(func(path string) string {
+	return "YAML " + path
+})
 
 var explainStreamStyle = assertdesc.StreamStyle{
 	List:      quoteList,

--- a/internal/explain/explain_test.go
+++ b/internal/explain/explain_test.go
@@ -789,7 +789,7 @@ scenarios:
 `
 	out := mustExplain(t, src)
 	for _, want := range []string{
-		`dir "dist" exists, contains index.html, does not contain .DS_Store, has >= 1 entries, has <= 100 entries, matches glob *.html, (recursive), ignoring tmp, cache`,
+		`dir "dist" exists, contains index.html, does not contain .DS_Store, has >= 1 entry, has <= 100 entries, matches glob *.html, (recursive), ignoring tmp, cache`,
 		`dir "empty" does not exist`,
 		`dir "exact" has 2 entries`,
 		`dir "snap" tree matches snapshot tree.snap`,
@@ -833,7 +833,7 @@ scenarios:
 		// Metadata keys are sorted, so Author precedes Title regardless of map order.
 		`Author contains "nao", Title contains "Report"`,
 		`text contains "Summary"`,
-		`pdf "bounded.pdf" >= 1 pages, <= 10 pages`,
+		`pdf "bounded.pdf" >= 1 page, <= 10 pages`,
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("explain pdf assert missing %q\n--- got ---\n%s", want, out)

--- a/internal/plural/plural.go
+++ b/internal/plural/plural.go
@@ -1,0 +1,26 @@
+// Package plural renders counted nouns for the messages atago shows a person:
+// "1 page" rather than "1 pages", "2 entries" rather than "2 entry".
+//
+// It exists because the same counted nouns appear in assertions, in the CLI's
+// own output, and in generated documentation, and each place had spelled them
+// differently — some pluralized, some always plural, some hedged with "(s)".
+// A reader should not have to notice which part of atago wrote a sentence.
+package plural
+
+import "strconv"
+
+// Count renders n with the noun that fits it: Count(1, "page", "pages") is
+// "1 page" and Count(0, "page", "pages") is "0 pages". Only ±1 takes the
+// singular, which is what English does with counted nouns.
+func Count(n int, singular, plural string) string {
+	return strconv.Itoa(n) + " " + Noun(n, singular, plural)
+}
+
+// Noun returns the form of the noun that fits n, without the number. Use it
+// when the count is already in the sentence for another reason.
+func Noun(n int, singular, plural string) string {
+	if n == 1 || n == -1 {
+		return singular
+	}
+	return plural
+}

--- a/internal/plural/plural_test.go
+++ b/internal/plural/plural_test.go
@@ -1,0 +1,39 @@
+package plural
+
+import "testing"
+
+func TestCount(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		n        int
+		singular string
+		plural   string
+		want     string
+	}{
+		{"zero takes the plural", 0, "page", "pages", "0 pages"},
+		{"one takes the singular", 1, "page", "pages", "1 page"},
+		{"two takes the plural", 2, "page", "pages", "2 pages"},
+		{"an irregular plural is spelled out", 1, "entry", "entries", "1 entry"},
+		{"an irregular plural for many", 3, "entry", "entries", "3 entries"},
+		{"minus one is still singular", -1, "line", "lines", "-1 line"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := Count(tt.n, tt.singular, tt.plural); got != tt.want {
+				t.Errorf("Count(%d, %q, %q) = %q, want %q", tt.n, tt.singular, tt.plural, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNoun(t *testing.T) {
+	t.Parallel()
+	if got := Noun(1, "file", "files"); got != "file" {
+		t.Errorf("Noun(1) = %q, want %q", got, "file")
+	}
+	if got := Noun(0, "file", "files"); got != "files" {
+		t.Errorf("Noun(0) = %q, want %q", got, "files")
+	}
+}

--- a/internal/report/console.go
+++ b/internal/report/console.go
@@ -73,27 +73,7 @@ func writeDetail(b *strings.Builder, color bool, suite, specPath string, sc *eng
 					continue
 				}
 				fmt.Fprintf(b, "\n%s %s / %s%s\n", colorize(color, cRed+cBold, "FAILED:"), suite, sc.Name, where)
-				fmt.Fprintf(b, "\nStep:\n  %s\n", ck.Desc)
-				if cmd != "" {
-					fmt.Fprintf(b, "\nCommand:\n  %s\n", cmd)
-				}
-				// Multi-line equals/snapshot failures render a unified diff
-				// (#28): the one-character difference the two raw blocks hide.
-				// Single-line failures keep the compact Expected/Actual form.
-				if diff := checkDiff(ck); diff != "" {
-					fmt.Fprintf(b, "\nDiff (-expected +actual):\n%s\n", indent(colorizeDiff(color, diff)))
-				} else {
-					expected, actual := visiblePair(ck.Expected, ck.Actual)
-					if expected != "" {
-						fmt.Fprintf(b, "\nExpected:\n%s\n", indent(expected))
-					}
-					if actual != "" {
-						fmt.Fprintf(b, "\nActual:\n%s\n", indent(actual))
-					}
-				}
-				if ck.Hint != "" {
-					fmt.Fprintf(b, "\nHint:\n  %s\n", ck.Hint)
-				}
+				writeCheckFailure(b, color, ck, cmd)
 				writeFailureStreams(b, ck, lastRun)
 				// Keep console output compact: reference the durable payloads by path
 				// rather than dumping them inline (#48).
@@ -213,21 +193,7 @@ func writeSuiteSteps(b *strings.Builder, color bool, suite, label string, steps 
 				continue
 			}
 			fmt.Fprintf(b, "\n%s %s\n", colorize(color, cRed+cBold, label), suite)
-			fmt.Fprintf(b, "\nStep:\n  %s\n", ck.Desc)
-			if diff := checkDiff(ck); diff != "" {
-				fmt.Fprintf(b, "\nDiff (-expected +actual):\n%s\n", indent(colorizeDiff(color, diff)))
-			} else {
-				expected, actual := visiblePair(ck.Expected, ck.Actual)
-				if expected != "" {
-					fmt.Fprintf(b, "\nExpected:\n%s\n", indent(expected))
-				}
-				if actual != "" {
-					fmt.Fprintf(b, "\nActual:\n%s\n", indent(actual))
-				}
-			}
-			if ck.Hint != "" {
-				fmt.Fprintf(b, "\nHint:\n  %s\n", ck.Hint)
-			}
+			writeCheckFailure(b, color, ck, "")
 		}
 		if step.ErrMsg != "" {
 			fmt.Fprintf(b, "\n%s %s\n  step %d (%s): %s\n",
@@ -305,4 +271,34 @@ func indent(s string) string {
 		lines[i] = "  " + l
 	}
 	return strings.Join(lines, "\n")
+}
+
+// writeCheckFailure renders the body every failure report shares: the step that
+// failed, the command behind it when there is one, the comparison, and the
+// hint. A scenario failure and a suite setup/teardown failure differ only in
+// their heading and in whether captured streams follow, so the body lives here
+// once — a change to how a comparison reads cannot apply to one and miss the
+// other.
+func writeCheckFailure(b *strings.Builder, color bool, ck *assert.CheckResult, cmd string) {
+	fmt.Fprintf(b, "\nStep:\n  %s\n", ck.Desc)
+	if cmd != "" {
+		fmt.Fprintf(b, "\nCommand:\n  %s\n", cmd)
+	}
+	// Multi-line equals/snapshot failures render a unified diff (#28): the
+	// one-character difference the two raw blocks hide. Single-line failures
+	// keep the compact Expected/Actual form.
+	if diff := checkDiff(ck); diff != "" {
+		fmt.Fprintf(b, "\nDiff (-expected +actual):\n%s\n", indent(colorizeDiff(color, diff)))
+	} else {
+		expected, actual := visiblePair(ck.Expected, ck.Actual)
+		if expected != "" {
+			fmt.Fprintf(b, "\nExpected:\n%s\n", indent(expected))
+		}
+		if actual != "" {
+			fmt.Fprintf(b, "\nActual:\n%s\n", indent(actual))
+		}
+	}
+	if ck.Hint != "" {
+		fmt.Fprintf(b, "\nHint:\n  %s\n", ck.Hint)
+	}
 }


### PR DESCRIPTION
atago told a reader "PDF `r.pdf` has 1 pages", "directory `d` has 1 entry", "stdout has only 1 line(s)", and "recorded: 1 file(s) created" — four sentences about the same grammar, written four different ways. Three packages each had their own idea of pluralization, and `internal/assert` carried a private `plural()` helper on top of that. A reader should not have to notice which part of atago wrote a sentence.

`internal/plural` holds the rule now, and every counted noun goes through it: assertion failures, `atago record`'s summary, the store's "selected N values", and the counted nouns in generated documentation (`has 1 entry`, `>= 1 page`). The regenerated `doc/e2e` pages show the difference.

Two other duplications came along with it. The console rendered the same failure body twice — once for a scenario, once for a suite setup/teardown — so a change to how a comparison reads could land in one and miss the other; that body is one function now. And the YAML flavor of a JSON matcher style was a field-by-field copy of the JSON one, in both `docgen` and `explain`, differing only in the path prefix: a field added to `JSONStyle` later would have been silently dropped from the copy, which is exactly what happened to nothing yet and would have happened eventually. `JSONStyle.WithPrefix` returns the copy instead.

Finally, the PDF metadata reader sorted its keys with a hand-rolled O(n²) swap loop; that is `sort.Strings`.

Tests: a table-driven test for the plural helper, a test that `WithPrefix` changes only the prefix and leaves the original untouched, and the existing suites updated where the wording improved. `make test`, `make lint`, `make e2e`, `make docs` are green.