### PR TITLE
revert(thirdparty): keep the TUI suites at a 20s timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,11 +32,13 @@ and this project follows [Semantic Versioning](https://semver.org/).
   longer requested, and the update and install are retried against a mirror that
   5xxes under load. The version pin itself is unchanged: the snapshot id and the
   SHA256-verified release archives still decide what gets installed.
-- The scheduled matrix runs with `--retry-failed 1`, and the two terminal-UI
-  suites wait up to 45s for a screen instead of 20s. The same specs and the same
-  pinned binaries alternated red and green from one scheduled run to the next on
-  nothing but load. A regression still fails both attempts; a flake is absorbed
-  and reported as flaky.
+- The scheduled matrix runs with `--retry-failed 1`: a flake is re-run once in a
+  fresh workdir and reported as flaky, while a regression still fails both
+  attempts. Raising the two terminal-UI suites' timeouts from 20s to 45s was tried
+  in the same change and reverted — it made the lazygit leg worse (4 failed
+  scenarios became 13, and the suite went from about a minute to six), because the
+  failures land on the plain `git` step that follows the pty step rather than on
+  the session itself. Tracked in #330.
 
 ### Changed
 

--- a/test/e2e/thirdparty/lazygit/lazygit.atago.yaml
+++ b/test/e2e/thirdparty/lazygit/lazygit.atago.yaml
@@ -14,10 +14,11 @@ suite:
     would pass on a version that draws a commit it never made.
 
 # Install: see .github/workflows/thirdparty.yml for the pinned CI version.
-# Session timeout: 45s. It bounds how long a session waits for a screen, and
-# nothing else — every expect and every assertion is unchanged. 20s was enough on
-# a quiet machine but not on a loaded CI runner, where the same specs and the same
-# pinned binary alternated red and green from one scheduled run to the next.
+# Session timeout: 20s. Raising it to 45s was tried and reverted: the lazygit leg
+# went from 4 failed scenarios to 13 and from about a minute to six, because the
+# failures land on the plain `git` step that FOLLOWS the pty step. Waiting longer
+# only holds onto whatever the previous scenario left running, so the number is
+# staying where it was until that is understood.
 scenarios:
   - name: version prints the pinned release
     only:
@@ -60,7 +61,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo
           rows: 30
           cols: 120
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -99,7 +100,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo/sub
           rows: 30
           cols: 120
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -142,7 +143,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo
           rows: 30
           cols: 120
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -187,7 +188,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo
           rows: 30
           cols: 120
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -233,7 +234,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo
           rows: 30
           cols: 120
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -281,7 +282,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo
           rows: 30
           cols: 120
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -325,7 +326,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo
           rows: 30
           cols: 120
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -382,7 +383,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo
           rows: 30
           cols: 120
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -439,7 +440,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo
           rows: 30
           cols: 120
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -488,7 +489,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo
           rows: 30
           cols: 120
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -534,7 +535,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo
           rows: 30
           cols: 120
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -580,7 +581,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo
           rows: 30
           cols: 120
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -629,7 +630,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo branch
           rows: 30
           cols: 120
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -672,7 +673,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo branch
           rows: 30
           cols: 120
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -715,7 +716,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo branch
           rows: 30
           cols: 120
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -759,7 +760,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo branch
           rows: 30
           cols: 120
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -804,7 +805,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo
           rows: 30
           cols: 120
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -858,7 +859,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo
           rows: 30
           cols: 120
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -912,7 +913,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo stash
           rows: 30
           cols: 120
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           session:
@@ -965,7 +966,7 @@ scenarios:
           command: lazygit -ucd ${workdir}/cfg -p ${workdir}/repo stash
           rows: 30
           cols: 120
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           session:

--- a/test/e2e/thirdparty/yazi/chooser_selection.atago.yaml
+++ b/test/e2e/thirdparty/yazi/chooser_selection.atago.yaml
@@ -29,7 +29,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -53,7 +53,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -77,7 +77,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -102,7 +102,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -125,7 +125,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -148,7 +148,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -171,7 +171,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -193,7 +193,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -213,7 +213,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -234,7 +234,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -257,7 +257,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -279,7 +279,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -302,7 +302,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -325,7 +325,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -348,7 +348,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true

--- a/test/e2e/thirdparty/yazi/entry_args.atago.yaml
+++ b/test/e2e/thirdparty/yazi/entry_args.atago.yaml
@@ -30,7 +30,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt target
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -48,7 +48,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt target/a.txt
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -66,7 +66,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt target/a.txt
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -85,7 +85,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt target/a.txt
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -106,7 +106,7 @@ scenarios:
           shell: true
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -125,7 +125,7 @@ scenarios:
           shell: true
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -144,7 +144,7 @@ scenarios:
           shell: true
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -162,7 +162,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt .hidden
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -180,7 +180,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt nested/deeper/file.txt
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -200,7 +200,7 @@ scenarios:
           shell: true
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -225,7 +225,7 @@ scenarios:
           shell: true
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -250,7 +250,7 @@ scenarios:
           shell: true
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -276,7 +276,7 @@ scenarios:
           shell: true
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true

--- a/test/e2e/thirdparty/yazi/links_and_overwrite.atago.yaml
+++ b/test/e2e/thirdparty/yazi/links_and_overwrite.atago.yaml
@@ -32,7 +32,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -65,7 +65,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -98,7 +98,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -128,7 +128,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -159,7 +159,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -189,7 +189,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -220,7 +220,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -252,7 +252,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true

--- a/test/e2e/thirdparty/yazi/navigation_tabs.atago.yaml
+++ b/test/e2e/thirdparty/yazi/navigation_tabs.atago.yaml
@@ -29,7 +29,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -51,7 +51,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -75,7 +75,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -95,7 +95,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -117,7 +117,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -138,7 +138,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -160,7 +160,7 @@ scenarios:
           shell: true
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -196,7 +196,7 @@ scenarios:
           shell: true
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -227,7 +227,7 @@ scenarios:
           shell: true
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -261,7 +261,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -285,7 +285,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true

--- a/test/e2e/thirdparty/yazi/search_tabs.atago.yaml
+++ b/test/e2e/thirdparty/yazi/search_tabs.atago.yaml
@@ -27,7 +27,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -54,7 +54,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -77,7 +77,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -102,7 +102,7 @@ scenarios:
           shell: true
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true

--- a/test/e2e/thirdparty/yazi/selection_matrix.atago.yaml
+++ b/test/e2e/thirdparty/yazi/selection_matrix.atago.yaml
@@ -28,7 +28,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -64,7 +64,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -99,7 +99,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -135,7 +135,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -173,7 +173,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -209,7 +209,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -242,7 +242,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -278,7 +278,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -315,7 +315,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true

--- a/test/e2e/thirdparty/yazi/yazi.atago.yaml
+++ b/test/e2e/thirdparty/yazi/yazi.atago.yaml
@@ -21,10 +21,11 @@ suite:
     navigation and tabs, search, and hardlinks and overwrites.
 
 # Install: see .github/workflows/thirdparty.yml for the pinned CI version.
-# Session timeout: 45s. It bounds how long a session waits for a screen, and
-# nothing else — every expect and every assertion is unchanged. 20s was enough on
-# a quiet machine but not on a loaded CI runner, where the same specs and the same
-# pinned binary alternated red and green from one scheduled run to the next.
+# Session timeout: 20s. Raising it to 45s was tried and reverted: the lazygit leg
+# went from 4 failed scenarios to 13 and from about a minute to six, because the
+# failures land on the plain `git` step that FOLLOWS the pty step. Waiting longer
+# only holds onto whatever the previous scenario left running, so the number is
+# staying where it was until that is understood.
 scenarios:
   - name: version prints a semantic version banner
     only:
@@ -149,7 +150,7 @@ scenarios:
           command: yazi ${workdir}
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -187,7 +188,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -219,7 +220,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -262,7 +263,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -314,7 +315,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -364,7 +365,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -411,7 +412,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -448,7 +449,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -484,7 +485,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -524,7 +525,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -567,7 +568,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -620,7 +621,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -656,7 +657,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -694,7 +695,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -738,7 +739,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -777,7 +778,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -831,7 +832,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -882,7 +883,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -929,7 +930,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -976,7 +977,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1019,7 +1020,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1065,7 +1066,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1100,7 +1101,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1135,7 +1136,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1170,7 +1171,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1205,7 +1206,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1240,7 +1241,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1275,7 +1276,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1310,7 +1311,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1343,7 +1344,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1378,7 +1379,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1405,7 +1406,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1435,7 +1436,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1465,7 +1466,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1498,7 +1499,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1533,7 +1534,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1564,7 +1565,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1592,7 +1593,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1621,7 +1622,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1655,7 +1656,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1697,7 +1698,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1739,7 +1740,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1780,7 +1781,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1813,7 +1814,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1843,7 +1844,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1873,7 +1874,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1901,7 +1902,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1932,7 +1933,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -1974,7 +1975,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2016,7 +2017,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2057,7 +2058,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2104,7 +2105,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2138,7 +2139,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2172,7 +2173,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2213,7 +2214,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2251,7 +2252,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2286,7 +2287,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2322,7 +2323,7 @@ scenarios:
           command: yazi --cwd-file ${workdir}/cwd.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2367,7 +2368,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2402,7 +2403,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2443,7 +2444,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2484,7 +2485,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2525,7 +2526,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2566,7 +2567,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2611,7 +2612,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2646,7 +2647,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2682,7 +2683,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2721,7 +2722,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2757,7 +2758,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2804,7 +2805,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2841,7 +2842,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2882,7 +2883,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2920,7 +2921,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2958,7 +2959,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -2996,7 +2997,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3036,7 +3037,7 @@ scenarios:
           command: yazi src
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3076,7 +3077,7 @@ scenarios:
           command: yazi --chooser-file ${workdir}/chosen.txt .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3108,7 +3109,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3140,7 +3141,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3173,7 +3174,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3205,7 +3206,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3240,7 +3241,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3273,7 +3274,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3307,7 +3308,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3341,7 +3342,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3373,7 +3374,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3405,7 +3406,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3438,7 +3439,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3470,7 +3471,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3512,7 +3513,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3545,7 +3546,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3577,7 +3578,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3610,7 +3611,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3643,7 +3644,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3675,7 +3676,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true
@@ -3708,7 +3709,7 @@ scenarios:
           command: yazi .
           rows: 24
           cols: 100
-          timeout: 45s
+          timeout: 20s
           clear_env: true
           pass_env: [PATH]
           sandbox_home: true


### PR DESCRIPTION
Reverts the timeout half of #328. The `--retry-failed 1` half stays.

I raised lazygit's and yazi's pty/run timeouts from 20s to 45s on the theory that a loaded runner just needed more time. A manual matrix run says otherwise:

| | lazygit failed scenarios | suite duration |
| --- | --- | --- |
| 20s | 4 of 21 | ~1 min |
| 45s | 13 of 21 | 6 min |

The reason the raise backfires is visible in the failures: the step that times out is not the pty session but the ordinary `git` step after it.

```
Step:
  run completes before its timeout
Command:
  git -C repo log --oneline -1
Actual:
  the command timed out after 20.0s and was killed
```

A `git log --oneline -1` on a three-commit repository does not take twenty seconds, so something the pty step leaves behind is holding it. Waiting longer does not let it finish — it keeps the run open while the block persists, and the extra six minutes of contention takes more scenarios down with it.

So the number goes back to 20s in both suites, with a comment recording the measurement so the next person does not retry the same idea, and the real problem is filed as #330 (with what is worth checking: whether a lazygit subprocess escapes the process group `ptyrun` kills, and whether the following run step inherits a pipe a surviving process holds open).

`make test`, `make lint`, `make docs`, and `make site` are green.