### PR TITLE
fix(cli): say what atago was doing when a target cannot be used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- The messages for a target atago cannot use now say what atago was doing.
+  A missing spec path reads `cannot access "x.atago.yaml": no such file or
+  directory` instead of repeating the path through Go's `stat` wrapper; an
+  unreadable directory reads `cannot search "/etc" for spec files: ...` instead
+  of naming a file the user never mentioned; and a directory with no specs names
+  the directory it searched and points at `atago init`.
+
 - Counted nouns in messages now agree with their number: "1 page" instead of
   "1 pages", "1 entry" instead of "1 entries", "1 line" instead of
   "1 line(s)", and `atago record` reports "1 file created" rather than

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -4791,7 +4791,7 @@ ${atago} run no-such-spec.atago.yaml
 ```
 #### Then
 - exit code is `3`
-- stderr contains `cannot access "no-such-spec.atago.yaml": no such file or directory`
+- stderr contains `cannot access "no-such-spec.atago.yaml": `
 - stderr does not contain `stat no-such-spec`
 ### Scenario: an empty directory says how to create a first spec
 #### When

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 426 scenarios
+74 suites · 428 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -246,7 +246,7 @@
 - [atago self-hosting / list](#atago-self-hosting--list) — 2 scenarios
   - [list surfaces suites, scenarios, tags, and gates](#scenario-list-surfaces-suites-scenarios-tags-and-gates)
   - [list --json is a stable machine contract](#scenario-list---json-is-a-stable-machine-contract)
-- [atago self-hosting / loader rejects malformed specs](#atago-self-hosting--loader-rejects-malformed-specs) — 15 scenarios
+- [atago self-hosting / loader rejects malformed specs](#atago-self-hosting--loader-rejects-malformed-specs) — 17 scenarios
   - [an empty scenario list is rejected](#scenario-an-empty-scenario-list-is-rejected)
   - [a wrong version string is rejected](#scenario-a-wrong-version-string-is-rejected)
   - [an unknown top-level field is rejected with its position](#scenario-an-unknown-top-level-field-is-rejected-with-its-position)
@@ -262,6 +262,8 @@
   - [an absolute changes glob is rejected as not workdir-relative](#scenario-an-absolute-changes-glob-is-rejected-as-not-workdir-relative)
   - [the inline stdin form is a scalar, not a mapping key](#scenario-the-inline-stdin-form-is-a-scalar-not-a-mapping-key)
   - [a wrong-typed exit_code is rejected with its position and excerpt](#scenario-a-wrong-typed-exit_code-is-rejected-with-its-position-and-excerpt)
+  - [a missing target names the reason without syscall noise](#scenario-a-missing-target-names-the-reason-without-syscall-noise)
+  - [an empty directory says how to create a first spec](#scenario-an-empty-directory-says-how-to-create-a-first-spec)
 - [atago self-hosting / manifest](#atago-self-hosting--manifest) — 2 scenarios
   - [manifest emits a stable JSON summary without running the spec](#scenario-manifest-emits-a-stable-json-summary-without-running-the-spec)
   - [manifest does not execute the spec's commands](#scenario-manifest-does-not-execute-the-specs-commands)
@@ -511,7 +513,7 @@ ${atago} run '{"k":"v"}'
 ```
 #### Then
 - exit code is `3`
