### PR TITLE
ci(thirdparty): stop reporting runner weather as a broken tool

### DIFF
--- a/.github/workflows/thirdparty.yml
+++ b/.github/workflows/thirdparty.yml
@@ -319,4 +319,11 @@ jobs:
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run the ${{ matrix.program.name }} suite
-        run: ./dist/atago run "${{ matrix.program.dir }}"
+        # --retry-failed 1 re-runs a failed scenario once, in a fresh workdir and
+        # a fresh sandboxed HOME, and reports a recovery as flaky rather than
+        # green-washing it. This matrix drives real terminal UIs against a shared
+        # runner, where a scheduled run alternated red and green for weeks on
+        # nothing but load: the TUI suites timed out waiting for a screen that
+        # arrives promptly on a quiet machine. A regression still fails both
+        # attempts; only a flake is absorbed, and the report names it.
+        run: ./dist/atago run --retry-failed 1 "${{ matrix.program.dir }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- The scheduled third-party matrix no longer reports the runner's weather as a
+  broken tool. Its pinned Ubuntu snapshot mirror served a 500 for the
+  command-not-found index — a file nothing here uses — and `apt-get update` exits
+  100 for any index it cannot fetch, so five suites never ran. That index is no
+  longer requested, and the update and install are retried against a mirror that
+  5xxes under load. The version pin itself is unchanged: the snapshot id and the
+  SHA256-verified release archives still decide what gets installed.
+- The scheduled matrix runs with `--retry-failed 1`, and the two terminal-UI
+  suites wait up to 45s for a screen instead of 20s. The same specs and the same
+  pinned binaries alternated red and green from one scheduled run to the next on
+  nothing but load. A regression still fails both attempts; a flake is absorbed
+  and reported as flaky.
+
+### Changed
+
 - Adding an assertion target is now guarded instead of remembered. Five layers
   dispatch on a target — the loader's validation, the runtime check, `atago doc`,
   `atago explain`, and the published JSON Schema — and each had its own switch

--- a/scripts/install_ubuntu_snapshot_packages.sh
+++ b/scripts/install_ubuntu_snapshot_packages.sh
@@ -12,5 +12,33 @@ snapshot_id="${ATAGO_UBUNTU_SNAPSHOT_ID:-20260721T000000Z}"
 # snapshot. The third-party matrix uses this so Ubuntu-packaged tools do not
 # drift as the runner image and apt repositories move forward.
 printf 'APT::Snapshot "%s";\n' "$snapshot_id" | sudo tee /etc/apt/apt.conf.d/99atago-snapshot >/dev/null
-sudo apt-get update
-sudo apt-get install -y --no-install-recommends "$@"
+
+# Do not fetch the command-not-found index. It exists to suggest a package for an
+# unknown shell command, which nothing here does, and it is the index that made
+# the pinned mirror fail the whole matrix: snapshot.ubuntu.com served a 500 for
+# dists/noble-updates/universe/cnf/Commands-amd64, apt exited 100 for one index
+# it could not fetch, and five suites never ran. Skipping it removes a request we
+# have no use for rather than ignoring a failure that matters.
+printf 'Acquire::IndexTargets::deb::Commands::DefaultEnabled "false";\n' |
+	sudo tee /etc/apt/apt.conf.d/99atago-no-command-not-found >/dev/null
+
+# The mirror still 5xxes under load. apt retries each acquire, and the whole
+# step is retried too, because a snapshot host that is briefly unhealthy is not a
+# reason to report the tool under test as broken.
+apt_retry() {
+	local attempt
+	for attempt in 1 2 3; do
+		if sudo "$@" -o Acquire::Retries=3; then
+			return 0
+		fi
+		if [ "$attempt" -lt 3 ]; then
+			echo "atago: '$*' failed (attempt $attempt/3); retrying in $((attempt * 15))s" >&2
+			sleep $((attempt * 15))
+		fi
+	done
+	echo "atago: '$*' failed three times against snapshot $snapshot_id" >&2
+	return 1
+}
+
+apt_retry apt-get update
+apt_retry apt-get install -y --no-install-recommends "$@"

--- a/test/e2e/thirdparty/lazygit/lazygit.atago.yaml
+++ b/test/e2e/thirdparty/lazygit/lazygit.atago.yaml
@@ -14,6 +14,10 @@ suite:
     would pass on a version that draws a commit it never made.
 
 # Install: see .github/workflows/thirdparty.yml for the pinned CI version.
+# Session timeout: 45s. It bounds how long a session waits for a screen, and
+# nothing else — every expect and every assertion is unchanged. 20s was enough on
+# a quiet machine but not on a loaded CI runner, where the same specs and the same
+# pinned binary alternated red and green from one scheduled run to the next.
 scenarios:
   - name: version prints the pinned release
     only:
