### PR TITLE
fix(pty): report a transcript cut short by a read error instead of asserting on it

### DIFF
--- a/internal/conpty/conpty_windows.go
+++ b/internal/conpty/conpty_windows.go
@@ -13,7 +13,9 @@ package conpty
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"sync"
@@ -172,15 +174,48 @@ func Start(commandLine, workDir string, env []string, rows, cols int) (*PseudoCo
 	}, nil
 }
 
-// Read drains the child's output (the transcript source). A broken/closed pipe
-// once the child exits is the ConPTY analog of POSIX EIO: it surfaces as an
-// error so the reader loop ends cleanly (after appending any final bytes).
+// Read drains the child's output (the transcript source).
+//
+// The error class is preserved, because the caller has to tell the end of a
+// session from a lost transcript (#345). This used to collapse every ReadFile
+// failure into os.ErrClosed, so the pty runner could not distinguish them even
+// if it wanted to — and a short transcript then produced a confidently wrong
+// screen assertion. The mapping:
+//
+//   - ERROR_BROKEN_PIPE / ERROR_HANDLE_EOF / ERROR_PIPE_NOT_CONNECTED are the
+//     ConPTY analog of POSIX EIO once the child is gone: the session ended, so
+//     they become io.EOF and the reader loop ends cleanly after appending any
+//     final bytes.
+//   - ERROR_INVALID_HANDLE / ERROR_OPERATION_ABORTED are what a pending read
+//     sees when Close runs on another goroutine — atago's own teardown, not a
+//     failure — so they stay os.ErrClosed, which the caller also treats as a
+//     normal end.
+//   - Anything else is a genuine read failure and is returned wrapped, so the
+//     caller can report the transcript as incomplete instead of silently
+//     truncating it.
 func (c *PseudoConsole) Read(p []byte) (int, error) {
 	var done uint32
 	if err := windows.ReadFile(c.outRead, p, &done, nil); err != nil {
-		return int(done), os.ErrClosed
+		return int(done), classifyReadError(err)
 	}
 	return int(done), nil
+}
+
+// classifyReadError implements Read's mapping. It is separate so the
+// classification is testable without a live pseudo console, which cannot be
+// made to fail on demand.
+func classifyReadError(err error) error {
+	switch {
+	case errors.Is(err, windows.ERROR_BROKEN_PIPE),
+		errors.Is(err, windows.ERROR_HANDLE_EOF),
+		errors.Is(err, windows.ERROR_PIPE_NOT_CONNECTED):
+		return io.EOF
+	case errors.Is(err, windows.ERROR_INVALID_HANDLE),
+		errors.Is(err, windows.ERROR_OPERATION_ABORTED):
+		return os.ErrClosed
+	default:
+		return fmt.Errorf("conpty: reading the pseudo console: %w", err)
+	}
 }
 
 // Write delivers a send to the child.

--- a/internal/conpty/conpty_windows_test.go
+++ b/internal/conpty/conpty_windows_test.go
@@ -2,7 +2,14 @@
 
 package conpty
 
-import "testing"
+import (
+	"errors"
+	"io"
+	"os"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
 
 // TestCommandLine covers how a command becomes the single command line ConPTY
 // hands to CreateProcess: a shell command reuses cmd.exe's `/S /C "<command>"`
@@ -30,6 +37,47 @@ func TestCommandLine(t *testing.T) {
 			}
 			if got != c.want {
 				t.Errorf("CommandLine(%q, %v) = %q, want %q", c.command, c.shell, got, c.want)
+			}
+		})
+	}
+}
+
+// TestReadErrorClassification pins the mapping Read applies to a ReadFile
+// failure (#345). Collapsing every failure into os.ErrClosed left the pty
+// runner unable to tell the end of a session from a lost transcript, so a
+// truncated transcript produced a confidently wrong screen assertion. The
+// end-of-session codes must read as io.EOF, atago's own close must read as
+// os.ErrClosed, and anything else must be neither — a genuine failure the
+// caller has to report.
+func TestReadErrorClassification(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		err     error
+		wantEOF bool
+		wantClo bool
+	}{
+		{"broken pipe is the end of a session", windows.ERROR_BROKEN_PIPE, true, false},
+		{"handle eof is the end of a session", windows.ERROR_HANDLE_EOF, true, false},
+		{"pipe not connected is the end of a session", windows.ERROR_PIPE_NOT_CONNECTED, true, false},
+		{"invalid handle is our own close", windows.ERROR_INVALID_HANDLE, false, true},
+		{"aborted is our own close", windows.ERROR_OPERATION_ABORTED, false, true},
+		{"access denied is a real failure", windows.ERROR_ACCESS_DENIED, false, false},
+		{"not enough memory is a real failure", windows.ERROR_NOT_ENOUGH_MEMORY, false, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			got := classifyReadError(c.err)
+			if errors.Is(got, io.EOF) != c.wantEOF {
+				t.Errorf("errors.Is(%v, io.EOF) = %v, want %v", got, !c.wantEOF, c.wantEOF)
+			}
+			if errors.Is(got, os.ErrClosed) != c.wantClo {
+				t.Errorf("errors.Is(%v, os.ErrClosed) = %v, want %v", got, !c.wantClo, c.wantClo)
+			}
+			// A real failure must still carry its cause so the report can name it.
+			if !c.wantEOF && !c.wantClo && !errors.Is(got, c.err) {
+				t.Errorf("a real failure lost its cause: %v does not wrap %v", got, c.err)
 			}
 		})
 	}

