### PR TITLE
refactor: share the spec-target and quoted-list plumbing

### DIFF
--- a/internal/assert/contains.go
+++ b/internal/assert/contains.go
@@ -32,16 +32,6 @@ func firstPresent(got string, subs spec.StringList) (sub string, idx int, ok boo
 	return "", 0, false
 }
 
-// quoteList renders a StringList as a space-separated list of quoted elements,
-// e.g. `"a", "b"`, for the multi-element failure description.
-func quoteList(subs spec.StringList) string {
-	parts := make([]string, len(subs))
-	for i, s := range subs {
-		parts[i] = fmt.Sprintf("%q", s)
-	}
-	return strings.Join(parts, ", ")
-}
-
 // fileContainsDesc renders the file assertion label, mirroring containsDesc but
 // with the file path in the subject.
 func fileContainsDesc(pathLabel string, subs spec.StringList, want bool) string {
@@ -52,9 +42,9 @@ func fileContainsDesc(pathLabel string, subs spec.StringList, want bool) string 
 		return fmt.Sprintf("assert file %q does not contain %q", pathLabel, subs[0])
 	}
 	if want {
-		return fmt.Sprintf("assert file %q contains all of %s", pathLabel, quoteList(subs))
+		return fmt.Sprintf("assert file %q contains all of %s", pathLabel, subs.Quoted())
 	}
-	return fmt.Sprintf("assert file %q contains none of %s", pathLabel, quoteList(subs))
+	return fmt.Sprintf("assert file %q contains none of %s", pathLabel, subs.Quoted())
 }
 
 // elementLabel returns "" for a single-element matcher (so the failure text is

--- a/internal/assert/stream.go
+++ b/internal/assert/stream.go
@@ -234,9 +234,9 @@ func containsDesc(name string, subs spec.StringList, want bool) string {
 		return fmt.Sprintf("assert %s does not contain %q", name, subs[0])
 	}
 	if want {
-		return fmt.Sprintf("assert %s contains all of %s", name, quoteList(subs))
+		return fmt.Sprintf("assert %s contains all of %s", name, subs.Quoted())
 	}
-	return fmt.Sprintf("assert %s contains none of %s", name, quoteList(subs))
+	return fmt.Sprintf("assert %s contains none of %s", name, subs.Quoted())
 }
 
 // equalsNormalized compares ignoring at most one trailing newline per side — the

--- a/internal/cli/doc.go
+++ b/internal/cli/doc.go
@@ -54,18 +54,9 @@ func docCmd(args []string, stdout, stderr io.Writer) int {
 		return ExitConfig
 	}
 
