### PR TITLE
fix(report): keep a multi-line command from breaking the report layout

### DIFF
--- a/internal/report/console.go
+++ b/internal/report/console.go
@@ -3,6 +3,7 @@ package report
 import (
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -268,6 +269,27 @@ func indent(s string) string {
 	return strings.Join(lines, "\n")
 }
 
+// oneLineCommand renders a command for a surface where it shares a line with
+// other text — the verbose trace's step line — so a newline in it can never
+// split that line. A raw newline there is ambiguous with the start of the next
+// step, and a grep for a step in a CI log stops matching at it (#348).
+//
+// A command with no embedded newline is returned untouched: that is nearly
+// every command, and this text is what users grep for, so the common case must
+// stay byte-identical. Only a multi-line command is quoted, and strconv.Quote is
+// the escaping chosen because `\n` is the same escape the spec author typed in
+// the YAML — the trace then reads recognizably like the source, and like the
+// failure block's indented rendering of the same command. A trailing newline (a
+// `>` block scalar carries one) is dropped first: it says nothing about the
+// command, and quoting it would show a `\n` the author did not write.
+func oneLineCommand(cmd string) string {
+	cmd = strings.TrimRight(cmd, "\r\n")
+	if !strings.ContainsAny(cmd, "\r\n") {
+		return cmd
+	}
+	return strconv.Quote(cmd)
+}
+
 // writeCheckFailure renders the body every failure report shares: the step that
 // failed, the command behind it when there is one, the comparison, and the
 // hint. A scenario failure and a suite setup/teardown failure differ only in
@@ -277,7 +299,12 @@ func indent(s string) string {
 func writeCheckFailure(b *strings.Builder, color bool, ck *assert.CheckResult, cmd string) {
 	fmt.Fprintf(b, "\nStep:\n  %s\n", ck.Desc)
 	if cmd != "" {
-		fmt.Fprintf(b, "\nCommand:\n  %s\n", cmd)
+		// Through indent(), like every other multi-line value in this block: a
+		// command carrying a newline (a YAML block scalar, a `shell: true` script)
+		// used to drop its continuation lines to column 0 (#348). indent() also
+		// trims the trailing newline a `>` block scalar leaves, so the section
+		// never ends in a dangling blank line.
+		fmt.Fprintf(b, "\nCommand:\n%s\n", indent(cmd))
 	}
 	// Multi-line equals/snapshot failures render a unified diff (#28): the
 	// one-character difference the two raw blocks hide. Single-line failures

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -1312,3 +1312,152 @@ func TestConsole_ExitCodeFailureShowsStderr(t *testing.T) {
 		t.Errorf("stream-assert failure must not print the exit_code stderr section:\n%s", b.String())
 	}
 }
+
+// multiLineCommandResults builds a failing scenario whose command carries an
+// embedded newline — a YAML block scalar, a `shell: true` script, a literal
+// `printf 'x\n'` — plus a trailing newline, which is what a `>` block scalar
+// leaves behind. Both console renderings interpolated the command raw, so the
+// continuation line landed at column 0 in the failure block and split the step
+// line in the verbose trace (#348).
+func multiLineCommandResults() []*engine.SuiteResult {
+	const cmd = "printf 'boom: no such file\n' 1>&2; exit 1\n"
+	run := &runner.Result{Command: cmd, ExitCode: 1, Stderr: []byte("boom: no such file\n")}
+	return []*engine.SuiteResult{{
+		Suite:    "probe",
+		Status:   engine.StatusFailed,
+		Duration: time.Millisecond,
+		Scenarios: []engine.ScenarioResult{{
+			Name:   "assert stdout when the tool prints to stderr",
+			Status: engine.StatusFailed,
+			Steps: []engine.StepResult{
+				{Index: 0, Kind: spec.StepRun, Run: run},
+				{Index: 1, Kind: spec.StepAssert, Run: run, Checks: []*assert.CheckResult{{
+					OK: false, Target: string(spec.AssertStdout), Desc: `assert stdout contains "boom"`,
+					Expected: `stdout contains "boom"`, Hint: `the substring "boom" was not present in stdout`,
+				}}},
+			},
+		}},
+	}}
+}
+
+// TestRender_Console_MultiLineCommandIsIndented pins that the failure block's
+// Command: section indents continuation lines like every other block in it, so
+// no line of the block starts at column 0 except the section headers, and a
+// trailing newline in the command leaves no dangling blank line (#348).
+func TestRender_Console_MultiLineCommandIsIndented(t *testing.T) {
+	t.Parallel()
+	var b bytes.Buffer
+	if err := Render(&b, FormatConsole, multiLineCommandResults()); err != nil {
+		t.Fatal(err)
+	}
+	out := b.String()
+	if !strings.Contains(out, "Command:\n  printf 'boom: no such file\n  ' 1>&2; exit 1\n") {
+		t.Errorf("Command: section does not indent its continuation line:\n%s", out)
+	}
+
+	// Walk the failure block: every non-empty line is either a section header
+	// ("Step:", "Command:", …) or an indented body line. A body line at column 0
+	// is the layout break this test exists for.
+	body, _, _ := strings.Cut(out, "\nPASSED")
+	body, _, _ = strings.Cut(body, "\nFAILED  ")
+	for _, line := range strings.Split(body, "\n") {
+		if line == "" || strings.HasPrefix(line, "  ") {
+			continue
+		}
+		if strings.HasSuffix(line, ":") || strings.HasPrefix(line, "FAILED:") {
+			continue // a section header, or the block heading
+		}
+		t.Errorf("line %q starts at column 0 inside the failure block:\n%s", line, out)
+	}
+	if strings.Contains(out, "exit 1\n\n\n") {
+		t.Errorf("trailing newline in the command produced a dangling blank line:\n%s", out)
+	}
+}
+
+// TestVerbose_MultiLineCommandStaysOnOneLine pins that the trace's step line —
+// where the command shares a line with the step label — is never split by a
+// newline in the command. A raw newline there is ambiguous with the start of a
+// new step, and a grep for a step in a CI log stops matching at it (#348).
+func TestVerbose_MultiLineCommandStaysOnOneLine(t *testing.T) {
+	t.Parallel()
+	res := multiLineCommandResults()[0].Scenarios[0]
+	res.Suite = "probe"
+	var b strings.Builder
+	NewVerbose(&b).Scenario(res)
+	out := b.String()
+
+	var stepLines []string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "  [") {
+			stepLines = append(stepLines, line)
+		}
+	}
+	if len(stepLines) != 2 {
+		t.Fatalf("step lines = %d, want 2 (a newline in the command split one):\n%s", len(stepLines), out)
+	}
+	// The escaped form must still be recognizably the same command as the one
+	// the failure block prints.
+	if !strings.Contains(stepLines[0], `printf 'boom: no such file\n' 1>&2; exit 1`) {
+		t.Errorf("step line does not carry the command in a readable escaped form: %q", stepLines[0])
+	}
+	if strings.Contains(out, "\n' 1>&2") {
+		t.Errorf("trace still contains a raw newline inside the command:\n%s", out)
+	}
+}
+
+// TestRender_TAP_MultiLineCommandKeepsOneLinePerPoint guards the newline-
+// delimited formats: TAP 13 points are lines, so a raw newline reaching one
+// would corrupt the stream for every consumer downstream of it.
+func TestRender_TAP_MultiLineCommandKeepsOneLinePerPoint(t *testing.T) {
+	t.Parallel()
+	var b bytes.Buffer
+	if err := Render(&b, FormatTAP, multiLineCommandResults()); err != nil {
+		t.Fatal(err)
+	}
+	out := b.String()
+	if n := strings.Count(out, "\nnot ok "); n != 1 {
+		t.Errorf("not-ok lines = %d, want 1:\n%s", n, out)
+	}
+	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		if strings.HasPrefix(line, "ok ") || strings.HasPrefix(line, "not ok ") {
+			continue
+		}
+		if line == "TAP version 13" || strings.HasPrefix(line, "1..") || strings.HasPrefix(line, "  ") {
+			continue
+		}
+		t.Errorf("stray unindented TAP line %q:\n%s", line, out)
+	}
+}
+
+// TestRender_Console_SingleLineCommandUnchanged is the parity guard for the
+// #348 fix: the overwhelmingly common single-line command must render exactly
+// as it did before, in both the failure block and the verbose trace.
+func TestRender_Console_SingleLineCommandUnchanged(t *testing.T) {
+	t.Parallel()
+	run := &runner.Result{Command: "atago run probe.atago.yaml", ExitCode: 1}
+	results := []*engine.SuiteResult{{
+		Suite:  "probe",
+		Status: engine.StatusFailed,
+		Scenarios: []engine.ScenarioResult{{
+			Name:   "one-liner",
+			Status: engine.StatusFailed,
+			Steps: []engine.StepResult{{Index: 0, Kind: spec.StepAssert, Run: run, Checks: []*assert.CheckResult{{
+				OK: false, Target: string(spec.AssertExitCode), Desc: "assert exit_code is 0",
+				Expected: "exit code 0", Actual: "exit code 1",
+			}}}},
+		}},
+	}}
+	var b bytes.Buffer
+	if err := Render(&b, FormatConsole, results); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(b.String(), "Command:\n  atago run probe.atago.yaml\n") {
+		t.Errorf("single-line Command: section changed shape:\n%s", b.String())
+	}
+
+	var v strings.Builder
+	NewVerbose(&v).Scenario(results[0].Scenarios[0])
+	if !strings.Contains(v.String(), "[0] assert: atago run probe.atago.yaml\n") {
+		t.Errorf("single-line trace step line changed shape:\n%s", v.String())
+	}
+}

