### PR TITLE
fix(yazi): end the three hanging sessions on their own assertions

### DIFF
--- a/test/e2e/thirdparty/yazi/search_tabs.atago.yaml
+++ b/test/e2e/thirdparty/yazi/search_tabs.atago.yaml
@@ -66,6 +66,15 @@ scenarios:
                   - alpha.txt
                   - alpha
                 stable_for: 100ms
+            # The spot panel takes the keyboard: `q` closes it instead of quitting
+            # yazi, so the panel is dismissed first and the session waits for the
+            # screen to prove it is gone. Sending esc and q back to back is not
+            # enough — q arrives while the panel still owns the keys, closes it,
+            # and yazi stays running until the session timeout kills it.
+            - send: {key: esc}
+            - expect_screen:
+                not_contains: [Mimetype]
+                stable_for: 100ms
             - send: "q"
 
   - name: tt opens a new tab rooted at the current cwd

--- a/test/e2e/thirdparty/yazi/yazi.atago.yaml
+++ b/test/e2e/thirdparty/yazi/yazi.atago.yaml
@@ -1884,6 +1884,15 @@ scenarios:
             - expect: "Rename:"
             - send: " two words"
             - send: {key: enter}
+            # Wait on the RENDERED screen, then quit. The redraw writes the new
+            # name in fragments separated by cursor moves, so the raw transcript
+            # never contains "old two words.txt" contiguously and a plain expect
+            # would hang; and without a quit key yazi outlives the session and the
+            # step fails on its timeout rather than on anything it asserted.
+            - expect_screen:
+                contains: ["old two words.txt"]
+                stable_for: 100ms
+            - send: "q"
       - assert:
           file:
             path: old two words.txt
@@ -1912,6 +1921,12 @@ scenarios:
             - expect: "Rename:"
             - send: " two words"
             - send: {key: enter}
+            # Same reason as the file case above: wait on the rendered screen for
+            # the new name, then quit so the step ends on its assertions.
+            - expect_screen:
+                contains: ["old-dir two words"]
+                stable_for: 100ms
+            - send: "q"
       - assert:
           file:
             path: old-dir two words/keep.txt


### PR DESCRIPTION
Three yazi scenarios have been failing on the scheduled matrix with `the command timed out and was killed` — the pty step's timeout, not any assertion they make. With the pinned yazi 26.5.6 installed locally they fail deterministically, so they were never flaky in the usual sense: they were passing in CI only when key timing happened to help.

## The two rename scenarios never quit

```yaml
- expect: "Rename:"
- send: " two words"
- send: {key: enter}
# session ends here
```

Nothing tells yazi to exit. The step then waits for a program that is still running, and only passes if yazi happens to quit when atago closes the pty — which it does not do reliably.

Fixed by waiting for the result and then quitting. The wait has to be on the rendered screen: the redraw writes the new name in fragments separated by cursor moves (`[24;23Htwo[24;27Hwords`), so `expect: "old two words.txt"` against the raw transcript hangs forever, which I confirmed before settling on `expect_screen`.

## The tab scenario quits into a panel that eats the key

That one does send `q`, but `tab` opens yazi's spot panel (Created/Modified/Mimetype/Spotter/…) and the panel takes the keyboard: `q` closes the panel instead of quitting yazi. Sending `esc` and `q` back to back does not fix it — `q` arrives while the panel still owns the keys. What works, verified against the pinned build, is to dismiss the panel and wait for the screen to prove it is gone:

```yaml
- send: {key: esc}
- expect_screen:
    not_contains: [Mimetype]
    stable_for: 100ms
- send: "q"
```

The comments in both specs record why, since the failing shapes look reasonable and the next person will otherwise try `esc`+`q` again.

## Verification

The pinned archive (v26.5.6, SHA256 as in the workflow) run locally:

```
PASSED  160 scenarios: 159 passed, 0 failed, 0 errored, 1 skipped (20.209s)
```

`make test`, `make lint`, `make docs`, and `make site` are green with no drift. This leaves the lazygit leg (#330) as the last known failure in the matrix.