### PR TITLE
fix(artifacts): give each attempt of a scenario its own artifact directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- `--artifacts-dir` no longer lets one attempt of a scenario overwrite another's
+  payloads. A `--repeat` run reports the first failing iteration inline and
+  points at its sidecar files, but every iteration wrote to the same paths, so
+  the last failure overwrote the evidence the report still referenced: opening
+  the artifact showed a payload from a different iteration than the diff printed
+  beside it, and the other iterations' payloads were gone. Each attempt after the
+  first now writes under an `attempt-<N>` directory, which also keeps a
+  `--retry-failed` attempt's evidence instead of dropping it. A run with neither
+  flag writes exactly where it always did.
+
 - `json: equals: null` now asserts that a field is null instead of being
   rejected as a matcher-less check. A YAML null and an omitted `equals` key both
   decode to the same Go nil, so the loader could not tell "assert this value is

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,16 +1,17 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 433 scenarios
+74 suites · 434 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
   - [a single-quoted argument with a space stays one argument](#scenario-a-single-quoted-argument-with-a-space-stays-one-argument)
   - [a block-scalar command splits on newlines like spaces](#scenario-a-block-scalar-command-splits-on-newlines-like-spaces)
   - [a folded-scalar command drops its trailing newline](#scenario-a-folded-scalar-command-drops-its-trailing-newline)
-- [atago self-hosting / artifacts-dir failure payloads](#atago-self-hosting--artifacts-dir-failure-payloads) — 4 scenarios
+- [atago self-hosting / artifacts-dir failure payloads](#atago-self-hosting--artifacts-dir-failure-payloads) — 5 scenarios
   - [a failing stdout equals writes expected and actual sidecars](#scenario-a-failing-stdout-equals-writes-expected-and-actual-sidecars)
   - [a passing scenario writes no failure payload](#scenario-a-passing-scenario-writes-no-failure-payload)
   - [the artifacts directory is created when it does not exist](#scenario-the-artifacts-directory-is-created-when-it-does-not-exist)
+  - [each repeat iteration keeps its own failure payloads](#scenario-each-repeat-iteration-keeps-its-own-failure-payloads)
   - [a file-content mismatch also writes a payload](#scenario-a-file-content-mismatch-also-writes-a-payload)
 - [atago self-hosting / variable expansion in assertion matcher values](#atago-self-hosting--variable-expansion-in-assertion-matcher-values) — 6 scenarios
   - [stdout.equals expands ${workdir}](#scenario-stdoutequals-expands-workdir)
@@ -618,6 +619,45 @@ ${atago} run --artifacts-dir deep/made/arts nested.atago.yaml
 #### Then
 - exit code is `1`
 - dir `deep/made/arts` exists
+### Scenario: each repeat iteration keeps its own failure payloads
+#### Given
+- Fixture file `repeated.atago.yaml` is created.
+#### Inputs
+_Fixture `repeated.atago.yaml`:_
+```text
+version: "1"
+suite: {name: repeated}
+scenarios:
+  - name: prints its own workdir
+    steps:
+      # $${workdir} escapes the OUTER expansion, so the inner run
+      # prints its own per-iteration workdir instead of a constant.
+      - run: {shell: true, command: "echo $${workdir}"}
+      - assert: {stdout: {equals: "never-this"}}
+```
+#### When
+```shell
+${atago} run --repeat 3 --artifacts-dir reparts repeated.atago.yaml
+find reparts -type d -name 'attempt-*' | sort | sed 's#.*/##'
+find reparts -name '*.actual.txt' | wc -l | tr -d ' '
+cat $(find reparts -name '*.actual.txt') | sort -u | wc -l | tr -d ' '
+```
+#### Then
+- after `${atago} run --repeat 3 --artifacts-dir reparts repeated.atago.yaml`:
+  - exit code is `1`
+- after `find reparts -type d -name 'attempt-*' | sort | sed 's#.*/##'`:
+  - exit code is `0`
+  - stdout equals an exact value
+- after `find reparts -name '*.actual.txt' | wc -l | tr -d ' '`:
+  - stdout equals an exact value
+- after `cat $(find reparts -name '*.actual.txt') | sort -u | wc -l | tr -d ' '`:
+  - stdout equals an exact value
+#### Expected output
+_expected stdout:_
+```text
+attempt-2
+attempt-3
+```
 ### Scenario: a file-content mismatch also writes a payload
 #### Given
 - Fixture file `filefail.atago.yaml` is created.

--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -90,24 +90,56 @@ func StepFile(stepIndex int, kind, role, ext string) string {
 	return fmt.Sprintf("step-%02d-%s.%s.%s", stepIndex, Slug(kind), Slug(role), ext)
 }
 
-// FailurePath composes the full relative path for a failed assertion's sidecar
-// file: <suite-token>/<scenario-token>/<step-file>. It is deterministic and
-// collision-free across suites, scenarios, steps, and parallel runs.
-func FailurePath(specPath, scenario string, scenarioIdx, stepIdx int, kind, role, ext string) string {
-	return path.Join(SuiteToken(specPath), ScenarioToken(scenario, scenarioIdx), StepFile(stepIdx, kind, role, ext))
+// Scenario identifies one execution of one scenario: everything an artifact path
+// needs apart from the step itself. Holding the fields together is what keeps a
+// caller from composing a path for the wrong execution — the engine writes
+// failure payloads, service logs, and mock request logs from four different
+// places for the same run.
+type Scenario struct {
+	// SpecPath is the spec file the scenario was loaded from.
+	SpecPath string
+	// Name is the scenario name; Index disambiguates scenarios that share one
+	// (matrix rows).
+	Name  string
+	Index int
+	// Attempt counts executions of this same scenario: 1 (or 0) for a plain run,
+	// then 2, 3, ... for each further --repeat iteration or --retry-failed
+	// attempt. Every attempt after the first gets its own subdirectory, because a
+	// report describes ONE attempt inline and points at that attempt's payloads:
+	// sharing a path lets a later attempt overwrite evidence the report still
+	// references, leaving the file disagreeing with the diff printed beside it.
+	Attempt int
+}
+
+// Dir is the directory every artifact of this execution lives in:
+// <suite-token>/<scenario-token>, plus an attempt-<N> segment from the second
+// attempt on. The first attempt keeps the plain path, so a run with neither
+// --repeat nor --retry-failed writes exactly where it always has.
+func (s Scenario) Dir() string {
+	dir := path.Join(SuiteToken(s.SpecPath), ScenarioToken(s.Name, s.Index))
+	if s.Attempt > 1 {
+		dir = path.Join(dir, fmt.Sprintf("attempt-%d", s.Attempt))
+	}
+	return dir
+}
+
+// FailurePath composes the relative path for a failed assertion's sidecar file:
+// <dir>/<step-file>. It is deterministic and collision-free across suites,
+// scenarios, attempts, steps, and parallel runs.
+func (s Scenario) FailurePath(stepIdx int, kind, role, ext string) string {
+	return path.Join(s.Dir(), StepFile(stepIdx, kind, role, ext))
 }
 
 // ServiceLogPath composes the relative path for a background service's preserved
-// combined stdout/stderr log (#51): <suite-token>/<scenario-token>/service-<name>.log.
-// It shares the scenario directory with failure sidecars and is collision-free
-// across services, scenarios, suites, and parallel runs.
-func ServiceLogPath(specPath, scenario string, scenarioIdx int, serviceName string) string {
-	return path.Join(SuiteToken(specPath), ScenarioToken(scenario, scenarioIdx), "service-"+Slug(serviceName)+".log")
+// combined stdout/stderr log (#51): <dir>/service-<name>.log, sharing the
+// scenario directory with failure sidecars.
+func (s Scenario) ServiceLogPath(serviceName string) string {
+	return path.Join(s.Dir(), "service-"+Slug(serviceName)+".log")
 }
 
 // MockLogPath composes the relative path for a mock server's preserved request
-// log: <suite-token>/<scenario-token>/mock-<name>.log. The mock- prefix keeps
-// it distinct from a service log even when a mock and a service share a name.
-func MockLogPath(specPath, scenario string, scenarioIdx int, mockName string) string {
-	return path.Join(SuiteToken(specPath), ScenarioToken(scenario, scenarioIdx), "mock-"+Slug(mockName)+".log")
+// log: <dir>/mock-<name>.log. The mock- prefix keeps it distinct from a service
+// log even when a mock and a service share a name.
+func (s Scenario) MockLogPath(mockName string) string {
+	return path.Join(s.Dir(), "mock-"+Slug(mockName)+".log")
 }

--- a/internal/artifact/artifact_test.go
+++ b/internal/artifact/artifact_test.go
@@ -1,6 +1,7 @@
 package artifact
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,7 +47,8 @@ func TestSuiteTokenDeterministicAndCollisionFree(t *testing.T) {
 
 func TestFailurePathStableAndUnique(t *testing.T) {
 	t.Parallel()
-	p := FailurePath("test/e2e/atago/run.atago.yaml", "prints hello", 0, 2, "stdout", "actual", "txt")
+	run := Scenario{SpecPath: "test/e2e/atago/run.atago.yaml", Name: "prints hello"}
+	p := run.FailurePath(2, "stdout", "actual", "txt")
 	if !strings.HasSuffix(p, "step-02-stdout.actual.txt") {
 		t.Errorf("FailurePath filename = %q", p)
 	}
@@ -54,7 +56,8 @@ func TestFailurePathStableAndUnique(t *testing.T) {
 		t.Errorf("FailurePath must use forward slashes: %q", p)
 	}
 	// Distinct scenarios in the same suite never collide.
-	q := FailurePath("test/e2e/atago/run.atago.yaml", "prints hello", 1, 2, "stdout", "actual", "txt")
+	second := Scenario{SpecPath: "test/e2e/atago/run.atago.yaml", Name: "prints hello", Index: 1}
+	q := second.FailurePath(2, "stdout", "actual", "txt")
 	if p == q {
 		t.Errorf("scenario index did not disambiguate path: %q", p)
 	}
@@ -64,11 +67,12 @@ func TestFailurePathStableAndUnique(t *testing.T) {
 // never collides with a service log even when both share a declared name.
 func TestMockLogPath_DistinctFromServiceLog(t *testing.T) {
 	t.Parallel()
-	m := MockLogPath("test/e2e/atago/mock.atago.yaml", "client posts", 0, "api")
+	run := Scenario{SpecPath: "test/e2e/atago/mock.atago.yaml", Name: "client posts"}
+	m := run.MockLogPath("api")
 	if !strings.HasSuffix(m, "mock-api.log") {
 		t.Errorf("MockLogPath = %q", m)
 	}
-	s := ServiceLogPath("test/e2e/atago/mock.atago.yaml", "client posts", 0, "api")
+	s := run.ServiceLogPath("api")
 	if m == s {
 		t.Errorf("mock and service logs for the same name collided: %q", m)
 	}
@@ -76,19 +80,67 @@ func TestMockLogPath_DistinctFromServiceLog(t *testing.T) {
 
 func TestServiceLogPathStableAndUnique(t *testing.T) {
 	t.Parallel()
-	p := ServiceLogPath("test/e2e/atago/services.atago.yaml", "peer talks", 0, "api server")
+	run := Scenario{SpecPath: "test/e2e/atago/services.atago.yaml", Name: "peer talks"}
+	p := run.ServiceLogPath("api server")
 	if !strings.HasSuffix(p, "service-api-server.log") {
 		t.Errorf("ServiceLogPath = %q", p)
 	}
 	// Distinct services in the same scenario land in distinct files.
-	q := ServiceLogPath("test/e2e/atago/services.atago.yaml", "peer talks", 0, "db server")
+	q := run.ServiceLogPath("db server")
 	if p == q {
 		t.Errorf("distinct services collided: %q", p)
 	}
 	// Same scenario dir as failure sidecars.
-	fp := FailurePath("test/e2e/atago/services.atago.yaml", "peer talks", 0, 1, "stdout", "actual", "txt")
+	fp := run.FailurePath(1, "stdout", "actual", "txt")
 	if dirOf(p) != dirOf(fp) {
 		t.Errorf("service log %q not in the scenario dir of %q", p, fp)
+	}
+}
+
+// TestScenarioDir_AttemptSeparatesRepeatedExecutions pins the attempt segment: a
+// plain run keeps the path it always had, and every further --repeat iteration or
+// --retry-failed attempt writes under its own directory so one attempt's payload
+// cannot overwrite another's while a report still points at it.
+func TestScenarioDir_AttemptSeparatesRepeatedExecutions(t *testing.T) {
+	t.Parallel()
+	base := Scenario{SpecPath: "test/e2e/atago/run.atago.yaml", Name: "prints hello"}
+	// Attempt 0 (never set) and 1 (the first execution) are the same location.
+	if got, want := base.Dir(), (Scenario{SpecPath: base.SpecPath, Name: base.Name, Attempt: 1}).Dir(); got != want {
+		t.Errorf("attempt 0 dir = %q, attempt 1 dir = %q, want them identical", got, want)
+	}
+	if strings.Contains(base.Dir(), "attempt-") {
+		t.Errorf("first attempt dir = %q, want no attempt segment", base.Dir())
+	}
+
+	seen := map[string]bool{base.Dir(): true}
+	for attempt := 2; attempt <= 4; attempt++ {
+		s := base
+		s.Attempt = attempt
+		dir := s.Dir()
+		if !strings.HasSuffix(dir, fmt.Sprintf("attempt-%d", attempt)) {
+			t.Errorf("attempt %d dir = %q, want it to name the attempt", attempt, dir)
+		}
+		if !strings.HasPrefix(dir, base.Dir()+"/") {
+			t.Errorf("attempt %d dir = %q, want it under the scenario dir %q", attempt, dir, base.Dir())
+		}
+		if seen[dir] {
+			t.Errorf("attempt %d reused directory %q", attempt, dir)
+		}
+		seen[dir] = true
+	}
+
+	// Every artifact of one attempt shares that attempt's directory, so a
+	// scenario's failure payloads, service logs, and mock logs stay together.
+	third := base
+	third.Attempt = 3
+	for _, p := range []string{
+		third.FailurePath(1, "stdout", "actual", "txt"),
+		third.ServiceLogPath("api"),
+		third.MockLogPath("api"),
+	} {
+		if dirOf(p) != third.Dir() {
+			t.Errorf("%q is not in the attempt dir %q", p, third.Dir())
+		}
 	}
 }
 

--- a/internal/engine/artifacts_test.go
+++ b/internal/engine/artifacts_test.go
@@ -154,6 +154,137 @@ scenarios:
 	}
 }
 
+// TestEngine_RepeatedIterationsKeepTheirOwnArtifacts is the regression for a
+// silent lie in a --repeat report: every iteration wrote its payloads to the
+// same paths, so the last failing iteration overwrote the earlier ones while the
+// folded result kept the FIRST failing iteration's inline diff. A reviewer
+// opening the referenced sidecar saw a payload from a different iteration than
+// the one the report described. Each iteration's ${workdir} is unique, so the
+// actual stdout differs per iteration with no timing dependence.
+func TestEngine_RepeatedIterationsKeepTheirOwnArtifacts(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	const src = `
+version: "1"
+suite:
+  name: s
+scenarios:
+  - name: prints its own workdir
+    steps:
+      - run:
+          shell: true
+          command: echo ${workdir}
+      - assert:
+          stdout: {contains: NOPE}
+`
+	s, err := loader.LoadBytes("rep.atago.yaml", []byte(src))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	eng := New()
+	eng.Artifacts = artifact.NewDir(root)
+	eng.Repeat = 3
+	res := eng.Run(context.Background(), s, "rep.atago.yaml")
+	if res.Status != StatusFailed {
+		t.Fatalf("status = %s, want failed (every iteration fails)", res.Status)
+	}
+
+	cr := failedCheck(t, res)
+	var actualPath string
+	for _, a := range cr.ArtifactFiles {
+		if a.Role == "actual" {
+			actualPath = a.Path
+		}
+	}
+	if actualPath == "" {
+		t.Fatalf("no actual artifact recorded: %+v", cr.ArtifactFiles)
+	}
+	got, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(actualPath)))
+	if err != nil {
+		t.Fatalf("read artifact: %v", err)
+	}
+	// The sidecar the report points at must carry the payload the report
+	// described, not a later iteration's.
+	if strings.TrimSpace(string(got)) != strings.TrimSpace(cr.Actual) {
+		t.Errorf("artifact %s = %q, but the report's actual is %q", actualPath, got, cr.Actual)
+	}
+
+	// And no iteration's evidence is lost: three failing iterations leave three
+	// distinct payload files behind.
+	var actuals []string
+	err = filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && strings.HasSuffix(d.Name(), "stdout.actual.txt") {
+			actuals = append(actuals, p)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk artifacts: %v", err)
+	}
+	if len(actuals) != 3 {
+		t.Errorf("found %d actual payloads, want one per iteration: %v", len(actuals), actuals)
+	}
+	seen := map[string]bool{}
+	for _, p := range actuals {
+		b, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("read %s: %v", p, err)
+		}
+		if seen[string(b)] {
+			t.Errorf("two iterations wrote the same payload %q", b)
+		}
+		seen[string(b)] = true
+	}
+}
+
+// TestEngine_RetriedAttemptArtifactsMatchTheReport pins the same contract for
+// --retry-failed: the reported attempt is the last one, and the payload it
+// references has to be that attempt's.
+func TestEngine_RetriedAttemptArtifactsMatchTheReport(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	const src = `
+version: "1"
+suite:
+  name: s
+scenarios:
+  - name: prints its own workdir
+    steps:
+      - run:
+          shell: true
+          command: echo ${workdir}
+      - assert:
+          stdout: {contains: NOPE}
+`
+	s, err := loader.LoadBytes("retry.atago.yaml", []byte(src))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	eng := New()
+	eng.Artifacts = artifact.NewDir(root)
+	eng.RetryFailed = 2
+	res := eng.Run(context.Background(), s, "retry.atago.yaml")
+	if res.Status != StatusFailed {
+		t.Fatalf("status = %s, want failed (retries cannot help)", res.Status)
+	}
+	cr := failedCheck(t, res)
+	for _, a := range cr.ArtifactFiles {
+		if a.Role != "actual" {
+			continue
+		}
+		got, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(a.Path)))
+		if err != nil {
+			t.Fatalf("read artifact: %v", err)
+		}
+		if strings.TrimSpace(string(got)) != strings.TrimSpace(cr.Actual) {
+			t.Errorf("artifact %s = %q, but the reported attempt's actual is %q", a.Path, got, cr.Actual)
+		}
+	}
+}
+
 // failedCheck returns the first failed CheckResult across a suite result.
 func failedCheck(t *testing.T, res *SuiteResult) *assert.CheckResult {
 	t.Helper()

--- a/internal/engine/attempts.go
+++ b/internal/engine/attempts.go
@@ -19,7 +19,7 @@ func (e *Engine) runScenarioWithPolicy(ctx context.Context, idx int, sc *spec.Sc
 	case e.RetryFailed > 0:
 		return e.runWithRetries(ctx, idx, sc, rc)
 	default:
-		return e.runScenario(ctx, idx, sc, rc)
+		return e.runScenario(ctx, idx, sc, rc, 1)
 	}
 }
 
@@ -46,7 +46,7 @@ func (e *Engine) runRepeated(ctx context.Context, idx int, sc *spec.Scenario, rc
 		if ctx.Err() != nil && i > 0 {
 			break // canceled mid-repeat: report what actually ran
 		}
-		run := e.runScenario(ctx, idx, sc, rc)
+		run := e.runScenario(ctx, idx, sc, rc, i+1)
 		iterations = append(iterations, run.Status)
 		total += run.Duration
 		bad := run.Status == StatusFailed || run.Status == StatusError
@@ -97,13 +97,13 @@ func (e *Engine) runRepeated(ctx context.Context, idx int, sc *spec.Scenario, rc
 // failure. Skipped scenarios return immediately (a skip gate is not
 // instability).
 func (e *Engine) runWithRetries(ctx context.Context, idx int, sc *spec.Scenario, rc runConfig) ScenarioResult {
-	run := e.runScenario(ctx, idx, sc, rc)
+	run := e.runScenario(ctx, idx, sc, rc, 1)
 	attempts := 1
 	for (run.Status == StatusFailed || run.Status == StatusError) && attempts <= e.RetryFailed {
 		if ctx.Err() != nil {
 			break
 		}
-		retry := e.runScenario(ctx, idx, sc, rc)
+		retry := e.runScenario(ctx, idx, sc, rc, attempts+1)
 		attempts++
 		if retry.Status == StatusPassed {
 			retry.Status = StatusFlaky

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1484,7 +1484,7 @@ func TestWriteArtifacts(t *testing.T) {
 		ArtifactExpected: []byte("expected output"),
 		ArtifactBlobs:    []assert.ArtifactBlob{{Role: "diff", Ext: "png", Data: []byte("PNGDATA")}, {Role: "empty", Ext: "bin", Data: nil}},
 	}
-	e.writeArtifacts(cr, "t.atago.yaml", "scn", 0, 1)
+	e.writeArtifacts(cr, artifact.Scenario{SpecPath: "t.atago.yaml", Name: "scn"}, 1)
 	if len(cr.ArtifactFiles) != 3 { // actual, expected, diff (empty blob skipped)
 		t.Fatalf("ArtifactFiles = %d, want 3: %+v", len(cr.ArtifactFiles), cr.ArtifactFiles)
 	}
@@ -1496,17 +1496,17 @@ func TestWriteArtifacts(t *testing.T) {
 
 	// No-op guards.
 	passing := &assert.CheckResult{OK: true, ArtifactKind: "stdout", ArtifactActual: []byte("x")}
-	e.writeArtifacts(passing, "t.atago.yaml", "scn", 0, 0)
+	e.writeArtifacts(passing, artifact.Scenario{SpecPath: "t.atago.yaml", Name: "scn"}, 0)
 	if len(passing.ArtifactFiles) != 0 {
 		t.Error("passing check should write nothing")
 	}
 	noKind := &assert.CheckResult{OK: false, ArtifactActual: []byte("x")}
-	e.writeArtifacts(noKind, "t.atago.yaml", "scn", 0, 0)
+	e.writeArtifacts(noKind, artifact.Scenario{SpecPath: "t.atago.yaml", Name: "scn"}, 0)
 	if len(noKind.ArtifactFiles) != 0 {
 		t.Error("empty ArtifactKind should write nothing")
 	}
 	// Nil Artifacts dir: no panic, no write.
-	(&Engine{}).writeArtifacts(cr, "t.atago.yaml", "scn", 0, 0)
+	(&Engine{}).writeArtifacts(cr, artifact.Scenario{SpecPath: "t.atago.yaml", Name: "scn"}, 0)
 }
 
 // TestEngine_LeadingFixtureFailureErrorsScenario proves a leading fixture that

--- a/internal/engine/lifecycle.go
+++ b/internal/engine/lifecycle.go
@@ -106,7 +106,7 @@ func (x *scenarioRun) startServices(ctx context.Context) bool {
 			if proc != nil {
 				x.services = append(x.services, proc)
 			}
-			x.e.writeServiceLogs(&x.out, x.masker, x.services, x.rc.specPath, x.sc.Name, x.idx)
+			x.e.writeServiceLogs(&x.out, x.masker, x.services, x.artifactScope())
 			// The readiness error can embed the service's raw output, so mask secrets
 			// before it reaches a report (issue #12).
 			x.out.Steps = append(x.out.Steps, StepResult{Kind: spec.StepNone, Setup: true, ErrMsg: x.masker.Mask(err.Error())})

--- a/internal/engine/mask.go
+++ b/internal/engine/mask.go
@@ -75,10 +75,10 @@ func maskCheck(m *security.Masker, cr *assert.CheckResult) {
 // recordChecks masks each check and writes its failure artifacts, in place. It
 // is the shared post-processing for both assert steps and retry `until` checks,
 // which can each carry several targets (one CheckResult apiece).
-func (e *Engine) recordChecks(m *security.Masker, checks []*assert.CheckResult, specPath, scenario string, scenarioIdx, stepIdx int) {
+func (e *Engine) recordChecks(m *security.Masker, checks []*assert.CheckResult, sc artifact.Scenario, stepIdx int) {
 	for _, cr := range checks {
 		maskCheck(m, cr)
-		e.writeArtifacts(cr, specPath, scenario, scenarioIdx, stepIdx)
+		e.writeArtifacts(cr, sc, stepIdx)
 	}
 }
 
@@ -88,7 +88,7 @@ func (e *Engine) recordChecks(m *security.Masker, checks []*assert.CheckResult, 
 // no-op when no artifacts dir is configured, the assertion passed, or the check
 // carries no exportable payload. Masking has already happened via maskCheck, so
 // the bytes written here never contain secrets.
-func (e *Engine) writeArtifacts(cr *assert.CheckResult, specPath, scenario string, scenarioIdx, stepIdx int) {
+func (e *Engine) writeArtifacts(cr *assert.CheckResult, sc artifact.Scenario, stepIdx int) {
 	if e.Artifacts == nil || cr == nil || cr.OK || cr.ArtifactKind == "" {
 		return
 	}
@@ -96,7 +96,7 @@ func (e *Engine) writeArtifacts(cr *assert.CheckResult, specPath, scenario strin
 		if len(content) == 0 {
 			return
 		}
-		rel := artifact.FailurePath(specPath, scenario, scenarioIdx, stepIdx, cr.ArtifactKind, role, "txt")
+		rel := sc.FailurePath(stepIdx, cr.ArtifactKind, role, "txt")
 		p, err := e.Artifacts.Write(rel, content)
 		if err != nil {
 			return
@@ -111,7 +111,7 @@ func (e *Engine) writeArtifacts(cr *assert.CheckResult, specPath, scenario strin
 		if len(blob.Data) == 0 {
 			continue
 		}
-		rel := artifact.FailurePath(specPath, scenario, scenarioIdx, stepIdx, cr.ArtifactKind, blob.Role, blob.Ext)
+		rel := sc.FailurePath(stepIdx, cr.ArtifactKind, blob.Role, blob.Ext)
 		p, err := e.Artifacts.Write(rel, blob.Data)
 		if err != nil {
 			continue
@@ -127,7 +127,7 @@ func (e *Engine) writeArtifacts(cr *assert.CheckResult, specPath, scenario strin
 // failure with a silent service never creates an empty, noisy artifact. Secrets
 // are masked before the log is written, keeping saved logs consistent with the
 // rest of the report. Already-recorded services are not written twice.
-func (e *Engine) writeServiceLogs(out *ScenarioResult, m *security.Masker, procs []*servicerunner.Proc, specPath, scenario string, scenarioIdx int) {
+func (e *Engine) writeServiceLogs(out *ScenarioResult, m *security.Masker, procs []*servicerunner.Proc, sc artifact.Scenario) {
 	if e.Artifacts == nil {
 		return
 	}
@@ -139,7 +139,7 @@ func (e *Engine) writeServiceLogs(out *ScenarioResult, m *security.Masker, procs
 		if strings.TrimSpace(raw) == "" {
 			continue // no output → no artifact (avoids empty/noisy files)
 		}
-		rel := artifact.ServiceLogPath(specPath, scenario, scenarioIdx, proc.Name())
+		rel := sc.ServiceLogPath(proc.Name())
 		p, err := e.Artifacts.Write(rel, m.MaskBytes([]byte(raw)))
 		if err != nil {
 			continue
@@ -154,7 +154,7 @@ func (e *Engine) writeServiceLogs(out *ScenarioResult, m *security.Masker, procs
 // log is often the sharpest failure evidence a mock scenario has — a typo'd
 // client path shows up as a recorded 404. Failure-gated and artifacts-dir-gated
 // like service logs; a mock that recorded no request writes nothing.
-func (e *Engine) writeMockLogs(out *ScenarioResult, m *security.Masker, mocks []*mockrunner.Server, specPath, scenario string, scenarioIdx int) {
+func (e *Engine) writeMockLogs(out *ScenarioResult, m *security.Masker, mocks []*mockrunner.Server, sc artifact.Scenario) {
 	if e.Artifacts == nil {
 		return
 	}
@@ -170,7 +170,7 @@ func (e *Engine) writeMockLogs(out *ScenarioResult, m *security.Masker, mocks []
 		if log == "" {
 			continue // no recorded request -> no artifact
 		}
-		rel := artifact.MockLogPath(specPath, scenario, scenarioIdx, srv.Name())
+		rel := sc.MockLogPath(srv.Name())
 		p, err := e.Artifacts.Write(rel, m.MaskBytes([]byte(log)))
 		if err != nil {
 			continue

--- a/internal/engine/scenario.go
+++ b/internal/engine/scenario.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/nao1215/atago/internal/artifact"
 	"github.com/nao1215/atago/internal/platform"
 	"github.com/nao1215/atago/internal/runner"
 	browserrunner "github.com/nao1215/atago/internal/runner/browser"
@@ -24,8 +25,13 @@ import (
 // phases share. Splitting runScenario across methods on this struct keeps each
 // phase readable while the state stays in one place.
 type scenarioRun struct {
-	e       *Engine
-	idx     int
+	e   *Engine
+	idx int
+	// attempt is which execution of this scenario this is: 1 for a plain run,
+	// counting up per --repeat iteration and --retry-failed attempt. It only
+	// separates artifact directories, so one attempt's evidence cannot overwrite
+	// another's while a report still references it.
+	attempt int
 	sc      *spec.Scenario
 	rc      runConfig
 	specDir string
@@ -52,7 +58,7 @@ type scenarioRun struct {
 // skip check, resource setup (store, mock servers, leading fixtures, services),
 // the step loop, teardown, and cleanup. It orchestrates the phases; the phases
 // themselves live in lifecycle.go and stepexec.go.
-func (e *Engine) runScenario(ctx context.Context, scenarioIdx int, sc *spec.Scenario, rc runConfig) ScenarioResult {
+func (e *Engine) runScenario(ctx context.Context, scenarioIdx int, sc *spec.Scenario, rc runConfig, attempt int) ScenarioResult {
 	if reason, skip := e.skipReason(ctx, sc); skip {
 		return ScenarioResult{Name: sc.Name, Status: StatusSkipped, SkipReason: reason}
 	}
@@ -60,6 +66,7 @@ func (e *Engine) runScenario(ctx context.Context, scenarioIdx int, sc *spec.Scen
 	x := &scenarioRun{
 		e:            e,
 		idx:          scenarioIdx,
+		attempt:      attempt,
 		sc:           sc,
 		rc:           rc,
 		specDir:      rc.specDir,
@@ -109,12 +116,18 @@ func (e *Engine) runScenario(ctx context.Context, scenarioIdx int, sc *spec.Scen
 	// readiness failure (#51). Green runs write nothing (artifact-dir + failure
 	// gated), keeping logs opt-in rather than mandatory noise.
 	if x.out.Status == StatusFailed || x.out.Status == StatusError {
-		x.e.writeServiceLogs(&x.out, x.masker, x.services, x.rc.specPath, x.sc.Name, x.idx)
-		x.e.writeMockLogs(&x.out, x.masker, x.mocks, x.rc.specPath, x.sc.Name, x.idx)
+		x.e.writeServiceLogs(&x.out, x.masker, x.services, x.artifactScope())
+		x.e.writeMockLogs(&x.out, x.masker, x.mocks, x.artifactScope())
 	}
 
 	x.out.Duration = time.Since(x.start)
 	return x.out
+}
+
+// artifactScope names where this execution's artifact files belong: the suite,
+// the scenario, and which attempt wrote them.
+func (x *scenarioRun) artifactScope() artifact.Scenario {
+	return artifact.Scenario{SpecPath: x.rc.specPath, Name: x.sc.Name, Index: x.idx, Attempt: x.attempt}
 }
 
 // skipReason reports whether a scenario should be skipped given its skip/only

--- a/internal/engine/stepexec.go
+++ b/internal/engine/stepexec.go
@@ -190,7 +190,7 @@ func (x *scenarioRun) recordUntil(sr *StepResult, i int, checks []*assert.CheckR
 	if len(checks) == 0 {
 		return StatusPassed
 	}
-	x.e.recordChecks(x.masker, checks, x.rc.specPath, x.sc.Name, x.idx, i)
+	x.e.recordChecks(x.masker, checks, x.artifactScope(), i)
 	sr.Checks = append(sr.Checks, checks...)
 	if !assert.AllOK(checks) {
 		return StatusFailed
@@ -201,7 +201,7 @@ func (x *scenarioRun) recordUntil(sr *StepResult, i int, checks []*assert.CheckR
 // fail reports one engine-generated check (a killed timeout, a never-matching
 // pty expect) the same way an assertion failure is reported.
 func (x *scenarioRun) fail(sr *StepResult, i int, ck *assert.CheckResult) Status {
-	x.e.recordChecks(x.masker, []*assert.CheckResult{ck}, x.rc.specPath, x.sc.Name, x.idx, i)
+	x.e.recordChecks(x.masker, []*assert.CheckResult{ck}, x.artifactScope(), i)
 	sr.Checks = append(sr.Checks, ck)
 	return StatusFailed
 }
@@ -246,7 +246,7 @@ func (x *scenarioRun) execStep(ctx context.Context, steps []spec.Step, i int, st
 			Scrub:           x.rc.scrubber.Apply,
 			MockRecords:     x.mockRecords,
 		})
-		x.e.recordChecks(x.masker, crs, x.rc.specPath, x.sc.Name, x.idx, i)
+		x.e.recordChecks(x.masker, crs, x.artifactScope(), i)
 		sr.Checks = crs
 		if !assert.AllOK(crs) {
 			status = StatusFailed

--- a/internal/engine/suite.go
+++ b/internal/engine/suite.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/nao1215/atago/internal/artifact"
 	"github.com/nao1215/atago/internal/assert"
 	"github.com/nao1215/atago/internal/fixture"
 	"github.com/nao1215/atago/internal/runner"
@@ -14,6 +15,14 @@ import (
 	"github.com/nao1215/atago/internal/spec"
 	"github.com/nao1215/atago/internal/store"
 )
+
+// suiteArtifactScope names where a suite setup/teardown step's artifacts belong.
+// Those steps run once per suite rather than per scenario, so they carry the
+// phase label as their scenario name, the -1 index that marks "not a scenario",
+// and no attempt of their own.
+func suiteArtifactScope(rc runConfig, label string) artifact.Scenario {
+	return artifact.Scenario{SpecPath: rc.specPath, Name: label, Index: -1}
+}
 
 // suiteSetupLabel names the phase of a scenario error caused by a failed
 // suite.setup step, mirroring the "service setup" labeling for pre-step
@@ -136,7 +145,7 @@ func (e *Engine) runSuiteSteps(ctx context.Context, steps []spec.Step, rt *suite
 				// recordChecks masks secrets in the check payloads and writes any
 				// --artifacts-dir sidecars, exactly as the scenario path does — the
 				// suite path used to set sr.Checks raw and leak both (#243).
-				e.recordChecks(rc.masker, untilChecks, rc.specPath, label, -1, i)
+				e.recordChecks(rc.masker, untilChecks, suiteArtifactScope(rc, label), i)
 				sr.Checks = untilChecks
 				if !assert.AllOK(untilChecks) {
 					failed = true
@@ -166,7 +175,7 @@ func (e *Engine) runSuiteSteps(ctx context.Context, steps []spec.Step, rt *suite
 					return nil, false
 				},
 			})
-			e.recordChecks(rc.masker, crs, rc.specPath, label, -1, i)
+			e.recordChecks(rc.masker, crs, suiteArtifactScope(rc, label), i)
 			sr.Checks = crs
 			if !assert.AllOK(crs) {
 				failed = true

--- a/test/e2e/atago/artifacts.atago.yaml
+++ b/test/e2e/atago/artifacts.atago.yaml
@@ -72,6 +72,51 @@ scenarios:
       - assert:
           dir: {path: deep/made/arts, exists: true}
 
+  # A --repeat run executes one scenario several times, but the report describes
+  # ONE iteration inline and points at its payloads. When every iteration wrote to
+  # the same paths, the last one overwrote the evidence the report referenced, so
+  # the sidecar disagreed with the diff printed beside it. Each iteration prints
+  # its own workdir, which differs per iteration, so the payloads are distinct
+  # without any timing dependence.
+  - name: each repeat iteration keeps its own failure payloads
+    steps:
+      - fixture:
+          file: repeated.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: repeated}
+            scenarios:
+              - name: prints its own workdir
+                steps:
+                  # $${workdir} escapes the OUTER expansion, so the inner run
+                  # prints its own per-iteration workdir instead of a constant.
+                  - run: {shell: true, command: "echo $${workdir}"}
+                  - assert: {stdout: {equals: "never-this"}}
+      - run: {command: "${atago} run --repeat 3 --artifacts-dir reparts repeated.atago.yaml"}
+      - assert: {exit_code: 1}
+      # Attempts 2 and 3 each get their own directory; attempt 1 stays at the
+      # scenario directory, so a plain run is unaffected.
+      - run:
+          shell: true
+          command: "find reparts -type d -name 'attempt-*' | sort | sed 's#.*/##'"
+      - assert:
+          exit_code: 0
+          stdout:
+            equals: "attempt-2\nattempt-3"
+      # Three failing iterations leave three different actual payloads.
+      - run:
+          shell: true
+          command: "find reparts -name '*.actual.txt' | wc -l | tr -d ' '"
+      - assert:
+          stdout:
+            equals: "3"
+      - run:
+          shell: true
+          command: "cat $(find reparts -name '*.actual.txt') | sort -u | wc -l | tr -d ' '"
+      - assert:
+          stdout:
+            equals: "3"
+
   - name: a file-content mismatch also writes a payload
     steps:
       - fixture:


### PR DESCRIPTION
## Problem

`--repeat` folds N iterations into one result: the reported steps belong to the first failing iteration, and each failed check references the sidecar files written for it. Every iteration wrote to the same paths, so the last failing iteration silently overwrote them.

```
$ atago run --repeat 3 --artifacts-dir arts --report json repeat.atago.yaml
"actual": "1",
"artifacts": [{"role": "actual", "path": ".../step-01-stdout.actual.txt"}]

$ cat arts/.../step-01-stdout.actual.txt
3
```

The report describes iteration 1 and points at a file holding iteration 3's payload — the artifact contradicts the diff printed next to it, which is the one thing a durable sidecar exists to prevent. The other two iterations' payloads no longer exist. `--retry-failed` had the same shape: only the last attempt's evidence survived, and a recovered flake left its failing attempt's payload behind under a path the next attempt would reuse.

## Change

The artifact path now carries which attempt wrote it. `artifact.Scenario` holds the four things a path needs — spec path, scenario name, index, attempt — and owns `Dir`, `FailurePath`, `ServiceLogPath`, and `MockLogPath`. The engine writes artifacts from four places (assert steps, retry `until` checks, service logs, mock request logs); each passed the same `(specPath, scenario, scenarioIdx)` triple separately, and none of them could have known about the attempt. Now they all take one value built by `scenarioRun.artifactScope()`.

Attempt 1 keeps the plain `<suite>/<scenario>/` directory, so a run with neither `--repeat` nor `--retry-failed` writes exactly where it always has. Attempts 2, 3, … land under `<suite>/<scenario>/attempt-<N>/`.

## Tests

- `internal/engine`: a `--repeat 3` run whose iterations each print their own workdir — the payload differs per iteration with no timing dependence — asserting the referenced sidecar matches the report's inline actual, and that three failing iterations leave three distinct payloads. The `--retry-failed` counterpart pins that the reported (last) attempt's payload is the one referenced. Both fail on main.
- `internal/artifact`: the attempt segment, including attempt 0 and 1 resolving to the same directory (the regression pin for existing paths), and every artifact kind of one attempt sharing that attempt's directory.
- `test/e2e/atago/artifacts.atago.yaml`: the same contract through the CLI, checking the written tree holds `attempt-2` and `attempt-3` and three distinct payloads.

`make test`, `make lint`, `make e2e` (454 scenarios), `make docs`, `make site` are green.