### PR TITLE
refactor(report): aggregate scenario counts once instead of per format

### DIFF
--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1328,6 +1328,46 @@ func TestSuiteResultCounts(t *testing.T) {
 	}
 }
 
+// TestCountsAdd proves Add folds every field, including Flaky. Report formats
+// aggregate per-suite counts through it, so a field this method forgot would
+// make a summary line disagree with the rows above it.
+func TestCountsAdd(t *testing.T) {
+	t.Parallel()
+	a := Counts{Passed: 1, Failed: 2, Skipped: 3, Errored: 4, Flaky: 5}
+	b := Counts{Passed: 10, Failed: 20, Skipped: 30, Errored: 40, Flaky: 50}
+	if got := a.Add(b); got != (Counts{Passed: 11, Failed: 22, Skipped: 33, Errored: 44, Flaky: 55}) {
+		t.Errorf("a.Add(b) = %+v", got)
+	}
+	// Adding the zero value must change nothing, in either direction.
+	if got := a.Add(Counts{}); got != a {
+		t.Errorf("a.Add(zero) = %+v, want %+v", got, a)
+	}
+	if got := (Counts{}).Add(a); got != a {
+		t.Errorf("zero.Add(a) = %+v, want %+v", got, a)
+	}
+}
+
+// TestSumCounts covers the aggregation the report formats used to open-code,
+// including the empty-slice bootstrap that must yield the zero value rather
+// than anything derived from the first element.
+func TestSumCounts(t *testing.T) {
+	t.Parallel()
+	if got := SumCounts(nil); got != (Counts{}) {
+		t.Errorf("SumCounts(nil) = %+v, want zero", got)
+	}
+	if got := SumCounts([]*SuiteResult{}); got != (Counts{}) {
+		t.Errorf("SumCounts(empty) = %+v, want zero", got)
+	}
+	results := []*SuiteResult{
+		{Scenarios: []ScenarioResult{{Status: StatusPassed}, {Status: StatusFailed}}},
+		{Scenarios: []ScenarioResult{{Status: StatusSkipped}, {Status: StatusError}, {Status: StatusFlaky}}},
+		{}, // a suite that produced no scenario row contributes nothing
+	}
+	if got := SumCounts(results); got != (Counts{Passed: 1, Failed: 1, Skipped: 1, Errored: 1, Flaky: 1}) {
+		t.Errorf("SumCounts = %+v", got)
+	}
+}
+
 // TestScenarioID proves the identity key is stable and distinguishes same-named
 // scenarios across different spec paths (the --rerun-failed / --select key).
 func TestScenarioID(t *testing.T) {

--- a/internal/engine/result.go
+++ b/internal/engine/result.go
@@ -135,6 +135,30 @@ type Counts struct {
 	Passed, Failed, Skipped, Errored, Flaky int
 }
 
+// Add returns the field-wise sum of two tallies. Every report format aggregates
+// per-suite counts for its summary line; they all go through this so a new
+// status is one edit here rather than a grep for open-coded additions that a
+// summary line would silently disagree with the rows above it about.
+func (c Counts) Add(o Counts) Counts {
+	c.Passed += o.Passed
+	c.Failed += o.Failed
+	c.Skipped += o.Skipped
+	c.Errored += o.Errored
+	c.Flaky += o.Flaky
+	return c
+}
+
+// SumCounts tallies every scenario of every suite in one call. An empty (or nil)
+// slice sums to the zero value, which is what an all-filtered-out run must
+// report.
+func SumCounts(results []*SuiteResult) Counts {
+	var agg Counts
+	for _, res := range results {
+		agg = agg.Add(res.Counts())
+	}
+	return agg
+}
+
 // Counts tallies scenario statuses.
 func (s *SuiteResult) Counts() Counts {
 	var c Counts

--- a/internal/report/console.go
+++ b/internal/report/console.go
@@ -29,12 +29,6 @@ func writeSummary(b *strings.Builder, color bool, c engine.Counts, total int, d 
 	if total == 1 {
 		plural = "scenario"
 	}
-	// Flaky scenarios (#29) are green for the verdict but never hidden: the
-	// count appears only when non-zero so steady-state output is unchanged.
-	flaky := ""
-	if c.Flaky > 0 {
-		flaky = fmt.Sprintf(", %d flaky", c.Flaky)
-	}
 	// Spec-load failures are not scenarios, so they get their own count in the
 	// tally line — otherwise the totals silently omit the dropped files (#120).
 	loadFail := ""
@@ -47,7 +41,7 @@ func writeSummary(b *strings.Builder, color bool, c engine.Counts, total int, d 
 	}
 	fmt.Fprintf(b, "\n%s  %d %s: %d passed, %d failed, %d errored, %d skipped%s%s (%s)\n",
 		colorize(color, code+cBold, status), total, plural,
-		c.Passed, c.Failed, c.Errored, c.Skipped, flaky, loadFail, d.Round(time.Millisecond))
+		c.Passed, c.Failed, c.Errored, c.Skipped, flakySuffix(c), loadFail, d.Round(time.Millisecond))
 }
 
 // writeDetail prints the failure/error block for a scenario, or nothing if it

--- a/internal/report/format_parity_test.go
+++ b/internal/report/format_parity_test.go
@@ -175,6 +175,21 @@ func TestRender_CrossFormatCountParity(t *testing.T) {
 			t.Errorf("gha missing warning annotation for the flaky scenario:\n%s", out)
 		}
 	})
