### PR TITLE
fix(pty): say the program outlived the session instead of blaming the clock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- A pty step killed because its program was still running now says that, instead
+  of offering a longer timeout that cannot help. A session does not close the
+  program: when the actions run out and it is still up, the step is killed, and
+  the old message ("the command timed out ... raise the timeout if the command is
+  merely slow") sent the reader to a knob that changes nothing, since the session
+  had already run to the end. It now reports that the session finished with the
+  program still running and names the fix — send its quit key last, and wait for
+  the screen to show the program can take it, because a dialog or prompt owns the
+  keyboard until it closes. A wait that never completed is a different failure and
+  keeps its own message naming the pattern. This is the shape that broke thirteen
+  scenarios in the lazygit suite and three in yazi.
+
 ### Fixed
 
 - A failure now names the command it was observed under. The console block and the

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 441 scenarios
+74 suites · 443 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -484,7 +484,7 @@
   - [a failing setup errors every scenario and none runs (exit 4)](#scenario-a-failing-setup-errors-every-scenario-and-none-runs-exit-4)
   - [a suite service starts once and its store reaches every scenario](#scenario-a-suite-service-starts-once-and-its-store-reaches-every-scenario)
   - [a failing suite teardown is loud but does not flip the verdict](#scenario-a-failing-suite-teardown-is-loud-but-does-not-flip-the-verdict)
-- [atago self-hosting / step timeouts (suite default + escape hatch)](#atago-self-hosting--step-timeouts-suite-default--escape-hatch) — 8 scenarios
+- [atago self-hosting / step timeouts (suite default + escape hatch)](#atago-self-hosting--step-timeouts-suite-default--escape-hatch) — 10 scenarios
   - [suite.timeout kills a hanging step and the hint names it](#scenario-suitetimeout-kills-a-hanging-step-and-the-hint-names-it)
   - [a step timeout beats the suite timeout and the hint says run.timeout](#scenario-a-step-timeout-beats-the-suite-timeout-and-the-hint-says-runtimeout)
   - [timeout zero disables a short suite bound](#scenario-timeout-zero-disables-a-short-suite-bound)
@@ -493,6 +493,8 @@
   - [an assert on the killed result keeps the timeout observable](#scenario-an-assert-on-the-killed-result-keeps-the-timeout-observable)
   - [timeout zero keeps an unasserted step green](#scenario-timeout-zero-keeps-an-unasserted-step-green)
   - [an invalid suite.timeout is a load-time error](#scenario-an-invalid-suitetimeout-is-a-load-time-error)
+  - [a session outlived by its program says so instead of blaming the clock](#scenario-a-session-outlived-by-its-program-says-so-instead-of-blaming-the-clock)
+  - [an expect that never matches still reports the pattern, not the quit advice](#scenario-an-expect-that-never-matches-still-reports-the-pattern-not-the-quit-advice)
 - [atago self-hosting / tui](#atago-self-hosting--tui) — 4 scenarios
   - [a pty step exports a usable TERM by default](#scenario-a-pty-step-exports-a-usable-term-by-default)
   - [an explicit TERM overrides the default](#scenario-an-explicit-term-overrides-the-default)
@@ -8989,6 +8991,59 @@ ${atago} run bad.atago.yaml
 #### Then
 - exit code is `2`
 - stderr contains `suite.timeout`
+### Scenario: a session outlived by its program says so instead of blaming the clock
+_skipped on Windows_
+#### Given
+- Fixture file `outlived.atago.yaml` is created.
+#### Inputs
+_Fixture `outlived.atago.yaml`:_
+```text
+version: "1"
+suite: {name: outlived}
+scenarios:
+  - name: the session ends with cat still reading
+    steps:
+      - pty:
+          command: cat
+          timeout: 2s
+          session:
+            - send: "hello\n"
+            - expect: "hello"
+```
+#### When
+```shell
+${atago} run outlived.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `the program was still running`, `send its quit key as the last action`
+- stdout does not contain `raise the timeout if the command is merely slow`
+### Scenario: an expect that never matches still reports the pattern, not the quit advice
+_skipped on Windows_
+#### Given
+- Fixture file `nomatch.atago.yaml` is created.
+#### Inputs
+_Fixture `nomatch.atago.yaml`:_
+```text
+version: "1"
+suite: {name: nomatch}
+scenarios:
+  - name: the prompt never appears
+    steps:
+      - pty:
+          command: cat
+          timeout: 2s
+          session:
+            - expect: "never-going-to-appear"
+```
+#### When
+```shell
+${atago} run nomatch.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `never-going-to-appear`, `never appeared in the terminal transcript`
+- stdout does not contain `send its quit key`
 ## atago self-hosting / tui
 Source: `test/e2e/atago/tui.atago.yaml`
 ### Scenario: a pty step exports a usable TERM by default

--- a/internal/engine/pty_test.go
+++ b/internal/engine/pty_test.go
@@ -559,3 +559,49 @@ scenarios:
 		t.Fatalf("status = %s, want passed: %+v", res.Status, res.Scenarios)
 	}
 }
+
+// TestEngine_PTY_SessionOutlivedByTheProgram covers the message a whole class of
+// broken sessions gets (#335). A pty session does not close the program: when the
+// actions run out and the program is still up, the step is killed by its timeout.
+// Reporting that as "the command timed out, raise the timeout if it is merely
+// slow" is true and useless — the session is already over, so a longer wait
+// cannot change the outcome, and the advice costs the reader the wait twice. A
+// wait that never completed is a different failure and keeps its own message.
+func TestEngine_PTY_SessionOutlivedByTheProgram(t *testing.T) {
+	skipOnWindows(t)
+	t.Parallel()
+	// cat reads forever: the session sends a line and ends without closing it.
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: s
+scenarios:
+  - name: the session ends with the program still running
+    steps:
+      - pty:
+          command: cat
+          timeout: 2s
+          session:
+            - send: "hello\n"
+            - expect: "hello"
+`)
+	if res.Status != StatusFailed {
+		t.Fatalf("status = %s, want failed: %+v", res.Status, res.Scenarios)
+	}
+	checks := res.Scenarios[0].Steps[0].Checks
+	if len(checks) == 0 || checks[0].OK {
+		t.Fatalf("want a failing check, got %+v", checks)
+	}
+	ck := checks[0]
+	if !strings.Contains(ck.Actual, "still running") {
+		t.Errorf("Actual = %q, want it to say the program was still running", ck.Actual)
+	}
+	if !strings.Contains(ck.Hint, "quit key") {
+		t.Errorf("Hint = %q, want it to name the fix (send the program's quit key)", ck.Hint)
+	}
+	// The misleading advice must be gone: waiting longer cannot help once the
+	// session has run to the end.
+	if strings.Contains(ck.Hint, "raise the timeout if the command is merely slow") {
+		t.Errorf("Hint = %q, still offers a bigger timeout for a finished session", ck.Hint)
+	}
+}

--- a/internal/engine/stepexec.go
+++ b/internal/engine/stepexec.go
@@ -77,6 +77,22 @@ func timeoutKillCheck(res *runner.Result, steps []spec.Step, i int) *assert.Chec
 		source = "run.timeout"
 	}
 	elapsed := res.Duration.Round(time.Millisecond)
+	if i < len(steps) && steps[i].Kind() == spec.StepPTY {
+		// A pty step that gets here ran its whole session: a wait that never
+		// completed is reported as its own expect failure instead (see
+		// ptyExpectCheck), so reaching this point means the actions all went out
+		// and the program stayed up. Saying "the command timed out" and offering a
+		// bigger timeout is true and useless — the session is already over, so
+		// waiting longer cannot change anything, and the reader who takes that
+		// advice loses the time twice.
+		return &assert.CheckResult{
+			Target:   string(spec.AssertExitCode),
+			Desc:     "pty session leaves the program exited",
+			Expected: "the program to exit once the session ends",
+			Actual:   fmt.Sprintf("the session finished its actions and the program was still running %s later, so it was killed", elapsed),
+			Hint:     "a pty session does not close the program: send its quit key as the last action, and wait for the screen to show the program can take it (a dialog or prompt owns the keyboard until it closes). Raising the timeout does not help here, because the session already ran to the end",
+		}
+	}
 	return &assert.CheckResult{
 		Target:   string(spec.AssertExitCode),
 		Desc:     "run completes before its timeout",

--- a/test/e2e/atago/timeouts.atago.yaml
+++ b/test/e2e/atago/timeouts.atago.yaml
@@ -228,3 +228,70 @@ scenarios:
           exit_code: 2
           stderr:
             contains: "suite.timeout"
+
+  # A pty session does not close the program. When the actions run out and the
+  # program is still up, the step is killed — and telling the reader to raise the
+  # timeout is advice that cannot work, because the session already ran to the end.
+  # This is the shape that broke thirteen lazygit scenarios and three yazi ones.
+  - name: a session outlived by its program says so instead of blaming the clock
+    skip: {os: windows}
+    steps:
+      - fixture:
+          file: outlived.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: outlived}
+            scenarios:
+              - name: the session ends with cat still reading
+                steps:
+                  - pty:
+                      command: cat
+                      timeout: 2s
+                      session:
+                        - send: "hello\n"
+                        - expect: "hello"
+      - run:
+          command: ${atago} run outlived.atago.yaml
+          timeout: 30s
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "the program was still running"
+              - "send its quit key as the last action"
+      - assert:
+          # The advice that cannot help is gone.
+          stdout:
+            not_contains: "raise the timeout if the command is merely slow"
+
+  - name: an expect that never matches still reports the pattern, not the quit advice
+    skip: {os: windows}
+    steps:
+      # The other half of the contract: a wait that never completed is a real
+      # timeout, where a longer budget can be the answer, and it keeps its own
+      # message naming the pattern.
+      - fixture:
+          file: nomatch.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: nomatch}
+            scenarios:
+              - name: the prompt never appears
+                steps:
+                  - pty:
+                      command: cat
+                      timeout: 2s
+                      session:
+                        - expect: "never-going-to-appear"
+      - run:
+          command: ${atago} run nomatch.atago.yaml
+          timeout: 30s
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "never-going-to-appear"
+              - "never appeared in the terminal transcript"
+      - assert:
+          stdout:
+            not_contains: "send its quit key"


### PR DESCRIPTION
Closes #335.

## The message that cost the most time today

A pty step whose program is still running when the session ends is killed by its timeout and reported like any other slow command:

```
Step:
  run completes before its timeout
Actual:
  the command timed out after 20.001s and was killed
Hint:
  the command hit its run.timeout after 20.001s and was killed before exiting; raise
  the timeout if the command is merely slow, or set timeout: "0" to let it run unbounded
```

Every word is true and the advice cannot work. The program was not slow: the session never told it to quit, or sent the quit key while a dialog still owned the keyboard. Raising the timeout only makes the run take longer to reach the same failure — which is exactly what I did on the strength of this message (#328), and it made the lazygit leg worse (#331, reverted). Thirteen scenarios there and three in yazi had this shape (#332, #334).

## Why the two cases can be told apart

A pty step only reaches the timeout-kill check when the session ran to the end: a wait that never completed is reported as its own expect failure via `ptyExpectCheck`. So "the actions all went out and the program stayed up" is already structurally distinct from "an expect never matched", and only the first needs the new wording:

```
Step:
  pty session leaves the program exited
Actual:
  the session finished its actions and the program was still running 20.001s later, so it was killed
Hint:
  a pty session does not close the program: send its quit key as the last action, and wait
  for the screen to show the program can take it (a dialog or prompt owns the keyboard until
  it closes). Raising the timeout does not help here, because the session already ran to the end
```

An expect that never matched keeps its own message naming the pattern, because there a longer budget genuinely can be the answer.

## Tests

- `internal/engine`: a session that ends with `cat` still reading must report the program as still running and name the quit-key fix, and must not offer the raise-the-timeout advice; the existing expect-timeout test pins the other branch.
- `test/e2e/atago/timeouts.atago.yaml`: both shapes through the CLI, each asserting it does not carry the other's message.

`make test`, `make lint`, `make e2e` (463 scenarios), `make docs`, `make site` are green.