### PR TITLE
feat(assert): point at the other stream when a stream assertion fails

### DIFF
--- a/doc/cookbook.md
+++ b/doc/cookbook.md
@@ -198,6 +198,11 @@ scenarios:
             exists: false
 ```
 
+Getting the stream wrong is easy — plenty of CLIs print their errors to stdout,
+and plenty print progress to stderr. If an assertion fails on one stream while
+the other holds exactly the text you asked for, atago says so in the hint and
+suggests the swap, so you do not have to re-run with `--verbose` to find out.
+
 Full spec: [run_and_assert](../examples/run_and_assert.atago.yaml)
 
 ## Feed stdin to a filter CLI

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 445 scenarios
+74 suites · 446 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -364,7 +364,7 @@
   - [console report prints the same counts in its summary line](#scenario-console-report-prints-the-same-counts-in-its-summary-line)
   - [an all-passing run reports a zero-failure suite and exits zero](#scenario-an-all-passing-run-reports-a-zero-failure-suite-and-exits-zero)
   - [an errored step is counted as an error, not a failure, across formats](#scenario-an-errored-step-is-counted-as-an-error-not-a-failure-across-formats)
-- [atago self-hosting / reports](#atago-self-hosting--reports) — 8 scenarios
+- [atago self-hosting / reports](#atago-self-hosting--reports) — 9 scenarios
   - [JUnit report is XML with a testsuite and testcase](#scenario-junit-report-is-xml-with-a-testsuite-and-testcase)
   - [GitHub Actions annotations are emitted on failure](#scenario-github-actions-annotations-are-emitted-on-failure)
   - [TAP report is a numbered TAP 13 stream with ok / not ok points](#scenario-tap-report-is-a-numbered-tap-13-stream-with-ok--not-ok-points)
@@ -373,6 +373,7 @@
   - [a failure names the command it was observed under](#scenario-a-failure-names-the-command-it-was-observed-under)
   - [a failure against an empty stream reports the stream as empty](#scenario-a-failure-against-an-empty-stream-reports-the-stream-as-empty)
   - [an exit_code failure states that the command printed nothing](#scenario-an-exit_code-failure-states-that-the-command-printed-nothing)
+  - [a stdout failure points at stderr when the text is there](#scenario-a-stdout-failure-points-at-stderr-when-the-text-is-there)
 - [atago self-hosting / rerun-failed](#atago-self-hosting--rerun-failed) — 5 scenarios
   - [a failing run is recorded and rerun-failed selects only it](#scenario-a-failing-run-is-recorded-and-rerun-failed-selects-only-it)
   - [rerun-failed with nothing recorded is a no-op success](#scenario-rerun-failed-with-nothing-recorded-is-a-no-op-success)
@@ -6834,6 +6835,27 @@ ${atago} run quiet.atago.yaml
 - exit code is `1`
 - stdout matches `/Stdout/Stderr:
   \(empty\)/`
+### Scenario: a stdout failure points at stderr when the text is there
+#### Given
+- Fixture file `wrongstream.atago.yaml` is created.
+#### Inputs
+_Fixture `wrongstream.atago.yaml`:_
+```text
+version: "1"
+suite: {name: wrongstream}
+scenarios:
+  - name: assert stdout when the tool prints to stderr
+    steps:
+      - run: {shell: true, command: "printf 'boom: no such file\n' 1>&2; exit 1"}
+      - assert: {stdout: {contains: "boom"}}
+```
+#### When
+```shell
+${atago} run wrongstream.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `stderr satisfies this assertion (assert `stderr:` instead?)`
 ## atago self-hosting / rerun-failed
 Source: `test/e2e/atago/rerun.atago.yaml`
 ### Scenario: a failing run is recorded and rerun-failed selects only it

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -157,9 +157,11 @@ func checkTarget(a *spec.Assert, target spec.AssertTarget, res *runner.Result, e
 	case spec.AssertExitCode:
 		return checkExitCode(a.ExitCode, res)
 	case spec.AssertStdout:
-		return checkStream("stdout", a.Stdout, streamBytes(res, "stdout"), res != nil, env)
+		return withCounterpartHint("stdout", a.Stdout, res, env,
+			checkStream("stdout", a.Stdout, streamBytes(res, "stdout"), res != nil, env))
 	case spec.AssertStderr:
-		return checkStream("stderr", a.Stderr, streamBytes(res, "stderr"), res != nil, env)
+		return withCounterpartHint("stderr", a.Stderr, res, env,
+			checkStream("stderr", a.Stderr, streamBytes(res, "stderr"), res != nil, env))
 	case spec.AssertFile:
 		return checkFile(a.File, env)
 	case spec.AssertStatus:
@@ -193,6 +195,70 @@ func checkTarget(a *spec.Assert, target spec.AssertTarget, res *runner.Result, e
 	default:
 		return &CheckResult{Desc: string(target), Hint: "assertion target not supported yet"}
 	}
+}
+
+// withCounterpartHint appends a suggestion to a failed stdout/stderr check when
+// the OTHER stream satisfies the very same assertion (#347). Asserting `stdout:`
+// on text a CLI actually prints to `stderr` is the most common mistake in CLI
+// end-to-end testing, and atago holds both streams while it reports the failure
+// — the answer used to sit in `--verbose` output the reader had to go find,
+// costing a round trip per occurrence in CI.
+//
+// It is a post-pass on the returned result, so checkStream stays unaware of
+// streams it does not own. It never changes the verdict, and it exists only for
+// the stdout/stderr pair: body/rows/message/value have no counterpart and the
+// code must not pretend otherwise.
+func withCounterpartHint(name string, s *spec.StreamAssert, res *runner.Result, env Env, out *CheckResult) *CheckResult {
+	if out == nil || out.OK || s == nil || res == nil || !canSuggestCounterpart(s) {
+		return out
+	}
+	other := "stderr"
+	if name == "stderr" {
+		other = "stdout"
+	}
+	// Re-run the SAME assertion through the SAME code path against the other
+	// stream. Anything less would have to re-derive CRLF folding and the `line:`
+	// selector, and a suggestion that is wrong on Windows — or wrong for a
+	// line-scoped assert — is worse than no suggestion at all. A `line:` that the
+	// counterpart does not have therefore simply fails to satisfy the assertion,
+	// and no suggestion is made.
+	if !checkStream(other, s, streamBytes(res, other), true, env).OK {
+		return out
+	}
+	suggestion := fmt.Sprintf("%s satisfies this assertion (assert `%s:` instead?)", other, other)
+	if out.Hint == "" {
+		out.Hint = suggestion
+	} else {
+		out.Hint += " — but " + suggestion
+	}
+	return out
+}
+
+// canSuggestCounterpart reports whether every matcher set on s is one whose
+// success against the other stream is evidence the author named the wrong one.
+//
+// Only the positive text matchers qualify. A negative matcher proves nothing: a
+// needle being absent from stderr too is not a reason to assert stderr. `empty`
+// is trivially satisfied by any silent stream and would fire constantly. `json`
+// and `yaml` compare a parsed document, where "the other stream also parses"
+// says little. `snapshot` is excluded for a second reason as well: re-running it
+// would compare against — and under --update-snapshots write — a golden file.
+//
+// Every set matcher must qualify, so a mixed assert (contains + not_contains)
+// stays silent rather than suggesting on the strength of half of it.
+func canSuggestCounterpart(s *spec.StreamAssert) bool {
+	set := s.SetMatchers()
+	if len(set) == 0 {
+		return false
+	}
+	for _, m := range set {
+		switch m {
+		case "contains", "matches", "equals":
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func streamBytes(res *runner.Result, which string) []byte {

--- a/internal/assert/assert_test.go
+++ b/internal/assert/assert_test.go
@@ -2491,3 +2491,165 @@ func TestCheckTarget_CoversEveryAssertTarget(t *testing.T) {
 		}
 	}
 }
+
+// TestCheckStream_WrongStreamHint covers #347: asserting `stdout:` on text a CLI
+// actually prints to `stderr` is the most common mistake in CLI end-to-end
+// testing, and atago holds both streams when it reports the failure. The hint
+// now names the counterpart when — and only when — the counterpart genuinely
+// satisfies the very same assertion. A wrong suggestion would be worse than
+// none, so the whole matcher is re-run against the other stream through the
+// same code path rather than approximated.
+func TestCheckStream_WrongStreamHint(t *testing.T) {
+	t.Parallel()
+
+	const suggestion = "(assert `stderr:` instead?)"
+	const mirrorSuggestion = "(assert `stdout:` instead?)"
+
+	t.Run("contains: the needle is on stderr", func(t *testing.T) {
+		t.Parallel()
+		res := &runner.Result{Stderr: []byte("boom: no such file\n"), ExitCode: 1}
+		got := Check(&spec.Assert{Stdout: &spec.StreamAssert{Contains: spec.StringList{"boom"}}}, res, Env{})
+		if got.OK {
+			t.Fatalf("assertion should still fail: %+v", got)
+		}
+		if !strings.Contains(got.Hint, "stderr") || !strings.Contains(got.Hint, suggestion) {
+			t.Errorf("hint does not point at stderr: %q", got.Hint)
+		}
+		// The original hint must survive: the suggestion is appended, not a
+		// replacement for what actually failed.
+		if !strings.Contains(got.Hint, `the substring "boom" was not present in stdout`) {
+			t.Errorf("hint lost the original explanation: %q", got.Hint)
+		}
+	})
+
+	t.Run("the mirror: the needle is on stdout", func(t *testing.T) {
+		t.Parallel()
+		res := &runner.Result{Stdout: []byte("all good\n")}
+		got := Check(&spec.Assert{Stderr: &spec.StreamAssert{Contains: spec.StringList{"all good"}}}, res, Env{})
+		if got.OK {
+			t.Fatalf("assertion should still fail: %+v", got)
+		}
+		if !strings.Contains(got.Hint, mirrorSuggestion) {
+			t.Errorf("hint does not point at stdout: %q", got.Hint)
+		}
+	})
+
+	t.Run("absent from both: today's hint, unchanged", func(t *testing.T) {
+		t.Parallel()
+		res := &runner.Result{Stdout: []byte("nothing here\n"), Stderr: []byte("nor here\n")}
+		got := Check(&spec.Assert{Stdout: &spec.StreamAssert{Contains: spec.StringList{"boom"}}}, res, Env{})
+		if got.Hint != `the substring "boom" was not present in stdout` {
+			t.Errorf("hint should be unchanged when neither stream matches: %q", got.Hint)
+		}
+	})
+
+	t.Run("matches: fires on a real match, silent on an anchored miss", func(t *testing.T) {
+		t.Parallel()
+		res := &runner.Result{Stderr: []byte("error: bad token\n")}
+		got := Check(&spec.Assert{Stdout: &spec.StreamAssert{Matches: strp("bad tok")}}, res, Env{})
+		if !strings.Contains(got.Hint, suggestion) {
+			t.Errorf("matches should fire when the counterpart matches: %q", got.Hint)
+		}
+		// An anchored pattern the counterpart does NOT satisfy must stay silent.
+		got = Check(&spec.Assert{Stdout: &spec.StreamAssert{Matches: strp("^bad token$")}}, res, Env{})
+		if strings.Contains(got.Hint, suggestion) {
+			t.Errorf("matches suggested a stream that does not satisfy the pattern: %q", got.Hint)
+		}
+	})
+
+	t.Run("equals fires only on an exact counterpart", func(t *testing.T) {
+		t.Parallel()
+		exact := &runner.Result{Stderr: []byte("done\n")}
+		got := Check(&spec.Assert{Stdout: &spec.StreamAssert{Equals: strp("done\n")}}, exact, Env{})
+		if !strings.Contains(got.Hint, suggestion) {
+			t.Errorf("equals should fire when the counterpart is exactly the expected text: %q", got.Hint)
+		}
+		partial := &runner.Result{Stderr: []byte("done, mostly\n")}
+		got = Check(&spec.Assert{Stdout: &spec.StreamAssert{Equals: strp("done\n")}}, partial, Env{})
+		if strings.Contains(got.Hint, suggestion) {
+			t.Errorf("equals suggested a counterpart that only partly matches: %q", got.Hint)
+		}
+	})
+
+	// CRLF folding is the primary matcher's rule, so the counterpart check must
+	// use it too or the suggestion would be silently wrong on Windows.
+	t.Run("CRLF on the counterpart still fires", func(t *testing.T) {
+		t.Parallel()
+		res := &runner.Result{Stderr: []byte("boom\r\n")}
+		got := Check(&spec.Assert{Stdout: &spec.StreamAssert{Contains: spec.StringList{"boom"}}}, res, Env{})
+		if !strings.Contains(got.Hint, suggestion) {
+			t.Errorf("CRLF counterpart did not fire the hint: %q", got.Hint)
+		}
+	})
+
+	// A `line:` selector is applied to the counterpart identically, so a
+	// counterpart that has no such line simply does not satisfy the assertion
+	// and no suggestion is made. This is the pinned contract.
+	t.Run("line: is applied to the counterpart identically", func(t *testing.T) {
+		t.Parallel()
+		res := &runner.Result{Stdout: []byte("first\n"), Stderr: []byte("only one line\n")}
+		got := Check(&spec.Assert{Stdout: &spec.StreamAssert{Line: intp(2), Contains: spec.StringList{"only"}}}, res, Env{})
+		if strings.Contains(got.Hint, suggestion) {
+			t.Errorf("line 2 does not exist on the counterpart; no suggestion should be made: %q", got.Hint)
+		}
+		// When the counterpart DOES have that line and it matches, it fires.
+		res = &runner.Result{Stdout: []byte("a\nb\n"), Stderr: []byte("x\nboom\n")}
+		got = Check(&spec.Assert{Stdout: &spec.StreamAssert{Line: intp(2), Contains: spec.StringList{"boom"}}}, res, Env{})
+		if !strings.Contains(got.Hint, suggestion) {
+			t.Errorf("a matching counterpart line should fire the hint: %q", got.Hint)
+		}
+	})
+
+	// Negative matchers prove nothing about the counterpart: an absence there is
+	// not evidence the author meant the other stream. Whole-stream and
+	// golden-file matchers are excluded too — re-running `snapshot:` against the
+	// counterpart would compare (or under --update-snapshots write) a golden.
+	t.Run("only positive text matchers can suggest", func(t *testing.T) {
+		t.Parallel()
+		res := &runner.Result{Stdout: []byte("boom\n"), Stderr: []byte("quiet\n")}
+		for name, a := range map[string]*spec.StreamAssert{
+			"not_contains": {NotContains: spec.StringList{"boom"}},
+			"not_matches":  {NotMatches: strp("boom")},
+			"empty":        {Empty: boolp(true)},
+			"snapshot":     {Snapshot: "snaps/out.txt"},
+			"mixed":        {Contains: spec.StringList{"quiet"}, NotContains: spec.StringList{"nothing"}},
+		} {
+			got := Check(&spec.Assert{Stdout: a}, res, Env{})
+			if got.OK {
+				continue // nothing to suggest on a passing check
+			}
+			if strings.Contains(got.Hint, suggestion) {
+				t.Errorf("%s must not suggest the counterpart: %q", name, got.Hint)
+			}
+		}
+	})
+
+	// The suggestion is about the stdout/stderr pair only. body/rows/message/
+	// value have no counterpart and the code must not pretend otherwise.
+	t.Run("other targets never grow the hint", func(t *testing.T) {
+		t.Parallel()
+		res := &runner.Result{IsHTTP: true, StatusCode: 200, Body: []byte("{}"), Stderr: []byte("boom")}
+		got := Check(&spec.Assert{Body: &spec.StreamAssert{Contains: spec.StringList{"boom"}}}, res, Env{})
+		if got.OK {
+			t.Fatalf("body assertion should fail: %+v", got)
+		}
+		if strings.Contains(got.Hint, "instead?") {
+			t.Errorf("body grew a counterpart suggestion: %q", got.Hint)
+		}
+		db := &runner.Result{IsDB: true, RowsJSON: []byte("[]"), Stdout: []byte("boom")}
+		got = Check(&spec.Assert{Rows: &spec.StreamAssert{Contains: spec.StringList{"boom"}}}, db, Env{})
+		if strings.Contains(got.Hint, "instead?") {
+			t.Errorf("rows grew a counterpart suggestion: %q", got.Hint)
+		}
+	})
+
+	// The verdict is never changed by the hint.
+	t.Run("the verdict is untouched", func(t *testing.T) {
+		t.Parallel()
+		res := &runner.Result{Stderr: []byte("boom\n")}
+		got := Check(&spec.Assert{Stdout: &spec.StreamAssert{Contains: spec.StringList{"boom"}}}, res, Env{})
+		if got.OK {
+			t.Error("the hint must not turn a failing assertion green")
+		}
+	})
+}

--- a/test/e2e/atago/reports.atago.yaml
+++ b/test/e2e/atago/reports.atago.yaml
@@ -260,3 +260,24 @@ scenarios:
           exit_code: 1
           stdout:
             matches: "Stdout/Stderr:\n  \\(empty\\)"
+
+  # Asserting the wrong stream is the most common mistake in CLI E2E testing,
+  # and atago holds both streams when it reports the failure. The hint names the
+  # counterpart rather than leaving the reader to re-run with --verbose (#347).
+  - name: a stdout failure points at stderr when the text is there
+    steps:
+      - fixture:
+          file: wrongstream.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: wrongstream}
+            scenarios:
+              - name: assert stdout when the tool prints to stderr
+                steps:
+                  - run: {shell: true, command: "printf 'boom: no such file\n' 1>&2; exit 1"}
+                  - assert: {stdout: {contains: "boom"}}
+      - run: {command: "${atago} run wrongstream.atago.yaml"}
+      - assert:
+          exit_code: 1
+          stdout:
+            contains: "stderr satisfies this assertion (assert `stderr:` instead?)"


### PR DESCRIPTION
Closes #347.

## Problem

Asserting `stdout:` on text a CLI actually prints to `stderr` is the single most common mistake in CLI end-to-end testing, and atago has every piece of information needed to name it — but did not.

```
Expected:
  stdout contains "boom"

Actual:
  (empty)

Hint:
  the substring "boom" was not present in stdout
```

True and useless. `--verbose` on the same run printed `stderr | boom: no such file`, so atago held the answer the whole time and made the reader go find it. In CI, where the console block is what lands in the log, that is a round trip per occurrence.

## Change

When a `stdout:`/`stderr:` text matcher fails and the counterpart stream satisfies **the same** assertion, the hint says so:

```
Hint:
  the substring "boom" was not present in stdout — but stderr satisfies this assertion (assert `stderr:` instead?)
```

`withCounterpartHint` is a post-pass on the returned `*CheckResult`, exactly the shape the issue suggests, so `checkStream` stays unaware of streams it does not own.

**How the counterpart is tested.** By re-running the same `*spec.StreamAssert` through `checkStream` against the other stream. Approximating the match would mean re-deriving CRLF folding and the `line:` selector, and a suggestion that is right on POSIX and wrong on Windows — or wrong for a line-scoped assert — is worse than none. This also settles the `line:` question the issue leaves open: it is applied to the counterpart **identically**, so a `line: 2` the counterpart does not have simply fails to satisfy the assertion and no suggestion is made. That contract is pinned by a test.

**Which matchers can suggest.** `contains`, `matches`, `equals` — and every matcher set on the assert must qualify, so a mixed `contains` + `not_contains` stays silent rather than suggesting on the strength of half of it. Excluded, with the reasoning in the code:

- `not_contains` / `not_matches` / `not_equals`: an absence on the other stream proves nothing.
- `empty`: trivially satisfied by any silent stream; it would fire constantly.
- `json` / `yaml`: "the other stream also parses" says little.
- `snapshot`: the same, plus a second reason — re-running it would compare against, and under `--update-snapshots` **write**, a golden file.

**Scope.** stdout/stderr only. `body`/`rows`/`message`/`value` have no counterpart. Hint text only; the verdict is never changed.

## Wording

The issue sketches `— but it IS present in stderr`, which reads well for `contains` and poorly for `matches`. One wording that is accurate for all three matchers is used instead: `— but stderr satisfies this assertion (assert \`stderr:\` instead?)`.

## Tests

`internal/assert/assert_test.go`, `TestCheckStream_WrongStreamHint`:

1. `contains` fails on stdout, needle on stderr → hint names stderr and suggests it, and the original explanation survives (the suggestion is appended, not a replacement).
2. The mirror: fails on stderr, needle on stdout.
3. Absent from both → the hint is byte-for-byte today's text.
4. `matches` fires on a real match; an anchored pattern the counterpart does not satisfy stays silent. `equals` fires on an exact counterpart and stays silent on a partial one.
5. CRLF: counterpart holds `boom\r\n`, needle `boom` → fires, same folding as the primary matcher.
6. `line: 2` against a one-line counterpart → silent; `line: 2` against a counterpart whose line 2 matches → fires. The contract, pinned.
7. `not_contains`, `not_matches`, `empty`, `snapshot`, and a mixed assert never suggest.
8. `body` and `rows` never grow the hint.
9. The verdict is untouched.

`test/e2e/atago/reports.atago.yaml`: a nested run whose stdout assert fails while stderr carries the text, asserting the suggestion reaches the console block. `doc/e2e/atago.md` regenerated with `make docs`.

`doc/cookbook.md`: two sentences in `## Test error handling: exit codes and stderr` noting that atago points this out. `TestCookbook_SnippetsValid` and `TestSite_InSync` both pass; `doc/` is mounted by the Hugo site so this publishes with no second copy.

No new `examples/` file: `examples/run_and_assert.atago.yaml` already demonstrates `stderr:`, and a wrong-stream example would be an example of a mistake.

Verified with `go test ./...`, `golangci-lint run` (0 issues), and `make e2e` (465 scenarios: 461 passed, 4 skipped).