+
+	// The console summary and the gha notice aggregate the same five counters.
+	// They used to do it with two hand-rolled copies of the same additions and
+	// two hand-rolled copies of the ", N flaky" suffix, so this subtest asserts
+	// the two lines carry the same numbers and the same wording for them.
+	t.Run("console and gha agree on the tally", func(t *testing.T) {
+		t.Parallel()
+		wantTally := "5 scenarios: 1 passed, 1 failed, 1 errored, 1 skipped, 1 flaky"
+		if out := render(t, FormatConsole, res); !strings.Contains(out, wantTally) {
+			t.Errorf("console summary missing %q:\n%s", wantTally, out)
+		}
+		if out := render(t, FormatGHA, res); !strings.Contains(out, wantTally) {
+			t.Errorf("gha notice missing %q:\n%s", wantTally, out)
+		}
+	})
 }
 
 // TestRender_CrossFormatCountParity_SetupErrored pins the format-cross count

--- a/internal/report/gha.go
+++ b/internal/report/gha.go
@@ -47,24 +47,15 @@ func writeGHA(w io.Writer, results []*engine.SuiteResult) error {
 			// not-ok points tap emits for the same run — so the ::notice:: summary
 			// agrees with the ::error:: annotations just written above instead of
 			// reading an all-zero, all-green line.
-			agg.Errored += len(pts)
+			agg = agg.Add(engine.Counts{Errored: len(pts)})
 			total += len(pts)
 		}
-		c := res.Counts()
-		agg.Passed += c.Passed
-		agg.Failed += c.Failed
-		agg.Errored += c.Errored
-		agg.Skipped += c.Skipped
-		agg.Flaky += c.Flaky
+		agg = agg.Add(res.Counts())
 		total += len(res.Scenarios)
-	}
-	flaky := ""
-	if agg.Flaky > 0 {
-		flaky = fmt.Sprintf(", %d flaky", agg.Flaky)
 	}
 	fmt.Fprintf(&b, "::notice title=atago::%s\n", ghaEscapeData(fmt.Sprintf(
 		"%d scenarios: %d passed, %d failed, %d errored, %d skipped%s",
-		total, agg.Passed, agg.Failed, agg.Errored, agg.Skipped, flaky)))
+		total, agg.Passed, agg.Failed, agg.Errored, agg.Skipped, flakySuffix(agg))))
 	_, err := io.WriteString(w, b.String())
 	return err
 }

--- a/internal/report/render.go
+++ b/internal/report/render.go
@@ -23,6 +23,18 @@ func flakyMessage(sc *engine.ScenarioResult) string {
 	return fmt.Sprintf("flaky: passed after %d attempts", sc.Attempts)
 }
 