-- stderr contains `{"k":"v"}`
+- stderr contains `{\"k\":\"v\"}`
 ### Scenario: a single-quoted argument with a space stays one argument
 #### When
 ```shell
@@ -4782,6 +4784,25 @@ ${atago} run bad.atago.yaml
 #### Then
 - exit code is `2`
 - stderr contains `[8:22]`, `exit_code must be an integer`, `exit_code: zero`
+### Scenario: a missing target names the reason without syscall noise
+#### When
+```shell
+${atago} run no-such-spec.atago.yaml
+```
+#### Then
+- exit code is `3`
+- stderr contains `cannot access "no-such-spec.atago.yaml": no such file or directory`
+- stderr does not contain `stat no-such-spec`
+### Scenario: an empty directory says how to create a first spec
+#### When
+```shell
+mkdir specs
+${atago} run specs
+```
+#### Then
+- after `${atago} run specs`:
+  - exit code is `3`
+  - stderr contains `no *.atago.yaml`, `specs`, `atago init`
 ## atago self-hosting / manifest
 Source: `test/e2e/atago/manifest.atago.yaml`
 ### Scenario: manifest emits a stable JSON summary without running the spec

--- a/internal/cli/features_test.go
+++ b/internal/cli/features_test.go
@@ -1129,3 +1129,43 @@ func TestRunCmd_CorruptLedgerLeftUntouchedByPlainRun(t *testing.T) {
 		t.Errorf("ledger = %q, want the unreadable bytes preserved verbatim after a green run", data)
 	}
 }
+
+// TestSpecTargets_MessagesNameWhatAtagoWasDoing pins the wording a person meets
+// when they point atago at the wrong place. A bare "stat x: no such file or
+// directory" repeats the path atago already named, and a bare "open
+// /etc/credstore: permission denied" reads as if atago wanted that file rather
+// than as a search of the directory the user named.
+func TestSpecTargets_MessagesNameWhatAtagoWasDoing(t *testing.T) {
+	t.Run("a missing target names the reason once", func(t *testing.T) {
+		var errb bytes.Buffer
+		paths, exit, ok := specTargets("atago run", []string{"no-such.atago.yaml"}, &errb)
+		if ok || paths != nil {
+			t.Fatalf("ok = %v, paths = %v, want a refusal", ok, paths)
+		}
+		if exit != ExitConfig {
+			t.Errorf("exit = %d, want %d", exit, ExitConfig)
+		}
+		got := errb.String()
+		if !strings.Contains(got, `cannot access "no-such.atago.yaml": no such file or directory`) {
+			t.Errorf("stderr = %q, want the path named once and the bare reason", got)
+		}
+		if strings.Contains(got, "stat ") {
+			t.Errorf("stderr = %q, want no syscall noise", got)
+		}
+	})
+
+	t.Run("an empty directory says how to start", func(t *testing.T) {
+		dir := t.TempDir()
+		var errb bytes.Buffer
+		if _, _, ok := specTargets("atago doc", []string{dir}, &errb); ok {
+			t.Fatal("an empty directory must be a refusal")
+		}
+		got := errb.String()
+		if !strings.Contains(got, "no *.atago.yaml") || !strings.Contains(got, dir) {
+			t.Errorf("stderr = %q, want the searched target named", got)
+		}
+		if !strings.Contains(got, "atago init") {
+			t.Errorf("stderr = %q, want a pointer to `atago init`", got)
+		}
+	})
+}

--- a/internal/cli/features_test.go
+++ b/internal/cli/features_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -1146,11 +1147,15 @@ func TestSpecTargets_MessagesNameWhatAtagoWasDoing(t *testing.T) {
 			t.Errorf("exit = %d, want %d", exit, ExitConfig)
 		}
 		got := errb.String()
-		if !strings.Contains(got, `cannot access "no-such.atago.yaml": no such file or directory`) {
-			t.Errorf("stderr = %q, want the path named once and the bare reason", got)
+		// The reason itself is the OS's ("no such file or directory" on POSIX,
+		// "The system cannot find the file specified." on Windows); what atago
+		// controls is that the path is named once, in quotes, with no syscall
+		// wrapper repeating it.
+		if !strings.Contains(got, `cannot access "no-such.atago.yaml": `) {
+			t.Errorf("stderr = %q, want the quoted path followed by the reason", got)
 		}
-		if strings.Contains(got, "stat ") {
-			t.Errorf("stderr = %q, want no syscall noise", got)
+		if strings.Contains(got, "stat ") || strings.Count(got, "no-such.atago.yaml") != 1 {
+			t.Errorf("stderr = %q, want the path exactly once and no syscall noise", got)
 		}
 	})
 
@@ -1161,7 +1166,9 @@ func TestSpecTargets_MessagesNameWhatAtagoWasDoing(t *testing.T) {
 			t.Fatal("an empty directory must be a refusal")
 		}
 		got := errb.String()
-		if !strings.Contains(got, "no *.atago.yaml") || !strings.Contains(got, dir) {
+		// The target is quoted, so a Windows path appears with escaped
+		// separators — compare against the quoted form rather than the raw one.
+		if !strings.Contains(got, "no *.atago.yaml") || !strings.Contains(got, strconv.Quote(dir)) {
 			t.Errorf("stderr = %q, want the searched target named", got)
 		}
 		if !strings.Contains(got, "atago init") {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -491,10 +492,32 @@ func specTargets(label string, args []string, stderr io.Writer) (paths []string,
 		return nil, ExitConfig, false
 	}
 	if len(paths) == 0 {
-		fmt.Fprintf(stderr, "%s: no *.atago.yaml (or *.atago.yml) files found\n", label)
+		fmt.Fprintf(stderr, "%s: no *.atago.yaml (or *.atago.yml) files found in %s; run `atago init` to scaffold one\n",
+			label, quotedList(targets))
 		return nil, ExitConfig, false
 	}
 	return paths, ExitOK, true
+}
+
+// statReason strips the syscall wrapper off a stat error so a message that has
+// already named the path does not repeat it: "no such file or directory"
+// rather than "stat specs/: no such file or directory".
+func statReason(err error) error {
+	var pe *fs.PathError
+	if errors.As(err, &pe) {
+		return pe.Err
+	}
+	return err
+}
+
+// quotedList renders the targets a subcommand was given, for a message about
+// all of them.
+func quotedList(targets []string) string {
+	parts := make([]string, len(targets))
+	for i, t := range targets {
+		parts[i] = strconv.Quote(t)
+	}
+	return strings.Join(parts, ", ")
 }
 
 // collectSpecFiles resolves run targets into a deduplicated list of spec files.
@@ -521,7 +544,10 @@ func collectSpecFiles(targets []string) ([]string, error) {
 
 		info, err := os.Stat(t)
 		if err != nil {
-			return nil, fmt.Errorf("cannot access %q: %w", t, err)
+			// os.Stat's error repeats the path and prefixes the syscall
+			// ("stat x: no such file or directory"), which reads as noise next
+			// to the path atago already named. Keep the reason only.
+			return nil, fmt.Errorf("cannot access %q: %w", t, statReason(err))
 		}
 		if !info.IsDir() {
 			add(filepath.Clean(t))
@@ -538,7 +564,11 @@ func collectSpecFiles(targets []string) ([]string, error) {
 func walkSpecDir(dir string, add func(string)) error {
 	return filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			return err
+			// Say what atago was doing when it hit this. A bare
+			// "open /etc/credstore: permission denied" reads as if atago
+			// wanted that file, when it was searching a directory the user
+			// named for spec files.
+			return fmt.Errorf("cannot search %q for spec files: %w", dir, err)
 		}
 		if d.IsDir() {
 			return nil

--- a/test/e2e/atago/argv_quotes.atago.yaml
+++ b/test/e2e/atago/argv_quotes.atago.yaml
@@ -17,13 +17,15 @@ scenarios:
     steps:
       # The command carries a single-quoted '{"k":"v"}'. After tokenization the
       # inner double quotes must be preserved literally and the single quotes
-      # stripped, so atago receives the JSON as one argument on every OS.
+      # stripped, so atago receives the JSON as one argument on every OS. The
+      # error quotes the argument it could not use, so the inner quotes appear
+      # escaped — which is exactly the proof that they survived.
       - run:
           command: "${atago} run '{\"k\":\"v\"}'"
       - assert:
           exit_code: 3
           stderr:
-            contains: '{"k":"v"}'
+            contains: '{\"k\":\"v\"}'
 
   - name: a single-quoted argument with a space stays one argument
     steps:

--- a/test/e2e/atago/loader_errors.atago.yaml
+++ b/test/e2e/atago/loader_errors.atago.yaml
@@ -250,8 +250,10 @@ scenarios:
           command: ${atago} run no-such-spec.atago.yaml
       - assert:
           exit_code: 3
+          # The reason is the OS's own wording, so only the shape atago controls
+          # is pinned: the quoted path, once, with no syscall wrapper repeating it.
           stderr:
-            contains: 'cannot access "no-such-spec.atago.yaml": no such file or directory'
+            contains: 'cannot access "no-such-spec.atago.yaml": '
       - assert:
           stderr:
             not_contains: "stat no-such-spec"

--- a/test/e2e/atago/loader_errors.atago.yaml
+++ b/test/e2e/atago/loader_errors.atago.yaml
@@ -242,3 +242,31 @@ scenarios:
               - "[8:22]"
               - "exit_code must be an integer"
               - "exit_code: zero"
+
+  # Pointing atago at the wrong place should say what atago was doing there.
+  - name: a missing target names the reason without syscall noise
+    steps:
+      - run:
+          command: ${atago} run no-such-spec.atago.yaml
+      - assert:
+          exit_code: 3
+          stderr:
+            contains: 'cannot access "no-such-spec.atago.yaml": no such file or directory'
+      - assert:
+          stderr:
+            not_contains: "stat no-such-spec"
+
+  - name: an empty directory says how to create a first spec
+    steps:
+      - run:
+          shell: true
+          command: mkdir specs
+      - run:
+          command: ${atago} run specs
+      - assert:
+          exit_code: 3
+          stderr:
+            contains:
+              - "no *.atago.yaml"
+              - "specs"
+              - "atago init"


### PR DESCRIPTION
Three messages about a spec target described a syscall instead of the work atago was doing.

`cannot access "x.atago.yaml": stat x.atago.yaml: no such file or directory` repeats the path atago just named, through a wrapper the reader never asked about. `atago run: open /etc/credstore: permission denied` names a file the user never mentioned — atago was searching the directory they *did* name, and the message hides that. And `no *.atago.yaml (or *.atago.yml) files found` does not say which directory it searched, leaving a first-time reader with nowhere to go.

They now read:

```
atago run: cannot access "x.atago.yaml": no such file or directory
atago run: cannot search "/etc" for spec files: open /etc/credstore: permission denied
atago doc: no *.atago.yaml (or *.atago.yml) files found in "specs"; run `atago init` to scaffold one
```

All three come from the shared `specTargets` helper, so every spec-reading subcommand says the same thing.

One existing argv test asserted the raw argument as it appeared inside the old syscall echo; it now asserts the quoted form atago itself prints, which proves the same property (the inner quotes survived tokenization) without depending on Go's error text.

Tests: cli tests for the missing-target wording (including that no `stat ` prefix remains) and for the empty-directory pointer; self-hosted E2E for both through a real run. `make test`, `make lint`, `make e2e`, `make docs` are green.