@@ -56,7 +60,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo
           rows: 30
           cols: 120
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -95,7 +99,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo/sub
           rows: 30
           cols: 120
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -138,7 +142,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo
           rows: 30
           cols: 120
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -183,7 +187,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo
           rows: 30
           cols: 120
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -229,7 +233,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo
           rows: 30
           cols: 120
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -277,7 +281,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo
           rows: 30
           cols: 120
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -321,7 +325,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo
           rows: 30
           cols: 120
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -378,7 +382,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo
           rows: 30
           cols: 120
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -435,7 +439,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo
           rows: 30
           cols: 120
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -484,7 +488,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo
           rows: 30
           cols: 120
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -530,7 +534,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo
           rows: 30
           cols: 120
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -576,7 +580,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo
           rows: 30
           cols: 120
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -625,7 +629,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo branch
           rows: 30
           cols: 120
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -668,7 +672,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo branch
           rows: 30
           cols: 120
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -711,7 +715,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo branch
           rows: 30
           cols: 120
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -755,7 +759,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo branch
           rows: 30
           cols: 120
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -800,7 +804,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo
           rows: 30
           cols: 120
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -854,7 +858,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo
           rows: 30
           cols: 120
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -908,7 +912,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo stash
           rows: 30
           cols: 120
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -961,7 +965,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo stash
           rows: 30
           cols: 120
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           session:

--- a/test/e2e/thirdparty/yazi/chooser_selection.atago.yaml
+++ b/test/e2e/thirdparty/yazi/chooser_selection.atago.yaml
@@ -29,7 +29,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -53,7 +53,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -77,7 +77,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -102,7 +102,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -125,7 +125,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -148,7 +148,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -171,7 +171,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -193,7 +193,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -213,7 +213,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -234,7 +234,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -257,7 +257,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -279,7 +279,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -302,7 +302,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -325,7 +325,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -348,7 +348,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true

--- a/test/e2e/thirdparty/yazi/entry_args.atago.yaml
+++ b/test/e2e/thirdparty/yazi/entry_args.atago.yaml
@@ -30,7 +30,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt target
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -48,7 +48,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt target/a.txt
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -66,7 +66,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt target/a.txt
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -85,7 +85,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt target/a.txt
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -106,7 +106,7 @@ scenarios:
           shell: true
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -125,7 +125,7 @@ scenarios:
           shell: true
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -144,7 +144,7 @@ scenarios:
           shell: true
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -162,7 +162,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt .hidden
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -180,7 +180,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt nested/deeper/file.txt
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -200,7 +200,7 @@ scenarios:
           shell: true
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -225,7 +225,7 @@ scenarios:
           shell: true
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -250,7 +250,7 @@ scenarios:
           shell: true
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -276,7 +276,7 @@ scenarios:
           shell: true
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true

--- a/test/e2e/thirdparty/yazi/links_and_overwrite.atago.yaml
+++ b/test/e2e/thirdparty/yazi/links_and_overwrite.atago.yaml
@@ -32,7 +32,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -65,7 +65,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -98,7 +98,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -128,7 +128,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -159,7 +159,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -189,7 +189,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -220,7 +220,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -252,7 +252,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true

--- a/test/e2e/thirdparty/yazi/navigation_tabs.atago.yaml
+++ b/test/e2e/thirdparty/yazi/navigation_tabs.atago.yaml
@@ -29,7 +29,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -51,7 +51,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -75,7 +75,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -95,7 +95,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -117,7 +117,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -138,7 +138,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -160,7 +160,7 @@ scenarios:
           shell: true
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -196,7 +196,7 @@ scenarios:
           shell: true
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -227,7 +227,7 @@ scenarios:
           shell: true
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -261,7 +261,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -285,7 +285,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true

--- a/test/e2e/thirdparty/yazi/search_tabs.atago.yaml
+++ b/test/e2e/thirdparty/yazi/search_tabs.atago.yaml
@@ -27,7 +27,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -54,7 +54,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -77,7 +77,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -102,7 +102,7 @@ scenarios:
           shell: true
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true

--- a/test/e2e/thirdparty/yazi/selection_matrix.atago.yaml
+++ b/test/e2e/thirdparty/yazi/selection_matrix.atago.yaml
@@ -28,7 +28,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -64,7 +64,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -99,7 +99,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -135,7 +135,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -173,7 +173,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -209,7 +209,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -242,7 +242,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -278,7 +278,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -315,7 +315,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true

--- a/test/e2e/thirdparty/yazi/yazi.atago.yaml
+++ b/test/e2e/thirdparty/yazi/yazi.atago.yaml
@@ -21,6 +21,10 @@ suite:
     navigation and tabs, search, and hardlinks and overwrites.
 
 # Install: see .github/workflows/thirdparty.yml for the pinned CI version.
+# Session timeout: 45s. It bounds how long a session waits for a screen, and
+# nothing else — every expect and every assertion is unchanged. 20s was enough on
+# a quiet machine but not on a loaded CI runner, where the same specs and the same
+# pinned binary alternated red and green from one scheduled run to the next.
 scenarios:
   - name: version prints a semantic version banner
     only:
@@ -145,7 +149,7 @@ scenarios:
           command: yazi ${workdir}
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -182,7 +186,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -214,7 +218,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -256,7 +260,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -307,7 +311,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -356,7 +360,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -402,7 +406,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -438,7 +442,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -474,7 +478,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -513,7 +517,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -555,7 +559,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -608,7 +612,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -644,7 +648,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -682,7 +686,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -726,7 +730,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -765,7 +769,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -819,7 +823,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -870,7 +874,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -917,7 +921,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -964,7 +968,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1007,7 +1011,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1053,7 +1057,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1088,7 +1092,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1123,7 +1127,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1158,7 +1162,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1193,7 +1197,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1228,7 +1232,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1263,7 +1267,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1298,7 +1302,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1331,7 +1335,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1366,7 +1370,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1393,7 +1397,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1423,7 +1427,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1453,7 +1457,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1486,7 +1490,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1521,7 +1525,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1552,7 +1556,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1580,7 +1584,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1609,7 +1613,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1643,7 +1647,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1685,7 +1689,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1727,7 +1731,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1768,7 +1772,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1801,7 +1805,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1831,7 +1835,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1861,7 +1865,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1889,7 +1893,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1920,7 +1924,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1962,7 +1966,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2004,7 +2008,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2045,7 +2049,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2092,7 +2096,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2126,7 +2130,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2160,7 +2164,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2201,7 +2205,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2239,7 +2243,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2274,7 +2278,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2310,7 +2314,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2355,7 +2359,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2390,7 +2394,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2431,7 +2435,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2472,7 +2476,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2513,7 +2517,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2554,7 +2558,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2599,7 +2603,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2634,7 +2638,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2670,7 +2674,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2709,7 +2713,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2745,7 +2749,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2792,7 +2796,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2829,7 +2833,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2870,7 +2874,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2908,7 +2912,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2946,7 +2950,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2984,7 +2988,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3024,7 +3028,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3064,7 +3068,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3096,7 +3100,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3128,7 +3132,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3161,7 +3165,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3193,7 +3197,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3228,7 +3232,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3261,7 +3265,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3295,7 +3299,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3329,7 +3333,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3361,7 +3365,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3393,7 +3397,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3426,7 +3430,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3458,7 +3462,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3500,7 +3504,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3533,7 +3537,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3565,7 +3569,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3598,7 +3602,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3631,7 +3635,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3663,7 +3667,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3696,7 +3700,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 20s
+          timeout: 45s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true


### PR DESCRIPTION
The scheduled ThirdParty matrix has been alternating red and green (2026-07-22 red, 23 green, 24 green, 25 red, 26 green, 27 red) on two infrastructure problems, not on the tools it tests. Latest failure: https://github.com/nao1215/atago/actions/runs/30247142946

## Five suites never ran: apt exited 100

```
Err:63 https://snapshot.ubuntu.com/ubuntu/20260721T000000Z noble-updates/universe amd64 c-n-f Metadata
  500  Internal Server Error
E: Failed to fetch .../dists/noble-updates/universe/cnf/Commands-amd64  500  Internal Server Error
E: Some index files failed to download.
##[error]Process completed with exit code 100.
```

That is the command-not-found index — the one apt reads to suggest a package for an unknown shell command. Nothing in this matrix uses it, but `apt-get update` exits 100 for any index it cannot fetch, so sqlite3, pandoc, python, imagemagick, and ghostscript were killed before installing anything.

To answer the question directly: the versions are pinned, and pinning is not what broke. `ATAGO_UBUNTU_SNAPSHOT_ID` fixes the archive to an immutable snapshot, the runner is pinned to `ubuntu-24.04`, and the non-apt tools come from SHA256-verified release archives. What failed was the pinned mirror's availability for one file we do not need. The script now disables that index target and retries update and install (with `Acquire::Retries=3` inside each attempt), so a briefly unhealthy snapshot host no longer looks like a broken tool.

## Two TUI suites timed out

lazygit (4 scenarios) and yazi (3) failed with `the command timed out after 20.0s and was killed` — the pty session never reached the screen it waits for. The same specs and the same pinned binaries pass on a quiet runner, which is the definition of a flake, so:

- The session timeout goes from 20s to 45s. It bounds how long a session waits; every expect, key, and assertion is unchanged.
- The matrix runs with `--retry-failed 1`. A retry gets a fresh workdir and a fresh sandboxed HOME, a recovery is reported as flaky rather than silently green, and a real regression still fails both attempts.

## Not fixed here

yazi's other 3 failures are a different problem: it starts its data-distribution service on some runs and writes `.atago-home/.local/state/yazi/.dds`, which an exhaustive `changes:` reports as an unexpected creation. That cannot be expressed today — adding the path to `created` fails on the runs where yazi does not write it — so it needs `changes: ignore:`, filed as #327 with the design and the tests it needs. `--retry-failed 1` makes it much rarer in the meantime.

`make test` and `make lint` are green; the specs' generated docs are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scheduled third-party test reliability by avoiding failures caused by Ubuntu snapshot package indexes.
  - Added automatic retries for package updates and installations.
  - Extended terminal interaction wait times to reduce failures caused by slower environments.

- **Tests**
  - Failed scenarios are retried once and reported as flaky when they subsequently recover, improving visibility into intermittent issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->