### PR TITLE
fix(record): replay the bytes a --pty session recorded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- `atago record --pty` now replays the bytes it recorded. A typed burst that is
+  not valid UTF-8 — a paste in another encoding, a keyboard macro emitting a high
+  byte — was rendered as text, so every such byte became U+FFFD and the generated
+  send typed three different bytes than the session captured. Those bursts are now
+  emitted as `!!binary`, the same escape hatch plain `record` already uses. An
+  `expect` anchor built from output carrying such a byte was corrupted the same
+  way, producing a pattern that could never match: the recorded session hung until
+  its timeout. An anchor is now the longest stretch of the line that really exists
+  in the transcript.
+- `atago record --pty` no longer fails on a command carrying a control character.
+  The scenario name was the recorded command verbatim, and the loader rejects a
+  control character in a name, so recording `printf 'a\rb'` produced a spec that
+  failed its own validation with "this is an atago bug, please report it". The
+  name is now a single-line label, as plain `record` already did; the command
+  itself is still replayed verbatim.
+
 - An assertion no longer hangs on an entry that is not a regular file. A `dir:`
   walk fingerprinted every non-directory entry it found, and a `file:` matcher
   read its target: opening a named pipe for reading blocks until another process

--- a/internal/record/fuzz_test.go
+++ b/internal/record/fuzz_test.go
@@ -1,6 +1,7 @@
 package record
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -158,3 +159,111 @@ func findRun(s *spec.Spec) *spec.Run {
 	}
 	return nil
 }
+
+// FuzzGeneratePTYRoundTrip drives `atago record --pty`'s session generator with
+// arbitrary transcripts. The round-trip law for an interactive recording is that
+// the generated session replays what was typed: for every input burst the
+// generated spec must carry a send whose decoded bytes are exactly the bytes the
+// recording captured (with a recorded CR rendered as the readable "\n" Enter and
+// ${...} escaped so the replay types it literally). Invariants:
+//   - GeneratePTY never errors on a recording the capture layer can produce (its
+//     own contract calls a validation failure an atago bug) and never panics;
+//   - the generated YAML reparses to one pty step;
+//   - every text send decodes back to its recorded burst, so a byte that is not
+//     valid UTF-8 survives instead of collapsing into U+FFFD;
+//   - an expect anchor is a verbatim substring of the output that preceded it,
+//     which is what lets the replay match it.
+func FuzzGeneratePTYRoundTrip(f *testing.F) {
+	f.Add("app", []byte("name: "), []byte("world\r"), []byte("done\r\n"), 0)
+	f.Add("login", []byte("caf\xe9 name: "), []byte("Andr\xe9\r"), []byte("ok\r\n"), 0)
+	f.Add("cat", []byte{0xff, 0xfe}, []byte{0x03}, []byte("\r\n"), 130)
+	f.Add("wiz", []byte("\x1b[32mProject: \x1b[0m"), []byte("demo\r"), []byte("created\r\n"), 1)
+	f.Add("sh", []byte("${VAR}> "), []byte("literal ${HOME}\r"), []byte("x"), 0)
+	f.Fuzz(func(t *testing.T, command string, before, input, after []byte, exitCode int) {
+		// Model the CLI: the recorded command line comes from argv, which cannot
+		// carry a NUL, and an empty command is not producible.
+		if command == "" || strings.ContainsRune(command, 0) {
+			t.Skip()
+		}
+		if len(input) == 0 {
+			t.Skip() // an input segment is a burst of at least one byte
+		}
+		rec := PTYRecording{
+			Command:  command,
+			Rows:     24,
+			Cols:     80,
+			ExitCode: exitCode,
+			Segments: []PTYSegment{{Output: before}, {Input: input}, {Output: after}},
+		}
+		out, err := GeneratePTY(rec, Options{SuiteName: "fz"})
+		if err != nil {
+			t.Fatalf("GeneratePTY failed for a capturable recording: %v\ncommand=%q before=%q input=%q", err, command, before, input)
+		}
+		s, err := loader.LoadBytes("recorded.atago.yaml", out)
+		if err != nil {
+			t.Fatalf("generated spec does not reparse: %v\n%s", err, out)
+		}
+		if len(s.Scenarios) != 1 || len(s.Scenarios[0].Steps) == 0 || s.Scenarios[0].Steps[0].PTY == nil {
+			t.Fatalf("generated spec has no leading pty step:\n%s", out)
+		}
+		pty := s.Scenarios[0].Steps[0].PTY
+
+		// A control-key burst is rendered as its named key instead of text; every
+		// other burst must decode back to the recorded bytes.
+		if _, named := spec.PTYKeyForSequence(string(input)); !named {
+			want := escapeVarRefs(literalSend(input))
+			var got *string
+			for _, act := range pty.Session {
+				if act.Send != nil && act.Send.Text != nil {
+					got = act.Send.Text
+				}
+			}
+			if got == nil {
+				t.Fatalf("no text send generated for input %q:\n%s", input, out)
+			}
+			if *got != want {
+				t.Fatalf("send round-trip broke: recorded %q, replayed %q\nspec:\n%s", want, *got, out)
+			}
+		}
+
+		// An expect must be a verbatim substring of the output it anchors on,
+		// after QuoteMeta is undone; otherwise the replay can never match it.
+		for _, act := range pty.Session {
+			if act.Expect == "" {
+				continue
+			}
+			literal, err := unquoteMeta(act.Expect)
+			if err != nil {
+				continue // a pattern with real regexp syntax is not an anchor
+			}
+			if !strings.Contains(string(before), literal) {
+				t.Fatalf("expect anchor %q is not a substring of the recorded output %q\nspec:\n%s", literal, before, out)
+			}
+		}
+	})
+}
+
+// unquoteMeta reverses regexp.QuoteMeta for a pattern that contains nothing but
+// escaped literals, so a fuzz case can compare an anchor against the raw
+// transcript. It reports an error for a pattern carrying unescaped regexp syntax.
+func unquoteMeta(pattern string) (string, error) {
+	var b strings.Builder
+	for i := 0; i < len(pattern); i++ {
+		c := pattern[i]
+		if c != '\\' {
+			if strings.IndexByte(`\.+*?()|[]{}^$`, c) >= 0 {
+				return "", errNotALiteral
+			}
+			b.WriteByte(c)
+			continue
+		}
+		i++
+		if i >= len(pattern) {
+			return "", errNotALiteral
+		}
+		b.WriteByte(pattern[i])
+	}
+	return b.String(), nil
+}
+
+var errNotALiteral = errors.New("pattern carries regexp syntax")

