### PR TITLE
ci(e2e-windows): retry the portable subset once

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -103,11 +103,18 @@ jobs:
       # `go run .` compiles atago and runs it; os.Executable() (which seeds the
       # ${atago} spec variable) points at that binary, so specs self-invoke
       # atago correctly without per-platform binary-name handling.
+      # --retry-failed 1 absorbs a Windows-only capture flake: a scenario that
+      # drives a nested atago occasionally reads back an EMPTY stdout from it while
+      # the run exits 0, which fails an assertion on output the child certainly
+      # wrote. It reproduced once in fourteen runs of this job and a re-run of the
+      # same commit was green. A retry re-runs in a fresh workdir and reports a
+      # recovery as flaky, so a real regression still fails both attempts. See #339
+      # for the cause; nothing here changes what any scenario asserts.
       - name: Run the portable self-hosted E2E subset
         shell: bash
         run: |
           mapfile -t targets < <(bash scripts/windows_portable_specs.sh)
-          go run . run "${targets[@]}"
+          go run . run --retry-failed 1 "${targets[@]}"
 
       # Real-world proof that the ConPTY pty runner drives an INTERACTIVE CLI on
       # Windows, not just self-terminating output: sqly's shell is a readline


### PR DESCRIPTION
`e2e-windows` failed on main (cf5f616) in a way that is not an assertion mismatch:

```
Step:
  assert stdout contains "PASSED"
Command:
  ...\atago.exe run nonewline.atago.yaml
Expected:
  stdout contains "PASSED"
Hint:
  the substring "PASSED" was not present in stdout
```

There is no `Actual:` section — the console block omits it only when the captured value is empty — and the sibling `exit_code: 0` assertion passed. A nested `atago run` that exits 0 always prints a `PASSED` summary line, so its output was produced and lost. No `pdf:` logic takes part in the failing step.

## Why a retry rather than a fix

I could not establish the cause from the log, and I would rather not repeat today's mistake of acting on a plausible story: the subset runs 38 specs at default parallelism and includes both a spec that spawns a nested atago and one that opens ConPTY sessions, which this repo already knows interfere on Windows (`e2e.yml` runs the sqly pty specs `--parallel 1 --retry-failed 3` for exactly that reason). That makes a console-handle race a good hypothesis and nothing more — no log line shows the two overlapped.

So this change absorbs the flake with the mechanism already used on this platform and files the cause as #339, rather than reordering the job on a guess. `--retry-failed 1` re-runs a failed scenario in a fresh workdir and reports a recovery as flaky; no assertion changes, and a real regression still fails both attempts.

Evidence it is non-deterministic: once in fourteen runs of this job, a re-run of the same commit green, and the identical code green in #338's `e2e-windows`.

#339 also records the question I think matters most here — whether the run-step capture can distinguish "the child wrote nothing" from "the pipe gave us nothing", because presenting the second as an empty observed value is the same class of confident-but-wrong report that #333 fixed.