### PR TITLE
fix(assert): say what the path is when a delta entry does not match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ and this project follows [Semantic Versioning](https://semver.org/).
   proves that table matches the fields on `Assert`, and each layer has a coverage
   test that walks the list. A half-wired target fails a test rather than shipping
   a weaker document.
+- A `changes:` entry that names a path the delta does not track now says what the
+  path is. A workdir delta scans regular files and symlinks, so a directory the
+  step really did create — or a named pipe, or a socket — is invisible to
+  `created`/`modified`/`deleted`, and the failure read "matched no file the step
+  created" while the author could see the thing sitting in the workdir. The note
+  names the kind and, for a directory, points at `dir:`.
+- A service that dies during its readiness probe now reports the exit status.
+  "service exited before it became ready" left the two cases an author checks
+  first indistinguishable: a missing binary (127) and a command that ran and
+  rejected its own configuration. The captured service output is still shown
+  beneath it.
 
 ### Added
 

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 436 scenarios
+74 suites · 438 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -29,7 +29,7 @@
   - [manifest surfaces the browser-runner configuration](#scenario-manifest-surfaces-the-browser-runner-configuration)
   - [an upload action without a file fails validation (exit 2)](#scenario-an-upload-action-without-a-file-fails-validation-exit-2)
   - [a download action without a click selector fails validation (exit 2)](#scenario-a-download-action-without-a-click-selector-fails-validation-exit-2)
-- [atago self-hosting / changes (workdir delta assertions)](#atago-self-hosting--changes-workdir-delta-assertions) — 18 scenarios
+- [atago self-hosting / changes (workdir delta assertions)](#atago-self-hosting--changes-workdir-delta-assertions) — 19 scenarios
   - [a generator touches exactly the files it should (POSIX)](#scenario-a-generator-touches-exactly-the-files-it-should-posix)
   - [an unexpected creation breaks the exact contract (POSIX)](#scenario-an-unexpected-creation-breaks-the-exact-contract-posix)
   - [stdout_to counts as created, and modified nothing holds (portable)](#scenario-stdout_to-counts-as-created-and-modified-nothing-holds-portable)
@@ -48,6 +48,7 @@
   - [writing through a symlink modifies the target only](#scenario-writing-through-a-symlink-modifies-the-target-only)
   - [removing a symlink is a deletion](#scenario-removing-a-symlink-is-a-deletion)
   - [a dangling symlink is still a creation](#scenario-a-dangling-symlink-is-still-a-creation)
+  - [a changes entry naming a directory says what the path is](#scenario-a-changes-entry-naming-a-directory-says-what-the-path-is)
 - [atago self-hosting / CLI scenario selection](#atago-self-hosting--cli-scenario-selection) — 9 scenarios
   - [filter selects by a name substring](#scenario-filter-selects-by-a-name-substring)
   - [filter is OR across a comma-separated list](#scenario-filter-is-or-across-a-comma-separated-list)
@@ -398,7 +399,7 @@
   - [--filter runs only matching scenarios](#scenario---filter-runs-only-matching-scenarios)
   - [--filter selects multiple scenarios with OR (comma and repeated)](#scenario---filter-selects-multiple-scenarios-with-or-comma-and-repeated)
   - [--skip-tag drops tagged scenarios](#scenario---skip-tag-drops-tagged-scenarios)
-- [atago self-hosting / background services](#atago-self-hosting--background-services) — 7 scenarios
+- [atago self-hosting / background services](#atago-self-hosting--background-services) — 8 scenarios
   - [file readiness captures a dynamic value into a variable](#scenario-file-readiness-captures-a-dynamic-value-into-a-variable)
   - [log readiness waits for a line on the service output](#scenario-log-readiness-waits-for-a-line-on-the-service-output)
   - [delay readiness waits a fixed duration](#scenario-delay-readiness-waits-a-fixed-duration)
@@ -406,6 +407,7 @@
   - [a readiness failure preserves the service log as an artifact](#scenario-a-readiness-failure-preserves-the-service-log-as-an-artifact)
   - [a step failure after the service is ready preserves the service log](#scenario-a-step-failure-after-the-service-is-ready-preserves-the-service-log)
   - [a green run with a healthy service writes no service log](#scenario-a-green-run-with-a-healthy-service-writes-no-service-log)
+  - [a service that dies before readiness names its exit status](#scenario-a-service-that-dies-before-readiness-names-its-exit-status)
 - [atago self-hosting / harness shell is not shadowed by the program PATH](#atago-self-hosting--harness-shell-is-not-shadowed-by-the-program-path) — 2 scenarios
   - [a PATH-resident fake sh does not hijack shell:true](#scenario-a-path-resident-fake-sh-does-not-hijack-shelltrue)
   - [ATAGO_SHELL overrides the shell used for shell:true](#scenario-atago_shell-overrides-the-shell-used-for-shelltrue)
@@ -1269,6 +1271,29 @@ ln -s no/such/target dangling
 #### Then
 - exit code is `0`
 - the step changed exactly created `dangling`, modified nothing, deleted nothing
+### Scenario: a changes entry naming a directory says what the path is
+#### Given
+- Fixture file `direntry.atago.yaml` is created.
+#### Inputs
+_Fixture `direntry.atago.yaml`:_
+```text
+version: "1"
+suite: {name: direntry}
+scenarios:
+  - name: the generator made a directory
+    steps:
+      - run: {shell: true, command: "mkdir out"}
+      - assert:
+          changes:
+            created: [out]
+```
+#### When
+```shell
+${atago} run direntry.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `"out" exists as a directory`, `tracks only regular files and symlinks`, `assert it with dir:`
 ## atago self-hosting / CLI scenario selection
 Source: `test/e2e/atago/cli_selection.atago.yaml`
 ### Scenario: filter selects by a name substring
@@ -7487,6 +7512,36 @@ ls arts 2>/dev/null | wc -l | tr -d " "
   - exit code is `0`
 - after `ls arts 2>/dev/null | wc -l | tr -d " "`:
   - stdout equals an exact value
+### Scenario: a service that dies before readiness names its exit status
+_skipped on Windows_
+#### Given
+- Fixture file `crasher.atago.yaml` is created.
+#### Inputs
+_Fixture `crasher.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: service exits with a status
+    services:
+      - name: dies
+        shell: true
+        command: 'echo starting; exit 3'
+        ready:
+          log: never-appears
+          timeout: 2s
+    steps:
+      - run:
+          command: echo unreached
+```
+#### When
+```shell
+${atago} run crasher.atago.yaml
+```
+#### Then
+- exit code is `4`
+- stdout contains `service exited before it became ready (exit status 3)`, `starting`
 ## atago self-hosting / harness shell is not shadowed by the program PATH
 Source: `test/e2e/atago/shell_path.atago.yaml`
 ### Scenario: a PATH-resident fake sh does not hijack shell:true

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -189,7 +189,7 @@ func checkTarget(a *spec.Assert, target spec.AssertTarget, res *runner.Result, e
 	case spec.AssertDuration:
 		return checkDuration(a.Duration, res)
 	case spec.AssertChanges:
-		return checkChanges(a.Changes, res)
+		return checkChanges(a.Changes, res, env)
 	default:
 		return &CheckResult{Desc: string(target), Hint: "assertion target not supported yet"}
 	}

--- a/internal/assert/changes.go
+++ b/internal/assert/changes.go
@@ -2,11 +2,14 @@ package assert
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/nao1215/atago/internal/fsdelta"
+	"github.com/nao1215/atago/internal/fskind"
 	"github.com/nao1215/atago/internal/runner"
 	"github.com/nao1215/atago/internal/spec"
 )
@@ -18,7 +21,7 @@ import (
 // observed path — so `modified: []` asserts "modified nothing". An omitted
 // (nil) field is unconstrained. Paths are compared with forward slashes, so the
 // same spec passes on Windows.
-func checkChanges(c *spec.ChangesAssert, res *runner.Result) *CheckResult {
+func checkChanges(c *spec.ChangesAssert, res *runner.Result, env Env) *CheckResult {
 	desc := "assert changes"
 	if res == nil || res.Changes == nil {
 		return &CheckResult{
@@ -29,9 +32,9 @@ func checkChanges(c *spec.ChangesAssert, res *runner.Result) *CheckResult {
 	d := res.Changes
 
 	var problems []string
-	checkCategory("created", c.Created, d.Created, &problems)
-	checkCategory("modified", c.Modified, d.Modified, &problems)
-	checkCategory("deleted", c.Deleted, d.Deleted, &problems)
+	checkCategory("created", c.Created, d.Created, &problems, env.Workdir)
+	checkCategory("modified", c.Modified, d.Modified, &problems, env.Workdir)
+	checkCategory("deleted", c.Deleted, d.Deleted, &problems, env.Workdir)
 
 	if len(problems) == 0 {
 		return pass(desc)
@@ -48,7 +51,7 @@ func checkChanges(c *spec.ChangesAssert, res *runner.Result) *CheckResult {
 // checkCategory enforces the exhaustive-set semantics for one category. A nil
 // entries pointer leaves the category unconstrained; a non-nil (possibly empty)
 // list requires an exact, bidirectional cover.
-func checkCategory(name string, entries *spec.StringList, observed []string, problems *[]string) {
+func checkCategory(name string, entries *spec.StringList, observed []string, problems *[]string, workdir string) {
 	if entries == nil {
 		return
 	}
@@ -69,10 +72,38 @@ func checkCategory(name string, entries *spec.StringList, observed []string, pro
 			msg := fmt.Sprintf("%s entry %q matched no file the step %s", name, pat, name)
 			if note := globMetaNote(pat); note != "" {
 				msg += "; " + note
+			} else if note := untrackedKindNote(workdir, pat); note != "" {
+				msg += "; " + note
 			}
 			*problems = append(*problems, msg)
 		}
 	}
+}
+
+// untrackedKindNote explains the other baffling case: the named path IS in the
+// workdir, but as something a delta does not track. fsdelta scans regular files
+// and symlinks, so a directory a generator created — or a named pipe or socket a
+// program left behind — is invisible to created/modified/deleted, and the failure
+// otherwise reads as "the tool never made it" while the author can see it right
+// there. Returns "" when the path is absent, is tracked, or the entry is a glob
+// (globMetaNote covers that case).
+func untrackedKindNote(workdir, pat string) string {
+	if workdir == "" {
+		return ""
+	}
+	info, err := os.Lstat(filepath.Join(workdir, filepath.FromSlash(pat)))
+	if err != nil {
+		return ""
+	}
+	mode := info.Mode()
+	if mode.IsRegular() || mode&os.ModeSymlink != 0 {
+		return ""
+	}
+	note := fmt.Sprintf("note: %q exists as a %s, and a workdir delta tracks only regular files and symlinks", pat, fskind.Name(mode))
+	if mode.IsDir() {
+		note += "; name the files inside it, or assert it with dir:"
+	}
+	return note
 }
 
 // globMetaNote explains a common footgun: a changes entry is a doublestar glob,

--- a/internal/assert/changes_test.go
+++ b/internal/assert/changes_test.go
@@ -1,6 +1,8 @@
 package assert
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -145,7 +147,7 @@ func TestCheckChanges(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := checkChanges(tt.assert, changesResult(tt.delta))
+			got := checkChanges(tt.assert, changesResult(tt.delta), Env{})
 			if got.OK != tt.wantOK {
 				t.Errorf("checkChanges OK = %v, want %v (hint: %s)", got.OK, tt.wantOK, got.Hint)
 			}
@@ -161,6 +163,7 @@ func TestCheckChanges_GlobMetaHint(t *testing.T) {
 	got := checkChanges(
 		&spec.ChangesAssert{Created: list("weird[1].txt")},
 		changesResult(fsdelta.Delta{Created: []string{"weird[1].txt"}}),
+		Env{},
 	)
 	if got.OK {
 		t.Fatal("an unescaped [ never matches the literal filename, so it should fail")
@@ -180,6 +183,7 @@ func TestCheckChanges_GlobBraceHint(t *testing.T) {
 	got := checkChanges(
 		&spec.ChangesAssert{Created: list("a{1}.txt")},
 		changesResult(fsdelta.Delta{Created: []string{"a{1}.txt"}}),
+		Env{},
 	)
 	if got.OK {
 		t.Fatal("an unescaped { never matches the literal filename, so it should fail")
@@ -194,11 +198,55 @@ func TestCheckChanges_GlobBraceHint(t *testing.T) {
 // is reported rather than silently passing.
 func TestCheckChanges_NoDelta(t *testing.T) {
 	t.Parallel()
-	got := checkChanges(&spec.ChangesAssert{Created: list("x")}, &runner.Result{})
+	got := checkChanges(&spec.ChangesAssert{Created: list("x")}, &runner.Result{}, Env{})
 	if got.OK {
 		t.Error("checkChanges with nil delta should not pass")
 	}
-	if got = checkChanges(&spec.ChangesAssert{Created: list("x")}, nil); got.OK {
+	if got = checkChanges(&spec.ChangesAssert{Created: list("x")}, nil, Env{}); got.OK {
 		t.Error("checkChanges with nil result should not pass")
+	}
+}
+
+// TestCheckChanges_UntrackedKindHint covers the other way an unmatched entry
+// reads as a lie: the path is right there in the workdir, but as something a
+// delta does not track. fsdelta scans regular files and symlinks, so a directory
+// a generator created is invisible to created/modified/deleted, and "matched no
+// file the step created" reads as "the tool never made it".
+func TestCheckChanges_UntrackedKindHint(t *testing.T) {
+	t.Parallel()
+	wd := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(wd, "out"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	got := checkChanges(
+		&spec.ChangesAssert{Created: list("out")},
+		changesResult(fsdelta.Delta{}),
+		Env{Workdir: wd},
+	)
+	if got.OK {
+		t.Fatal("a directory is not tracked by the delta, so the entry should fail")
+	}
+	for _, want := range []string{
+		`"out" exists as a directory`,
+		"tracks only regular files and symlinks",
+		"assert it with dir:",
+	} {
+		if !strings.Contains(got.Hint, want) {
+			t.Errorf("Hint should say what the path is.\n got: %s\nwant substring: %s", got.Hint, want)
+		}
+	}
+
+	// An entry naming nothing at all keeps the plain message: there is no kind to
+	// report, and inventing one would be worse than saying less.
+	plain := checkChanges(
+		&spec.ChangesAssert{Created: list("never-created.txt")},
+		changesResult(fsdelta.Delta{}),
+		Env{Workdir: wd},
+	)
+	if plain.OK {
+		t.Fatal("an absent path should fail")
+	}
+	if strings.Contains(plain.Hint, "exists as") {
+		t.Errorf("Hint for an absent path should not claim it exists: %s", plain.Hint)
 	}
 }

--- a/internal/runner/service/service.go
+++ b/internal/runner/service/service.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"regexp"
 	"strings"
 	"sync"
@@ -24,8 +25,27 @@ import (
 
 // errExitedEarly is the readiness failure when the service process exits before
 // its probe (delay/file/port/log) succeeds. Shared so every wait path words it
-// identically.
+// identically; exitedEarly wraps it with how the process ended.
 var errExitedEarly = errors.New("service exited before it became ready")
+
+// exitedEarly is the error a readiness wait returns when the process is gone. It
+// names the exit status, which is the first thing an author needs: a service that
+// died with status 127 is a missing binary and one that died with 1 is a config
+// error, and the two are indistinguishable from "it exited" alone. Callers must
+// only use it after p.done has fired, which is what orders the read of waitErr.
+func (p *Proc) exitedEarly() error {
+	var ee *exec.ExitError
+	switch {
+	case p.waitErr == nil:
+		return fmt.Errorf("%w (exit status 0)", errExitedEarly)
+	case errors.As(p.waitErr, &ee):
+		// ExitError renders "exit status 3", or "signal: killed" when a signal
+		// ended it.
+		return fmt.Errorf("%w (%w)", errExitedEarly, ee)
+	default:
+		return fmt.Errorf("%w (%w)", errExitedEarly, p.waitErr)
+	}
+}
 
 // defaultReadyTimeout bounds a readiness probe when the spec omits one.
 const defaultReadyTimeout = 5 * time.Second
@@ -46,6 +66,10 @@ type Proc struct {
 	c    *processCmd
 	out  *syncBuffer
 	done chan struct{}
+	// waitErr is what Wait returned, written before done is closed and read only
+	// after done is received from, so the channel's close orders the two. It lets
+	// a readiness failure say HOW the process ended instead of only that it did.
+	waitErr error
 }
 
 // Name returns the service's declared name.
@@ -93,7 +117,7 @@ func Start(ctx context.Context, svc *spec.Service, workdir string) (*Proc, strin
 
 	p := &Proc{name: svc.Name, c: pc, out: out, done: make(chan struct{})}
 	go func() {
-		_ = pc.cmd.Wait()
+		p.waitErr = pc.cmd.Wait()
 		close(p.done)
 	}()
 
@@ -204,7 +228,7 @@ func (p *Proc) waitReady(ctx context.Context, r *spec.Ready, workdir string) (st
 			// how the file/port/log probes detect an early exit via p.done. Without
 			// this, a command that crashes (e.g. `exit 3`) during the delay was
 			// reported READY and the scenario ran against a dead peer.
-			return "", errExitedEarly
+			return "", p.exitedEarly()
 		case <-time.After(wait):
 			if cappedByTimeout {
 				return "", fmt.Errorf("timed out after %s waiting for readiness (ready.delay %s exceeds ready.timeout)", timeout, r.Delay)
@@ -213,7 +237,7 @@ func (p *Proc) waitReady(ctx context.Context, r *spec.Ready, workdir string) (st
 			// same instant; check once more so a crash at the boundary is not missed.
 			select {
 			case <-p.done:
-				return "", errExitedEarly
+				return "", p.exitedEarly()
 			default:
 				return "", nil
 			}
@@ -314,7 +338,7 @@ func (p *Proc) poll(ctx context.Context, timeout time.Duration, check func() boo
 			if check() {
 				return nil
 			}
-			return errExitedEarly
+			return p.exitedEarly()
 		case <-deadlineC:
 			return fmt.Errorf("timed out after %s waiting for readiness", timeout)
 		case <-ctx.Done():

--- a/internal/runner/service/service_test.go
+++ b/internal/runner/service/service_test.go
@@ -135,6 +135,11 @@ func TestStart_DelayReadyDetectsEarlyExit(t *testing.T) {
 	if !strings.Contains(err.Error(), "exited before it became ready") {
 		t.Errorf("error = %v, want it to report the early exit", err)
 	}
+	// The status is the first thing an author needs: 127 is a missing binary and
+	// 1 is a config error, and "it exited" tells them neither.
+	if !strings.Contains(err.Error(), "exit status 3") {
+		t.Errorf("error = %v, want it to name the exit status the service died with", err)
+	}
 }
 
 // TestStart_DelayBoundedByTimeout is a regression: ready.timeout must bound the

--- a/test/e2e/atago/changes.atago.yaml
+++ b/test/e2e/atago/changes.atago.yaml
@@ -412,3 +412,30 @@ scenarios:
             created: [dangling]
             modified: []
             deleted: []
+
+  # A workdir delta tracks regular files and symlinks. When an entry names a
+  # directory the step really did create, "matched no file the step created" reads
+  # as "the tool never made it" while the author can see it sitting there.
+  - name: a changes entry naming a directory says what the path is
+    steps:
+      - fixture:
+          file: direntry.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: direntry}
+            scenarios:
+              - name: the generator made a directory
+                steps:
+                  - run: {shell: true, command: "mkdir out"}
+                  - assert:
+                      changes:
+                        created: [out]
+      - run:
+          command: ${atago} run direntry.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - '"out" exists as a directory'
+              - "tracks only regular files and symlinks"
+              - "assert it with dir:"

--- a/test/e2e/atago/services.atago.yaml
+++ b/test/e2e/atago/services.atago.yaml
@@ -184,3 +184,38 @@ scenarios:
       - assert:
           stdout:
             equals: "0"
+
+  # "service exited before it became ready" leaves the author guessing why. The
+  # exit status separates the two cases they will check first: a missing binary
+  # (127) and a command that ran and rejected its own config.
+  - name: a service that dies before readiness names its exit status
+    skip: {os: windows}
+    steps:
+      - fixture:
+          file: crasher.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: sample
+            scenarios:
+              - name: service exits with a status
+                services:
+                  - name: dies
+                    shell: true
+                    command: 'echo starting; exit 3'
+                    ready:
+                      log: never-appears
+                      timeout: 2s
+                steps:
+                  - run:
+                      command: echo unreached
+      - run:
+          command: ${atago} run crasher.atago.yaml
+      - assert:
+          exit_code: 4
+          stdout:
+            contains:
+              - "service exited before it became ready (exit status 3)"
+              # The captured output is still shown, so the two together say what
+              # the service managed to do before dying.
+              - "starting"


### PR DESCRIPTION
Two messages that made a reader doubt what they could see. Both were found while attacking `changes:` and the service lifecycle with hostile inputs, and both are output changes, which is why they are separate from the structural refactor in #325.

## A `changes:` entry naming an untracked path

```yaml
- run: {shell: true, command: "mkdir out"}
- assert:
    changes:
      created: [out]
```

```
created entry "out" matched no file the step created
```

A workdir delta scans regular files and symlinks, so the directory the step plainly created is invisible to `created`/`modified`/`deleted`. The message reads as "your tool did nothing" while the author is looking at the directory. It now names what the path is, and for a directory points at the assertion that does cover it:

```
created entry "out" matched no file the step created; note: "out" exists as a
directory, and a workdir delta tracks only regular files and symlinks; name the
files inside it, or assert it with dir:
```

A named pipe or a socket gets the same treatment, which pairs with #322 — that PR stopped atago from blocking on those entries, and this one stops the delta from pretending they are absent. An entry naming nothing at all keeps the plain message: there is no kind to report, and inventing one would be worse than saying less.

## A service that dies during readiness

```
service "db" not ready: service exited before it became ready
--- service output ---
starting
```

The two cases an author checks first — a missing binary (127) and a command that ran and rejected its config — are indistinguishable there. The status is now in the message:

```
service "db" not ready: service exited before it became ready (exit status 3)
```

`Proc` keeps what `Wait` returned, written before `done` is closed and read only after a receive from it, so the channel's close orders the two. Both errors are wrapped, so `errors.Is` against the sentinel and against `*exec.ExitError` both work.

## Tests

- `internal/assert`: the directory case, and the absent-path case proving the note is not invented.
- `internal/runner/service`: the existing early-exit regression now also pins the status.
- `test/e2e/atago/changes.atago.yaml` and `services.atago.yaml`: both messages through the CLI, the service one gated to non-Windows for the shell exit.

`make test`, `make lint`, `make e2e` (458 scenarios), `make docs`, `make site` are green.