--- a/internal/record/pty.go
+++ b/internal/record/pty.go
@@ -1,9 +1,11 @@
 package record
 
 import (
+	"encoding/base64"
 	"fmt"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/nao1215/atago/internal/buildinfo"
 	"github.com/nao1215/atago/internal/loader"
@@ -77,7 +79,10 @@ func GeneratePTY(rec PTYRecording, opts Options) ([]byte, error) {
 	b.WriteString("# prompt that preceded it. Tighten the matchers to pin what you care about.\n")
 	fmt.Fprintf(&b, "suite:\n  name: %s\n\n", yamlScalar(opts.SuiteName))
 	b.WriteString("scenarios:\n")
-	fmt.Fprintf(&b, "  - name: %s # TODO: describe the behavior\n", yamlScalar(rec.Command))
+	// scenarioLabel, not the raw command: the loader rejects a control character
+	// in a name, so a recorded command carrying a tab or a CR generated a spec
+	// that failed its own validation and told the user to report an atago bug.
+	fmt.Fprintf(&b, "  - name: %s # TODO: describe the behavior\n", yamlScalar(scenarioLabel(rec.Command)))
 	b.WriteString("    steps:\n")
 	b.WriteString("      - pty:\n")
 	if rec.Shell {
@@ -158,7 +163,20 @@ func renderSend(seg PTYSegment, secretN *int) []string {
 	// Typed text is raw: escape ${...} so the replay engine types the literal
 	// bytes the user typed instead of expanding them (the secret placeholder
 	// above is the one send that MUST stay a live reference).
-	return []string{fmt.Sprintf("            - send: %s\n", yamlDoubleQuoted(escapeVarRefs(literalSend(seg.Input))))}
+	text := escapeVarRefs(literalSend(seg.Input))
+	if !utf8.ValidString(text) {
+		// A YAML scalar carries text, and rendering these bytes as one would
+		// replace each invalid byte with U+FFFD — the replay would type three
+		// different bytes than the recording captured. !!binary keeps them
+		// exactly, the same escape hatch plain record uses for a capture that is
+		// not valid UTF-8.
+		return []string{
+			"            # not valid UTF-8 (a paste in another encoding, a keyboard macro):\n",
+			"            # base64 so the replay types the recorded bytes exactly.\n",
+			fmt.Sprintf("            - send: !!binary \"%s\"\n", base64.StdEncoding.EncodeToString([]byte(text))),
+		}
+	}
+	return []string{fmt.Sprintf("            - send: %s\n", yamlDoubleQuoted(text))}
 }
 
 // yamlDoubleQuoted renders s as a YAML double-quoted flow scalar, escaping
@@ -231,8 +249,14 @@ func stableLine(output []byte) string {
 }
 
 // longestPlainRun returns the longest run of line that contains no C0 control
-// byte (the NUL standing in for an ANSI sequence, a tab, or any other), trimmed
-// of surrounding whitespace. Each such run existed verbatim in the raw output.
+// byte (the NUL standing in for an ANSI sequence, a tab, or any other) and no
+// byte that is not valid UTF-8, trimmed of surrounding whitespace. Each such run
+// existed verbatim in the raw output, which is what lets an expect built from it
+// match the replayed transcript. A rune-by-rune scan silently turned an invalid
+// byte into U+FFFD, so a Latin-1 prompt yielded an anchor that appears nowhere in
+// the output and an expect that could never match — the session then hung until
+// its timeout. Such a byte now breaks the run, and the anchor is the longest
+// valid stretch around it.
 func longestPlainRun(line string) string {
 	best := ""
 	var cur strings.Builder
@@ -242,8 +266,10 @@ func longestPlainRun(line string) string {
 		}
 		cur.Reset()
 	}
-	for _, r := range line {
-		if r < 0x20 {
+	for i := 0; i < len(line); {
+		r, size := utf8.DecodeRuneInString(line[i:])
+		i += size
+		if r < 0x20 || (r == utf8.RuneError && size == 1) {
 			flush()
 			continue
 		}

--- a/internal/record/pty_test.go
+++ b/internal/record/pty_test.go
@@ -1,8 +1,10 @@
 package record
 
 import (
+	"bytes"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/nao1215/atago/internal/loader"
 	"github.com/nao1215/atago/internal/spec"
@@ -231,6 +233,111 @@ func TestStableLine_AnchorIsRawSubstring(t *testing.T) {
 		if anchor == "" {
 			t.Errorf("stableLine(%q) = empty, want a non-empty anchor", raw)
 			continue
+		}
+		if !strings.Contains(raw, anchor) {
+			t.Errorf("stableLine(%q) = %q, which is NOT a substring of the raw transcript", raw, anchor)
+		}
+	}
+}
+
+// TestGeneratePTY_NonUTF8InputReplaysTheSameBytes is a regression for the pty
+// round-trip law: a typed burst that is not valid UTF-8 — a Latin-1 paste, a
+// keyboard macro emitting a high byte — was rendered rune by rune, so every
+// invalid byte became U+FFFD and the replay typed three different bytes than the
+// recording captured. The generated send has to reproduce the recorded bytes
+// exactly.
+func TestGeneratePTY_NonUTF8InputReplaysTheSameBytes(t *testing.T) {
+	t.Parallel()
+	raw := []byte("Andr\xe9\r")
+	rec := PTYRecording{
+		Command:  "app",
+		ExitCode: 0,
+		Segments: []PTYSegment{
+			outSeg("name: "),
+			{Input: raw},
+			outSeg("done\r\n"),
+		},
+	}
+	out, err := GeneratePTY(rec, Options{SuiteName: "s"})
+	if err != nil {
+		t.Fatalf("GeneratePTY: %v", err)
+	}
+	if bytes.ContainsRune(out, utf8.RuneError) {
+		t.Errorf("generated spec carries a replacement character:\n%s", out)
+	}
+	pty := loadGenerated(t, out)
+	if len(pty.Session) == 0 {
+		t.Fatalf("no session generated:\n%s", out)
+	}
+	var sent *string
+	for _, act := range pty.Session {
+		if act.Send != nil && act.Send.Text != nil {
+			sent = act.Send.Text
+		}
+	}
+	if sent == nil {
+		t.Fatalf("no text send in the session:\n%s", out)
+	}
+	// literalSend renders a recorded CR as the readable "\n" Enter; every other
+	// byte must survive untouched.
+	if want := "Andr\xe9\n"; *sent != want {
+		t.Errorf("send bytes = % x, want % x", *sent, want)
+	}
+}
+
+// TestGeneratePTY_ControlCharacterInCommandStillGenerates is a regression found
+// by FuzzGeneratePTYRoundTrip: the scenario name was the recorded command
+// verbatim, and the loader rejects a control character in a name, so recording a
+// command carrying a CR or a tab produced a spec that failed its own validation
+// and told the user to report an atago bug. The name is now a single-line label,
+// while the command itself stays verbatim in the pty step.
+func TestGeneratePTY_ControlCharacterInCommandStillGenerates(t *testing.T) {
+	t.Parallel()
+	for _, command := range []string{"printf 'a\rb'", "sh -c 'echo one\necho two'", "run\twith\ttabs", "\r"} {
+		rec := PTYRecording{
+			Command:  command,
+			ExitCode: 0,
+			Segments: []PTYSegment{outSeg("> "), inSeg("x\r"), outSeg("ok\r\n")},
+		}
+		out, err := GeneratePTY(rec, Options{SuiteName: "ctl"})
+		if err != nil {
+			t.Fatalf("GeneratePTY(%q): %v", command, err)
+		}
+		s, err := loader.LoadBytes("gen.atago.yaml", out)
+		if err != nil {
+			t.Fatalf("generated spec for %q does not load: %v\n%s", command, err, out)
+		}
+		name := s.Scenarios[0].Name
+		if strings.ContainsAny(name, "\t\r\n") {
+			t.Errorf("scenario name %q still carries a control character", name)
+		}
+		// The command is replayed verbatim, control bytes and all.
+		if got := s.Scenarios[0].Steps[0].PTY.Command; got != command {
+			t.Errorf("pty command = %q, want the recorded %q", got, command)
+		}
+	}
+}
+
+// TestStableLine_SkipsNonUTF8Bytes pins the anchor rule for output that is not
+// valid UTF-8: an anchor must be a verbatim substring of the raw transcript, and
+// a rune-by-rune scan turned an invalid byte into U+FFFD — producing an expect
+// regexp that could never match, so the recorded session hung until the session
+// timeout. Such a byte now breaks the run like a control byte does, and the
+// anchor is the longest valid stretch around it.
+func TestStableLine_SkipsNonUTF8Bytes(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"caf\xe9 name: ",
+		"\xff\xfe binary noise then a real prompt: ",
+		"Se\xf1or, enter a value: ",
+	}
+	for _, raw := range cases {
+		anchor := stableLine([]byte(raw))
+		if anchor == "" {
+			continue // no valid stretch is long enough to anchor on: acceptable
+		}
+		if strings.ContainsRune(anchor, utf8.RuneError) {
+			t.Errorf("stableLine(%q) = %q, which carries a replacement character", raw, anchor)
 		}
 		if !strings.Contains(raw, anchor) {
 			t.Errorf("stableLine(%q) = %q, which is NOT a substring of the raw transcript", raw, anchor)

--- a/internal/record/testdata/fuzz/FuzzGeneratePTYRoundTrip/ab86266b79dda2df
+++ b/internal/record/testdata/fuzz/FuzzGeneratePTYRoundTrip/ab86266b79dda2df
@@ -1,0 +1,6 @@
+go test fuzz v1
+string("\r")
+[]byte("0")
+[]byte("0")
+[]byte("0")
+int(0)


### PR DESCRIPTION
Two round-trip breaks in `atago record --pty`, both found by attacking the recorder with bytes a real terminal can deliver.

## Non-UTF-8 input did not replay

A recorded burst was rendered as a YAML text scalar, one rune at a time, so any byte that is not valid UTF-8 became U+FFFD:

```yaml
session:
  - expect: "caf� name:"
  - send: "Andr�\n"
```

The send types three bytes (`ef bf bd`) where the recording captured one (`e9`), so the replay drives the program with input the user never typed. The expect is worse: the pattern cannot match the program's actual output, so the recorded session hangs until the session timeout and fails a spec atago itself wrote.

Such a burst is now emitted as `!!binary`, the escape hatch plain `record` already uses for a capture that is not valid UTF-8 (and the reason the loader keeps `!!binary` when it rejects every other explicit tag). The anchor rule changes instead of being encoded: `longestPlainRun` treats a byte that is not valid UTF-8 like a control byte, so the anchor is the longest stretch that really exists in the transcript — which is what the comment there already promised.

## A control character in the command failed validation

```
$ atago record --pty --out s.yaml -- printf 'a\rb'
generated spec does not validate (this is an atago bug, please report it):
  scenarios[0].name must not contain the control character "\r"
```

The scenario name was the recorded command verbatim. Plain `record` has had `scenarioLabel` for exactly this since #30; the pty generator did not use it. It does now, and the command itself is still replayed verbatim in the pty step.

## Tests

- `FuzzGeneratePTYRoundTrip` (new): for an arbitrary transcript, the generated spec must validate, reparse, decode every text send back to the recorded burst, and carry only expect anchors that are verbatim substrings of the output before them. It found the control-character case in under two seconds; the crash input is committed as a seed, alongside the deterministic table test for it. Clean over 650k execs after the fix.
- `internal/record`: the non-UTF-8 send round-trip, the anchor rule for non-UTF-8 output, and the control-character command cases.

`make test`, `make lint`, `make e2e` (456 scenarios), `make docs`, `make site` are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PTY recordings now reliably replay non-UTF-8 input without corrupting bytes or output anchors.
  * Recording commands containing control characters no longer cause failures.
  * Assertions no longer hang or report incorrect results for non-file entries.
  * Repeated runs using `--artifacts-dir` now preserve separate payloads and evidence for each attempt.
* **Documentation**
  * Added changelog entries describing these fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->