--- a/internal/report/verbose.go
+++ b/internal/report/verbose.go
@@ -70,7 +70,10 @@ func (v *Verbose) writeStep(b *strings.Builder, phase string, sr *engine.StepRes
 	}
 	fmt.Fprintf(b, "  [%s%d] %s", phase, sr.Index, label)
 	if sr.Run != nil && sr.Run.Command != "" {
-		fmt.Fprintf(b, ": %s", sr.Run.Command)
+		// The command shares this line with the step label, so it is rendered on
+		// one line: a raw newline would be ambiguous with the next step's line and
+		// would stop a CI-log grep mid-command (#348).
+		fmt.Fprintf(b, ": %s", oneLineCommand(sr.Run.Command))
 	}
 	fmt.Fprintln(b)
 


### PR DESCRIPTION
Closes #348.

## Problem

A command containing a newline — a YAML block scalar, a `shell: true` script, a literal `printf 'x\n'` — broke the layout of both console renderings, because it was the one multi-line value interpolated without indentation.

```
Command:
  printf 'boom: no such file
' 1>&2; exit 1
```

and under `--verbose`:

```
  [0] run: printf 'boom: no such file
' 1>&2; exit 1
      exit 1
```

The second line sits at column 0 in the failure block; in the trace it is ambiguous with a new step line, and a grep for a step in a CI log stops matching at the newline.

