### PR TITLE
fix(report): state an empty observation instead of omitting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,9 +46,10 @@ and this project follows [Semantic Versioning](https://semver.org/).
   It now names the exit code the process reached along with the capture error,
   and — for the one cause a spec author can act on, a background process that
   outlives the command and holds the pipes open past `WaitDelay` — points at the
-  `service:` step. The bytes read before the cut are still withheld rather than
-  handed back as the observed stream: a stream atago only partly read must not be
-  assertable as though it were complete.
+  `service:` step. The bytes read before the cut are withheld rather than handed
+  back as the observed stream, and `stdout_to`/`stderr_to` no longer write them
+  to a file either: a stream atago only partly read must not be assertable as
+  though it were complete, in the step that produced it or in a later one.
 
 ## [0.16.0] - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,24 @@ and this project follows [Semantic Versioning](https://semver.org/).
   through a `file:` assert, including the empty file that proves nothing of the
   UI leaked.
 
+### Fixed
+
+- A failure whose observed value was empty now says so. The console block prints
+  an `Actual:` section only for a non-empty value, so an assertion over a stream,
+  file, or snapshot that captured nothing rendered with no `Actual:` at all — the
+  same shape as a report that never recorded what it saw. Reading such a failure
+  meant knowing that the omission itself meant "empty" (#339). An observed empty
+  payload now renders as `(empty)`, the wording an empty JSON/YAML payload
+  already used.
+- A run step whose process ran to completion while its output capture did not no
+  longer reports `failed to execute`, which says the opposite of what happened.
+  It now names the exit code the process reached along with the capture error,
+  and — for the one cause a spec author can act on, a background process that
+  outlives the command and holds the pipes open past `WaitDelay` — points at the
+  `service:` step. The bytes read before the cut are still withheld rather than
+  handed back as the observed stream: a stream atago only partly read must not be
+  assertable as though it were complete.
+
 ## [0.16.0] - 2026-07-27
 
 A minor release about output you can act on. Three failure messages were true

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 443 scenarios
+74 suites · 444 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -364,13 +364,14 @@
   - [console report prints the same counts in its summary line](#scenario-console-report-prints-the-same-counts-in-its-summary-line)
   - [an all-passing run reports a zero-failure suite and exits zero](#scenario-an-all-passing-run-reports-a-zero-failure-suite-and-exits-zero)
   - [an errored step is counted as an error, not a failure, across formats](#scenario-an-errored-step-is-counted-as-an-error-not-a-failure-across-formats)
-- [atago self-hosting / reports](#atago-self-hosting--reports) — 6 scenarios
+- [atago self-hosting / reports](#atago-self-hosting--reports) — 7 scenarios
   - [JUnit report is XML with a testsuite and testcase](#scenario-junit-report-is-xml-with-a-testsuite-and-testcase)
   - [GitHub Actions annotations are emitted on failure](#scenario-github-actions-annotations-are-emitted-on-failure)
   - [TAP report is a numbered TAP 13 stream with ok / not ok points](#scenario-tap-report-is-a-numbered-tap-13-stream-with-ok--not-ok-points)
   - [failure artifacts are written and referenced in the JSON report](#scenario-failure-artifacts-are-written-and-referenced-in-the-json-report)
   - [a multi-line snapshot failure renders a unified diff with hunks](#scenario-a-multi-line-snapshot-failure-renders-a-unified-diff-with-hunks)
   - [a failure names the command it was observed under](#scenario-a-failure-names-the-command-it-was-observed-under)
+  - [a failure against an empty stream reports the stream as empty](#scenario-a-failure-against-an-empty-stream-reports-the-stream-as-empty)
 - [atago self-hosting / rerun-failed](#atago-self-hosting--rerun-failed) — 5 scenarios
   - [a failing run is recorded and rerun-failed selects only it](#scenario-a-failing-run-is-recorded-and-rerun-failed-selects-only-it)
   - [rerun-failed with nothing recorded is a no-op success](#scenario-rerun-failed-with-nothing-recorded-is-a-no-op-success)
@@ -6788,6 +6789,28 @@ ${atago} run --report json attrib.atago.yaml
 - after `${atago} run --report json attrib.atago.yaml`:
   - exit code is `1`
   - stdout at `$.suites[0].failures[0].command` matches `/early/`
+### Scenario: a failure against an empty stream reports the stream as empty
+#### Given
+- Fixture file `silent.atago.yaml` is created.
+#### Inputs
+_Fixture `silent.atago.yaml`:_
+```text
+version: "1"
+suite: {name: silent}
+scenarios:
+  - name: a command that prints nothing is asserted to have printed
+    steps:
+      - run: {shell: true, command: "exit 0"}
+      - assert: {stdout: {contains: "PASSED"}}
+```
+#### When
+```shell
+${atago} run silent.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout matches `/Actual:
+  \(empty\)/`
 ## atago self-hosting / rerun-failed
 Source: `test/e2e/atago/rerun.atago.yaml`
 ### Scenario: a failing run is recorded and rerun-failed selects only it

--- a/internal/assert/assert_test.go
+++ b/internal/assert/assert_test.go
@@ -268,6 +268,50 @@ func TestCheck_ContainsList_FailureNamesElement(t *testing.T) {
 	}
 }
 
+// TestCheck_EmptyObservationIsReported pins that a check which observed an
+// empty payload SAYS it observed nothing, instead of leaving Actual unset. The
+// console block prints an Actual: section only for a non-empty string, so an
+// empty capture used to render as a failure with no Actual: at all — the same
+// shape as a report that never recorded what it saw. That ambiguity is what a
+// Windows CI flake (#339) had to be read through: a nested atago exited 0 with
+// empty stdout, and the only evidence of the emptiness was a missing section.
+//
+// Every stream/file/snapshot comparison funnels its observed value through
+// excerpt, so the cases below cover the ones a reader hits first.
+func TestCheck_EmptyObservationIsReported(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "out.txt"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	empty := &runner.Result{Stdout: nil, Stderr: nil, Workdir: dir}
+
+	tests := []struct {
+		name string
+		a    *spec.Assert
+	}{
+		{"stdout contains", &spec.Assert{Stdout: &spec.StreamAssert{Contains: spec.StringList{"PASSED"}}}},
+		{"stdout equals", &spec.Assert{Stdout: &spec.StreamAssert{Equals: strp("PASSED")}}},
+		{"stdout matches", &spec.Assert{Stdout: &spec.StreamAssert{Matches: strp("PASS.D")}}},
+		{"stdout empty: false", &spec.Assert{Stdout: &spec.StreamAssert{Empty: boolp(false)}}},
+		{"stderr contains", &spec.Assert{Stderr: &spec.StreamAssert{Contains: spec.StringList{"boom"}}}},
+		{"file contains", &spec.Assert{File: &spec.FileAssert{Path: "out.txt", Contains: spec.StringList{"PASSED"}}}},
+		{"file equals", &spec.Assert{File: &spec.FileAssert{Path: "out.txt", Equals: strp("PASSED")}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cr := Check(tt.a, empty, Env{Workdir: dir})
+			if cr.OK {
+				t.Fatalf("expected the assertion to fail against empty output, got %+v", cr)
+			}
+			if cr.Actual != "(empty)" {
+				t.Errorf("Actual = %q, want %q so the report states what it observed", cr.Actual, "(empty)")
+			}
+		})
+	}
+}
+
 // TestCheckAll_MultiTarget verifies one assert with several targets yields one
 // result per target, in SetTargets order, and that AllOK aggregates them.
 func TestCheckAll_MultiTarget(t *testing.T) {

--- a/internal/assert/stream.go
+++ b/internal/assert/stream.go
@@ -313,9 +313,23 @@ func emptiness(want bool) string {
 
 const excerptLimit = 2000
 
+// emptyExcerpt is what an observed-but-empty payload renders as. The console
+// block prints an Expected:/Actual: section only for a non-empty string, so an
+// empty observation used to render as no section at all — a report that looks
+// like it never recorded what it saw, when in fact it saw nothing. A reader then
+// has to know that omission means "empty" to read the failure, which is how a
+// Windows flake (#339) had to be diagnosed. Naming it keeps every excerpt-based
+// comparison self-describing, and matches the wording parseDoc already uses for
+// an empty JSON/YAML payload.
+const emptyExcerpt = "(empty)"
+
 func excerpt(s string) string {
-	if len(s) <= excerptLimit {
+	switch {
+	case s == "":
+		return emptyExcerpt
+	case len(s) <= excerptLimit:
 		return s
+	default:
+		return s[:excerptLimit] + "\n... (truncated)"
 	}
-	return s[:excerptLimit] + "\n... (truncated)"
 }

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nao1215/atago/internal/assert"
 	"github.com/nao1215/atago/internal/engine"
 	"github.com/nao1215/atago/internal/runner"
+	"github.com/nao1215/atago/internal/spec"
 )
 
 func sampleResults() []*engine.SuiteResult {
@@ -45,6 +46,40 @@ func TestRender_Console(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("console output missing %q\n%s", want, out)
 		}
+	}
+}
+
+// TestRender_Console_EmptyCaptureIsVisible walks the whole path a #339-shaped
+// failure takes — a command that exited 0 with nothing on stdout, a `contains`
+// assertion over it, the console block — and pins that the block states the
+// stream was empty. The Actual: section is printed only for a non-empty value,
+// so before this the report simply had no Actual: at all and a reader had to
+// know that the omission meant "empty" to tell an empty capture from a value
+// the report never recorded.
+func TestRender_Console_EmptyCaptureIsVisible(t *testing.T) {
+	t.Parallel()
+	silent := &runner.Result{Command: "atago run nonewline.atago.yaml", ExitCode: 0}
+	ck := assert.Check(&spec.Assert{Stdout: &spec.StreamAssert{Contains: spec.StringList{"PASSED"}}}, silent, assert.Env{})
+	if ck.OK {
+		t.Fatalf("expected the contains assertion to fail against empty stdout, got %+v", ck)
+	}
+	results := []*engine.SuiteResult{{
+		Suite:  "s",
+		Status: engine.StatusFailed,
+		Scenarios: []engine.ScenarioResult{{
+			Name:   "a nested run reports what it printed",
+			Status: engine.StatusFailed,
+			Steps:  []engine.StepResult{{Kind: "assert", Run: silent, Checks: []*assert.CheckResult{ck}}},
+		}},
+	}}
+
+	var b bytes.Buffer
+	if err := Render(&b, FormatConsole, results); err != nil {
+		t.Fatal(err)
+	}
+	out := b.String()
+	if !strings.Contains(out, "Actual:\n  (empty)") {
+		t.Errorf("console output does not say the stream was empty:\n%s", out)
 	}
 }
 

--- a/internal/runner/cmd/cmd.go
+++ b/internal/runner/cmd/cmd.go
@@ -127,11 +127,32 @@ func (r *Runner) Run(ctx context.Context, run *spec.Run, workdir string) (*runne
 		res.ExitCode = 0
 	case errors.As(runErr, &exitErr):
 		res.ExitCode = exitCodeFor(exitErr)
+	case cmd.ProcessState != nil:
+		// The process started and exited; what failed is the capture of its
+		// output. Returning the bytes collected so far would present a stream we
+		// only partly read — possibly an empty one — as the observed value, and an
+		// assertion cannot tell that apart from a command that printed nothing.
+		// Say what happened instead (#339).
+		return nil, captureFailure(run.Command, cmd.ProcessState.ExitCode(), runErr)
 	default:
 		// Could not start the process at all (not found, permission, ...).
 		return nil, fmt.Errorf("failed to execute %q: %w", run.Command, runErr)
 	}
 	return res, nil
+}
+
+// captureFailure describes a command that ran to completion while its
+// stdout/stderr capture did not. It names the exit code the process reached, so
+// the reader can see the program itself was fine, and — for the one cause a spec
+// author can act on — points at the `service:` step: a run step that leaves a
+// background process behind keeps the pipes open past the command's own exit,
+// and os/exec force-closes them after WaitDelay rather than waiting forever.
+func captureFailure(command string, exitCode int, err error) error {
+	hint := ""
+	if errors.Is(err, exec.ErrWaitDelay) {
+		hint = "; a process it started outlived it and kept the pipes open — declare a long-running program with a `service:` step instead of backgrounding it inside a run step"
+	}
+	return fmt.Errorf("run %q exited with code %d but its output could not be captured: %w%s", command, exitCode, err, hint)
 }
 
 // stdinReader builds the reader fed to the command's standard input (#18):

--- a/internal/runner/cmd/cmd.go
+++ b/internal/runner/cmd/cmd.go
@@ -87,6 +87,21 @@ func (r *Runner) Run(ctx context.Context, run *spec.Run, workdir string) (*runne
 	runErr := cmd.Run()
 	elapsed := time.Since(start)
 
+	// A capture that was cut short is classified before ANY of it is persisted or
+	// returned: stdout_to/stderr_to must not write a stream atago only partly
+	// read, and a redirect error must not mask the capture diagnostic either.
+	// A cancel or a step timeout is a different outcome, handled below — the
+	// output a killed command managed to produce IS observable — so ctx state
+	// wins over this check (#339).
+	var captureErr *exec.ExitError
+	if ctx.Err() == nil && runErr != nil && !errors.As(runErr, &captureErr) && cmd.ProcessState != nil {
+		// The process started and exited; what failed is the capture of its
+		// output. Returning the bytes collected so far would present a stream we
+		// only partly read — possibly an empty one — as the observed value, and an
+		// assertion cannot tell that apart from a command that printed nothing.
+		return nil, captureFailure(run.Command, cmd.ProcessState.ExitCode(), runErr)
+	}
+
 	// Redirect captured stdout/stderr to workdir-relative files when requested
 	// (run.stdout_to / run.stderr_to). This lets a `shell: false` step write output
 	// to a file without the shell's `>` operator; the streams stay captured above,
@@ -127,15 +142,10 @@ func (r *Runner) Run(ctx context.Context, run *spec.Run, workdir string) (*runne
 		res.ExitCode = 0
 	case errors.As(runErr, &exitErr):
 		res.ExitCode = exitCodeFor(exitErr)
-	case cmd.ProcessState != nil:
-		// The process started and exited; what failed is the capture of its
-		// output. Returning the bytes collected so far would present a stream we
-		// only partly read — possibly an empty one — as the observed value, and an
-		// assertion cannot tell that apart from a command that printed nothing.
-		// Say what happened instead (#339).
-		return nil, captureFailure(run.Command, cmd.ProcessState.ExitCode(), runErr)
 	default:
-		// Could not start the process at all (not found, permission, ...).
+		// Could not start the process at all (not found, permission, ...). A
+		// process that DID run and failed only to be captured returned above, so
+		// this message never claims a command that ran never started.
 		return nil, fmt.Errorf("failed to execute %q: %w", run.Command, runErr)
 	}
 	return res, nil

--- a/internal/runner/cmd/cmd_test.go
+++ b/internal/runner/cmd/cmd_test.go
@@ -825,7 +825,11 @@ func TestHelperProcess(t *testing.T) {
 		child := exec.CommandContext(context.Background(), os.Args[0], "-test.run=TestHelperProcess")
 		child.Env = append(os.Environ(), "ATAGO_CMD_HELPER=holder")
 		// The grandchild inherits this process's stdout: that is the whole point —
-		// the pipe outlives the command that wrote to it.
+		// the pipe outlives the command that wrote to it. It must NOT inherit the
+		// working directory too: on Windows a live process holding the step's
+		// workdir as its cwd makes the directory unremovable, which would fail the
+		// test's cleanup for a reason that has nothing to do with the capture.
+		child.Dir = os.TempDir()
 		child.Stdout = os.Stdout
 		child.Stderr = os.Stderr
 		if err := child.Start(); err != nil {
@@ -844,15 +848,30 @@ func TestHelperProcess(t *testing.T) {
 // what happened, and must never hand back a Result built from a partial capture.
 func TestRun_CaptureFailureIsNotSilentEmptyOutput(t *testing.T) {
 	t.Parallel()
+	// Not t.TempDir(): the grandchild deliberately outlives the step, and on
+	// Windows a process that still exists can keep a directory from being
+	// removed. TempDir's cleanup would fail the test on that, so clean up
+	// best-effort like TestRun_ShellCancelKillsChildPromptly does.
+	wd, err := os.MkdirTemp("", "atago-capture-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(wd) })
 	res, err := New().Run(context.Background(), &spec.Run{
-		Command: helperCommand(),
-		Env:     map[string]string{"ATAGO_CMD_HELPER": "lingering-writer"},
-	}, t.TempDir())
+		Command:  helperCommand(),
+		Env:      map[string]string{"ATAGO_CMD_HELPER": "lingering-writer"},
+		StdoutTo: "out.txt",
+	}, wd)
 	if err == nil {
 		t.Fatalf("Run() error = nil; a capture cut short must be reported, got Stdout %q", res.Stdout)
 	}
 	if res != nil {
 		t.Errorf("Run() returned a Result alongside the capture error: %+v", res)
+	}
+	// stdout_to is the same claim written to a file: a later step reading it
+	// would see a truncated stream with nothing marking it as truncated.
+	if _, err := os.Stat(filepath.Join(wd, "out.txt")); !os.IsNotExist(err) {
+		t.Errorf("stdout_to file exists after a failed capture (stat err = %v); a partial stream must not be persisted either", err)
 	}
 	for _, want := range []string{"could not be captured", "exited with code 0", "service:"} {
 		if !strings.Contains(err.Error(), want) {

--- a/internal/runner/cmd/cmd_test.go
+++ b/internal/runner/cmd/cmd_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -799,5 +800,68 @@ func TestConfigureShell_NoopOnPOSIX(t *testing.T) {
 	ConfigureShell(c, "echo hi")
 	if len(c.Args) != len(before) {
 		t.Errorf("ConfigureShell mutated argv: %v -> %v", before, c.Args)
+	}
+}
+
+// helperCommand runs the test binary as the command under test. The path is
+// double-quoted so a space in it survives the runner's argv tokenizer on both
+// platforms.
+func helperCommand() string {
+	return `"` + os.Args[0] + `" -test.run=TestHelperProcess`
+}
+
+// TestHelperProcess is not a real test: it lets a test spawn a REAL process tree
+// on every OS. With no ATAGO_CMD_HELPER set (a normal `go test` run) it is an
+// instant no-op. Mode "lingering-writer" writes a line to stdout, hands the same
+// stdout to a detached grandchild, and exits 0 — so the command itself succeeds
+// while the capture pipe stays open behind it. Mode "holder" just idles, holding
+// that pipe; it self-terminates so no process survives the test.
+func TestHelperProcess(t *testing.T) {
+	switch os.Getenv("ATAGO_CMD_HELPER") {
+	case "holder":
+		time.Sleep(10 * time.Second)
+	case "lingering-writer":
+		fmt.Println("produced")
+		child := exec.CommandContext(context.Background(), os.Args[0], "-test.run=TestHelperProcess")
+		child.Env = append(os.Environ(), "ATAGO_CMD_HELPER=holder")
+		// The grandchild inherits this process's stdout: that is the whole point —
+		// the pipe outlives the command that wrote to it.
+		child.Stdout = os.Stdout
+		child.Stderr = os.Stderr
+		if err := child.Start(); err != nil {
+			t.Fatalf("helper could not start its grandchild: %v", err)
+		}
+	}
+}
+
+// TestRun_CaptureFailureIsNotSilentEmptyOutput pins the promise a stream
+// assertion depends on: what a Result carries is what the command produced. When
+// a grandchild keeps the stdout pipe open past the command's own exit, os/exec
+// force-closes the pipes after WaitDelay and reports it — the captured bytes are
+// then whatever arrived before the cut, which may be nothing at all. Presenting
+// that as the observed stream would make "the capture failed" indistinguishable
+// from "the command printed nothing", the ambiguity behind #339. Run must say
+// what happened, and must never hand back a Result built from a partial capture.
+func TestRun_CaptureFailureIsNotSilentEmptyOutput(t *testing.T) {
+	t.Parallel()
+	res, err := New().Run(context.Background(), &spec.Run{
+		Command: helperCommand(),
+		Env:     map[string]string{"ATAGO_CMD_HELPER": "lingering-writer"},
+	}, t.TempDir())
+	if err == nil {
+		t.Fatalf("Run() error = nil; a capture cut short must be reported, got Stdout %q", res.Stdout)
+	}
+	if res != nil {
+		t.Errorf("Run() returned a Result alongside the capture error: %+v", res)
+	}
+	for _, want := range []string{"could not be captured", "exited with code 0", "service:"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %q, want it to mention %q", err, want)
+		}
+	}
+	// "failed to execute" is the message for a command that never ran; this one
+	// ran fine, and saying otherwise sends the reader after the wrong problem.
+	if strings.Contains(err.Error(), "failed to execute") {
+		t.Errorf("error = %q, want it to distinguish a capture failure from a command that could not start", err)
 	}
 }

--- a/test/e2e/atago/reports.atago.yaml
+++ b/test/e2e/atago/reports.atago.yaml
@@ -219,3 +219,26 @@ scenarios:
             json:
               - path: "$.suites[0].failures[0].command"
                 matches: "early"
+
+  # A check that observed nothing must say it observed nothing. The console block
+  # prints an Actual: section only for a non-empty value, so an empty stream used
+  # to render with the section missing altogether — the same shape as a report
+  # that never recorded what it saw. Reading a CI failure then depended on
+  # knowing that the omission itself meant "empty" (#339).
+  - name: a failure against an empty stream reports the stream as empty
+    steps:
+      - fixture:
+          file: silent.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: silent}
+            scenarios:
+              - name: a command that prints nothing is asserted to have printed
+                steps:
+                  - run: {shell: true, command: "exit 0"}
+                  - assert: {stdout: {contains: "PASSED"}}
+      - run: {command: "${atago} run silent.atago.yaml"}
+      - assert:
+          exit_code: 1
+          stdout:
+            matches: "Actual:\n  \\(empty\\)"


### PR DESCRIPTION
## Summary

Refs #339. This does not close the issue: the Windows anomaly it reports is not explained, and closing it would claim otherwise. The flake it reports — a nested `atago run` on Windows that exited 0 while its stdout came back empty — could not be diagnosed from the log, because the report's silence about the empty value is exactly what a report that never recorded a value looks like. This PR removes that ambiguity in the two places it exists: an observed-but-empty payload now renders as `(empty)` rather than as a missing section, and a run step whose process ran fine while its capture did not now says so instead of claiming the command could not be executed. The root cause of the misrouted output is still unproven; what changes is that the next occurrence reports itself.

## Changes

- `internal/assert/stream.go`: `excerpt` renders an empty payload as `(empty)`. Every stream, file, snapshot, and PDF-metadata comparison routes its observed (and expected) value through it, so a failure over nothing now prints `Actual:\n  (empty)`. The wording matches what `parseDoc` already emits for an empty JSON/YAML payload, so the report has one spelling for "there was nothing here".
- `internal/runner/cmd/cmd.go`: a `cmd.Run` error that is not an `*exec.ExitError` while `cmd.ProcessState` is set means the process ran to completion and the capture did not. That case gets its own message naming the exit code the process reached, plus a pointer to the `service:` step for the one cause a spec author can act on (a background process holding the pipes past `WaitDelay`). The `failed to execute` message is now reserved for a command that never started.
- `internal/assert/assert_test.go`, `internal/report/report_test.go`, `internal/runner/cmd/cmd_test.go`: regression tests. The report test walks the whole #339 shape — a command that exits 0 printing nothing, a `contains` over it, the rendered console block. The runner test builds a real process tree (the test binary re-executed as a helper that hands its stdout to a detached grandchild and exits 0) so the capture is genuinely cut short rather than simulated.
- `test/e2e/atago/reports.atago.yaml`: the same guarantee asserted through the binary, so the rendered failure block is pinned where a user reads it.

## Design Decisions

The capture failure stays an error and still withholds the bytes read before the cut. Handing them back as `Stdout` would let an assertion pass or fail against a stream atago only partly read, which is the same class of confident-wrong-answer the issue objects to; refusing to answer is the honest option, and it is also the behavior that was already there — only the message changes.

I did not touch the Windows CI legs. The issue's ConPTY hypothesis is unproven, `e2e-windows` already absorbs the flake with `--retry-failed 1`, and serializing spec execution on a guess would slow the leg without evidence. On the issue's third question: `conpty.Start` does not touch the parent's console state — it calls no `AllocConsole`/`AttachConsole`/`FreeConsole`/`SetStdHandle`, and reaches the child only through `STARTF_USESTDHANDLES` with NULL std handles plus the `PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE` attribute. The one `SetConsoleMode` call in the tree belongs to `atago record` and is a no-op when stdout is not a console, so it cannot run during a spec run in CI.

## Limitations

This does not explain where the child's output went on that Windows run, and it cannot: at the parent, a child that wrote to a handle other than our pipe is indistinguishable from a child that wrote nothing — both end as EOF with zero bytes and no error. Nor does os/exec expose a capture failure when the process also exits non-zero (the `*ExitError` wins), so that combination stays silent. If the flake recurs, the failure block will now say `Actual:` followed by `(empty)`, which at least confirms the capture, not the assertion, is what to chase — so #339 stays open until that evidence arrives or the flake stops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failure reports now clearly identify empty captured output as `(empty)`.
  * Reports distinguish between empty observations and missing capture data.
  * Capture failures after a process exits now show the exit code and relevant capture details.
  * Background processes that keep output streams open are identified more accurately.
  * Partial output is no longer presented as complete when capture fails.

* **Documentation**
  * Added end-to-end coverage and documentation for empty-output failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