--- a/internal/engine/pty_test.go
+++ b/internal/engine/pty_test.go
@@ -605,3 +605,67 @@ scenarios:
 		t.Errorf("Hint = %q, still offers a bigger timeout for a finished session", ck.Hint)
 	}
 }
+
+// TestEngine_PTY_ErroredStepIsNotAFailedAssertion pins the routing a lost
+// transcript depends on (#345): the engine gives a pty step's hard error and its
+// expect failure two DIFFERENT verdicts, and the reports treat them differently.
+// An error is StatusError carrying an ErrMsg and no checks — nothing was
+// asserted, because atago could not observe the session. A never-matching expect
+// is StatusFailed carrying a failing check. A transcript atago knows is
+// incomplete takes the first path, so it can never be reported as the spec's
+// assertion being wrong about output that never arrived.
+func TestEngine_PTY_ErroredStepIsNotAFailedAssertion(t *testing.T) {
+	skipOnWindows(t)
+	t.Parallel()
+
+	// An execution error: the send never resolves, so the session cannot run.
+	errored := runSpec(t, `
+version: "1"
+suite:
+  name: verdicts
+scenarios:
+  - name: the step could not run
+    steps:
+      - pty:
+          command: cat
+          timeout: 10s
+          session:
+            - send: "${no_such_var}\n"
+`)
+	if errored.Status != StatusError {
+		t.Fatalf("status = %s, want error: %+v", errored.Status, errored.Scenarios)
+	}
+	step := errored.Scenarios[0].Steps[0]
+	if step.ErrMsg == "" {
+		t.Error("an errored pty step must carry an ErrMsg")
+	}
+	if len(step.Checks) != 0 {
+		t.Errorf("an errored pty step must assert nothing, got %+v", step.Checks)
+	}
+
+	// A failed assertion: the session ran and observed everything; the expect
+	// simply never matched.
+	failed := runSpec(t, `
+version: "1"
+suite:
+  name: verdicts
+scenarios:
+  - name: the step ran and the expect did not match
+    steps:
+      - pty:
+          command: cat
+          timeout: 2s
+          session:
+            - expect: "never-going-to-appear"
+`)
+	if failed.Status != StatusFailed {
+		t.Fatalf("status = %s, want failed: %+v", failed.Status, failed.Scenarios)
+	}
+	fstep := failed.Scenarios[0].Steps[0]
+	if fstep.ErrMsg != "" {
+		t.Errorf("a failed expect must not be reported as an execution error: %q", fstep.ErrMsg)
+	}
+	if len(fstep.Checks) == 0 || fstep.Checks[0].OK {
+		t.Fatalf("want a failing expect check, got %+v", fstep.Checks)
+	}
+}