## Change

- **`internal/report/console.go`** (`writeCheckFailure`): the `Command:` section goes through `indent()`, like every other block in the failure report. `indent()` also trims the trailing newline a `>` block scalar carries, so the section never ends in a dangling blank line.
- **`internal/report/verbose.go`** (`writeStep`): the command goes through a new `oneLineCommand()`, because there it shares a line with the step label and must not be split at all.

`oneLineCommand` drops a trailing newline, returns the string untouched when it has no embedded newline, and otherwise applies `strconv.Quote`. The choices, all commented in the code:

- **Untouched when single-line** — that is nearly every command, this text is what users grep for, and the common case must stay byte-identical.
- **`strconv.Quote`** rather than a `␊` marker or a first-line ellipsis: `\n` is the same escape the spec author typed into the YAML, so the trace reads like the source, and quotes/backslashes inside the command survive unmangled. It also keeps the trace and the failure block recognizably the same command, and stays pure ASCII, which a `␊` marker would not on a Windows console.

## The other formats

Checked in the same pass, as the issue asks:

- `junit.go` and `tap.go` embed `detailText(sc)` and the scenario name; neither carries a command, and `tapInline`/`tapFlatten` already collapse newlines in descriptions and quoted messages.
- `gha.go` already passes failure text through `oneLine()`.
- `json.go` puts the command in a JSON string, where a newline is escaped by the encoder.

So only the two console surfaces interpolated a command raw, and nothing else needed changing.

## Tests

`internal/report/report_test.go`:

1. A failure whose `Result.Command` has an embedded newline **and** a trailing newline → the `Command:` section indents its continuation line; no line of the failure block starts at column 0 except section headers; no dangling blank line.
2. The same command in the verbose trace → exactly two step lines (a raw newline would make three), the escaped command is still readable, and no raw newline survives inside it.
3. TAP with the same result → one `not ok` line and no stray unindented line, guarding the newline-delimited format.
4. A single-line command renders byte-identically in both the failure block and the trace — the parity guard for the whole change.

Verified with `go test ./...`, `golangci-lint run` (0 issues), and `make e2e` (464 scenarios: 460 passed, 4 skipped).