### PR TITLE
docs(changelog): release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-07-27
+
+Two changes can turn a passing spec red, so read these first.
+
+- `changes:` now tracks symlinks. A step that plants a link, retargets one, or
+  removes one is now a creation, a modification, or a deletion. A spec that
+  wrote `created: []` for such a step passed only because the link was
+  invisible to the delta; it now fails and has to name the link.
+- `file: exists` and `file: executable` no longer accept a directory. Both were
+  satisfied by one — every directory carries the execute bit — so an assertion
+  written to catch "the tool left a directory where a file belongs" passed
+  instead of catching it. Both now fail and point at `dir:`.
+
+The rest of the release is about failure messages that name the difference
+rather than printing both sides identically, and about three new third-party
+suites — Ghostscript, zstd, and ImageMagick — that put the `pdf:` and `image:`
+matchers on the output of real programs, which is how the two `pdf:` extraction
+bugs below were found.
+
 ### Added
 
 - The git third-party suite gains a second spec covering what a script leans on:


### PR DESCRIPTION
Move the 18 accumulated `[Unreleased]` entries into `## [0.15.0] - 2026-07-27`.

The release opens with the two entries that can turn a passing spec red, so a
reader upgrading does not have to find them among the failure-message work:

- `changes:` now tracks symlinks, so a spec that wrote `created: []` for a step
  that plants a link now fails.
- `file: exists` / `file: executable` no longer accept a directory.

No code changes. `make test`, `make lint`, `make e2e`, `make docs`, and
`make site` are green on this branch with no drift.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.15.0.
  * Documented improved symlink tracking in `changes:`, including creation, modification, removal, and clearer failure messages.
  * Documented updated `file: exists` and `file: executable` behavior so directories no longer satisfy these matchers.
  * Added notes on expanded third-party test coverage and related extraction fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->