### PR TITLE
fix(assert): never open an entry that is not a regular file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- An assertion no longer hangs on an entry that is not a regular file. A `dir:`
+  walk fingerprinted every non-directory entry it found, and a `file:` matcher
+  read its target: opening a named pipe for reading blocks until another process
+  writes to it, and nothing bounds the assertion phase — a step timeout covers
+  the command, not the checks — so a program under test that left a `mkfifo` pipe
+  (or a socket, or a device node) where a file was expected froze the run until
+  the CI job was killed, instead of failing it in milliseconds. A `dir:` tree now
+  records such an entry by kind and never opens it: it stays a present path for
+  `contains`, is not one of the regular files `count` counts, and appears in a
+  tree snapshot as `fifo <path>` rather than a content hash. A `file:` matcher
+  fails saying the path is a named pipe, not a regular file.
+
 - `--artifacts-dir` no longer lets one attempt of a scenario overwrite another's
   payloads. A `--repeat` run reports the first failing iteration inline and
   points at its sidecar files, but every iteration wrote to the same paths, so

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 434 scenarios
+74 suites · 436 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -74,7 +74,7 @@
   - [an unsupported defaults field is a load-time error (exit 2)](#scenario-an-unsupported-defaults-field-is-a-load-time-error-exit-2)
   - [defaults.run.env merges per key and a step env wins the collisions](#scenario-defaultsrunenv-merges-per-key-and-a-step-env-wins-the-collisions)
   - [a step opts out of defaults.run.shell with an explicit shell false](#scenario-a-step-opts-out-of-defaultsrunshell-with-an-explicit-shell-false)
-- [atago self-hosting / dir assertion](#atago-self-hosting--dir-assertion) — 7 scenarios
+- [atago self-hosting / dir assertion](#atago-self-hosting--dir-assertion) — 9 scenarios
   - [directory/tree assertions cover a multi-file generator](#scenario-directorytree-assertions-cover-a-multi-file-generator)
   - [a missing directory can be asserted absent](#scenario-a-missing-directory-can-be-asserted-absent)
   - [a dangling symlink is a present directory entry (membership uses Lstat)](#scenario-a-dangling-symlink-is-a-present-directory-entry-membership-uses-lstat)
@@ -82,6 +82,8 @@
   - [a failed count assert lists the entries it counted](#scenario-a-failed-count-assert-lists-the-entries-it-counted)
   - [a failed recursive assert lists the walked tree](#scenario-a-failed-recursive-assert-lists-the-walked-tree)
   - [a dir assertion on a file path says the path is a file](#scenario-a-dir-assertion-on-a-file-path-says-the-path-is-a-file)
+  - [a named pipe in the tree does not block the walk](#scenario-a-named-pipe-in-the-tree-does-not-block-the-walk)
+  - [a file assertion on a named pipe fails instead of hanging](#scenario-a-file-assertion-on-a-named-pipe-fails-instead-of-hanging)
 - [atago self-hosting / recursive dir asserts + tree snapshots](#atago-self-hosting--recursive-dir-asserts--tree-snapshots) — 3 scenarios
   - [record, compare green, then a mutation names the changed paths](#scenario-record-compare-green-then-a-mutation-names-the-changed-paths)
   - [recursive matchers and ignore globs walk the tree](#scenario-recursive-matchers-and-ignore-globs-walk-the-tree)
@@ -1927,6 +1929,59 @@ ${atago} run mistaken.atago.yaml
 #### Then
 - exit code is `1`
 - stdout contains `exists but is a regular file`, `use a file: assertion`
+### Scenario: a named pipe in the tree does not block the walk
+_skipped on Windows_
+#### Given
+- Fixture file `treespec.atago.yaml` is created.
+#### Inputs
+_Fixture `treespec.atago.yaml`:_
+```text
+version: "1"
+suite: {name: treesnap}
+scenarios:
+  - name: snapshot a tree holding a pipe
+    steps:
+      - run: {shell: true, command: "mkdir out && mkfifo out/pipe && printf 'x' > out/real.txt"}
+      - assert: {dir: {path: out, snapshot: pipe_tree}}
+```
+#### When
+```shell
+mkdir out && mkfifo out/pipe && printf 'x' > out/real.txt
+${atago} run --update-snapshots treespec.atago.yaml
+cat pipe_tree
+${atago} run treespec.atago.yaml
+```
+#### Then
+- after `mkdir out && mkfifo out/pipe && printf 'x' > out/real.txt`:
+  - dir `out` contains `pipe`, contains `real.txt`, has 1 entry, (recursive)
+- after `${atago} run --update-snapshots treespec.atago.yaml`:
+  - exit code is `0`
+- after `cat pipe_tree`:
+  - stdout contains `fifo pipe`, `file real.txt sha256:`
+- after `${atago} run treespec.atago.yaml`:
+  - exit code is `0`
+### Scenario: a file assertion on a named pipe fails instead of hanging
+_skipped on Windows_
+#### Given
+- Fixture file `piped.atago.yaml` is created.
+#### Inputs
+_Fixture `piped.atago.yaml`:_
+```text
+version: "1"
+suite: {name: piped}
+scenarios:
+  - name: the tool left a pipe where a file was expected
+    steps:
+      - run: {shell: true, command: "mkfifo out.txt"}
+      - assert: {file: {path: out.txt, equals: "data"}}
+```
+#### When
+```shell
+${atago} run piped.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `is a named pipe, not a regular file`
 ## atago self-hosting / recursive dir asserts + tree snapshots
 Source: `test/e2e/atago/dir_tree.atago.yaml`
 ### Scenario: record, compare green, then a mutation names the changed paths

--- a/internal/assert/dir.go
+++ b/internal/assert/dir.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/nao1215/atago/internal/fskind"
 	"github.com/nao1215/atago/internal/plural"
 	"github.com/nao1215/atago/internal/security"
 	"github.com/nao1215/atago/internal/spec"
@@ -251,20 +252,8 @@ func dirStatActual(info os.FileInfo, err error) string {
 
 // fileKind names what a non-directory path actually is, so a failure can say
 // "regular file" instead of leaving the author to guess why a directory
-// assertion reports the path as absent.
+// assertion reports the path as absent. The vocabulary is shared with the tree
+// manifest and the read refusals so one word means one thing everywhere.
 func fileKind(info os.FileInfo) string {
-	switch mode := info.Mode(); {
-	case mode.IsRegular():
-		return "regular file"
-	case mode&os.ModeSymlink != 0:
-		return "symlink"
-	case mode&os.ModeNamedPipe != 0:
-		return "named pipe"
-	case mode&os.ModeSocket != 0:
-		return "socket"
-	case mode&os.ModeDevice != 0:
-		return "device"
-	default:
-		return "non-directory entry"
-	}
+	return fskind.Name(info.Mode())
 }

--- a/internal/assert/tree.go
+++ b/internal/assert/tree.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/nao1215/atago/internal/fskind"
 	"github.com/nao1215/atago/internal/spec"
 )
 
@@ -33,7 +34,8 @@ func (e treeEntry) manifestLine() string {
 	case "link":
 		return "link " + escapeManifestField(e.rel) + " -> " + escapeManifestField(e.target)
 	default:
-		return "dir " + escapeManifestField(e.rel)
+		// dir, and the kinds that carry no content: fifo, socket, device.
+		return e.kind + " " + escapeManifestField(e.rel)
 	}
 }
 
@@ -60,7 +62,8 @@ func escapeManifestField(s string) string {
 // walkTree walks dirPath depth-first and returns every entry (root excluded)
 // with /-separated relative paths, sorted, so manifests are deterministic
 // across platforms. Symlinks are recorded, never traversed; an ignored
-// directory prunes its whole subtree.
+// directory prunes its whole subtree; an entry that is not a regular file is
+// recorded by kind and never opened.
 func walkTree(dirPath string, ignore []string) ([]treeEntry, error) {
 	var out []treeEntry
 	err := filepath.WalkDir(dirPath, func(p string, d fs.DirEntry, err error) error {
@@ -86,12 +89,18 @@ func walkTree(dirPath string, ignore []string) ([]treeEntry, error) {
 			out = append(out, treeEntry{rel: rel, kind: "link", target: filepath.ToSlash(target)})
 		case d.IsDir():
 			out = append(out, treeEntry{rel: rel, kind: "dir"})
-		default:
+		case d.Type().IsRegular():
 			h, herr := hashFile(p)
 			if herr != nil {
 				return herr
 			}
 			out = append(out, treeEntry{rel: rel, kind: "file", hash: h})
+		default:
+			// A named pipe, socket, or device node is a directory entry like any
+			// other, but it has no bytes to fingerprint — and opening a pipe for
+			// reading blocks until another process writes to it, which no step
+			// timeout covers. Record what it is; never open it.
+			out = append(out, treeEntry{rel: rel, kind: fskind.Token(d.Type())})
 		}
 		return nil
 	})
@@ -273,31 +282,29 @@ func checkDirSnapshot(d *spec.DirAssert, dirPath string, env Env) *CheckResult {
 // lists. A path present in both with a different line (hash or kind) counts
 // as changed.
 func manifestDiff(expected, actual string) string {
-	// Parse by the known line grammar (dir/file/link), not a whitespace
-	// split: relative paths may contain spaces.
+	// Parse by the line grammar ("<kind> <path>" plus a per-kind suffix), not a
+	// whitespace split: relative paths may contain spaces.
 	parse := func(text string) map[string]string {
 		m := map[string]string{}
 		for _, line := range strings.Split(strings.TrimRight(text, "\n"), "\n") {
-			var p string
-			switch {
-			case strings.HasPrefix(line, "dir "):
-				p = strings.TrimPrefix(line, "dir ")
-			case strings.HasPrefix(line, "file "):
-				rest := strings.TrimPrefix(line, "file ")
+			kind, rest, ok := strings.Cut(line, " ")
+			if !ok {
+				continue
+			}
+			switch kind {
+			case "file":
 				if i := strings.LastIndex(rest, " sha256:"); i >= 0 {
 					rest = rest[:i]
 				}
-				p = rest
-			case strings.HasPrefix(line, "link "):
-				rest := strings.TrimPrefix(line, "link ")
+			case "link":
 				if i := strings.Index(rest, " -> "); i >= 0 {
 					rest = rest[:i]
 				}
-				p = rest
+			case "dir", "fifo", "socket", "device", "irregular":
 			default:
 				continue
 			}
-			m[p] = line
+			m[rest] = line
 		}
 		return m
 	}

--- a/internal/assert/tree_test.go
+++ b/internal/assert/tree_test.go
@@ -2,10 +2,12 @@ package assert
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nao1215/atago/internal/spec"
 )
@@ -87,6 +89,95 @@ func TestWalkTree_SymlinkRecordedNotTraversed(t *testing.T) {
 	}
 	if strings.Contains(joined, "alias/f.txt") {
 		t.Errorf("symlink was traversed:\n%s", joined)
+	}
+}
+
+// mkfifo creates a named pipe at p, skipping the test where that is not
+// available. It is how the tree tests get a directory entry that is neither a
+// regular file, a directory, nor a symlink.
+func mkfifo(t *testing.T, p string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("no named pipes in the filesystem namespace on Windows")
+	}
+	bin, err := exec.LookPath("mkfifo")
+	if err != nil {
+		t.Skip("mkfifo not available")
+	}
+	if out, err := exec.CommandContext(t.Context(), bin, p).CombinedOutput(); err != nil {
+		t.Skipf("mkfifo %s: %v (%s)", p, err, out)
+	}
+}
+
+// TestWalkTree_DoesNotOpenANamedPipe is the hang regression: the walk hashed
+// every non-directory entry, and opening a named pipe for reading blocks until
+// something writes to it. A program under test that leaves a pipe in the workdir
+// froze the assertion — forever, since no step timeout covers the assert phase —
+// so a suite that should fail in milliseconds burned the whole CI job. The pipe
+// is still reported as a directory entry, like a dangling symlink is; it is just
+// never opened.
+func TestWalkTree_DoesNotOpenANamedPipe(t *testing.T) {
+	t.Parallel()
+	wd := t.TempDir()
+	if err := os.WriteFile(filepath.Join(wd, "real.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mkfifo(t, filepath.Join(wd, "pipe"))
+
+	type result struct {
+		entries []treeEntry
+		err     error
+	}
+	done := make(chan result, 1)
+	go func() {
+		entries, err := walkTree(wd, nil)
+		done <- result{entries, err}
+	}()
+	var got result
+	select {
+	case got = <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("walkTree blocked on a named pipe; it must never open a non-regular file")
+	}
+	if got.err != nil {
+		t.Fatalf("walkTree: %v", got.err)
+	}
+
+	var pipe *treeEntry
+	for i := range got.entries {
+		if got.entries[i].rel == "pipe" {
+			pipe = &got.entries[i]
+		}
+	}
+	if pipe == nil {
+		t.Fatalf("the pipe is missing from the walk: %+v", got.entries)
+	}
+	if pipe.kind == "file" {
+		t.Errorf("pipe recorded as a regular file: %+v", *pipe)
+	}
+	if pipe.hash != "" {
+		t.Errorf("pipe was hashed: %+v", *pipe)
+	}
+	if line := pipe.manifestLine(); !strings.Contains(line, "pipe") || strings.Contains(line, "sha256:") {
+		t.Errorf("manifest line = %q, want it to name the entry without a hash", line)
+	}
+}
+
+// TestCheckDir_RecursiveOverAPipeStillMatches proves the matchers keep working
+// with an unopenable entry in the tree: the pipe is a present path, and the
+// file-only count does not count it.
+func TestCheckDir_RecursiveOverAPipeStillMatches(t *testing.T) {
+	t.Parallel()
+	wd := t.TempDir()
+	if err := os.WriteFile(filepath.Join(wd, "real.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mkfifo(t, filepath.Join(wd, "pipe"))
+
+	one := 1
+	d := &spec.DirAssert{Path: ".", Recursive: true, Contains: spec.StringList{"pipe", "real.txt"}, Count: &one}
+	if cr := checkDirRecursive(d, wd); cr != nil {
+		t.Errorf("recursive matchers over a tree holding a pipe failed: %s / %s", cr.Hint, cr.Actual)
 	}
 }
 

--- a/internal/fskind/fskind.go
+++ b/internal/fskind/fskind.go
@@ -1,0 +1,61 @@
+// Package fskind names what a filesystem entry is. atago tells a spec author
+// which kind of thing sits at a path in three unrelated places — a failed dir
+// assertion, a refused read, a tree snapshot manifest — and the three used to
+// spell the vocabulary separately, so a name could drift while the reader
+// assumed one word meant one thing everywhere.
+package fskind
+
+import "io/fs"
+
+// Name is the prose name of an entry, for a sentence a spec author reads:
+// "%q exists but is a named pipe".
+func Name(mode fs.FileMode) string {
+	switch {
+	case mode.IsRegular():
+		return "regular file"
+	case mode&fs.ModeDir != 0:
+		return "directory"
+	case mode&fs.ModeSymlink != 0:
+		return "symlink"
+	case mode&fs.ModeNamedPipe != 0:
+		return "named pipe"
+	case mode&fs.ModeSocket != 0:
+		return "socket"
+	case mode&fs.ModeDevice != 0:
+		return "device"
+	default:
+		return "non-regular entry"
+	}
+}
+
+// Token is the single-word name a tree snapshot manifest uses as its first
+// field. It stays one word (no spaces) because the manifest grammar is
+// "<kind> <path>[...]" with one entry per line, so a two-word kind would read as
+// part of the path.
+func Token(mode fs.FileMode) string {
+	switch {
+	case mode.IsRegular():
+		return "file"
+	case mode&fs.ModeDir != 0:
+		return "dir"
+	case mode&fs.ModeSymlink != 0:
+		return "link"
+	case mode&fs.ModeNamedPipe != 0:
+		return "fifo"
+	case mode&fs.ModeSocket != 0:
+		return "socket"
+	case mode&fs.ModeDevice != 0:
+		return "device"
+	default:
+		return "irregular"
+	}
+}
+
+// Openable reports whether reading the entry's bytes is a bounded operation.
+// Opening a named pipe for reading blocks until another process writes to it,
+// and a device node can block or return the host's data, so a path atago walks
+// or asserts on must be checked before it is opened: no step timeout covers the
+// assertion phase, and a blocked assertion hangs the run to death.
+func Openable(mode fs.FileMode) bool {
+	return mode.IsRegular()
+}

--- a/internal/fskind/fskind_test.go
+++ b/internal/fskind/fskind_test.go
@@ -1,0 +1,57 @@
+package fskind
+
+import (
+	"io/fs"
+	"testing"
+)
+
+// TestNameAndToken pins the two vocabularies against each other: every kind has
+// a prose name for a failure sentence and a single-word token for the tree
+// manifest, and the token never carries a space (the manifest grammar puts the
+// path in the next field).
+func TestNameAndToken(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		mode  fs.FileMode
+		name  string
+		token string
+	}{
+		{0, "regular file", "file"},
+		{0o755, "regular file", "file"},
+		{fs.ModeDir, "directory", "dir"},
+		{fs.ModeSymlink, "symlink", "link"},
+		{fs.ModeNamedPipe, "named pipe", "fifo"},
+		{fs.ModeSocket, "socket", "socket"},
+		{fs.ModeDevice, "device", "device"},
+		{fs.ModeDevice | fs.ModeCharDevice, "device", "device"},
+		{fs.ModeIrregular, "non-regular entry", "irregular"},
+	}
+	for _, tt := range cases {
+		if got := Name(tt.mode); got != tt.name {
+			t.Errorf("Name(%v) = %q, want %q", tt.mode, got, tt.name)
+		}
+		if got := Token(tt.mode); got != tt.token {
+			t.Errorf("Token(%v) = %q, want %q", tt.mode, got, tt.token)
+		}
+		for _, r := range Token(tt.mode) {
+			if r == ' ' {
+				t.Errorf("Token(%v) = %q contains a space", tt.mode, Token(tt.mode))
+			}
+		}
+	}
+}
+
+// TestOpenable pins the one question the read paths ask: only a regular file may
+// be opened. A pipe blocks until a writer appears, and no step timeout covers an
+// assertion, so opening one hangs a run to death.
+func TestOpenable(t *testing.T) {
+	t.Parallel()
+	if !Openable(0) || !Openable(0o600) {
+		t.Error("a regular file must be openable")
+	}
+	for _, mode := range []fs.FileMode{fs.ModeDir, fs.ModeSymlink, fs.ModeNamedPipe, fs.ModeSocket, fs.ModeDevice, fs.ModeIrregular} {
+		if Openable(mode) {
+			t.Errorf("Openable(%v) = true, want false", mode)
+		}
+	}
+}

--- a/internal/security/path.go
+++ b/internal/security/path.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"github.com/nao1215/atago/internal/fskind"
 )
 
 // A user-declared path in a spec (a file assertion target, a store source, a
@@ -56,8 +58,18 @@ func resolveInRoot(field, rootLabel, root, p string) (string, error) {
 // path-taking feature enforces the same rule instead of a plain, link-following
 // os.ReadFile.
 func ReadFileNoFollow(path string) ([]byte, error) {
-	if fi, err := os.Lstat(path); err == nil && fi.Mode()&os.ModeSymlink != 0 {
-		return nil, fmt.Errorf("refusing to read through the symlink %q (it escapes the scenario root)", path)
+	if fi, err := os.Lstat(path); err == nil {
+		switch {
+		case fi.Mode()&os.ModeSymlink != 0:
+			return nil, fmt.Errorf("refusing to read through the symlink %q (it escapes the scenario root)", path)
+		case !fi.IsDir() && !fskind.Openable(fi.Mode()):
+			// Opening a named pipe for reading blocks until another process
+			// writes to it, and nothing bounds the assertion phase, so a program
+			// under test that leaves a pipe where a file was expected used to
+			// hang the whole run instead of failing it. A directory is left to
+			// os.ReadFile, whose "is a directory" error already says it.
+			return nil, fmt.Errorf("%q is a %s, not a regular file", path, fskind.Name(fi.Mode()))
+		}
 	}
 	return os.ReadFile(path) //nolint:gosec // path is containment-checked by the caller and Lstat-guarded against a leaf symlink
 }

--- a/internal/security/path_test.go
+++ b/internal/security/path_test.go
@@ -2,11 +2,13 @@ package security
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestResolveWorkdirPath(t *testing.T) {
@@ -120,6 +122,48 @@ func TestReadFileNoFollow(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "symlink") {
 		t.Errorf("error %q should name the refused symlink", err)
+	}
+}
+
+// TestReadFileNoFollow_RefusesANamedPipe is the hang regression: opening a named
+// pipe for reading blocks until another process writes to it, and nothing bounds
+// the assertion phase, so a program under test that left a pipe where a file was
+// expected hung the run forever instead of failing it. The refusal has to name
+// what the path is, since "could not read" alone sends the author looking for a
+// permission problem.
+func TestReadFileNoFollow_RefusesANamedPipe(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no named pipes in the filesystem namespace on Windows")
+	}
+	bin, lookErr := exec.LookPath("mkfifo")
+	if lookErr != nil {
+		t.Skip("mkfifo not available")
+	}
+	t.Parallel()
+	pipe := filepath.Join(t.TempDir(), "pipe")
+	if out, err := exec.CommandContext(t.Context(), bin, pipe).CombinedOutput(); err != nil {
+		t.Skipf("mkfifo: %v (%s)", err, out)
+	}
+
+	type result struct {
+		data []byte
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		data, err := ReadFileNoFollow(pipe)
+		done <- result{data, err}
+	}()
+	select {
+	case got := <-done:
+		if got.err == nil {
+			t.Fatalf("ReadFileNoFollow(pipe) = %q, nil; want an error", got.data)
+		}
+		if !strings.Contains(got.err.Error(), "named pipe") {
+			t.Errorf("error %q should name the entry as a named pipe", got.err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("ReadFileNoFollow blocked on a named pipe; it must refuse a non-regular file instead of opening it")
 	}
 }
 

--- a/test/e2e/atago/dir.atago.yaml
+++ b/test/e2e/atago/dir.atago.yaml
@@ -162,3 +162,71 @@ scenarios:
             contains:
               - 'exists but is a regular file'
               - 'use a file: assertion'
+
+  # A program under test can leave an entry that is not a regular file — a named
+  # pipe from a `mkfifo`, a socket from a daemon. Hashing it meant opening it, and
+  # opening a pipe for reading blocks until something writes to it, which no step
+  # timeout covers: the run hung instead of finishing in milliseconds. The pipe is
+  # a directory entry like any other; it is simply never opened.
+  - name: a named pipe in the tree does not block the walk
+    skip: {os: windows}
+    steps:
+      - run:
+          shell: true
+          command: "mkdir out && mkfifo out/pipe && printf 'x' > out/real.txt"
+      - assert:
+          dir:
+            path: out
+            recursive: true
+            contains: [pipe, real.txt]
+            # Counts are over regular files, so the pipe is not one of them.
+            count: 1
+      # The tree snapshot records what the entry is instead of a content hash.
+      # A nested spec keeps the written golden inside the scenario workdir.
+      - fixture:
+          file: treespec.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: treesnap}
+            scenarios:
+              - name: snapshot a tree holding a pipe
+                steps:
+                  - run: {shell: true, command: "mkdir out && mkfifo out/pipe && printf 'x' > out/real.txt"}
+                  - assert: {dir: {path: out, snapshot: pipe_tree}}
+      - run:
+          command: ${atago} run --update-snapshots treespec.atago.yaml
+      - assert: {exit_code: 0}
+      - run:
+          shell: true
+          command: "cat pipe_tree"
+      - assert:
+          stdout:
+            contains:
+              - "fifo pipe"
+              - "file real.txt sha256:"
+      # And the written golden verifies on a second run: update then check is
+      # idempotent for a tree that holds an unopenable entry.
+      - run:
+          command: ${atago} run treespec.atago.yaml
+      - assert: {exit_code: 0}
+
+  - name: a file assertion on a named pipe fails instead of hanging
+    skip: {os: windows}
+    steps:
+      - fixture:
+          file: piped.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: piped}
+            scenarios:
+              - name: the tool left a pipe where a file was expected
+                steps:
+                  - run: {shell: true, command: "mkfifo out.txt"}
+                  - assert: {file: {path: out.txt, equals: "data"}}
+      - run:
+          command: ${atago} run piped.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "is a named pipe, not a regular file"


### PR DESCRIPTION
## Problem

A program under test can leave a directory entry that is not a regular file — a `mkfifo` pipe, a daemon's socket, a device node. atago opened it:

```yaml
- run: {shell: true, command: "mkdir out && mkfifo out/pipe"}
- assert:
    dir: {path: out, recursive: true, contains: [pipe]}
```

This never finishes. `walkTree` fingerprints every non-directory entry, and opening a pipe for reading blocks until another process writes to it. The same happens for any `file:` content matcher whose target is a pipe. Nothing bounds it: `run.timeout` covers the command, not the assertion phase, so a suite that should fail in milliseconds burns the whole CI job until the runner's global timeout kills it.

## Change

- `walkTree` only hashes regular files. Anything else is recorded by kind and never opened: it stays a present path for `contains`/`not_contains`, is not one of the regular files `count` counts, and renders in a tree snapshot manifest as `fifo <path>` (or `socket`/`device`/`irregular`) instead of a content hash. This mirrors how a dangling symlink is already treated — the entry is what the program left behind, whether or not its bytes can be read.
- `security.ReadFileNoFollow` refuses a non-regular target the way it already refuses a symlink, so every `file:` matcher, the store file source, and the snapshot reader fail with `"out.txt" is a named pipe, not a regular file` instead of blocking. A directory still falls through to `os.ReadFile`, whose own error already says so.
- `manifestDiff` parses the manifest by its grammar (`<kind> <path>` plus a per-kind suffix) rather than enumerating three prefixes, so the new kinds diff like the rest.
- The kind vocabulary moves into `internal/fskind`. Three places tell an author what sits at a path — a failed `dir:` assertion, a refused read, a snapshot manifest — and each spelled it separately; `Name` is the prose form, `Token` the single word the manifest grammar needs, `Openable` the one question the read paths ask.

`changes:` was already immune: `fsdelta` skips non-regular entries when scanning.

## Tests

Each hang test runs the call in a goroutine with a 15s bound, so a regression fails the test instead of hanging the package.

- `internal/assert`: the walk over a tree holding a pipe completes, records it without a hash, and the recursive matchers still work over it (`contains` sees the pipe, `count: 1` counts only the regular file).
- `internal/security`: `ReadFileNoFollow` on a pipe returns an error naming it as a named pipe.
- `internal/fskind`: the prose/token pair per kind, and that no token carries a space (it would read as part of the path).
- `test/e2e/atago/dir.atago.yaml`: the CLI contract — a pipe in the tree does not block, its snapshot manifest line is `fifo pipe`, the written golden verifies on a second run, and a `file: equals` on a pipe fails with the message instead of hanging. Both scenarios skip on Windows, which has no filesystem-namespace pipes.

`make test`, `make lint`, `make e2e` (456 scenarios), `make docs`, `make site` are green.