-	targets := fs.Args()
-	if len(targets) == 0 {
-		targets = []string{"."}
-	}
-	paths, err := collectSpecFiles(targets)
-	if err != nil {
-		fmt.Fprintf(stderr, "atago doc: %v\n", err)
-		return ExitConfig
-	}
-	if len(paths) == 0 {
-		fmt.Fprintln(stderr, "atago doc: no *.atago.yaml (or *.atago.yml) files found")
-		return ExitConfig
+	paths, exitCode, ok := specTargets("atago doc", fs.Args(), stderr)
+	if !ok {
+		return exitCode
 	}
 
 	sources := make([]docgen.Source, 0, len(paths))

--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -33,18 +33,9 @@ func explainCmd(args []string, stdout, stderr io.Writer) int {
 		return ExitConfig
 	}
 
-	targets := fs.Args()
-	if len(targets) == 0 {
-		targets = []string{"."} // parity with run/lint/doc
-	}
-	paths, err := collectSpecFiles(targets)
-	if err != nil {
-		fmt.Fprintf(stderr, "atago explain: %v\n", err)
-		return ExitConfig
-	}
-	if len(paths) == 0 {
-		fmt.Fprintln(stderr, "atago explain: no *.atago.yaml (or *.atago.yml) files found")
-		return ExitConfig
+	paths, exitCode, ok := specTargets("atago explain", fs.Args(), stderr)
+	if !ok {
+		return exitCode
 	}
 
 	exit := ExitOK

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -44,18 +44,9 @@ func listCmd(args []string, stdout, stderr io.Writer) int {
 		return ExitConfig
 	}
 
-	targets := fs.Args()
-	if len(targets) == 0 {
-		targets = []string{"."}
-	}
-	paths, err := collectSpecFiles(targets)
-	if err != nil {
-		fmt.Fprintf(stderr, "atago list: %v\n", err)
-		return ExitConfig
-	}
-	if len(paths) == 0 {
-		fmt.Fprintln(stderr, "atago list: no *.atago.yaml (or *.atago.yml) files found")
-		return ExitConfig
+	paths, exitCode, ok := specTargets("atago list", fs.Args(), stderr)
+	if !ok {
+		return exitCode
 	}
 
 	inputs := make([]manifest.Input, 0, len(paths))

--- a/internal/cli/manifest.go
+++ b/internal/cli/manifest.go
@@ -37,18 +37,9 @@ func manifestCmd(args []string, stdout, stderr io.Writer) int {
 		return ExitConfig
 	}
 
-	targets := fs.Args()
-	if len(targets) == 0 {
-		targets = []string{"."}
-	}
-	paths, err := collectSpecFiles(targets)
-	if err != nil {
-		fmt.Fprintf(stderr, "atago manifest: %v\n", err)
-		return ExitConfig
-	}
-	if len(paths) == 0 {
-		fmt.Fprintln(stderr, "atago manifest: no *.atago.yaml (or *.atago.yml) files found")
-		return ExitConfig
+	paths, exitCode, ok := specTargets("atago manifest", fs.Args(), stderr)
+	if !ok {
+		return exitCode
 	}
 
 	inputs := make([]manifest.Input, 0, len(paths))

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -173,19 +173,9 @@ func parseRunFlags(label string, args []string, stdout, stderr io.Writer) (*runO
 		return nil, ExitConfig, true
 	}
 
-	targets := fs.Args()
-	if len(targets) == 0 {
-		targets = []string{"."}
-	}
-
-	paths, err := collectSpecFiles(targets)
-	if err != nil {
-		fmt.Fprintf(stderr, label+": %v\n", err)
-		return nil, ExitConfig, true
-	}
-	if len(paths) == 0 {
-		fmt.Fprintln(stderr, label+": no *.atago.yaml (or *.atago.yml) files found")
-		return nil, ExitConfig, true
+	paths, exitCode, ok := specTargets(label, fs.Args(), stderr)
+	if !ok {
+		return nil, exitCode, true
 	}
 
 	// --repeat and --retry-failed answer opposite questions (does it flake? /
@@ -479,6 +469,32 @@ func runSpecs(ctx context.Context, eng *engine.Engine, paths []string) ([]*engin
 // --fail-fast: a failed or errored verdict, or a security-policy violation.
 func suiteFailed(res *engine.SuiteResult) bool {
 	return res != nil && (res.Status == engine.StatusFailed || res.Status == engine.StatusError || res.SecurityViolation)
+}
+
+// specTargets resolves a subcommand's positional arguments into the spec files
+// it should act on, and reports the failures in the caller's own voice. Every
+// subcommand that takes spec paths — run, list, explain, doc, manifest — needs
+// the same three steps: default to the current directory, expand directories,
+// and refuse an empty result. Keeping them here is what makes a new
+// spec-reading subcommand behave identically without copying the messages, and
+// stops the "no spec files found" wording from drifting between commands.
+//
+// ok is false when the caller should return the accompanying exit code.
+func specTargets(label string, args []string, stderr io.Writer) (paths []string, exit int, ok bool) {
+	targets := args
+	if len(targets) == 0 {
+		targets = []string{"."}
+	}
+	paths, err := collectSpecFiles(targets)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s: %v\n", label, err)
+		return nil, ExitConfig, false
+	}
+	if len(paths) == 0 {
+		fmt.Fprintf(stderr, "%s: no *.atago.yaml (or *.atago.yml) files found\n", label)
+		return nil, ExitConfig, false
+	}
+	return paths, ExitOK, true
 }
 
 // collectSpecFiles resolves run targets into a deduplicated list of spec files.

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -406,17 +406,6 @@ func describePDF(p *spec.PDFAssert) string {
 	return assertdesc.DescribePDF(p, explainPDFStyle)
 }
 
-// quoteList renders a contains/not_contains matcher argument. A single element
-// is rendered as %q (byte-identical to the pre-list format); a list joins its
-// quoted elements with ", ".
-func quoteList(subs spec.StringList) string {
-	parts := make([]string, len(subs))
-	for i, s := range subs {
-		parts[i] = fmt.Sprintf("%q", s)
-	}
-	return strings.Join(parts, ", ")
-}
-
 var explainJSONStyle = assertdesc.JSONStyle{
 	Prefix:  func(path string) string { return "JSON " + path },
 	Equals:  func(v any) string { return fmt.Sprintf("== %v", v) },
@@ -431,7 +420,7 @@ var explainYAMLStyle = explainJSONStyle.WithPrefix(func(path string) string {
 })
 
 var explainStreamStyle = assertdesc.StreamStyle{
-	List:      quoteList,
+	List:      spec.StringList.Quoted,
 	Regex:     func(s string) string { return fmt.Sprintf("/%s/", s) },
 	Equals:    "equals exact text",
 	NotEquals: "does not equal exact text",
@@ -444,7 +433,7 @@ var explainStreamStyle = assertdesc.StreamStyle{
 
 var explainFileStyle = assertdesc.FileStyle{
 	Path:       func(s string) string { return fmt.Sprintf("%q", s) },
-	List:       quoteList,
+	List:       spec.StringList.Quoted,
 	JSON:       explainJSONStyle,
 	Snapshot:   func(s string) string { return s },
 	Checked:    func(path string) string { return path },

--- a/internal/spec/assert.go
+++ b/internal/spec/assert.go
@@ -3,6 +3,7 @@ package spec
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/goccy/go-yaml"
@@ -328,6 +329,18 @@ type StreamAssert struct {
 // the whole list counts as a single matcher (the one-of matcher rule is
 // unchanged).
 type StringList []string
+
+// Quoted renders the list the way atago talks about it in prose: each element
+// quoted, joined with ", ". A single element therefore reads exactly like the
+// pre-list scalar form did. Assertion failures and `atago explain` both need
+// this rendering, and each used to carry its own copy.
+func (l StringList) Quoted() string {
+	parts := make([]string, len(l))
+	for i, s := range l {
+		parts[i] = strconv.Quote(s)
+	}
+	return strings.Join(parts, ", ")
+}
 
 // UnmarshalYAML accepts a scalar string or a sequence of strings. It uses the
 // interface-based decoder (not the raw-bytes form) so escapes like "\x1b" are

--- a/internal/spec/step_test.go
+++ b/internal/spec/step_test.go
@@ -233,3 +233,28 @@ func TestExitCode_UnmarshalYAML(t *testing.T) {
 		}
 	})
 }
+
+// TestStringList_Quoted pins the rendering assertion failures and `atago
+// explain` share: a single element reads exactly like the pre-list scalar form,
+// and a list joins quoted elements with ", ".
+func TestStringList_Quoted(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		list StringList
+		want string
+	}{
+		{"empty", StringList{}, ""},
+		{"one element", StringList{"alpha"}, `"alpha"`},
+		{"several elements", StringList{"alpha", "beta"}, `"alpha", "beta"`},
+		{"quotes and escapes are visible", StringList{"say \"hi\"", "tab\there"}, `"say \"hi\"", "tab\there"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.list.Quoted(); got != tt.want {
+				t.Errorf("Quoted() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Five subcommands — `run`, `list`, `explain`, `doc`, `manifest` — each opened with the same three steps: default to the current directory, expand directories into spec files, refuse an empty result. Five copies meant five places for the "no *.atago.yaml (or *.atago.yml) files found" wording to drift apart, and the next spec-reading subcommand would have started by copying one of them. `specTargets` does it once and reports in the caller's own voice.

The same shape appeared one level down: `internal/assert` and `internal/explain` carried byte-identical `quoteList` functions over a `spec.StringList`. That rendering belongs to the type, so it is `StringList.Quoted()` now, and both callers use it.

No behavior changes — the messages, exit codes, and rendered text are the ones that were already there. Tests: a table-driven test for `Quoted` (single element reads exactly like the old scalar form, quotes and tabs stay visible); the existing CLI suites cover the target resolution, including the empty-result and unreadable-target paths. `make test`, `make lint`, `make e2e` are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent quoted-list formatting for assertion messages and `atago explain` output.
* **Bug Fixes**
  * Improved escaping and presentation of lists containing quotes or backslashes.
  * Standardized target path handling and error reporting across specification-related commands.
* **Tests**
  * Added coverage for empty, single-item, multi-item, and escaped string lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->