### PR TITLE
fix(json): let equals: null assert that a field is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `json: equals: null` now asserts that a field is null instead of being
+  rejected as a matcher-less check. A YAML null and an omitted `equals` key both
+  decode to the same Go nil, so the loader could not tell "assert this value is
+  null" from "no matcher was written" and turned the first into an error. It now
+  records which one the spec authored: `equals: null` passes only for a JSON
+  null — the string `"null"`, `0`, `false`, `""` all fail, and a path that
+  selects nothing still reports that rather than passing — while a check with no
+  `equals` key is rejected exactly as before. "This field is null" and "this
+  field is absent" are different contracts, ordinary in API output, and neither
+  could be pinned. `atago doc` and `atago explain` spell the expected value
+  `null` rather than Go's `<nil>`, matching the failure messages.
+
 ## [0.15.0] - 2026-07-27
 
 Two changes can turn a passing spec red, so read these first.

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 428 scenarios
+74 suites · 433 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -211,7 +211,7 @@
   - [a json list fails the inner spec when one listed path mismatches](#scenario-a-json-list-fails-the-inner-spec-when-one-listed-path-mismatches)
   - [a stdout json list against a JSON-producing command](#scenario-a-stdout-json-list-against-a-json-producing-command)
   - [a yaml list asserts several paths on one document](#scenario-a-yaml-list-asserts-several-paths-on-one-document)
-- [atago self-hosting / json matcher boundary values](#atago-self-hosting--json-matcher-boundary-values) — 14 scenarios
+- [atago self-hosting / json matcher boundary values](#atago-self-hosting--json-matcher-boundary-values) — 19 scenarios
   - [an array element is addressable by index](#scenario-an-array-element-is-addressable-by-index)
   - [a top-level array reports its length](#scenario-a-top-level-array-reports-its-length)
   - [an empty array has length zero](#scenario-an-empty-array-has-length-zero)
@@ -226,6 +226,11 @@
   - [a numeric mismatch stays unquoted](#scenario-a-numeric-mismatch-stays-unquoted)
   - [a null value is spelled null, not the Go zero value](#scenario-a-null-value-is-spelled-null-not-the-go-zero-value)
   - [a failure against a null value names it as null](#scenario-a-failure-against-a-null-value-names-it-as-null)
+  - [equals null asserts the field is null](#scenario-equals-null-asserts-the-field-is-null)
+  - [equals null rejects every value that is not null](#scenario-equals-null-rejects-every-value-that-is-not-null)
+  - [an absent path is not null either](#scenario-an-absent-path-is-not-null-either)
+  - [a json check with no matcher at all is still rejected](#scenario-a-json-check-with-no-matcher-at-all-is-still-rejected)
+  - [explain and doc describe a null assertion as one](#scenario-explain-and-doc-describe-a-null-assertion-as-one)
 - [atago self-hosting / line selector](#atago-self-hosting--line-selector) — 3 scenarios
   - [line selector narrows stdout to a single 1-based line](#scenario-line-selector-narrows-stdout-to-a-single-1-based-line)
   - [a trailing newline does not add a phantom final line](#scenario-a-trailing-newline-does-not-add-a-phantom-final-line)
@@ -4282,6 +4287,115 @@ ${atago} run nulled.atago.yaml
 - exit code is `1`
 - stdout contains `$.v = null`
 - stdout does not contain `<nil>`
+### Scenario: equals null asserts the field is null
+#### When
+```shell
+printf '{"done": null, "count": 0}'
+```
+#### Then
+- stdout at `$.done` equals `null`; at `$.count` equals `0`
+### Scenario: equals null rejects every value that is not null
+#### Given
+- Fixture file `notnull.atago.yaml` is created.
+#### Inputs
+_Fixture `notnull.atago.yaml`:_
+```text
+version: "1"
+suite: {name: notnull}
+scenarios:
+  - name: the string spelling of null
+    steps:
+      - run: {shell: true, command: 'printf ''{"v": "null"}'''}
+      - assert: {stdout: {json: {path: "$.v", equals: null}}}
+  - name: zero is not null
+    steps:
+      - run: {shell: true, command: 'printf ''{"v": 0}'''}
+      - assert: {stdout: {json: {path: "$.v", equals: null}}}
+  - name: false is not null
+    steps:
+      - run: {shell: true, command: 'printf ''{"v": false}'''}
+      - assert: {stdout: {json: {path: "$.v", equals: null}}}
+  - name: the empty string is not null
+    steps:
+      - run: {shell: true, command: 'printf ''{"v": ""}'''}
+      - assert: {stdout: {json: {path: "$.v", equals: null}}}
+```
+#### When
+```shell
+${atago} run notnull.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `0 passed, 4 failed`, `$.v == null`, `$.v = "null"`, `$.v = 0`, `$.v = false`, `$.v = ""`
+### Scenario: an absent path is not null either
+#### Given
+- Fixture file `absent.atago.yaml` is created.
+#### Inputs
+_Fixture `absent.atago.yaml`:_
+```text
+version: "1"
+suite: {name: absent}
+scenarios:
+  - name: the field is not in the document
+    steps:
+      - run: {shell: true, command: 'printf ''{"other": 1}'''}
+      - assert: {stdout: {json: {path: "$.v", equals: null}}}
+```
+#### When
+```shell
+${atago} run absent.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `selected no value`
+### Scenario: a json check with no matcher at all is still rejected
+#### Given
+- Fixture file `bare.atago.yaml` is created.
+#### Inputs
+_Fixture `bare.atago.yaml`:_
+```text
+version: "1"
+suite: {name: bare}
+scenarios:
+  - name: a path with nothing to assert
+    steps:
+      - run: {shell: true, command: 'printf ''{"v": null}'''}
+      - assert: {stdout: {json: {path: "$.v"}}}
+```
+#### When
+```shell
+${atago} run bare.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `must set one of equals/matches/length/gt/gte/lt/lte`
+### Scenario: explain and doc describe a null assertion as one
+#### Given
+- Fixture file `nullspec.atago.yaml` is created.
+#### Inputs
+_Fixture `nullspec.atago.yaml`:_
+```text
+version: "1"
+suite: {name: nullspec}
+scenarios:
+  - name: a cleared field
+    steps:
+      - run: {shell: true, command: 'printf ''{"v": null}'''}
+      - assert: {stdout: {json: {path: "$.v", equals: null}}}
+```
+#### When
+```shell
+${atago} explain nullspec.atago.yaml
+${atago} doc nullspec.atago.yaml
+```
+#### Then
+- after `${atago} explain nullspec.atago.yaml`:
+  - exit code is `0`
+  - stdout contains `stdout JSON $.v == null`
+  - stdout does not contain `<nil>`
+- after `${atago} doc nullspec.atago.yaml`:
+  - exit code is `0`
+  - stdout contains `equals `null``
 ## atago self-hosting / line selector
 Source: `test/e2e/atago/line.atago.yaml`
 ### Scenario: line selector narrows stdout to a single 1-based line

--- a/internal/assert/assert_test.go
+++ b/internal/assert/assert_test.go
@@ -2340,6 +2340,69 @@ func TestCheck_JSON_NullRendersAsNull(t *testing.T) {
 	}
 }
 
+// TestCheck_JSONEquals_Null covers the assertion `equals: null` enables (#309):
+// "this field is null" is a contract of its own, distinct from "this field is
+// absent" and from the string "null". The loader records the key presence;
+// here the matcher has to act on it.
+func TestCheck_JSONEquals_Null(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		stdout  string
+		wantOK  bool
+		wantOut string // substring the failure must name
+	}{
+		{name: "a null value passes", stdout: `{"v":null}`, wantOK: true},
+		{name: "the string null fails", stdout: `{"v":"null"}`, wantOut: `$.v = "null"`},
+		{name: "zero fails", stdout: `{"v":0}`, wantOut: "$.v = 0"},
+		{name: "false fails", stdout: `{"v":false}`, wantOut: "$.v = false"},
+		{name: "the empty string fails", stdout: `{"v":""}`, wantOut: `$.v = ""`},
+		{name: "an empty object fails", stdout: `{"v":{}}`, wantOut: "$.v = "},
+		{name: "a missing field is not null", stdout: `{"other":1}`, wantOut: "selected no value"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			res := &runner.Result{Stdout: []byte(tt.stdout)}
+			// EqualsSet is what a decoded `equals: null` carries; Equals stays nil.
+			check := spec.JSONChecks{{Path: "$.v", EqualsSet: true}}
+			got := Check(&spec.Assert{Stdout: &spec.StreamAssert{JSON: check}}, res, Env{})
+			if got.OK != tt.wantOK {
+				t.Fatalf("OK = %v, want %v (hint: %s)", got.OK, tt.wantOK, got.Hint)
+			}
+			if tt.wantOK {
+				if !strings.Contains(got.Desc, "== null") {
+					t.Errorf("Desc = %q, want it to spell the expected value null", got.Desc)
+				}
+				return
+			}
+			if !strings.Contains(got.Actual+got.Hint, tt.wantOut) {
+				t.Errorf("Actual = %q / Hint = %q, want one to contain %q", got.Actual, got.Hint, tt.wantOut)
+			}
+			if strings.Contains(got.Actual, "<nil>") || strings.Contains(got.Expected, "<nil>") {
+				t.Errorf("message leaks a Go nil: Expected = %q, Actual = %q", got.Expected, got.Actual)
+			}
+		})
+	}
+}
+
+// TestCheck_JSONEquals_NullVsNoMatcher pins that the two states the loader
+// separates stay separated at run time: a check carrying only a path is still
+// reported as matcher-less rather than silently asserting null.
+func TestCheck_JSONEquals_NullVsNoMatcher(t *testing.T) {
+	t.Parallel()
+	res := &runner.Result{Stdout: []byte(`{"v":null}`)}
+	got := Check(&spec.Assert{Stdout: &spec.StreamAssert{
+		JSON: spec.JSONChecks{{Path: "$.v"}},
+	}}, res, Env{})
+	if got.OK {
+		t.Fatal("a json check with no matcher must not pass against a null value")
+	}
+	if !strings.Contains(got.Hint, "must set equals/matches/length") {
+		t.Errorf("Hint = %q, want the matcher-less hint", got.Hint)
+	}
+}
+
 // TestCheck_DirExists_OnAFilePathSaysSo pins the hint for the confusing case: a
 // path that exists as a file reported a bare "exists=false", which reads as
 // "nothing is there" and sends the author looking for output that is sitting

--- a/internal/assert/jsonmatch.go
+++ b/internal/assert/jsonmatch.go
@@ -140,7 +140,7 @@ func applyJSONMatch(desc string, parsed any, j *spec.JSONAssert) *CheckResult {
 		return jsonCompare(desc, j.Path, nodes, "lt", *j.Lt)
 	case j.Lte != nil:
 		return jsonCompare(desc, j.Path, nodes, "lte", *j.Lte)
-	case j.Equals != nil:
+	case j.HasEquals():
 		return jsonEquals(desc, j.Path, nodes, j.Equals)
 	default:
 		return &CheckResult{Desc: desc, Hint: "json matcher must set equals/matches/length/gt/gte/lt/lte"}

--- a/internal/assertdesc/describe.go
+++ b/internal/assertdesc/describe.go
@@ -47,6 +47,18 @@ func (s JSONStyle) WithPrefix(prefix func(string) string) JSONStyle {
 	return s
 }
 
+// JSONValueText renders a json/yaml matcher's expected value for prose. Go
+// prints a nil as "<nil>", which since #309 is a value a spec can legitimately
+// assert (`equals: null`), and a Go-ism in a sentence about someone else's
+// document. The failure messages already spell a JSON null the way the document
+// does; the generated docs and `explain` now agree with them.
+func JSONValueText(v any) string {
+	if v == nil {
+		return "null"
+	}
+	return fmt.Sprint(v)
+}
+
 func DescribeJSONChecks(list spec.JSONChecks, style JSONStyle) string {
 	parts := make([]string, len(list))
 	for i := range list {
@@ -57,7 +69,7 @@ func DescribeJSONChecks(list spec.JSONChecks, style JSONStyle) string {
 
 func DescribeJSONMatcher(j *spec.JSONAssert, style JSONStyle) string {
 	switch {
-	case j.Equals != nil:
+	case j.HasEquals():
 		return style.Equals(j.Equals)
 	case j.Matches != nil:
 		return style.Matches(*j.Matches)

--- a/internal/assertdesc/describe_test.go
+++ b/internal/assertdesc/describe_test.go
@@ -260,6 +260,31 @@ func f64ptr(f float64) *float64 { return &f }
 // TestJSONStyle_WithPrefix pins that only the path prefix changes: the YAML
 // variant of a JSON style used to be a field-by-field copy, so a field added
 // later was silently dropped from it.
+// TestDescribeJSONMatcher_EqualsNull pins that a null assertion (#309) is
+// described as the matcher it is, not as an unset one, and that the value is
+// spelled the way the document spells it rather than as a Go nil.
+func TestDescribeJSONMatcher_EqualsNull(t *testing.T) {
+	t.Parallel()
+	style := JSONStyle{
+		Prefix:  func(path string) string { return path },
+		Equals:  func(v any) string { return "== " + JSONValueText(v) },
+		Matches: func(s string) string { return "matches " + s },
+		Length:  func(n int) string { return fmt.Sprintf("length %d", n) },
+		Compare: func(op string, v any) string { return fmt.Sprintf("%s %v", op, v) },
+		Default: "is checked",
+	}
+	if got := DescribeJSONChecks(spec.JSONChecks{{Path: "$.v", EqualsSet: true}}, style); got != "$.v == null" {
+		t.Errorf("equals null = %q, want %q", got, "$.v == null")
+	}
+	// A check with no matcher at all still falls through to the default text.
+	if got := DescribeJSONChecks(spec.JSONChecks{{Path: "$.v"}}, style); got != "$.v is checked" {
+		t.Errorf("no matcher = %q, want %q", got, "$.v is checked")
+	}
+	if got := JSONValueText("x"); got != "x" {
+		t.Errorf("JSONValueText(%q) = %q, want the value unchanged", "x", got)
+	}
+}
+
 func TestJSONStyle_WithPrefix(t *testing.T) {
 	t.Parallel()
 	base := JSONStyle{

--- a/internal/docgen/describe.go
+++ b/internal/docgen/describe.go
@@ -24,7 +24,7 @@ func codeList(subs spec.StringList) string {
 
 var docgenJSONStyle = assertdesc.JSONStyle{
 	Prefix:  func(path string) string { return "at " + markdown.Code(path) },
-	Equals:  func(v any) string { return "equals " + markdown.Code(fmt.Sprint(v)) },
+	Equals:  func(v any) string { return "equals " + markdown.Code(assertdesc.JSONValueText(v)) },
 	Matches: func(s string) string { return "matches " + markdown.Code("/"+s+"/") },
 	Length:  func(n int) string { return fmt.Sprintf("has length %d", n) },
 	Compare: func(op string, v any) string { return "is " + markdown.Code(fmt.Sprintf("%s %v", op, v)) },

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -408,7 +408,7 @@ func describePDF(p *spec.PDFAssert) string {
 
 var explainJSONStyle = assertdesc.JSONStyle{
 	Prefix:  func(path string) string { return "JSON " + path },
-	Equals:  func(v any) string { return fmt.Sprintf("== %v", v) },
+	Equals:  func(v any) string { return "== " + assertdesc.JSONValueText(v) },
 	Matches: func(s string) string { return fmt.Sprintf("matches /%s/", s) },
 	Length:  func(n int) string { return fmt.Sprintf("length %d", n) },
 	Compare: func(op string, v any) string { return fmt.Sprintf("%s %v", op, v) },

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -907,6 +907,54 @@ func TestLoadBytes_BinaryTagAccepted(t *testing.T) {
 	}
 }
 
+// TestLoadBytes_JSONEqualsNull pins the difference between `equals: null` — an
+// assertion that the selected value IS JSON null — and an omitted `equals` key,
+// which means no matcher was set (#309). Both decode the value to a nil
+// interface, so only the recorded key presence separates them.
+func TestLoadBytes_JSONEqualsNull(t *testing.T) {
+	t.Parallel()
+
+	for _, spelling := range []string{"equals: null", "equals: ~", "equals: Null"} {
+		src := specSteps("assert: {stdout: {json: {path: \"$.v\", " + spelling + "}}}")
+		s, err := LoadBytes("t.atago.yaml", []byte(src))
+		if err != nil {
+			t.Fatalf("LoadBytes(%s) error = %v, want a clean load", spelling, err)
+		}
+		checks := s.Scenarios[0].Steps[0].Assert.Stdout.JSON
+		if len(checks) != 1 {
+			t.Fatalf("%s: got %d checks, want 1", spelling, len(checks))
+		}
+		if checks[0].Equals != nil {
+			t.Errorf("%s: Equals = %#v, want a nil value (the YAML null)", spelling, checks[0].Equals)
+		}
+		if !checks[0].HasEquals() {
+			t.Errorf("%s: HasEquals() = false, want the matcher recorded as present", spelling)
+		}
+	}
+
+	// An `equals` key written with a real value keeps reporting present, and a
+	// check with no `equals` key at all is still matcher-less.
+	src := specSteps("assert: {stdout: {json: [{path: \"$.a\", equals: 1}, {path: \"$.b\", equals: null}]}}")
+	s, err := LoadBytes("t.atago.yaml", []byte(src))
+	if err != nil {
+		t.Fatalf("LoadBytes(list form) error = %v", err)
+	}
+	for i, c := range s.Scenarios[0].Steps[0].Assert.Stdout.JSON {
+		if !c.HasEquals() {
+			t.Errorf("list check %d: HasEquals() = false, want true", i)
+		}
+	}
+	mustReject(t, "json without equals", specSteps("assert: {stdout: {json: {path: \"$.v\"}}}"),
+		"must set one of equals/matches/length/gt/gte/lt/lte")
+	mustReject(t, "json equals null with a second matcher", specSteps("assert: {stdout: {json: {path: \"$.v\", equals: null, length: 1}}}"),
+		"must set exactly one of equals/matches/length/gt/gte/lt/lte")
+	// The presence check must not swallow the strict unknown-key rejection: a
+	// custom UnmarshalYAML bypasses the loader's document-wide yaml.Strict(),
+	// so a typo inside a check has to be caught by the check itself.
+	mustReject(t, "json typo'd matcher key", specSteps("assert: {stdout: {json: {path: \"$.v\", equal: null}}}"),
+		"equal")
+}
+
 // specSteps assembles a minimal one-scenario spec whose steps are the given
 // flow-style step entries (each is the text after "- " in a steps list). It
 // keeps the many one-off validation cases readable without hand-indenting YAML.

--- a/internal/loader/validate_assert.go
+++ b/internal/loader/validate_assert.go
@@ -245,7 +245,7 @@ func validateJSON(add func(string, ...any), where string, j *spec.JSONAssert) {
 		add("%s.path is required", where)
 	}
 	n := 0
-	if j.Equals != nil {
+	if j.HasEquals() {
 		n++
 	}
 	if j.Matches != nil {

--- a/internal/spec/assert.go
+++ b/internal/spec/assert.go
@@ -407,6 +407,73 @@ type JSONAssert struct {
 	Gte     *float64 `yaml:"gte,omitempty"`
 	Lt      *float64 `yaml:"lt,omitempty"`
 	Lte     *float64 `yaml:"lte,omitempty"`
+
+	// EqualsSet records that the `equals` key was written, which is the only way
+	// to tell `equals: null` (assert the value IS JSON null) from an omitted key
+	// (no matcher set): both decode Equals to a nil interface (#309). It is set
+	// by UnmarshalYAML and carries no YAML key of its own; read it through
+	// HasEquals so a spec built in Go — a test, a generator — needs no extra
+	// bookkeeping.
+	EqualsSet bool `yaml:"-"`
+}
+
+// HasEquals reports whether the check sets an `equals` matcher. A non-nil value
+// counts on its own so a JSONAssert constructed in Go behaves like a decoded
+// one, and EqualsSet covers the null case, whose value is indistinguishable
+// from absence.
+func (j *JSONAssert) HasEquals() bool {
+	return j.Equals != nil || j.EqualsSet
+}
+
+// UnmarshalYAML decodes the mapping with the plain struct rules and then records
+// whether `equals` was present. It decodes strictly so an unknown key inside a
+// check is still rejected: a custom unmarshaler bypasses the loader's
+// document-wide yaml.Strict(), the same trap ExitCode and PTYSend document.
+// Presence is read from a generic map decode rather than by walking the AST so
+// an aliased or merged mapping is resolved first.
+func (j *JSONAssert) UnmarshalYAML(node ast.Node) error {
+	type plain JSONAssert // no UnmarshalYAML, so the default decode applies
+	var p plain
+	if err := yaml.NodeToValue(node, &p, yaml.Strict()); err != nil {
+		return err
+	}
+	*j = JSONAssert(p)
+	var keys map[string]any
+	if err := yaml.NodeToValue(node, &keys); err == nil {
+		_, j.EqualsSet = keys["equals"]
+	}
+	return nil
+}
+
+// MarshalYAML writes the keys in the order the struct declares them, emitting
+// `equals` whenever HasEquals reports it set. The default struct marshal drops
+// an `equals: null` (omitempty cannot see the difference), which would turn a
+// null assertion into a matcher-less check the loader then rejects — the same
+// asymmetry ExitCode.MarshalYAML exists to avoid.
+func (j JSONAssert) MarshalYAML() (any, error) {
+	out := yaml.MapSlice{{Key: "path", Value: j.Path}}
+	if j.HasEquals() {
+		out = append(out, yaml.MapItem{Key: "equals", Value: j.Equals})
+	}
+	if j.Matches != nil {
+		out = append(out, yaml.MapItem{Key: "matches", Value: *j.Matches})
+	}
+	if j.Length != nil {
+		out = append(out, yaml.MapItem{Key: "length", Value: *j.Length})
+	}
+	if j.Gt != nil {
+		out = append(out, yaml.MapItem{Key: "gt", Value: *j.Gt})
+	}
+	if j.Gte != nil {
+		out = append(out, yaml.MapItem{Key: "gte", Value: *j.Gte})
+	}
+	if j.Lt != nil {
+		out = append(out, yaml.MapItem{Key: "lt", Value: *j.Lt})
+	}
+	if j.Lte != nil {
+		out = append(out, yaml.MapItem{Key: "lte", Value: *j.Lte})
+	}
+	return out, nil
 }
 
 // JSONChecks is the argument to a `json:` (and `yaml:`) matcher (#156). It

--- a/internal/spec/roundtrip_test.go
+++ b/internal/spec/roundtrip_test.go
@@ -3,6 +3,7 @@ package spec
 import (
 	"math/rand"
 	"reflect"
+	"strings"
 	"testing"
 	"testing/quick"
 
@@ -101,6 +102,63 @@ func TestPTYSend_YAMLRoundTrip(t *testing.T) {
 				t.Errorf("send round-trip:\n in  = %+v\n got = %+v", in, got)
 			}
 		})
+	}
+}
+
+// TestJSONAssert_YAMLRoundTrip covers the pair `equals: null` and no `equals`
+// key at all (#309). The default struct marshal drops a null `equals` (omitempty
+// cannot see the difference between "null" and "unset"), which would rewrite a
+// null assertion as a matcher-less check the loader then rejects.
+func TestJSONAssert_YAMLRoundTrip(t *testing.T) {
+	t.Parallel()
+	cases := map[string]JSONAssert{
+		"equals null":   {Path: "$.v", EqualsSet: true},
+		"equals string": {Path: "$.v", Equals: "x"},
+		"equals number": {Path: "$.v", Equals: uint64(2)},
+		"equals bool":   {Path: "$.v", Equals: true},
+		"equals empty":  {Path: "$.v", Equals: ""},
+		"matches":       {Path: "$.v", Matches: strp("^a")},
+		"length":        {Path: "$.v", Length: intp(0)},
+		"gt":            {Path: "$.v", Gt: float64p(1.5)},
+		"lte":           {Path: "$.v", Lte: float64p(-2)},
+		"no matcher":    {Path: "$.v"}, // invalid, but must not gain one on the way out
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			want := in
+			// A non-nil value implies the key: HasEquals reports both the same
+			// way, so a reloaded check carries the flag its YAML shows.
+			want.EqualsSet = in.HasEquals()
+			got := marshalReload(t, in)
+			if !reflect.DeepEqual(want, got) {
+				t.Errorf("json check round-trip:\n in  = %+v\n got = %+v", want, got)
+			}
+			if got.HasEquals() != in.HasEquals() {
+				t.Errorf("HasEquals() = %v, want %v", got.HasEquals(), in.HasEquals())
+			}
+		})
+	}
+}
+
+// TestJSONAssert_MarshalSpellsNull pins the emitted text, not just the reload:
+// the whole point is that the written spec says `equals: null` where an absent
+// matcher writes nothing.
+func TestJSONAssert_MarshalSpellsNull(t *testing.T) {
+	t.Parallel()
+	b, err := yaml.Marshal(JSONAssert{Path: "$.v", EqualsSet: true})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if got := string(b); !strings.Contains(got, "equals: null") {
+		t.Errorf("marshaled = %q, want it to spell equals: null", got)
+	}
+	b, err = yaml.Marshal(JSONAssert{Path: "$.v"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if got := string(b); strings.Contains(got, "equals") {
+		t.Errorf("marshaled = %q, want no equals key at all", got)
 	}
 }
 

--- a/internal/spec/step_test.go
+++ b/internal/spec/step_test.go
@@ -7,9 +7,10 @@ import (
 	"github.com/goccy/go-yaml"
 )
 
-func intp(i int) *int       { return &i }
-func strp(s string) *string { return &s }
-func boolp(b bool) *bool    { return &b }
+func intp(i int) *int             { return &i }
+func strp(s string) *string       { return &s }
+func boolp(b bool) *bool          { return &b }
+func float64p(f float64) *float64 { return &f }
 
 func TestStep_SetKeysAndKind(t *testing.T) {
 	t.Parallel()

--- a/schema/atago.schema.json
+++ b/schema/atago.schema.json
@@ -2454,7 +2454,9 @@
           "minLength": 1,
           "description": "JSONPath selecting the value under test (e.g. \"$.items[0].name\")."
         },
-        "equals": true,
+        "equals": {
+          "description": "Requires the selected value to equal this value, compared by JSON type (the string \"true\" does not equal the boolean true). Write null to assert the value is JSON null; omitting the key means no matcher was set."
+        },
         "matches": {
           "type": "string",
           "description": "Requires the selected value (as a string) to match this Go regular expression."

--- a/test/e2e/atago/json_matcher_edges.atago.yaml
+++ b/test/e2e/atago/json_matcher_edges.atago.yaml
@@ -214,3 +214,124 @@ scenarios:
       - assert:
           stdout:
             not_contains: "<nil>"
+
+  # `equals: null` asserts the value IS null. Both a written null and an omitted
+  # key decode to the same Go nil, so the loader records which was authored;
+  # without that, this assertion was rejected as if no matcher were set.
+  - name: equals null asserts the field is null
+    steps:
+      - run:
+          shell: true
+          command: "printf '{\"done\": null, \"count\": 0}'"
+      - assert:
+          stdout:
+            json:
+              - path: "$.done"
+                equals: null
+              - path: "$.count"
+                equals: 0
+
+  - name: equals null rejects every value that is not null
+    steps:
+      # One spec per value keeps the failure attributable: the string "null", a
+      # zero, a false, and an empty string are the values most likely to be
+      # confused with a null.
+      - fixture:
+          file: notnull.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: notnull}
+            scenarios:
+              - name: the string spelling of null
+                steps:
+                  - run: {shell: true, command: 'printf ''{"v": "null"}'''}
+                  - assert: {stdout: {json: {path: "$.v", equals: null}}}
+              - name: zero is not null
+                steps:
+                  - run: {shell: true, command: 'printf ''{"v": 0}'''}
+                  - assert: {stdout: {json: {path: "$.v", equals: null}}}
+              - name: false is not null
+                steps:
+                  - run: {shell: true, command: 'printf ''{"v": false}'''}
+                  - assert: {stdout: {json: {path: "$.v", equals: null}}}
+              - name: the empty string is not null
+                steps:
+                  - run: {shell: true, command: 'printf ''{"v": ""}'''}
+                  - assert: {stdout: {json: {path: "$.v", equals: null}}}
+      - run: {command: "${atago} run notnull.atago.yaml"}
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "0 passed, 4 failed"
+              - "$.v == null"
+              - '$.v = "null"'
+              - "$.v = 0"
+              - "$.v = false"
+              - '$.v = ""'
+
+  - name: an absent path is not null either
+    steps:
+      # A missing field and a null field are different contracts: the missing one
+      # reports that the path selected nothing rather than passing as null.
+      - fixture:
+          file: absent.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: absent}
+            scenarios:
+              - name: the field is not in the document
+                steps:
+                  - run: {shell: true, command: 'printf ''{"other": 1}'''}
+                  - assert: {stdout: {json: {path: "$.v", equals: null}}}
+      - run: {command: "${atago} run absent.atago.yaml"}
+      - assert:
+          exit_code: 1
+          stdout:
+            contains: "selected no value"
+
+  - name: a json check with no matcher at all is still rejected
+    steps:
+      # The other half of the contract: recording the null must not turn a
+      # matcher-less check into an accidental null assertion.
+      - fixture:
+          file: bare.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: bare}
+            scenarios:
+              - name: a path with nothing to assert
+                steps:
+                  - run: {shell: true, command: 'printf ''{"v": null}'''}
+                  - assert: {stdout: {json: {path: "$.v"}}}
+      - run: {command: "${atago} run bare.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr:
+            contains: "must set one of equals/matches/length/gt/gte/lt/lte"
+
+  - name: explain and doc describe a null assertion as one
+    steps:
+      - fixture:
+          file: nullspec.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: nullspec}
+            scenarios:
+              - name: a cleared field
+                steps:
+                  - run: {shell: true, command: 'printf ''{"v": null}'''}
+                  - assert: {stdout: {json: {path: "$.v", equals: null}}}
+      - run: {command: "${atago} explain nullspec.atago.yaml"}
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "stdout JSON $.v == null"
+      - assert:
+          stdout:
+            not_contains: "<nil>"
+      - run: {command: "${atago} doc nullspec.atago.yaml"}
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "equals `null`"


### PR DESCRIPTION
Closes #309.

## Problem

```yaml
- assert:
    stdout:
      json:
        path: "$.v"
        equals: null
```

```
must set one of equals/matches/length/gt/gte/lt/lte
```

`JSONAssert.Equals` is `any`, so a YAML null decodes to a nil interface — exactly
what an absent key looks like. The presence check could not tell "assert this
value is null" from "no matcher was written", so the assertion was impossible to
express. `"this field is null"` and `"this field is absent"` are different
contracts and ordinary in API output; neither could be pinned.

## Change

`JSONAssert` records whether the `equals` key was authored:

- `UnmarshalYAML` decodes the mapping with the plain struct rules (strictly, so a
  typo inside a check is still rejected — a custom unmarshaler bypasses the
  loader's document-wide `yaml.Strict()`) and then sets `EqualsSet` from a
  generic map decode, which resolves aliases before the key check.
- `MarshalYAML` writes `equals: null` back out. The default struct marshal drops
  it (`omitempty` cannot see the difference), which would rewrite a null
  assertion into the matcher-less check the loader rejects.
- `HasEquals()` is what the loader, the matcher, and the describers now ask. A
  non-nil value counts on its own, so a spec built in Go needs no bookkeeping.

`valuesEqual` already handled nil on both sides, so the comparison itself is
unchanged.

`atago doc` and `atago explain` rendered the expected value with `fmt.Sprint`,
which prints a nil as `<nil>`; they now go through `assertdesc.JSONValueText` and
spell it `null`, agreeing with the failure messages. The schema's `equals`
property gains a description that says null is a value, not an omission.

## Behavior

| document | `equals: null` |
| --- | --- |
| `{"v": null}` | passes |
| `{"v": "null"}` | fails, `$.v = "null"` |
| `{"v": 0}` / `{"v": false}` / `{"v": ""}` | fails, value named |
| `{"other": 1}` | fails with "selected no value" |
| no `equals` key at all | still rejected at load |

## Tests

- `internal/spec`: round trip per matcher form including `equals: null` versus an
  absent key, plus the emitted text.
- `internal/loader`: `null`, `~`, and `Null` all load with the matcher present;
  list form; a second matcher still rejected; a typo'd key still rejected.
- `internal/assert`: the table above, and a matcher-less check against a null
  document still failing as matcher-less.
- `internal/assertdesc`: null described as a matcher, `null` not `<nil>`.
- `test/e2e/atago/json_matcher_edges.atago.yaml`: 6 new scenarios covering the
  passing assertion, the four near-miss values with their failure text, the
  absent path, the still-rejected bare check, and `doc`/`explain` output.

`make test`, `make lint`, `make e2e` (453 scenarios), `make docs`, `make site`
are green.