--- a/internal/runner/ptyrun/session.go
+++ b/internal/runner/ptyrun/session.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/nao1215/atago/internal/assert"
@@ -72,8 +74,17 @@ func driveSession(ctx context.Context, p *spec.PTY, proc ptyProcess) (*runner.Re
 	// Transcript accumulator: one goroutine drains the master so the child never
 	// blocks on a full terminal buffer. Reads end when the child exits (EOF/EIO)
 	// or the master is closed.
+	//
+	// readErr holds the error that ended the loop when it is NOT one of those
+	// ends (#345). Every error used to end the loop the same way, so a transcript
+	// lost to a real read failure left exactly the state a completed session
+	// leaves — and every expect_screen/screen/transcript assertion afterwards ran
+	// against a partial transcript atago believed was whole. finish reads it and
+	// refuses to hand back a Result at all, the same call the cmd runner makes
+	// for a cut-short capture (#343).
 	var mu sync.Mutex
 	var transcript []byte
+	var readErr error
 	readDone := make(chan struct{})
 	go func() {
 		defer close(readDone)
@@ -86,9 +97,20 @@ func driveSession(ctx context.Context, p *spec.PTY, proc ptyProcess) (*runner.Re
 				mu.Unlock()
 				queries.consume(buf[:n])
 			}
-			if rerr != nil {
-				return
+			if rerr == nil {
+				continue
 			}
+			// An interrupted read is not an end: resume it, or a signal
+			// arriving mid-read truncates the transcript.
+			if errors.Is(rerr, syscall.EINTR) {
+				continue
+			}
+			if !isSessionEnd(rerr) {
+				mu.Lock()
+				readErr = rerr
+				mu.Unlock()
+			}
+			return
 		}
 	}()
 	snapshot := func() []byte {
@@ -152,6 +174,25 @@ func driveSession(ctx context.Context, p *spec.PTY, proc ptyProcess) (*runner.Re
 		proc.closeTerm()
 		<-readDone
 		tr := snapshot()
+		// A transcript atago knows is incomplete must not become a Result: an
+		// expect_screen compared against missing bytes is a confidently wrong
+		// verdict, and it would read as the spec's fault rather than atago's. So
+		// this outranks even a pending ExpectFailure — that expect may have failed
+		// only because the bytes never arrived.
+		//
+		// Every caller of finish has already reaped the child (the session loop
+		// receives proc.exit; abort and failHard kill and wait), so an end-of-
+		// session read error accepted here is by construction one that arrived
+		// after the child exited. That is why the reader can classify on the error
+		// alone without racing the exit.
+		mu.Lock()
+		rerr := readErr
+		mu.Unlock()
+		if rerr != nil {
+			return nil, nil, fmt.Errorf(
+				"pty %q: the terminal transcript is incomplete — reading the terminal failed after %d bytes: %w",
+				p.Command, len(tr), rerr)
+		}
 		res := &runner.Result{
 			Command:  p.Command,
 			Stdout:   tr,
@@ -342,6 +383,29 @@ func driveSession(ctx context.Context, p *spec.PTY, proc ptyProcess) (*runner.Re
 		}
 		return abort(nil)
 	}
+}
+
+// isSessionEnd reports whether a terminal read error is how a session ends
+// rather than how a transcript is lost (#345).
+//
+// Three things end a pty session normally. io.EOF is the generic one. syscall.EIO
+// is what a POSIX master returns once the last slave handle is gone — the child
+// exited — and on Windows conpty.Read maps the equivalent ConPTY conditions
+// (ERROR_BROKEN_PIPE, ERROR_HANDLE_EOF, ERROR_PIPE_NOT_CONNECTED) to io.EOF, so
+// this list stays platform-neutral. fs.ErrClosed covers atago's own
+// proc.closeTerm: finish closes the master and then waits for the drain
+// goroutine, whose pending read fails precisely because of that close.
+//
+// Everything else is a read that failed for a reason atago did not cause and
+// cannot account for, which means the transcript is short by an unknown amount.
+// The service runner already holds this line — its syncBuffer prefixes a
+// truncated log with how many bytes it dropped — and truncation must not be
+// silent in the runner whose whole output is one accumulated stream.
+func isSessionEnd(err error) bool {
+	return errors.Is(err, io.EOF) ||
+		errors.Is(err, syscall.EIO) ||
+		errors.Is(err, fs.ErrClosed) ||
+		errors.Is(err, io.ErrClosedPipe)
 }
 
 func sessionWaitContext(parent context.Context, timeout string) (context.Context, context.CancelFunc) {

--- a/internal/runner/ptyrun/session_test.go
+++ b/internal/runner/ptyrun/session_test.go
@@ -1,0 +1,228 @@
+package ptyrun
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/nao1215/atago/internal/spec"
+)
+
+// readStep is one scripted outcome of a Read: some bytes, or an error, in the
+// order the drain loop will see them.
+type readStep struct {
+	data []byte
+	err  error
+}
+
+func bytesStep(s string) readStep { return readStep{data: []byte(s)} }
+func errStep(err error) readStep  { return readStep{err: err} }
+
+// fakePTY is a scripted terminal master: each Read returns the next step, and
+// once the script is exhausted it returns end forever (or blocks until
+// closeTerm when end is nil). It lets driveSession's drain loop be driven
+// deterministically — including down error paths a real pty cannot be made to
+// take on demand.
+type fakePTY struct {
+	mu     sync.Mutex
+	script []readStep
+	// end terminates the read loop once the script runs out. Nil means the
+	// terminal simply has nothing more to say until it is closed.
+	end error
+	// closed reports that closeTerm was called; a Read after that fails the way
+	// a read on a closed handle does.
+	closed bool
+	writes []byte
+}
+
+func (f *fakePTY) Read(p []byte) (int, error) {
+	for {
+		f.mu.Lock()
+		if f.closed {
+			f.mu.Unlock()
+			return 0, io.ErrClosedPipe
+		}
+		if len(f.script) > 0 {
+			step := f.script[0]
+			f.script = f.script[1:]
+			f.mu.Unlock()
+			if step.err != nil {
+				return 0, step.err
+			}
+			return copy(p, step.data), nil
+		}
+		end := f.end
+		f.mu.Unlock()
+		if end != nil {
+			return 0, end
+		}
+		// Nothing left and no terminating error: block until closed rather than
+		// spinning, mirroring a live terminal with nothing to say.
+		time.Sleep(pollInterval)
+	}
+}
+
+func (f *fakePTY) Write(p []byte) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.writes = append(f.writes, p...)
+	return len(p), nil
+}
+
+func (f *fakePTY) close() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closed = true
+}
+
+// fakeSession wires a fakePTY into a ptyProcess whose child has already exited
+// with code, which is the state driveSession's finish path always runs in.
+func fakeSession(f *fakePTY, code int) ptyProcess {
+	exit := make(chan int, 1)
+	exit <- code
+	return ptyProcess{
+		rw:        f,
+		exit:      exit,
+		kill:      func() {},
+		closeTerm: f.close,
+		dir:       "/tmp/fake",
+	}
+}
+
+// TestDriveSession_ReadErrorIsNotSilence is the #345 regression. Every read
+// error used to end the drain loop identically, so a transcript lost to a real
+// read failure was indistinguishable from a session that simply ended — and
+// every screen/transcript assertion afterwards ran against a partial transcript
+// atago believed was complete. A lost transcript must be a hard error naming the
+// pty step, not a confidently wrong assertion.
+func TestDriveSession_ReadErrorIsNotSilence(t *testing.T) {
+	t.Parallel()
+	f := &fakePTY{script: []readStep{bytesStep("hello")}, end: syscall.EBADF}
+	p := &spec.PTY{Command: "mytool"}
+
+	res, ef, err := driveSession(context.Background(), p, fakeSession(f, 0))
+	if err == nil {
+		t.Fatalf("a lost transcript must be an error; got res=%+v ef=%+v", res, ef)
+	}
+	for _, want := range []string{"pty", "mytool", "incomplete"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q should mention %q", err, want)
+		}
+	}
+	// The contract, pinned so it cannot silently change: no Result reaches the
+	// caller, so no assertion can run against the partial transcript. The bytes
+	// read before the failure are named in the message instead.
+	if res != nil {
+		t.Errorf("a lost transcript must not hand back a Result: %+v", res)
+	}
+	if ef != nil {
+		t.Errorf("a lost transcript is not an expect failure: %+v", ef)
+	}
+	if !strings.Contains(err.Error(), "5 bytes") {
+		t.Errorf("error should say how much was read before the failure: %v", err)
+	}
+}
+
+// TestDriveSession_NormalEndsStayNormal proves the classification did not turn
+// an ordinary end of session into an error: a pty master returns EOF or, on
+// POSIX, EIO once the child is gone, and both are how every green session ends.
+func TestDriveSession_NormalEndsStayNormal(t *testing.T) {
+	t.Parallel()
+	for name, endErr := range map[string]error{
+		"eof": io.EOF,
+		"eio": syscall.EIO,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			f := &fakePTY{script: []readStep{bytesStep("hello")}, end: endErr}
+			res, ef, err := driveSession(context.Background(), &spec.PTY{
+				Command: "mytool",
+				Session: []spec.PTYAction{{Expect: "hello"}},
+			}, fakeSession(f, 0))
+			if err != nil {
+				t.Fatalf("a normal end must not error: %v", err)
+			}
+			if ef != nil {
+				t.Fatalf("expect should have matched: %+v", ef)
+			}
+			if string(res.Stdout) != "hello" {
+				t.Errorf("transcript = %q, want %q", res.Stdout, "hello")
+			}
+			if res.ExitCode != 0 {
+				t.Errorf("exit code = %d, want 0", res.ExitCode)
+			}
+		})
+	}
+}
+
+// TestDriveSession_DeliberateCloseIsNotALostTranscript covers the path every
+// session takes: finish closes the terminal itself and then waits for the drain
+// goroutine, whose pending Read fails precisely because of that close. Treating
+// atago's own close as a lost transcript would turn every green pty step red.
+func TestDriveSession_DeliberateCloseIsNotALostTranscript(t *testing.T) {
+	t.Parallel()
+	// No terminating error: the fake blocks until closeTerm, so the read that
+	// ends the loop is the one atago's own close interrupts.
+	f := &fakePTY{script: []readStep{bytesStep("ready")}}
+	res, ef, err := driveSession(context.Background(), &spec.PTY{
+		Command: "mytool",
+		Session: []spec.PTYAction{{Expect: "ready"}},
+	}, fakeSession(f, 0))
+	if err != nil {
+		t.Fatalf("a deliberate close must not read as a lost transcript: %v", err)
+	}
+	if ef != nil {
+		t.Fatalf("expect should have matched: %+v", ef)
+	}
+	if string(res.Stdout) != "ready" {
+		t.Errorf("transcript = %q, want %q", res.Stdout, "ready")
+	}
+}
+
+// TestDriveSession_EINTRIsRetried proves an interrupted read is resumed rather
+// than mistaken for the end of the session: a signal arriving mid-read must not
+// truncate the transcript, silently or loudly.
+func TestDriveSession_EINTRIsRetried(t *testing.T) {
+	t.Parallel()
+	// The interrupt lands BETWEEN the two chunks, so the tail is delivered only
+	// if the drain loop survives it.
+	f := &fakePTY{
+		script: []readStep{bytesStep("be"), errStep(syscall.EINTR), bytesStep("fore")},
+		end:    io.EOF,
+	}
+	res, _, err := driveSession(context.Background(), &spec.PTY{
+		Command: "mytool",
+		Session: []spec.PTYAction{{Expect: "before"}},
+	}, fakeSession(f, 0))
+	if err != nil {
+		t.Fatalf("EINTR must be retried, not treated as an end: %v", err)
+	}
+	if string(res.Stdout) != "before" {
+		t.Errorf("transcript = %q, want %q (EINTR truncated it)", res.Stdout, "before")
+	}
+}
+
+// TestDriveSession_LostTranscriptOutranksAnExpectFailure: when the transcript is
+// incomplete, the expect that failed against it may have failed only because the
+// bytes are missing. Reporting it as an assertion failure would blame the spec
+// for atago's own lost data, so the hard error wins.
+func TestDriveSession_LostTranscriptOutranksAnExpectFailure(t *testing.T) {
+	t.Parallel()
+	f := &fakePTY{script: []readStep{bytesStep("partial")}, end: syscall.EBADF}
+	res, ef, err := driveSession(context.Background(), &spec.PTY{
+		Command: "mytool",
+		Timeout: "200ms",
+		Session: []spec.PTYAction{{Expect: "never-arrives"}},
+	}, fakeSession(f, 0))
+	if err == nil {
+		t.Fatalf("a lost transcript must outrank the expect failure; got res=%+v ef=%+v", res, ef)
+	}
+	if !errors.Is(err, syscall.EBADF) {
+		t.Errorf("error should wrap the underlying read failure: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #345.

## Problem

The pty transcript is accumulated by one draining goroutine in `internal/runner/ptyrun/session.go`, and every read error ended the loop identically:

```go
n, rerr := proc.rw.Read(buf)
if n > 0 { /* append */ }
if rerr != nil { return }
```

A pty master returning `EIO` after the child exits is the normal end of a session. A read that failed for any other reason is a lost transcript. Both left the same state behind, `finish()` built the `Result` from whatever `snapshot()` held, and every `expect_screen:`, `screen:`, and transcript assertion afterwards compared against a transcript atago believed was complete — with nothing marking it truncated. A silently short transcript in the pty runner produces a confidently wrong screen assertion, which is the exact failure mode #339 spent a day being unreadable for.

On Windows it was worse by construction: `conpty.Read` collapsed **every** `ReadFile` failure into `os.ErrClosed`, so the caller could not distinguish the cases even if it wanted to.

## Change

**`internal/runner/ptyrun/session.go`** — the drain goroutine classifies the error that ends it:

- `io.EOF`, `syscall.EIO`, and `fs.ErrClosed`/`io.ErrClosedPipe` are how a session ends. The last covers atago's own `proc.closeTerm()`: `finish` closes the master and then waits for the drain goroutine, whose pending read fails precisely because of that close.
- `syscall.EINTR` is **retried**, so a signal arriving mid-read no longer truncates the transcript.
- Anything else records `readErr`. `finish` then returns a hard error — `pty "cat": the terminal transcript is incomplete — reading the terminal failed after N bytes: ...` — and **no `Result`**, the same call the cmd runner now makes for a cut-short capture (#343). That contract (no Result, byte count named in the message) is pinned by a test.

**On "after the child exited".** The issue asks that an end-of-session error count as one only after the child exits. That falls out for free rather than needing a race with the exit channel: every caller of `finish` has already reaped the child (the session loop receives `proc.exit`; `abort` and `failHard` kill and wait), so an end-of-session error accepted there is by construction one that arrived after the child exited. The reader can classify on the error alone. This is commented at the classification site.

**Precedence.** The hard error outranks a pending `ExpectFailure`. An expect that failed against an incomplete transcript may have failed *only* because the bytes never arrived, and reporting it as an assertion failure would blame the spec for atago's own lost data.

**`internal/conpty/conpty_windows.go`** — `Read` preserves the error class through a testable `classifyReadError`:

| Windows error | Mapped to | Why |
|---|---|---|
| `ERROR_BROKEN_PIPE`, `ERROR_HANDLE_EOF`, `ERROR_PIPE_NOT_CONNECTED` | `io.EOF` | the ConPTY analog of POSIX `EIO` once the child is gone |
| `ERROR_INVALID_HANDLE`, `ERROR_OPERATION_ABORTED` | `os.ErrClosed` | what a pending read sees when atago's own `Close` runs on another goroutine — teardown, not failure |
| anything else | wrapped | a genuine read failure the caller must report |

Keeping the second row as `os.ErrClosed` matters: without it, atago's own teardown on Windows would read as a lost transcript and turn every green pty step red.

The change follows the precedent already in the tree — the service runner's `syncBuffer` prefixes a truncated log with `[atago] earlier output truncated (N bytes dropped, ...)`. Truncation is never silent there, and it is not silent in the pty runner now either.

## Tests

New `internal/runner/ptyrun/session_test.go` with a scripted `fakePTY` (a list of read outcomes, so an error can be placed exactly where it is needed):

1. **A read error mid-session is not silence.** Bytes, then `EBADF` → a hard error naming the pty step, the command, "incomplete", and the byte count; no `Result`, no `ExpectFailure`.
2. **A normal end is still a normal end.** `io.EOF` and `syscall.EIO` both finish green with the full transcript and exit 0.
3. **A deliberate close is not a lost transcript** — the path every session takes.
4. **`EINTR` is retried**: the interrupt lands *between* two chunks and the tail still arrives.
5. **A lost transcript outranks an expect failure**, and the error wraps the underlying cause.

`internal/conpty/conpty_windows_test.go` (Windows-only, in the existing `_windows_test.go` file): a table over the end-of-session codes → `io.EOF`, atago's own close codes → `os.ErrClosed`, and unrelated codes → neither, still wrapping their cause.

`internal/engine/pty_test.go`: an engine-level case proving a hard error and an expect failure stay **different verdicts** — an errored step carries an `ErrMsg` and asserts nothing, a failed expect carries a failing check and no `ErrMsg`. That is the routing a lost transcript relies on to not be reported as the spec's assertion being wrong.

Verified with `go test ./...`, `go test -race` on `internal/runner/ptyrun` and `internal/engine`, `GOOS=windows go build ./...` plus a Windows test compile, `golangci-lint run` (0 issues), and `make e2e` (464 scenarios: 460 passed, 4 skipped).

No `examples/` spec, no doc change: no spec keys change, and this only alters a path that was previously silent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal session handling to distinguish normal session completion from unexpected read failures.
  - Prevented incomplete terminal transcripts from being reported as successful or misleading results.
  - Added clearer error reporting when terminal output cannot be fully captured, including relevant progress details.
  - Preserved accurate result statuses by distinguishing execution errors from unmet expectations.
  - Ensured interrupted terminal reads retry correctly and normal shutdowns do not produce false errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->