### PR TITLE
refactor(spec): make the assertion-target list enumerable and drift-guarded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Adding an assertion target is now guarded instead of remembered. Five layers
+  dispatch on a target — the loader's validation, the runtime check, `atago doc`,
+  `atago explain`, and the published JSON Schema — and each had its own switch
+  whose default silently degraded: doc and explain rendered the bare target name
+  as a sentence, and the schema would have made a valid spec light up red in an
+  editor. `spec.AllAssertTargets` now derives the list from one table, a test
+  proves that table matches the fields on `Assert`, and each layer has a coverage
+  test that walks the list. A half-wired target fails a test rather than shipping
+  a weaker document.
+
 ### Added
 
 - Third-party suite for Info-ZIP `zip` and `unzip`, the first real-world coverage

--- a/internal/assert/assert_test.go
+++ b/internal/assert/assert_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/nao1215/atago/internal/runner"
 	"github.com/nao1215/atago/internal/runner/mock"
 	"github.com/nao1215/atago/internal/spec"
+	"github.com/nao1215/atago/internal/spectest"
 )
 
 func intp(i int) *int         { return &i }
@@ -2423,5 +2424,26 @@ func TestCheck_DirExists_OnAFilePathSaysSo(t *testing.T) {
 	}
 	if !strings.Contains(got.Actual, "regular file") {
 		t.Errorf("Actual = %q, want it to name the kind of entry", got.Actual)
+	}
+}
+
+// TestCheckTarget_CoversEveryAssertTarget walks spec.AllAssertTargets and proves
+// the runtime has a case for each one. The switch's default reports "assertion
+// target not supported yet", which a loaded spec should never be able to reach:
+// the loader accepts a target the runtime cannot evaluate only if the two
+// switches have drifted. The Assert values are minimal, so a target legitimately
+// fails here for a missing matcher — what must not happen is the not-supported
+// hint.
+func TestCheckTarget_CoversEveryAssertTarget(t *testing.T) {
+	t.Parallel()
+	for _, target := range spec.AllAssertTargets() {
+		got := checkTarget(spectest.AssertForTarget(target), target, &runner.Result{}, Env{Workdir: t.TempDir()})
+		if got == nil {
+			t.Errorf("target %q produced no CheckResult", target)
+			continue
+		}
+		if strings.Contains(got.Hint, "not supported yet") {
+			t.Errorf("target %q fell through to the default branch: %s", target, got.Hint)
+		}
 	}
 }

--- a/internal/docgen/describe_test.go
+++ b/internal/docgen/describe_test.go
@@ -1,0 +1,27 @@
+package docgen
+
+import (
+	"testing"
+
+	"github.com/nao1215/atago/internal/spec"
+	"github.com/nao1215/atago/internal/spectest"
+)
+
+// TestDescribeTarget_CoversEveryAssertTarget walks spec.AllAssertTargets and
+// proves the doc renderer has a case for each one. The switch's default returns
+// the bare target name, which reads as a heading with no sentence — a new target
+// would silently publish that instead of describing what the scenario
+// guarantees. The Assert values are minimal (the target's field allocated, no
+// matcher set), so this covers the dispatch, not the phrasing.
+func TestDescribeTarget_CoversEveryAssertTarget(t *testing.T) {
+	t.Parallel()
+	for _, target := range spec.AllAssertTargets() {
+		got := describeTarget(spectest.AssertForTarget(target), target)
+		if got == "" {
+			t.Errorf("target %q renders as an empty bullet", target)
+		}
+		if got == string(target) {
+			t.Errorf("target %q fell through to the default branch (rendered as the bare name)", target)
+		}
+	}
+}

--- a/internal/docgen/docgen.go
+++ b/internal/docgen/docgen.go
@@ -416,6 +416,21 @@ type thenGroup struct {
 	bullets   []string
 }
 
+// isActionStep reports whether a step performs an action an assertion can be
+// read against. It is the one definition of that set: writeThen counts actions
+// to decide between a flat bullet list and grouped ones, and thenGroups assigns
+// each assert to the most recent action. When the two spelled the set
+// separately, a step kind added to one of them either flattened grouped bullets
+// or grouped flat ones.
+func isActionStep(kind spec.StepKind) bool {
+	switch kind {
+	case spec.StepRun, spec.StepHTTP, spec.StepQuery, spec.StepGRPC, spec.StepCDP, spec.StepSignal:
+		return true
+	default:
+		return false
+	}
+}
+
 // thenGroups walks the steps and groups each assert under the most recent
 // action step (run/http/query/grpc/cdp). Fixture and store steps never break a
 // group: they observe nothing.
