### PR TITLE
refactor(security): one workdir-confined write helper and one file mode

### DIFF
--- a/internal/fixture/fixture.go
+++ b/internal/fixture/fixture.go
@@ -22,7 +22,7 @@ import (
 // A `symlink` fixture creates a symbolic link instead of a regular file. Optional
 // `mode` (octal) and `mtime` (RFC3339) are applied after writing.
 func Write(f *spec.Fixture, workdir, specDir string) error {
-	dest, err := safeJoin(workdir, f.File)
+	dest, err := security.ResolveWorkdirPath("fixture path", workdir, f.File)
 	if err != nil {
 		return err
 	}
@@ -48,7 +48,7 @@ func Write(f *spec.Fixture, workdir, specDir string) error {
 	// existing file in place — e.g. chmod a file a previous step created — rather
 	// than truncating it. This lets a spec make a tool-created file read-only.
 	if f.Content == "" && f.Base64 == "" && f.From == "" && (f.Mode != "" || f.Mtime != "") {
-		// dest is lexically inside the workdir (safeJoin), but the untrusted
+		// dest is lexically inside the workdir (ResolveWorkdirPath), but the untrusted
 		// program under test may have replaced it with a symlink pointing outside
 		// — and chmod/chtimes FOLLOW symlinks, so applying mode/mtime here would
 		// escape containment and re-permission a host file. Reject an existing
@@ -84,10 +84,11 @@ func Write(f *spec.Fixture, workdir, specDir string) error {
 		data = []byte(f.Content)
 	}
 
-	// dest is contained within workdir by safeJoin above (cannot escape) — but the
-	// untrusted program under test may have planted a symlink at dest pointing
-	// outside the workdir; writing must not follow it (TOCTOU, issue #16).
-	if err := security.WriteFileNoFollow(dest, data, 0o600); err != nil {
+	// dest is contained within workdir by ResolveWorkdirPath above (cannot
+	// escape) — WriteConfinedFile handles the rest of the policy: the untrusted
+	// program under test may have planted a symlink at dest pointing outside the
+	// workdir, and writing must not follow it (TOCTOU, issue #16).
+	if err := security.WriteConfinedFile(dest, data); err != nil {
 		return fmt.Errorf("fixture %q: %w", f.File, err)
 	}
 	if err := applyMode(f, dest); err != nil {
@@ -145,12 +146,4 @@ func checkSymlinkTarget(workdir, dest, target string) error {
 		return fmt.Errorf("symlink target %q escapes the scenario workdir", target)
 	}
 	return nil
-}
-
-// safeJoin joins rel onto base and ensures the result stays within base, so a
-// fixture cannot write outside the scenario workdir. It shares
-// the workdir-containment policy used by file/store/service/browser/snapshot
-// paths so every path-taking feature enforces the same rule.
-func safeJoin(base, rel string) (string, error) {
-	return security.ResolveWorkdirPath("fixture path", base, rel)
 }

--- a/internal/runner/browser/browser.go
+++ b/internal/runner/browser/browser.go
@@ -153,9 +153,10 @@ func (r *Runner) Run(ctx context.Context, actions []spec.CDPAction, workdir stri
 	// Persist any screenshots after the run completes, so the captured bytes are
 	// on disk before the scenario's file/image assertions read them (#50).
 	for _, s := range shots {
-		// The page under test may have planted a symlink at the screenshot target
-		// pointing outside the workdir; write without following it (issue #16).
-		if err := security.WriteFileNoFollow(s.path, *s.buf, 0o600); err != nil {
+		// s.path was confined to the workdir when the task was built; the confined
+		// write creates its parents and refuses to follow a symlink the page under
+		// test may have planted at the target (issue #16).
+		if err := security.WriteConfinedFile(s.path, *s.buf); err != nil {
 			return nil, fmt.Errorf("cdp screenshot: writing %q: %w", s.path, err)
 		}
 	}

--- a/internal/runner/cmd/cmd.go
+++ b/internal/runner/cmd/cmd.go
@@ -209,21 +209,8 @@ func writeRedirects(run *spec.Run, workdir, stdout, stderr string) error {
 		if r.path == "" {
 			continue
 		}
-		abs, err := security.ResolveWorkdirPath(r.field, workdir, r.path)
-		if err != nil {
+		if _, err := security.WriteWorkdirFile(r.field, workdir, r.path, []byte(r.data)); err != nil {
 			return err
-		}
-		// Create the parent directory so a redirect to a nested path (stdout_to:
-		// logs/out.txt) works without a prior mkdir step, mirroring the fixture
-		// writer. The parent is inside the workdir (ResolveWorkdirPath confined it),
-		// so this creates only scenario-local directories.
-		if err := os.MkdirAll(filepath.Dir(abs), 0o750); err != nil {
-			return fmt.Errorf("%s: %w", r.field, err)
-		}
-		// The program under test may have planted a symlink at the redirect target
-		// pointing outside the workdir; write without following it (issue #16).
-		if err := security.WriteFileNoFollow(abs, []byte(r.data), 0o644); err != nil {
-			return fmt.Errorf("%s: %w", r.field, err)
 		}
 	}
 	return nil

--- a/internal/runner/cmd/cmd_test.go
+++ b/internal/runner/cmd/cmd_test.go
@@ -100,6 +100,33 @@ func TestRun_StdoutToCreatesParentDir(t *testing.T) {
 	}
 }
 
+// TestRun_StdoutToFileMode pins the mode of a redirect file. stdout_to/stderr_to
+// used to write 0o644 while every other workdir-confined write (http.body_to,
+// fixtures, snapshots) used 0o600, undocumented and untested — which is what a
+// divergence looks like right before someone asserts on it. They all share one
+// helper and one mode now (#349); this keeps it from drifting back silently.
+func TestRun_StdoutToFileMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not honor POSIX permission bits")
+	}
+	t.Parallel()
+	wd := t.TempDir()
+	r := New()
+	if _, err := r.Run(context.Background(), &spec.Run{
+		Command:  argvCommand("echo produced", "cmd /c echo produced"),
+		StdoutTo: "out.txt",
+	}, wd); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	fi, err := os.Stat(filepath.Join(wd, "out.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fi.Mode().Perm(); got != 0o600 {
+		t.Errorf("stdout_to mode = %04o, want 0600", got)
+	}
+}
+
 // TestRun_StdoutToConfinedToWorkdir proves a redirect path may not escape the
 // scenario workdir.
 func TestRun_StdoutToConfinedToWorkdir(t *testing.T) {

--- a/internal/runner/http/http.go
+++ b/internal/runner/http/http.go
@@ -147,17 +147,8 @@ func (r *Runner) Do(ctx context.Context, h *spec.HTTP) (*runner.Result, error) {
 	// body_to persists the response for the file/image/pdf assertion targets —
 	// the http analogue of run's stdout_to (workdir-confined, create/truncate).
 	if h.BodyTo != "" {
-		dst, perr := security.ResolveWorkdirPath("http.body_to", r.workdir, h.BodyTo)
-		if perr != nil {
+		if _, perr := security.WriteWorkdirFile("http.body_to", r.workdir, h.BodyTo, data); perr != nil {
 			return nil, perr
-		}
-		if perr := os.MkdirAll(filepath.Dir(dst), 0o750); perr != nil {
-			return nil, fmt.Errorf("creating directory for http.body_to %q: %w", h.BodyTo, perr)
-		}
-		// The program under test may have planted a symlink at the body_to target
-		// pointing outside the workdir; write without following it (issue #16).
-		if perr := security.WriteFileNoFollow(dst, data, 0o600); perr != nil {
-			return nil, fmt.Errorf("writing http.body_to %q: %w", h.BodyTo, perr)
 		}
 	}
 

--- a/internal/security/path.go
+++ b/internal/security/path.go
@@ -49,6 +49,47 @@ func resolveInRoot(field, rootLabel, root, p string) (string, error) {
 	return dest, nil
 }
 
+// confinedFileMode is the mode of every file atago writes on a spec's behalf
+// inside a containment root — run.stdout_to/stderr_to, http.body_to, fixtures,
+// snapshots, CDP screenshots. These land in a private scenario workdir (a
+// per-run temp directory) or next to the spec, so nothing is gained by making
+// them group- or world-readable; one mode across every site is one fewer thing
+// to diverge. run.stdout_to used to write 0o644 for no documented reason (#349).
+const confinedFileMode = 0o600
+
+// WriteConfinedFile creates dest's parent directories and writes data there
+// without following a symlink planted at the leaf. dest must already be
+// containment-checked by ResolveWorkdirPath or ResolveSpecPath — this helper
+// enforces the rest of the policy (create parents, never follow the leaf, one
+// file mode) that every confined write used to spell out for itself.
+//
+// Parent creation means a spec can name a nested destination (stdout_to:
+// logs/out.txt) without a prior mkdir step; the parent is inside the containment
+// root, so only root-local directories are ever created.
+func WriteConfinedFile(dest string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(dest), 0o750); err != nil {
+		return err
+	}
+	// The program under test may have planted a symlink at dest pointing outside
+	// the containment root; write without following it (issue #16).
+	return WriteFileNoFollow(dest, data, confinedFileMode)
+}
+
+// WriteWorkdirFile resolves rel against the scenario workdir and writes data
+// there, confined to the workdir. field names the spec field so both the
+// containment error and the write error say which key produced them. It returns
+// the absolute destination, which callers put in the Result or log.
+func WriteWorkdirFile(field, workdir, rel string, data []byte) (string, error) {
+	dest, err := ResolveWorkdirPath(field, workdir, rel)
+	if err != nil {
+		return "", err
+	}
+	if err := WriteConfinedFile(dest, data); err != nil {
+		return "", fmt.Errorf("%s: %w", field, err)
+	}
+	return dest, nil
+}
+
 // ReadFileNoFollow reads path but refuses to follow a symlink planted at the
 // leaf. Lexical containment (ResolveWorkdirPath/ResolveSpecPath) proves path is
 // inside its root, but the untrusted program under test may have replaced the

--- a/internal/security/path_test.go
+++ b/internal/security/path_test.go
@@ -289,3 +289,109 @@ func TestResolveWorkdirPath_ForwardSlashRelative(t *testing.T) {
 		t.Errorf("resolved path %q is not within root %q", got, root)
 	}
 }
+
+// TestWriteWorkdirFile covers the confined-write helper the four
+// workdir-scoped features share (#349): stdout_to/stderr_to, http.body_to,
+// fixtures, and (via WriteConfinedFile) snapshots and CDP screenshots. Each of
+// them used to open-code resolve → MkdirAll → WriteFileNoFollow, and the file
+// mode had already drifted between them.
+func TestWriteWorkdirFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("creates parent directories", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		dest, err := WriteWorkdirFile("run.stdout_to", root, filepath.Join("logs", "deep", "out.txt"), []byte("produced"))
+		if err != nil {
+			t.Fatalf("WriteWorkdirFile: %v", err)
+		}
+		if want := filepath.Join(root, "logs", "deep", "out.txt"); dest != want {
+			t.Errorf("dest = %q, want %q", dest, want)
+		}
+		got, err := os.ReadFile(dest)
+		if err != nil || string(got) != "produced" {
+			t.Fatalf("read back = %q, %v", got, err)
+		}
+	})
+
+	t.Run("rejects an escape and names the field", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		for _, rel := range []string{
+			filepath.Join("sub", "..", "..", "escape.txt"),
+			filepath.Join(t.TempDir(), "absolute-outside.txt"),
+		} {
+			_, err := WriteWorkdirFile("http.body_to", root, rel, []byte("x"))
+			if err == nil {
+				t.Fatalf("WriteWorkdirFile(%q) succeeded; want a containment error", rel)
+			}
+			if !strings.Contains(err.Error(), "http.body_to") {
+				t.Errorf("error does not name the field: %v", err)
+			}
+			if !strings.Contains(err.Error(), "escapes the scenario workdir") {
+				t.Errorf("error does not say what went wrong: %v", err)
+			}
+		}
+	})
+
+	t.Run("refuses to write through a planted leaf symlink", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("symlink creation is not reliably available on Windows CI")
+		}
+		t.Parallel()
+		root := t.TempDir()
+		victim := filepath.Join(t.TempDir(), "victim.txt")
+		if err := os.WriteFile(victim, []byte("original"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(victim, filepath.Join(root, "redirect.txt")); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := WriteWorkdirFile("run.stdout_to", root, "redirect.txt", []byte("pwned")); err == nil {
+			t.Fatal("wrote through the planted symlink; want error")
+		}
+		if got, _ := os.ReadFile(victim); string(got) != "original" {
+			t.Errorf("host file was modified through the symlink: %q", got)
+		}
+	})
+
+	// One mode for every confined write. stdout_to used to be the odd one out at
+	// 0o644 (#349); pin the agreed mode so it cannot drift back unnoticed.
+	t.Run("uses the confined file mode", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("Windows does not honor POSIX permission bits")
+		}
+		t.Parallel()
+		root := t.TempDir()
+		dest, err := WriteWorkdirFile("run.stdout_to", root, "out.txt", []byte("x"))
+		if err != nil {
+			t.Fatalf("WriteWorkdirFile: %v", err)
+		}
+		fi, err := os.Stat(dest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := fi.Mode().Perm(); got != confinedFileMode {
+			t.Errorf("mode = %04o, want %04o", got, confinedFileMode)
+		}
+	})
+}
+
+// TestWriteConfinedFile is the resolved-path form used by snapshot writes, which
+// resolve against the spec directory rather than the workdir, and by CDP
+// screenshots, which resolve when the task is built and write after the run.
+func TestWriteConfinedFile(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	dest := filepath.Join(root, "golden", "out.snap")
+	if err := WriteConfinedFile(dest, []byte("v1")); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if err := WriteConfinedFile(dest, []byte("v2")); err != nil {
+		t.Fatalf("overwrite: %v", err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil || string(got) != "v2" {
+		t.Fatalf("read back = %q, %v; want %q", got, err, "v2")
+	}
+}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -9,7 +9,6 @@ package snapshot
 import (
 	"errors"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -196,10 +195,10 @@ func Compare(path string, actual []byte, opt Options) (ok bool, expected, actual
 
 // Update writes the normalized actual output to path, creating parent dirs.
 func Update(path string, actual []byte, opt Options) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
-		return err
-	}
-	// The program under test may have planted a symlink at the snapshot target
-	// pointing outside the spec directory; write without following it (issue #16).
-	return security.WriteFileNoFollow(path, Normalize(actual, opt), 0o600)
+	// path is resolved against the SPEC directory (security.ResolveSpecPath), not
+	// the scenario workdir, so this takes the resolved-path form of the confined
+	// write rather than the workdir-shaped one. The rest of the policy — create
+	// parents, refuse a symlink the program under test may have planted at the
+	// target (issue #16), one file mode — is the same.
+	return security.WriteConfinedFile(path, Normalize(actual, opt))
 }


### PR DESCRIPTION
Closes #349.

## Problem

"Write a file the spec named, confined to the scenario workdir" was spelled out four times as the same three-step dance — `security.ResolveWorkdirPath` (or `safeJoin`, a one-line wrapper around it) → `os.MkdirAll(filepath.Dir(dst), 0o750)` → `security.WriteFileNoFollow(dst, data, mode)` — each with its own error wrapping and its own copy of the "the program under test may have planted a symlink here" comment.

Two consequences, both called out in the issue:

1. **The file mode had already diverged.** `run.stdout_to`/`stderr_to` wrote `0o644`; `http.body_to`, fixtures, and snapshots wrote `0o600`. Nothing documented the difference and nothing tested it.
2. **A fix had to be applied four times.** `WriteFileNoFollow` exists because this path is security-relevant (#16); resolve, create parents, and wrap the error are just as much part of the policy, and they were copy-pasted.

## Change

`internal/security/path.go` gains, next to the policy it enforces:

```go
func WriteWorkdirFile(field, workdir, rel string, data []byte) (string, error)
func WriteConfinedFile(dest string, data []byte) error
```

- `WriteWorkdirFile` resolves, creates parents, writes without following a leaf symlink, and returns the absolute path (callers use it for the `Result`/log) with an error already naming `field`. Used by `run.stdout_to`/`stderr_to` and `http.body_to`.
- `WriteConfinedFile` is the resolved-path form, for the two callers that resolve elsewhere: snapshot writes resolve against the **spec** directory (`ResolveSpecPath`), and CDP screenshots resolve when the chromedp task is built but write after the run completes. They are not forced through a workdir-shaped API.
- `confinedFileMode = 0o600` is the single mode, with the reasoning written down: these files land in a private per-run temp directory or next to the spec, so a looser mode buys nothing.
- `internal/fixture`'s `safeJoin` — a wrapper around a wrapper — is inlined.

`internal/artifact/artifact.go` keeps its plain `os.WriteFile`, and the reasoning still holds: the artifacts dir is named by the user on the command line rather than derived from a spec, and the relative paths under it are atago-generated (`Slug`), so there is no untrusted component to confine.

## Behavior changes

- **Mode**: `stdout_to`/`stderr_to` files are now `0o600` instead of `0o644`. No spec, doc, or test asserts the old mode.
- **CDP screenshots** now create their parent directory, which they did not before — a `screenshot.path` of `shots/a.png` used to fail with a raw "no such file or directory". This makes it consistent with every other confined write.
- **`http.body_to` error text** is now `http.body_to: <cause>` rather than `creating directory for http.body_to "x": <cause>` / `writing http.body_to "x": <cause>`, matching the wording `run.stdout_to` already used. Nothing pinned the old strings.
- The `stdout_to` write still happens **after** the capture is known good — #343's ordering is preserved; `writeRedirects` is called from the same place.

## Tests

`internal/security/path_test.go`:
- `WriteWorkdirFile` creates nested parents and returns the resolved path.
- `../` traversal and an absolute path outside the workdir are rejected, with the field name and the reason in the error.
- A symlink planted at the leaf is refused and the host file outside the root is untouched (POSIX; skipped on Windows like the sibling tests).
- The created file's mode is `confinedFileMode` (POSIX only).
- `WriteConfinedFile` creates parents and overwrites cleanly.

`internal/runner/cmd/cmd_test.go`: `TestRun_StdoutToFileMode` pins the redirect mode at `0600` so it cannot drift back silently.

Every existing test in `internal/runner/cmd`, `internal/runner/http`, `internal/fixture`, and `internal/snapshot` passes unchanged.

Verified with `go test ./...`, `golangci-lint run` (0 issues), and `make e2e` (464 scenarios: 460 passed, 4 skipped).