### PR TITLE
fix(report): name the command a failure was observed under

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- A failure now names the command it was observed under. The console block and the
+  JSON report's `failures[].command` used the scenario's LAST run command, so a
+  scenario that keeps working after the failure blamed the wrong step: an
+  interactive step killed by its timeout was reported against the verification
+  command that followed it and passed. That is a diagnosis pointing the wrong way,
+  and it cost real time — the reader tunes a step that never had a problem.
+
 ### Added
 
 - `changes: ignore:` drops matching paths from the observed workdir delta before

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 440 scenarios
+74 suites · 441 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -364,12 +364,13 @@
   - [console report prints the same counts in its summary line](#scenario-console-report-prints-the-same-counts-in-its-summary-line)
   - [an all-passing run reports a zero-failure suite and exits zero](#scenario-an-all-passing-run-reports-a-zero-failure-suite-and-exits-zero)
   - [an errored step is counted as an error, not a failure, across formats](#scenario-an-errored-step-is-counted-as-an-error-not-a-failure-across-formats)
-- [atago self-hosting / reports](#atago-self-hosting--reports) — 5 scenarios
+- [atago self-hosting / reports](#atago-self-hosting--reports) — 6 scenarios
   - [JUnit report is XML with a testsuite and testcase](#scenario-junit-report-is-xml-with-a-testsuite-and-testcase)
   - [GitHub Actions annotations are emitted on failure](#scenario-github-actions-annotations-are-emitted-on-failure)
   - [TAP report is a numbered TAP 13 stream with ok / not ok points](#scenario-tap-report-is-a-numbered-tap-13-stream-with-ok--not-ok-points)
   - [failure artifacts are written and referenced in the JSON report](#scenario-failure-artifacts-are-written-and-referenced-in-the-json-report)
   - [a multi-line snapshot failure renders a unified diff with hunks](#scenario-a-multi-line-snapshot-failure-renders-a-unified-diff-with-hunks)
+  - [a failure names the command it was observed under](#scenario-a-failure-names-the-command-it-was-observed-under)
 - [atago self-hosting / rerun-failed](#atago-self-hosting--rerun-failed) — 5 scenarios
   - [a failing run is recorded and rerun-failed selects only it](#scenario-a-failing-run-is-recorded-and-rerun-failed-selects-only-it)
   - [rerun-failed with nothing recorded is a no-op success](#scenario-rerun-failed-with-nothing-recorded-is-a-no-op-success)
@@ -6756,6 +6757,35 @@ ${atago} run --report json diffspec.atago.yaml; true
   - stdout contains `Diff (-expected +actual):`, `--- snapshot (golden)`, `-beta`, `+BETA`, `snaps/out.txt`
 - after `${atago} run --report json diffspec.atago.yaml; true`:
   - stdout contains `"diff":`
+### Scenario: a failure names the command it was observed under
+#### Given
+- Fixture file `attrib.atago.yaml` is created.
+#### Inputs
+_Fixture `attrib.atago.yaml`:_
+```text
+version: "1"
+suite: {name: attrib}
+scenarios:
+  - name: the first command fails and a later one passes
+    steps:
+      - run: {shell: true, command: "printf 'early\n'; exit 3"}
+      - assert: {exit_code: 0}
+      - run: {shell: true, command: "printf 'later-and-fine\n'"}
+      - assert: {exit_code: 0}
+```
+#### When
+```shell
+${atago} run attrib.atago.yaml
+${atago} run --report json attrib.atago.yaml
+```
+#### Then
+- after `${atago} run attrib.atago.yaml`:
+  - exit code is `1`
+  - stdout contains `printf 'early`
+  - stdout does not contain `later-and-fine`
+- after `${atago} run --report json attrib.atago.yaml`:
+  - exit code is `1`
+  - stdout at `$.suites[0].failures[0].command` matches `/early/`
 ## atago self-hosting / rerun-failed
 Source: `test/e2e/atago/rerun.atago.yaml`
 ### Scenario: a failing run is recorded and rerun-failed selects only it

--- a/internal/report/console.go
+++ b/internal/report/console.go
@@ -59,12 +59,11 @@ func writeDetail(b *strings.Builder, color bool, suite, specPath string, sc *eng
 	where := specSuffix(specPath)
 	switch sc.Status {
 	case engine.StatusFailed:
-		cmd := lastCommand(sc)
 		var lastRun *runner.Result
 		for _, step := range sc.Steps {
 			// Track the most recent run result BEFORE rendering this step's
 			// checks: a run step's own retry `until` checks assert against that
-			// step's result.
+			// step's result, and every failure block names THAT command.
 			if step.Run != nil {
 				lastRun = step.Run
 			}
@@ -73,7 +72,7 @@ func writeDetail(b *strings.Builder, color bool, suite, specPath string, sc *eng
 					continue
 				}
 				fmt.Fprintf(b, "\n%s %s / %s%s\n", colorize(color, cRed+cBold, "FAILED:"), suite, sc.Name, where)
-				writeCheckFailure(b, color, ck, cmd)
+				writeCheckFailure(b, color, ck, commandOf(lastRun))
 				writeFailureStreams(b, ck, lastRun)
 				// Keep console output compact: reference the durable payloads by path
 				// rather than dumping them inline (#48).
@@ -202,15 +201,17 @@ func writeSuiteSteps(b *strings.Builder, color bool, suite, label string, steps 
 	}
 }
 
-// lastCommand returns the most recent run command in a scenario, for context.
-func lastCommand(sc *engine.ScenarioResult) string {
-	cmd := ""
-	for _, step := range sc.Steps {
-		if step.Run != nil {
-			cmd = step.Run.Command
-		}
+// commandOf names the command a failure was observed under: the result the
+// failing check asserts on, not the scenario's last command. Using the last one
+// mislabeled every failure in a scenario that keeps working afterwards — an
+// interactive step that timed out was reported against the verification command
+// that followed it and passed, which sends the reader to tune a step that never
+// had a problem.
+func commandOf(res *runner.Result) string {
+	if res == nil {
+		return ""
 	}
-	return cmd
+	return res.Command
 }
 
 // specSuffix renders the spec-file annotation appended to failure headers, or

--- a/internal/report/json.go
+++ b/internal/report/json.go
@@ -207,8 +207,14 @@ func teardownFailuresOf(sc *engine.ScenarioResult) []jsonFailure {
 
 func failuresOf(sc *engine.ScenarioResult) []jsonFailure {
 	var fs []jsonFailure
-	cmd := lastCommand(sc)
+	// The command a failure is reported under is the one the failing check
+	// asserts on, tracked as the steps are walked; the scenario's last command
+	// belongs to whatever ran after the failure.
+	cmd := ""
 	for _, step := range sc.Steps {
+		if step.Run != nil {
+			cmd = step.Run.Command
+		}
 		for _, ck := range step.Checks {
 			if ck == nil || ck.OK {
 				continue

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -1030,6 +1030,59 @@ func TestConsole_FailedScenarioShowsCommand(t *testing.T) {
 	}
 }
 
+// TestFailureNamesTheCommandItRanUnder is a regression: the command shown beside
+// a failure was the scenario's LAST run command, not the one the failing check
+// asserts on. A scenario whose interactive step times out and is followed by a
+// verification command reported that later, passing command as the failing one,
+// which is a diagnosis sent in the wrong direction — the reader tunes the
+// timeout of a step that never had a problem. Both the console block and the JSON
+// report's failures[].command must name the step's own command.
+func TestFailureNamesTheCommandItRanUnder(t *testing.T) {
+	t.Parallel()
+	res := &engine.SuiteResult{
+		Suite:  "attrib",
+		Status: engine.StatusFailed,
+		Scenarios: []engine.ScenarioResult{
+			{Name: "tui then verify", Status: engine.StatusFailed, Steps: []engine.StepResult{
+				// The failing step: an interactive program that never exited. Its
+				// check lives on the step itself, like a timeout kill does.
+				{Kind: "pty", Run: &runner.Result{Command: "tui --interactive", ExitCode: -1}, Checks: []*assert.CheckResult{{
+					OK: false, Desc: "run completes before its timeout",
+					Expected: "the command to exit on its own", Actual: "the command timed out after 20s and was killed",
+				}}},
+				// A later command that ran fine and asserts fine.
+				{Kind: "run", Run: &runner.Result{Command: "verify --after"}},
+				{Kind: "assert", Checks: []*assert.CheckResult{{OK: true, Desc: "assert exit_code is 0"}}},
+			}},
+		},
+	}
+	out := render(t, FormatConsole, res)
+	if !strings.Contains(out, "Command:\n  tui --interactive") {
+		t.Errorf("console failure should name the step's own command:\n%s", out)
+	}
+	if strings.Contains(out, "verify --after") {
+		t.Errorf("console failure names a later, passing command:\n%s", out)
+	}
+
+	var doc struct {
+		Suites []struct {
+			Failures []struct {
+				Step    string `json:"step"`
+				Command string `json:"command"`
+			} `json:"failures"`
+		} `json:"suites"`
+	}
+	if err := json.Unmarshal([]byte(render(t, FormatJSON, res)), &doc); err != nil {
+		t.Fatalf("json report invalid: %v", err)
+	}
+	if len(doc.Suites) != 1 || len(doc.Suites[0].Failures) != 1 {
+		t.Fatalf("expected one failure, got %+v", doc.Suites)
+	}
+	if got := doc.Suites[0].Failures[0].Command; got != "tui --interactive" {
+		t.Errorf("json failures[].command = %q, want the failing step's own command", got)
+	}
+}
+
 // TestSuiteFailurePoints_GenericFallback proves the runtime-creation path (a
 // suite that errored without scenarios AND without any recorded suite.setup
 // detail) still synthesizes one generic failure point so the failure is never

--- a/test/e2e/atago/reports.atago.yaml
+++ b/test/e2e/atago/reports.atago.yaml
@@ -183,3 +183,39 @@ scenarios:
       - assert:
           stdout:
             contains: '"diff":'
+
+  # A failure block names the command the failing check asserts on. Naming the
+  # scenario's LAST command instead sent the reader to a step that had no problem:
+  # an interactive step that times out is followed by a verification command that
+  # runs fine, and the report blamed that one.
+  - name: a failure names the command it was observed under
+    steps:
+      - fixture:
+          file: attrib.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: attrib}
+            scenarios:
+              - name: the first command fails and a later one passes
+                steps:
+                  - run: {shell: true, command: "printf 'early\n'; exit 3"}
+                  - assert: {exit_code: 0}
+                  - run: {shell: true, command: "printf 'later-and-fine\n'"}
+                  - assert: {exit_code: 0}
+      - run: {command: "${atago} run attrib.atago.yaml"}
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "printf 'early"
+      - assert:
+          # The later, passing command must not appear in the failure block at all.
+          stdout:
+            not_contains: "later-and-fine"
+      - run: {command: "${atago} run --report json attrib.atago.yaml"}
+      - assert:
+          exit_code: 1
+          stdout:
+            json:
+              - path: "$.suites[0].failures[0].command"
+                matches: "early"


### PR DESCRIPTION
## The bug

`writeDetail` and `failuresOf` both computed the command once, before walking the steps:

```go
cmd := lastCommand(sc)   // the scenario's LAST run command
```

Every failure block in that scenario then carried it. For a scenario that stops at its first failure this is right by accident; for one that keeps going it names a command that ran *after* the failure and succeeded.

I hit this diagnosing the lazygit suite. The report said:

```
Step:
  run completes before its timeout
Command:
  git -C repo log --oneline -1
Actual:
  the command timed out after 20.0s and was killed
```

which reads as "a `git log --oneline -1` on a three-commit repository took twenty seconds". `--verbose` told the truth:

```
[11] pty: lazygit -ucd ... -p ...
     exit -1
     FAIL run completes before its timeout
[12] run: git -C repo log --oneline -1
     exit 0
```

The pty step timed out; the git step ran fine. The misattribution sent me to raise timeouts on a step that never had a problem, which then made things worse (#331). This is the failure mode that matters most in a report: not that it says too little, but that it says something confidently wrong.

## Change

Both renderers track the command while walking the steps, so a failure names the result its check asserts on. The console loop already tracked `lastRun` for the captured streams; the command now comes from the same place, and the JSON builder does the same. A check with no preceding run (an assertion after only fixtures) reports no command instead of borrowing a later one.

## Tests

- `internal/report`: a scenario whose interactive step times out and whose later command passes — the console block and `failures[].command` must both name the failing step's command, and the later command must not appear. Fails on main in all three assertions.
- `test/e2e/atago/reports.atago.yaml`: the same contract through the CLI, in both console and `--report json`.

`make test`, `make lint`, `make e2e` (461 scenarios), `make docs`, `make site` are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failure reports now attribute each failure to the command where it occurred.
  * Console and JSON reports no longer incorrectly reference a later command after timeouts or subsequent steps.

* **Documentation**
  * Updated behavior specifications and changelog to reflect the corrected failure attribution.
  * Added coverage for the new reporting scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->