### PR TITLE
fix(report): state an empty stream instead of omitting it

### DIFF
--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 444 scenarios
+74 suites · 445 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -364,7 +364,7 @@
   - [console report prints the same counts in its summary line](#scenario-console-report-prints-the-same-counts-in-its-summary-line)
   - [an all-passing run reports a zero-failure suite and exits zero](#scenario-an-all-passing-run-reports-a-zero-failure-suite-and-exits-zero)
   - [an errored step is counted as an error, not a failure, across formats](#scenario-an-errored-step-is-counted-as-an-error-not-a-failure-across-formats)
-- [atago self-hosting / reports](#atago-self-hosting--reports) — 7 scenarios
+- [atago self-hosting / reports](#atago-self-hosting--reports) — 8 scenarios
   - [JUnit report is XML with a testsuite and testcase](#scenario-junit-report-is-xml-with-a-testsuite-and-testcase)
   - [GitHub Actions annotations are emitted on failure](#scenario-github-actions-annotations-are-emitted-on-failure)
   - [TAP report is a numbered TAP 13 stream with ok / not ok points](#scenario-tap-report-is-a-numbered-tap-13-stream-with-ok--not-ok-points)
@@ -372,6 +372,7 @@
   - [a multi-line snapshot failure renders a unified diff with hunks](#scenario-a-multi-line-snapshot-failure-renders-a-unified-diff-with-hunks)
   - [a failure names the command it was observed under](#scenario-a-failure-names-the-command-it-was-observed-under)
   - [a failure against an empty stream reports the stream as empty](#scenario-a-failure-against-an-empty-stream-reports-the-stream-as-empty)
+  - [an exit_code failure states that the command printed nothing](#scenario-an-exit_code-failure-states-that-the-command-printed-nothing)
 - [atago self-hosting / rerun-failed](#atago-self-hosting--rerun-failed) — 5 scenarios
   - [a failing run is recorded and rerun-failed selects only it](#scenario-a-failing-run-is-recorded-and-rerun-failed-selects-only-it)
   - [rerun-failed with nothing recorded is a no-op success](#scenario-rerun-failed-with-nothing-recorded-is-a-no-op-success)
@@ -6810,6 +6811,28 @@ ${atago} run silent.atago.yaml
 #### Then
 - exit code is `1`
 - stdout matches `/Actual:
+  \(empty\)/`
+### Scenario: an exit_code failure states that the command printed nothing
+#### Given
+- Fixture file `quiet.atago.yaml` is created.
+#### Inputs
+_Fixture `quiet.atago.yaml`:_
+```text
+version: "1"
+suite: {name: quiet}
+scenarios:
+  - name: exit code failure with no output at all
+    steps:
+      - run: {shell: true, command: "exit 7"}
+      - assert: {exit_code: 0}
+```
+#### When
+```shell
+${atago} run quiet.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout matches `/Stdout/Stderr:
   \(empty\)/`
 ## atago self-hosting / rerun-failed
 Source: `test/e2e/atago/rerun.atago.yaml`

--- a/internal/assert/stream.go
+++ b/internal/assert/stream.go
@@ -313,7 +313,7 @@ func emptiness(want bool) string {
 
 const excerptLimit = 2000
 
-// emptyExcerpt is what an observed-but-empty payload renders as. The console
+// EmptyExcerpt is what an observed-but-empty payload renders as. The console
 // block prints an Expected:/Actual: section only for a non-empty string, so an
 // empty observation used to render as no section at all — a report that looks
 // like it never recorded what it saw, when in fact it saw nothing. A reader then
@@ -321,12 +321,16 @@ const excerptLimit = 2000
 // Windows flake (#339) had to be diagnosed. Naming it keeps every excerpt-based
 // comparison self-describing, and matches the wording parseDoc already uses for
 // an empty JSON/YAML payload.
-const emptyExcerpt = "(empty)"
+//
+// It is exported because internal/report states the same thing in its own
+// surfaces — the exit_code failure block and the verbose trace (#346) — and one
+// spelling of "there was nothing here" must serve the whole report.
+const EmptyExcerpt = "(empty)"
 
 func excerpt(s string) string {
 	switch {
 	case s == "":
-		return emptyExcerpt
+		return EmptyExcerpt
 	case len(s) <= excerptLimit:
 		return s
 	default:

--- a/internal/report/console.go
+++ b/internal/report/console.go
@@ -240,6 +240,18 @@ func writeFailureStreams(b *strings.Builder, ck *assert.CheckResult, run *runner
 		stream, label = run.Stdout, "Stdout"
 	}
 	if len(stream) == 0 {
+		// The command exited non-zero without printing a word. That is a notable
+		// fact about the program under test — arguably the most notable one in
+		// this report — and the block used to stay quiet about it, which is what
+		// a reader also sees when there is no rule at all (#346). Say it instead,
+		// in the one spelling internal/assert already uses.
+		//
+		// Only for a result family that HAS these streams: an HTTP response or a
+		// DB query has no stdout, so "(empty)" there would describe a stream that
+		// does not exist rather than one that was silent.
+		if hasProcessStreams(run) {
+			fmt.Fprintf(b, "\nStdout/Stderr:\n  %s\n", assert.EmptyExcerpt)
+		}
 		return
 	}
 	tail, kept, total := tailLines(stream, failureStreamTail)
@@ -248,6 +260,15 @@ func writeFailureStreams(b *strings.Builder, ck *assert.CheckResult, run *runner
 		return
 	}
 	fmt.Fprintf(b, "\n%s:\n%s\n", label, indent(tail))
+}
+
+// hasProcessStreams reports whether a Result belongs to a family that has
+// stdout/stderr at all — a process run or a pty session. An HTTP, DB, gRPC, or
+// CDP result has its own observable surface (body, rows, message, value) and
+// leaves Stdout/Stderr permanently nil, so describing them as "(empty)" would
+// name a stream that does not exist rather than one that was silent (#346).
+func hasProcessStreams(run *runner.Result) bool {
+	return !run.IsHTTP && !run.IsDB && !run.IsGRPC && !run.IsCDP
 }
 
 // tailLines returns the last n lines of buf (sans trailing newline), how many

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -1271,14 +1271,22 @@ func TestConsole_ExitCodeFailureShowsStderr(t *testing.T) {
 		t.Errorf("exit_code failure with empty stderr does not surface stdout:\n%s", out)
 	}
 
-	// Both empty -> neither section appears.
+	// Both empty -> one section saying so. This used to assert that NEITHER
+	// section appeared, which is the omission #346 replaced: a block with no
+	// stream section reads the same as a block that has no such rule, so a reader
+	// could not tell "the command printed nothing" from "atago did not show it".
+	// The single Stdout/Stderr: section is not either of the per-stream sections
+	// above, so their exclusivity is still asserted.
 	b.Reset()
 	if err := Render(&b, FormatConsole, failedExitResults("", nil, nil)); err != nil {
 		t.Fatal(err)
 	}
 	out = b.String()
-	if strings.Contains(out, "Stderr:") || strings.Contains(out, "Stdout:") {
-		t.Errorf("exit_code failure with no output must not print empty sections:\n%s", out)
+	if strings.Contains(out, "\nStderr:") || strings.Contains(out, "\nStdout:") {
+		t.Errorf("exit_code failure with no output must not print a per-stream section:\n%s", out)
+	}
+	if !strings.Contains(out, "Stdout/Stderr:\n  "+assert.EmptyExcerpt) {
+		t.Errorf("exit_code failure with no output must state that the command printed nothing:\n%s", out)
 	}
 
 	// A long stderr is tailed, newest lines kept, with an honest header.
@@ -1460,4 +1468,150 @@ func TestRender_Console_SingleLineCommandUnchanged(t *testing.T) {
 	if !strings.Contains(v.String(), "[0] assert: atago run probe.atago.yaml\n") {
 		t.Errorf("single-line trace step line changed shape:\n%s", v.String())
 	}
+}
+
+// TestRender_Console_ExitCodeFailureStatesSilence pins that an exit_code failure
+// block states it when the command produced no output at all (#346). The block
+// used to print no stream section in that case — the same thing a reader sees
+// when there is no rule at all — so "the command printed nothing" was
+// indistinguishable from "atago decided not to show it here". A command that
+// exits non-zero without a word is a notable fact about the program under test.
+func TestRender_Console_ExitCodeFailureStatesSilence(t *testing.T) {
+	t.Parallel()
+
+	exitCodeFailure := func(run *runner.Result) []*engine.SuiteResult {
+		return []*engine.SuiteResult{{
+			Suite:  "probe2",
+			Status: engine.StatusFailed,
+			Scenarios: []engine.ScenarioResult{{
+				Name:   "exit code failure with no output at all",
+				Status: engine.StatusFailed,
+				Steps: []engine.StepResult{{Index: 0, Kind: spec.StepAssert, Run: run, Checks: []*assert.CheckResult{{
+					OK: false, Target: string(spec.AssertExitCode), Desc: "assert exit_code is 0",
+					Expected: "exit code 0", Actual: "exit code 7",
+					Hint: "expected exit code 0 but the command exited with 7",
+				}}}},
+			}},
+		}}
+	}
+
+	t.Run("both streams empty says so", func(t *testing.T) {
+		t.Parallel()
+		var b bytes.Buffer
+		if err := Render(&b, FormatConsole, exitCodeFailure(&runner.Result{Command: "exit 7", ExitCode: 7})); err != nil {
+			t.Fatal(err)
+		}
+		out := b.String()
+		if !strings.Contains(out, "Stdout/Stderr:\n  "+assert.EmptyExcerpt+"\n") {
+			t.Errorf("exit_code failure block does not state that the command printed nothing:\n%s", out)
+		}
+	})
+
+	// Guard against the new branch stealing the existing one: a command that did
+	// print to stderr must render exactly what it rendered before.
+	t.Run("non-empty stderr is unchanged", func(t *testing.T) {
+		t.Parallel()
+		var b bytes.Buffer
+		run := &runner.Result{Command: "sh -c 'echo boom 1>&2; exit 7'", ExitCode: 7, Stderr: []byte("boom\n")}
+		if err := Render(&b, FormatConsole, exitCodeFailure(run)); err != nil {
+			t.Fatal(err)
+		}
+		out := b.String()
+		if !strings.Contains(out, "Stderr:\n  boom\n") {
+			t.Errorf("stderr tail section changed shape:\n%s", out)
+		}
+		if strings.Contains(out, "Stdout/Stderr:") {
+			t.Errorf("empty-stream section fired for a command that did print:\n%s", out)
+		}
+	})
+
+	// A result family with no stdout/stderr of its own (an HTTP response, a DB
+	// query) must not grow a "Stdout/Stderr: (empty)" line: those streams are not
+	// merely empty there, they do not exist.
+	t.Run("a non-process result family says nothing", func(t *testing.T) {
+		t.Parallel()
+		var b bytes.Buffer
+		run := &runner.Result{Command: "GET http://x/", IsHTTP: true, StatusCode: 204}
+		if err := Render(&b, FormatConsole, exitCodeFailure(run)); err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(b.String(), "Stdout/Stderr:") {
+			t.Errorf("an http result grew a stdout/stderr section:\n%s", b.String())
+		}
+	})
+}
+
+// TestVerbose_EmptyStreamStatedOnlyWhenItMatters pins the deliberate split
+// #346 asks for: the trace omits an empty stream for a passing step, where the
+// compactness argument is real for a 300-step green trace, and states it for a
+// step that failed or errored — the step the reader came to look at, where the
+// omission makes a silent command indistinguishable from a lost capture.
+func TestVerbose_EmptyStreamStatedOnlyWhenItMatters(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a passing step stays compact", func(t *testing.T) {
+		t.Parallel()
+		var b strings.Builder
+		NewVerbose(&b).Scenario(engine.ScenarioResult{
+			Suite: "demo", Name: "quiet but fine", Status: engine.StatusPassed,
+			Steps: []engine.StepResult{
+				{Index: 0, Kind: spec.StepRun, Run: &runner.Result{Command: "true", ExitCode: 0}},
+				{Index: 1, Kind: spec.StepAssert, Checks: []*assert.CheckResult{{OK: true, Desc: "assert exit_code is 0"}}},
+			},
+		})
+		if strings.Contains(b.String(), "stdout |") || strings.Contains(b.String(), assert.EmptyExcerpt) {
+			t.Errorf("a passing step grew an empty-stream block:\n%s", b.String())
+		}
+	})
+
+	t.Run("a failing scenario states the silence", func(t *testing.T) {
+		t.Parallel()
+		var b strings.Builder
+		NewVerbose(&b).Scenario(engine.ScenarioResult{
+			Suite: "demo", Name: "silent failure", Status: engine.StatusFailed,
+			Steps: []engine.StepResult{
+				{Index: 0, Kind: spec.StepRun, Run: &runner.Result{Command: "exit 7", ExitCode: 7}},
+				{Index: 1, Kind: spec.StepAssert, Checks: []*assert.CheckResult{{Desc: "assert exit_code is 0"}}},
+			},
+		})
+		out := b.String()
+		if !strings.Contains(out, "stdout |\n        "+assert.EmptyExcerpt+"\n") {
+			t.Errorf("trace does not state that stdout was empty:\n%s", out)
+		}
+		if !strings.Contains(out, "stderr |\n        "+assert.EmptyExcerpt+"\n") {
+			t.Errorf("trace does not state that stderr was empty:\n%s", out)
+		}
+	})
+
+	// An errored step in an otherwise-passing scenario (a failed teardown) is
+	// still a step the reader came to look at.
+	t.Run("an errored step states the silence", func(t *testing.T) {
+		t.Parallel()
+		var b strings.Builder
+		NewVerbose(&b).Scenario(engine.ScenarioResult{
+			Suite: "demo", Name: "teardown blew up", Status: engine.StatusPassed,
+			Teardown: []engine.StepResult{
+				{Index: 0, Kind: spec.StepRun, Run: &runner.Result{Command: "cleanup", ExitCode: 0}, ErrMsg: "boom"},
+			},
+		})
+		if !strings.Contains(b.String(), "stdout |\n        "+assert.EmptyExcerpt+"\n") {
+			t.Errorf("an errored teardown step does not state that stdout was empty:\n%s", b.String())
+		}
+	})
+
+	// The rule is applied per family, not only to stdout/stderr: an HTTP 204 with
+	// an empty body has exactly the same ambiguity.
+	t.Run("other result families state it too", func(t *testing.T) {
+		t.Parallel()
+		var b strings.Builder
+		NewVerbose(&b).Scenario(engine.ScenarioResult{
+			Suite: "demo", Name: "empty body", Status: engine.StatusFailed,
+			Steps: []engine.StepResult{
+				{Index: 0, Kind: spec.StepHTTP, Run: &runner.Result{Command: "GET http://x/", IsHTTP: true, StatusCode: 204}},
+			},
+		})
+		if !strings.Contains(b.String(), "body |\n        "+assert.EmptyExcerpt+"\n") {
+			t.Errorf("an http step does not state that the body was empty:\n%s", b.String())
+		}
+	})
 }

--- a/internal/report/verbose.go
+++ b/internal/report/verbose.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/nao1215/atago/internal/assert"
 	"github.com/nao1215/atago/internal/engine"
 )
 
@@ -48,11 +49,16 @@ func (v *Verbose) Scenario(res engine.ScenarioResult) {
 		fmt.Fprintf(&b, "    skipped: %s\n", res.SkipReason)
 	}
 
+	// A trace of a scenario that did not pass is a trace the reader opened to
+	// find something, so its empty streams are stated rather than omitted (#346).
+	// See writeStream for why the split exists at all.
+	interesting := res.Status == engine.StatusFailed || res.Status == engine.StatusError
+
 	for i := range res.Steps {
-		v.writeStep(&b, "", &res.Steps[i])
+		v.writeStep(&b, "", &res.Steps[i], interesting)
 	}
 	for i := range res.Teardown {
-		v.writeStep(&b, "teardown ", &res.Teardown[i])
+		v.writeStep(&b, "teardown ", &res.Teardown[i], interesting)
 	}
 
 	v.mu.Lock()
@@ -63,7 +69,13 @@ func (v *Verbose) Scenario(res engine.ScenarioResult) {
 // writeStep renders one step: its label line, the executed command and outcome
 // for run-family steps, captured output, any execution error, and one verdict
 // line per assertion check.
-func (v *Verbose) writeStep(b *strings.Builder, phase string, sr *engine.StepResult) {
+//
+// scenarioFailed carries down the scenario's own verdict: a step that failed or
+// errored is one the reader came to look at, and so is every step of a scenario
+// that did not pass — the failing assert step carries no Result of its own, so
+// the silent command's own step is where the stream has to be stated (#346).
+func (v *Verbose) writeStep(b *strings.Builder, phase string, sr *engine.StepResult, scenarioFailed bool) {
+	stateEmpty := scenarioFailed || sr.ErrMsg != "" || !assert.AllOK(sr.Checks)
 	label := string(sr.Kind)
 	if sr.Setup {
 		label = setupPhaseLabelFor(*sr)
@@ -83,18 +95,18 @@ func (v *Verbose) writeStep(b *strings.Builder, phase string, sr *engine.StepRes
 		switch {
 		case sr.Run.IsHTTP:
 			fmt.Fprintf(b, "      status %d\n", sr.Run.StatusCode)
-			writeStream(b, "body", sr.Run.Body)
+			writeStream(b, "body", sr.Run.Body, stateEmpty)
 		case sr.Run.IsDB:
-			writeStream(b, "rows", sr.Run.RowsJSON)
+			writeStream(b, "rows", sr.Run.RowsJSON, stateEmpty)
 		case sr.Run.IsGRPC:
 			fmt.Fprintf(b, "      grpc status %d\n", sr.Run.GRPCStatus)
-			writeStream(b, "message", sr.Run.MessageJSON)
+			writeStream(b, "message", sr.Run.MessageJSON, stateEmpty)
 		case sr.Run.IsCDP:
-			writeStream(b, "value", sr.Run.CDPValue)
+			writeStream(b, "value", sr.Run.CDPValue, stateEmpty)
 		default:
 			fmt.Fprintf(b, "      exit %d\n", sr.Run.ExitCode)
-			writeStream(b, "stdout", sr.Run.Stdout)
-			writeStream(b, "stderr", sr.Run.Stderr)
+			writeStream(b, "stdout", sr.Run.Stdout, stateEmpty)
+			writeStream(b, "stderr", sr.Run.Stderr, stateEmpty)
 		}
 	}
 	if sr.ErrMsg != "" {
@@ -113,9 +125,21 @@ func (v *Verbose) writeStep(b *strings.Builder, phase string, sr *engine.StepRes
 }
 
 // writeStream renders one captured stream as an indented block, excerpted at
-// the shared limit. Empty streams are omitted to keep traces compact.
-func writeStream(b *strings.Builder, name string, data []byte) {
+// the shared limit.
+//
+// An empty stream is omitted when stateEmpty is false and stated as (empty)
+// when it is true. The split is deliberate (#346): compactness is a real
+// argument for a 300-step green trace, where an empty stream is not what the
+// reader is scanning for, and no argument at all for the step they opened the
+// trace to read — there, an omitted block makes a command that printed nothing
+// indistinguishable from one whose capture was lost. The rule applies to every
+// result family, not just stdout/stderr: an HTTP 204 with an empty body carries
+// exactly the same ambiguity.
+func writeStream(b *strings.Builder, name string, data []byte, stateEmpty bool) {
 	if len(data) == 0 {
+		if stateEmpty {
+			fmt.Fprintf(b, "      %s |\n        %s\n", name, assert.EmptyExcerpt)
+		}
 		return
 	}
 	s := string(data)

--- a/test/e2e/atago/reports.atago.yaml
+++ b/test/e2e/atago/reports.atago.yaml
@@ -242,3 +242,21 @@ scenarios:
           exit_code: 1
           stdout:
             matches: "Actual:\n  \\(empty\\)"
+
+  - name: an exit_code failure states that the command printed nothing
+    steps:
+      - fixture:
+          file: quiet.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: quiet}
+            scenarios:
+              - name: exit code failure with no output at all
+                steps:
+                  - run: {shell: true, command: "exit 7"}
+                  - assert: {exit_code: 0}
+      - run: {command: "${atago} run quiet.atago.yaml"}
+      - assert:
+          exit_code: 1
+          stdout:
+            matches: "Stdout/Stderr:\n  \\(empty\\)"


### PR DESCRIPTION
Closes #346.

## Problem

#343 fixed one place where the report omits an empty observation instead of stating it. Two more remained, and they were now inconsistent with it.

**1. The `exit_code` failure block.** `writeFailureStreams` inlines the failing command's stderr tail (or stdout when stderr is empty) so the reason for a non-zero exit is visible without `--verbose`. When both streams were empty it returned and printed nothing — the same thing a reader sees when there is no such rule at all. They could not tell "the command printed nothing" from "atago decided not to show it here", and a command that exits 7 without a word is arguably the most notable fact in that report.

**2. The `--verbose` trace.** `writeStream` returned early for an empty stream "to keep traces compact", so a step rendered as `exit 0` with no `stdout |` block whether the command was silent or its capture was lost.

## Change

- `internal/assert`'s `emptyExcerpt` is exported as **`assert.EmptyExcerpt`** and reused by `internal/report`, so the literal is not spelled a second time and the report has one spelling for "there was nothing here".
- **`console.go`**: an `exit_code` failure whose command produced no output at all now renders one section, `Stdout/Stderr:` / `  (empty)`. It fires only for a result family that *has* those streams — a new `hasProcessStreams()` excludes HTTP, DB, gRPC, and CDP results, whose `Stdout`/`Stderr` are permanently nil and whose observable surface is `body`/`rows`/`message`/`value`. Calling those "(empty)" would name a stream that does not exist.
- **`verbose.go`**: `writeStream` takes a `stateEmpty` flag. Passing steps keep omitting an empty stream — the compactness argument is real for a 300-step green trace — and a step the reader came to look at states it. The comment on `writeStream` spells out why the split exists.

  The trigger is `scenario did not pass || step.ErrMsg != "" || a check failed`. The scenario-level term is load-bearing rather than belt-and-braces: the engine gives the *assert* step the failing checks and the *run* step the `Result`, so a step-level-only rule would never fire for the very case in the issue — the silent command's own step is where the stream has to be stated.
- The rule is applied per family in the trace, uniformly: an HTTP 204 with an empty body carries exactly the same ambiguity as a silent command, as the issue notes.

## One existing test changed deliberately

`TestConsole_ExitCodeFailureShowsStderr` asserted "Both empty -> neither section appears" — precisely the omission this issue replaces. Its both-empty case now asserts the new section, and still asserts that neither *per-stream* section (`Stderr:` / `Stdout:`) appears, so the exclusivity between the two remains pinned. Every other report test passes untouched.

## Tests

`internal/report/report_test.go`:

1. An `exit_code` failure with empty `Stdout` and `Stderr` renders the section saying so.
2. An `exit_code` failure with non-empty stderr renders exactly what it rendered before (guarding against the new branch stealing the existing one).
3. An `exit_code` failure on an HTTP result grows no stdout/stderr section.
4. A **passing** step in the verbose trace with an empty stream still prints no stream block.
5. A **failing** scenario's trace prints the empty marker for both `stdout` and `stderr`.
6. An **errored** step in an otherwise-passing scenario (a failed teardown) states it too.
7. An HTTP step with an empty body states it, pinning the per-family decision.

`test/e2e/atago/reports.atago.yaml`: a nested run that fails on `exit_code` with a silent command, asserting the console block reaches the user, placed next to the sibling scenario from #343. `doc/e2e/atago.md` regenerated with `make docs`.

Verified with `go test ./...`, `golangci-lint run` (0 issues), `make e2e` (465 scenarios: 461 passed, 4 skipped), and the `TestDocs_E2EDocsInSync` / `TestSite_InSync` drift guards.