@@ -424,9 +439,11 @@ func thenGroups(sc *spec.Scenario, expand func(string) string) []thenGroup {
 	actionIdx, actionLbl := -1, ""
 	for i := range sc.Steps {
 		step := &sc.Steps[i]
-		switch step.Kind() {
-		case spec.StepRun, spec.StepHTTP, spec.StepQuery, spec.StepGRPC, spec.StepCDP, spec.StepSignal:
+		if isActionStep(step.Kind()) {
 			actionIdx, actionLbl = i, actionLabel(step, expand)
+			continue
+		}
+		switch step.Kind() {
 		case spec.StepAssert:
 			if len(groups) == 0 || groups[len(groups)-1].actionIdx != actionIdx {
 				groups = append(groups, thenGroup{actionIdx: actionIdx, action: actionLbl})
@@ -470,12 +487,9 @@ func writeThen(md *markdown.Markdown, sc *spec.Scenario, expand func(string) str
 	if len(groups) == 0 {
 		return
 	}
-	// Keep this action set in sync with thenGroups: a drift flattens grouped
-	// bullets (or vice versa) for scenarios mixing the two step kinds.
 	actions := 0
 	for i := range sc.Steps {
-		switch sc.Steps[i].Kind() {
-		case spec.StepRun, spec.StepHTTP, spec.StepQuery, spec.StepGRPC, spec.StepCDP, spec.StepSignal:
+		if isActionStep(sc.Steps[i].Kind()) {
 			actions++
 		}
 	}

--- a/internal/explain/explain_test.go
+++ b/internal/explain/explain_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/nao1215/atago/internal/loader"
+	"github.com/nao1215/atago/internal/spec"
+	"github.com/nao1215/atago/internal/spectest"
 )
 
 func TestExplain(t *testing.T) {
@@ -1086,5 +1088,22 @@ scenarios:
 	out = mustExplain(t, b64Src)
 	if !strings.Contains(out, "binary stdin (base64)") {
 		t.Errorf("explain binary-stdin missing\n--- got ---\n%s", out)
+	}
+}
+
+// TestDescribeTarget_CoversEveryAssertTarget walks spec.AllAssertTargets and
+// proves `atago explain` has a case for each one. The switch's default prints the
+// bare target name, so a new target would appear in the plan as a word with no
+// statement of what it checks — the one thing explain exists to provide.
+func TestDescribeTarget_CoversEveryAssertTarget(t *testing.T) {
+	t.Parallel()
+	for _, target := range spec.AllAssertTargets() {
+		got := describeTarget(spectest.AssertForTarget(target), target)
+		if got == "" {
+			t.Errorf("target %q renders as an empty line", target)
+		}
+		if got == string(target) {
+			t.Errorf("target %q fell through to the default branch (printed as the bare name)", target)
+		}
 	}
 }

--- a/internal/spec/asserttarget_test.go
+++ b/internal/spec/asserttarget_test.go
@@ -1,0 +1,88 @@
+package spec
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// assertTargetFields maps every yaml key on Assert to the field that carries it.
+// It is how the coverage tests build a minimal Assert for one target and how they
+// prove the target list matches the struct.
+func assertTargetFields(t *testing.T) map[string]reflect.StructField {
+	t.Helper()
+	out := map[string]reflect.StructField{}
+	rt := reflect.TypeOf(Assert{})
+	for i := range rt.NumField() {
+		f := rt.Field(i)
+		tag := strings.Split(f.Tag.Get("yaml"), ",")[0]
+		if tag == "" || tag == "-" {
+			continue
+		}
+		out[tag] = f
+	}
+	return out
+}
+
+// assertForTarget returns an Assert with exactly the given target's field
+// allocated to a zero value. internal/spectest carries the same helper for the
+// packages that dispatch on a target; this copy keeps the spec package's own
+// tests free of an import cycle.
+func assertForTarget(target AssertTarget) *Assert {
+	a := &Assert{}
+	rv := reflect.ValueOf(a).Elem()
+	rt := rv.Type()
+	for i := range rt.NumField() {
+		if strings.Split(rt.Field(i).Tag.Get("yaml"), ",")[0] != string(target) {
+			continue
+		}
+		f := rv.Field(i)
+		if f.Kind() == reflect.Pointer {
+			f.Set(reflect.New(f.Type().Elem()))
+		}
+		return a
+	}
+	return a
+}
+
+// TestAssertTargets_CoverEveryAssertField is the drift guard for the whole
+// assert-target structure. Five layers switch on a target — loader validation,
+// the runtime check, doc, explain, and the JSON schema — and each of those has a
+// coverage test that walks AllAssertTargets. That only protects anything if the
+// list itself is complete, so this test derives the truth from the Assert struct:
+// a new target field with no entry in assertTargets fails here first.
+func TestAssertTargets_CoverEveryAssertField(t *testing.T) {
+	t.Parallel()
+	fields := assertTargetFields(t)
+	listed := map[AssertTarget]bool{}
+	for _, target := range AllAssertTargets() {
+		if listed[target] {
+			t.Errorf("target %q is listed twice", target)
+		}
+		listed[target] = true
+		if _, ok := fields[string(target)]; !ok {
+			t.Errorf("target %q has no field on Assert carrying that yaml key", target)
+		}
+	}
+	for key := range fields {
+		if !listed[AssertTarget(key)] {
+			t.Errorf("Assert field %q is a target family with no entry in assertTargets; SetTargets will never report it", key)
+		}
+	}
+}
+
+// TestSetTargets_ReportsEachTargetAlone pins the pairing between a target and
+// its field: an Assert built for one target reports exactly that target, so the
+// table's presence checks cannot be wired to the wrong field.
+func TestSetTargets_ReportsEachTargetAlone(t *testing.T) {
+	t.Parallel()
+	for _, target := range AllAssertTargets() {
+		got := assertForTarget(target).SetTargets()
+		if len(got) != 1 || got[0] != target {
+			t.Errorf("SetTargets for a %q assert = %v, want exactly [%s]", target, got, target)
+		}
+	}
+	if got := (&Assert{}).SetTargets(); len(got) != 0 {
+		t.Errorf("SetTargets on an empty assert = %v, want none", got)
+	}
+}

--- a/internal/spec/step.go
+++ b/internal/spec/step.go
@@ -96,63 +96,57 @@ const (
 	AssertChanges    AssertTarget = "changes"
 )
 
+// assertTargets is the one list of assertion target families: the name each
+// carries in a spec, in the order SetTargets reports them, paired with the
+// question "does this Assert set it?". Five layers switch on a target — the
+// loader's validation, the runtime check, the doc and explain descriptions, and
+// the JSON schema — and each of those switches is drift-tested against this
+// list, so a target cannot be half-wired: adding a field to Assert without an
+// entry here fails TestAssertTargets_CoverEveryAssertField, and a layer that
+// forgets the new target fails its own coverage test.
+var assertTargets = []struct {
+	target AssertTarget
+	set    func(*Assert) bool
+}{
+	{AssertExitCode, func(a *Assert) bool { return a.ExitCode != nil }},
+	{AssertStdout, func(a *Assert) bool { return a.Stdout != nil }},
+	{AssertStderr, func(a *Assert) bool { return a.Stderr != nil }},
+	{AssertFile, func(a *Assert) bool { return a.File != nil }},
+	{AssertStatus, func(a *Assert) bool { return a.Status != nil }},
+	{AssertHeader, func(a *Assert) bool { return a.Header != nil }},
+	{AssertBody, func(a *Assert) bool { return a.Body != nil }},
+	{AssertRows, func(a *Assert) bool { return a.Rows != nil }},
+	{AssertGRPCStatus, func(a *Assert) bool { return a.GRPCStatus != nil }},
+	{AssertMessage, func(a *Assert) bool { return a.Message != nil }},
+	{AssertValue, func(a *Assert) bool { return a.Value != nil }},
+	{AssertImage, func(a *Assert) bool { return a.Image != nil }},
+	{AssertDir, func(a *Assert) bool { return a.Dir != nil }},
+	{AssertPDF, func(a *Assert) bool { return a.PDF != nil }},
+	{AssertMock, func(a *Assert) bool { return a.Mock != nil }},
+	{AssertScreen, func(a *Assert) bool { return a.Screen != nil }},
+	{AssertDuration, func(a *Assert) bool { return a.Duration != nil }},
+	{AssertChanges, func(a *Assert) bool { return a.Changes != nil }},
+}
+
+// AllAssertTargets returns every assertion target family, in the order
+// SetTargets reports them. It exists so a layer that must handle all of them can
+// be tested against the list instead of against a reader's memory.
+func AllAssertTargets() []AssertTarget {
+	out := make([]AssertTarget, len(assertTargets))
+	for i, e := range assertTargets {
+		out[i] = e.target
+	}
+	return out
+}
+
 // SetTargets returns the assertion target families present. A valid assert has
 // exactly one.
 func (a *Assert) SetTargets() []AssertTarget {
 	var t []AssertTarget
-	if a.ExitCode != nil {
-		t = append(t, AssertExitCode)
-	}
-	if a.Stdout != nil {
-		t = append(t, AssertStdout)
-	}
-	if a.Stderr != nil {
-		t = append(t, AssertStderr)
-	}
-	if a.File != nil {
-		t = append(t, AssertFile)
-	}
-	if a.Status != nil {
-		t = append(t, AssertStatus)
-	}
-	if a.Header != nil {
-		t = append(t, AssertHeader)
-	}
-	if a.Body != nil {
-		t = append(t, AssertBody)
-	}
-	if a.Rows != nil {
-		t = append(t, AssertRows)
-	}
-	if a.GRPCStatus != nil {
-		t = append(t, AssertGRPCStatus)
-	}
-	if a.Message != nil {
-		t = append(t, AssertMessage)
-	}
-	if a.Value != nil {
-		t = append(t, AssertValue)
-	}
-	if a.Image != nil {
-		t = append(t, AssertImage)
-	}
-	if a.Dir != nil {
-		t = append(t, AssertDir)
-	}
-	if a.PDF != nil {
-		t = append(t, AssertPDF)
-	}
-	if a.Mock != nil {
-		t = append(t, AssertMock)
-	}
-	if a.Screen != nil {
-		t = append(t, AssertScreen)
-	}
-	if a.Duration != nil {
-		t = append(t, AssertDuration)
-	}
-	if a.Changes != nil {
-		t = append(t, AssertChanges)
+	for _, e := range assertTargets {
+		if e.set(a) {
+			t = append(t, e.target)
+		}
 	}
 	return t
 }

--- a/internal/spectest/spectest.go
+++ b/internal/spectest/spectest.go
@@ -1,0 +1,33 @@
+// Package spectest builds minimal spec values for tests in other packages. Five
+// layers dispatch on spec.AssertTarget — the loader's validation, the runtime
+// check, doc, explain, and the JSON schema — and each needs a coverage test that
+// walks spec.AllAssertTargets and exercises its own switch. That needs an Assert
+// carrying exactly one target, built without a per-target constructor in every
+// test file.
+package spectest
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/nao1215/atago/internal/spec"
+)
+
+// AssertForTarget returns an Assert with exactly the given target's field
+// allocated to a zero value. The field is located by its yaml key, which is the
+// target's name, so a new target needs no change here.
+func AssertForTarget(target spec.AssertTarget) *spec.Assert {
+	a := &spec.Assert{}
+	rv := reflect.ValueOf(a).Elem()
+	rt := rv.Type()
+	for i := range rt.NumField() {
+		if strings.Split(rt.Field(i).Tag.Get("yaml"), ",")[0] != string(target) {
+			continue
+		}
+		if f := rv.Field(i); f.Kind() == reflect.Pointer {
+			f.Set(reflect.New(f.Type().Elem()))
+		}
+		return a
+	}
+	return a
+}

--- a/schema_test.go
+++ b/schema_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/nao1215/atago/internal/loader"
 	"github.com/nao1215/atago/internal/manifest"
+	"github.com/nao1215/atago/internal/spec"
 )
 
 // loadSchema compiles the published JSON Schema.
@@ -581,5 +582,70 @@ func TestReportExample_Conforms(t *testing.T) {
 	s := compileSchema(t, "schema/report.schema.json")
 	if err := s.Validate(readJSONAny(t, "schema/examples/report.example.json")); err != nil {
 		t.Errorf("report example does not conform to schema:\n%v", err)
+	}
+}
+
+// TestSchema_AssertTargetsAreAllDeclared is the last of the assert-target
+// coverage guards: the published schema is what an editor validates a spec
+// against, so a target the runtime accepts but the schema omits makes a correct
+// spec light up red in the author's editor — and one listed in `properties` but
+// missing from `anyOf` would be accepted only in combination with another target.
+// Both halves are derived from spec.AllAssertTargets rather than restated here.
+func TestSchema_AssertTargetsAreAllDeclared(t *testing.T) {
+	t.Parallel()
+	raw, err := os.ReadFile("schema/atago.schema.json")
+	if err != nil {
+		t.Fatalf("read schema: %v", err)
+	}
+	// Navigated as a generic document rather than decoded into structs: the keys
+	// are JSON Schema's own ($defs, anyOf), not names atago chose.
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("decode schema: %v", err)
+	}
+	defs, ok := doc["$defs"].(map[string]any)
+	if !ok {
+		t.Fatal("schema has no $defs object")
+	}
+	assertDef, ok := defs["assert"].(map[string]any)
+	if !ok {
+		t.Fatal("schema has no $defs/assert object")
+	}
+	properties, ok := assertDef["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("$defs/assert has no properties object")
+	}
+	alternatives, ok := assertDef["anyOf"].([]any)
+	if !ok {
+		t.Fatal("$defs/assert has no anyOf list")
+	}
+	required := map[string]bool{}
+	for _, alt := range alternatives {
+		m, ok := alt.(map[string]any)
+		if !ok {
+			continue
+		}
+		names, ok := m["required"].([]any)
+		if !ok {
+			continue
+		}
+		for _, n := range names {
+			if s, ok := n.(string); ok {
+				required[s] = true
+			}
+		}
+	}
+	for _, target := range spec.AllAssertTargets() {
+		if _, ok := properties[string(target)]; !ok {
+			t.Errorf("assert target %q has no property in $defs/assert; an editor would reject a valid spec", target)
+		}
+		if !required[string(target)] {
+			t.Errorf("assert target %q is not one of the anyOf alternatives; a spec setting only it would fail validation", target)
+		}
+	}
+	for key := range properties {
+		if !required[key] {
+			t.Errorf("$defs/assert declares %q but no anyOf alternative requires it", key)
+		}
 	}
 }


### PR DESCRIPTION
## The structure this addresses

Adding an assertion target touches seven places: the field on `spec.Assert`, the `AssertTarget` constant, `SetTargets`, the loader's validation switch, the runtime's check switch, the doc and explain description switches (each with its own style bundle), and the JSON Schema.

I looked at collapsing the five dispatch switches into one registry — a table where each target declares its accessor, validator, checker, and describers — and decided against it. The four operations have genuinely different signatures (a checker needs the run result and the assert env, a describer needs a style bundle, a validator needs an error sink and a path prefix), so the entries would carry `func(*spec.Assert) any` accessors and per-target closures that re-assert types. That trades compile-time safety and locality for indirection, and it blurs what each layer is: the switch in `internal/assert` reads as "how atago evaluates a target", which is exactly where a reader looks for it.

What was actually wrong is that nothing enforced completeness, and every default branch degraded silently rather than loudly:

- `docgen.describeTarget` and `explain.describeTarget` return `string(target)`, so a forgotten target publishes the bare word `pdf` where a sentence belongs — a weaker contract than the suite guards, the same class of bug #216 fixed for multi-matcher assertions.
- `assert.checkTarget` answers "assertion target not supported yet", reachable only if the loader accepts something the runtime cannot evaluate.
- The schema silently omits it, which makes a valid spec light up red in the author's editor — the worst failure mode, because atago itself stays green.

So the fix is enforcement, not indirection.

## Change

- `spec.AllAssertTargets` derives the ordered list from one table that pairs each target with "does this Assert set it?". The constant block and the eighteen `if` statements in `SetTargets` were two lists that could drift; now there is one, and `SetTargets` walks it.
- `TestAssertTargets_CoverEveryAssertField` derives the truth from the `Assert` struct tags: a new target field with no table entry fails there, so the coverage tests below cannot be passing over an incomplete list.
- Coverage tests per layer, each walking `AllAssertTargets`: doc and explain must not fall through to the bare name, `checkTarget` must not answer "not supported yet", and the schema must declare the target in both `properties` and an `anyOf` alternative (with the reverse direction checked too, so a stale property is caught).
- `internal/spectest` builds the minimal `Assert` those tests need, locating the field by its yaml key, so a new target needs no change there either.
- `docgen` spelled its action-step-kind set twice, with a comment asking the reader to keep the copies in sync or grouped bullets would flatten. One predicate now.

No behavior change: `make test`, `make lint`, `make e2e` (456 scenarios), `make docs`, and `make site` are green, with no doc or site drift.

The message-clarity work from the same review is deliberately not here — it changes output, so it belongs in its own PR.