+// flakySuffix renders the ", N flaky" tail of a summary tally. Flaky scenarios
+// (#29) are green for the verdict but never hidden, and the suffix appears only
+// when non-zero so steady-state output is unchanged. Console and gha share this
+// for the same reason they share flakyMessage: the wording must not drift
+// between two lines describing the same run.
+func flakySuffix(c engine.Counts) string {
+	if c.Flaky == 0 {
+		return ""
+	}
+	return fmt.Sprintf(", %d flaky", c.Flaky)
+}
+
 // Option configures an optional aspect of a Render call. It keeps the common
 // three-argument form unchanged while letting callers pass extra run-level
 // context (e.g. spec-load failures) without a signature churn.
@@ -67,7 +79,7 @@ func Render(w io.Writer, f Format, results []*engine.SuiteResult, opts ...Option
 	case FormatConsole:
 		var b strings.Builder
 		color := isTTY(w)
-		var agg engine.Counts
+		agg := engine.SumCounts(results)
 		var total int
 		var dur time.Duration
 		hardFail := false
@@ -78,12 +90,6 @@ func Render(w io.Writer, f Format, results []*engine.SuiteResult, opts ...Option
 			writeSuiteDetail(&b, color, res)
 			writeRepeatRates(&b, color, res)
 			writeFlaky(&b, color, res)
-			c := res.Counts()
-			agg.Passed += c.Passed
-			agg.Failed += c.Failed
-			agg.Errored += c.Errored
-			agg.Skipped += c.Skipped
-			agg.Flaky += c.Flaky
 			total += len(res.Scenarios)
 			dur += res.Duration
 			// A suite that errored before producing any scenario row (#7) has


### PR DESCRIPTION
Closes #350.

## Problem

`internal/report/render.go` (console) and `internal/report/gha.go` each carried their own field-by-field sum of the same five scenario counters:

```go
c := res.Counts()
agg.Passed += c.Passed
agg.Failed += c.Failed
agg.Errored += c.Errored
agg.Skipped += c.Skipped
agg.Flaky += c.Flaky
```

and both built the `", N flaky"` summary suffix from scratch. `engine.Counts` had no way to add two of them, so every consumer re-derived the addition. Adding a sixth status meant finding every open-coded sum by grep, and a miss produces a summary line that disagrees with the annotations in the same report — the class of drift `internal/report/format_parity_test.go` already exists to catch.

## Change

- `engine.Counts.Add(Counts) Counts` folds two tallies field-wise; `engine.SumCounts([]*SuiteResult) Counts` covers the "every suite in this run" case and yields the zero value for an empty slice.
- `internal/report.flakySuffix(engine.Counts) string` is the single owner of the `", N flaky"` wording, following the precedent `flakyMessage` already set ("Every format shares this so the wording never drifts between them"). Console and gha both call it.
- The gha writer's synthesized points for a suite that errored before producing any scenario row (#7) now go through `Add(engine.Counts{Errored: len(pts)})` rather than a lone open-coded field bump, so the one case with the subtle comment is covered by the same helper.

`internal/report/junit.go` aggregates `Tests`/`Failures`/`Errors`/`Skipped`/`Time` on its own XML-schema struct — a different shape from `Counts` (no `Passed`, no `Flaky`, plus `Time`), so it is deliberately left alone. `tap.go` does not aggregate at all.

## No output change

This is a pure consolidation. Every existing report test passes untouched.

## Tests

- `internal/engine`: `TestCountsAdd` (every field including `Flaky`; adding the zero value is a no-op in both directions) and `TestSumCounts` (nil and empty slices sum to the zero value; a scenario-less suite contributes nothing).
- `internal/report/format_parity_test.go`: a new subtest of `TestRender_CrossFormatCountParity` renders the one-of-every-status fixture to console *and* gha and asserts both carry the identical tally string, including the flaky suffix. One test now fails if the two aggregations diverge again.
- `TestRender_CrossFormatCountParity_SetupErrored` (unchanged) still guards the synthesized-points path.

Verified with `go test ./...` and `golangci-lint run` (0 issues).