### PR TITLE
feat(runner): own the capture pipes so an empty stream can be attributed

### DIFF
--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -157,11 +157,16 @@ func checkTarget(a *spec.Assert, target spec.AssertTarget, res *runner.Result, e
 	case spec.AssertExitCode:
 		return checkExitCode(a.ExitCode, res)
 	case spec.AssertStdout:
-		return withCounterpartHint("stdout", a.Stdout, res, env,
-			checkStream("stdout", a.Stdout, streamBytes(res, "stdout"), res != nil, env))
+		// Two independent post-passes over a failing stream check, applied in the
+		// order they read best: where the text actually is (#347), then why this
+		// stream may be short (#344).
+		return withEarlyEOFHint("stdout", res,
+			withCounterpartHint("stdout", a.Stdout, res, env,
+				checkStream("stdout", a.Stdout, streamBytes(res, "stdout"), res != nil, env)))
 	case spec.AssertStderr:
-		return withCounterpartHint("stderr", a.Stderr, res, env,
-			checkStream("stderr", a.Stderr, streamBytes(res, "stderr"), res != nil, env))
+		return withEarlyEOFHint("stderr", res,
+			withCounterpartHint("stderr", a.Stderr, res, env,
+				checkStream("stderr", a.Stderr, streamBytes(res, "stderr"), res != nil, env)))
 	case spec.AssertFile:
 		return checkFile(a.File, env)
 	case spec.AssertStatus:
@@ -230,6 +235,38 @@ func withCounterpartHint(name string, s *spec.StreamAssert, res *runner.Result, 
 		out.Hint = suggestion
 	} else {
 		out.Hint += " — but " + suggestion
+	}
+	return out
+}
+
+// withEarlyEOFHint appends the one fact a failing stream check cannot derive for
+// itself: that the stream ended before the command did (#344).
+//
+// The cmd runner closes the parent's copy of each capture pipe's write end right
+// after Start, so the child is its only holder and EOF cannot arrive first —
+// unless the child closed its own stdout, or never had atago's pipe at all. A
+// report that says only "the substring was not present in stdout" leaves those
+// indistinguishable from a command that printed nothing, which is exactly what
+// made #339 unreadable.
+//
+// It is a hint on an existing failure, never a failure of its own: closing stdout
+// early is legal (a daemonizing tool does it), so a step that asserts nothing
+// about the stream must stay green. Results with no observation — every ordinary
+// command, and every non-process result family — grow no note.
+func withEarlyEOFHint(name string, res *runner.Result, out *CheckResult) *CheckResult {
+	if out == nil || out.OK || res == nil {
+		return out
+	}
+	d, ok := res.EarlyEOF[name]
+	if !ok {
+		return out
+	}
+	note := fmt.Sprintf("%s ended %s before the command exited — its %s was closed, or was never connected to atago's pipe",
+		name, d.Round(time.Millisecond), name)
+	if out.Hint == "" {
+		out.Hint = note
+	} else {
+		out.Hint += " — " + note
 	}
 	return out
 }

--- a/internal/assert/assert_test.go
+++ b/internal/assert/assert_test.go
@@ -2653,3 +2653,65 @@ func TestCheckStream_WrongStreamHint(t *testing.T) {
 		}
 	})
 }
+
+// TestCheckStream_EarlyEOFHint covers #344's reporting half: a failing stream
+// check whose Result carries the early-EOF observation says so, and one that
+// does not carries no phantom note. The observation itself is what the cmd
+// runner records now that it owns the capture pipes — a stream that ended before
+// the command did was closed by the child or never carried atago's pipe, which
+// is the distinction #339 could not make.
+func TestCheckStream_EarlyEOFHint(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a failing check names the early end", func(t *testing.T) {
+		t.Parallel()
+		res := &runner.Result{ExitCode: 0, EarlyEOF: map[string]time.Duration{"stdout": time.Second}}
+		got := Check(&spec.Assert{Stdout: &spec.StreamAssert{Contains: spec.StringList{"anything"}}}, res, Env{})
+		if got.OK {
+			t.Fatalf("assertion should fail against empty stdout: %+v", got)
+		}
+		for _, want := range []string{"stdout ended 1s before the command exited", "never connected to atago's pipe"} {
+			if !strings.Contains(got.Hint, want) {
+				t.Errorf("hint %q should mention %q", got.Hint, want)
+			}
+		}
+		// The original explanation survives; the observation is appended to it.
+		if !strings.Contains(got.Hint, `the substring "anything" was not present in stdout`) {
+			t.Errorf("hint lost the original explanation: %q", got.Hint)
+		}
+	})
+
+	t.Run("an ordinary failure grows no note", func(t *testing.T) {
+		t.Parallel()
+		res := &runner.Result{ExitCode: 0, Stdout: []byte("something else\n")}
+		got := Check(&spec.Assert{Stdout: &spec.StreamAssert{Contains: spec.StringList{"anything"}}}, res, Env{})
+		if strings.Contains(got.Hint, "before the command exited") {
+			t.Errorf("a result with no observation must grow no note: %q", got.Hint)
+		}
+	})
+
+	t.Run("the other stream's observation is not borrowed", func(t *testing.T) {
+		t.Parallel()
+		res := &runner.Result{ExitCode: 0, EarlyEOF: map[string]time.Duration{"stderr": time.Second}}
+		got := Check(&spec.Assert{Stdout: &spec.StreamAssert{Contains: spec.StringList{"anything"}}}, res, Env{})
+		if strings.Contains(got.Hint, "before the command exited") {
+			t.Errorf("stdout borrowed stderr's observation: %q", got.Hint)
+		}
+	})
+
+	t.Run("a passing check stays green and silent", func(t *testing.T) {
+		t.Parallel()
+		res := &runner.Result{
+			ExitCode: 0,
+			Stdout:   []byte("hello\n"),
+			EarlyEOF: map[string]time.Duration{"stdout": time.Second},
+		}
+		got := Check(&spec.Assert{Stdout: &spec.StreamAssert{Contains: spec.StringList{"hello"}}}, res, Env{})
+		if !got.OK {
+			t.Fatalf("closing stdout early is legal and must not fail a step: %+v", got)
+		}
+		if got.Hint != "" {
+			t.Errorf("a passing check must carry no hint: %q", got.Hint)
+		}
+	})
+}

--- a/internal/runner/cmd/capture.go
+++ b/internal/runner/cmd/capture.go
@@ -1,0 +1,158 @@
+package cmd
+
+import (
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"time"
+)
+
+// captureDrainGrace bounds how long Run waits for a capture pipe to reach EOF
+// after the command has exited.
+//
+// It exists because owning the pipes means owning what os/exec was doing for us:
+// Cmd.WaitDelay's force-close applies only to pipes os/exec created itself, so
+// with atago's own pipes a lingering grandchild would block the drain forever.
+// The value mirrors the WaitDelay configureCancellation sets, so a run step that
+// backgrounds a long-running program fails the same way and after the same wait
+// as it did before (#343, #344).
+const captureDrainGrace = 2 * time.Second
+
+// earlyEOFMargin is how far ahead of the command's exit a stream's EOF must be
+// before atago calls it early.
+//
+// EOF and process exit are observed by two different goroutines — the drain's
+// io.Copy returning, and Wait returning — so on a loaded CI runner they can land
+// a few milliseconds apart in either order for a perfectly ordinary command. 50ms
+// is comfortably above that scheduling jitter and far below the gap the case this
+// exists for produces (a daemonizing tool holds its stdout closed for the rest of
+// its run). A smaller margin would put a phantom note on ordinary failures, which
+// is worse than saying nothing.
+const earlyEOFMargin = 50 * time.Millisecond
+
+// errDrainDeadline reports that a capture pipe was still open captureDrainGrace
+// after the command exited, which happens when something the command started
+// inherited the pipe and outlived it. It stands in for exec.ErrWaitDelay, which
+// os/exec no longer produces for these streams now that atago owns them: the
+// condition and the advice are identical, so captureFailure treats them alike
+// and the message a user sees is unchanged.
+var errDrainDeadline = errors.New("the capture pipe was still open 2s after the command exited")
+
+// capture owns one of the command's output streams end to end: the pipe handed
+// to the child, the goroutine draining it, and the bytes it collected.
+//
+// Owning the pipe (rather than assigning a strings.Builder and letting os/exec
+// create the pipe and copier internally) is what makes EOF observable at all.
+// os/exec would only ever hand back the final byte count, so a child that wrote
+// to a handle that was not our pipe and a child that printed nothing produced the
+// identical observation: EOF, zero bytes, nil error (#344).
+type capture struct {
+	r, w *os.File
+	buf  strings.Builder
+	done chan struct{}
+
+	// endedAt is when the drain loop finished, eof reports whether it finished at
+	// a real end-of-file, and err holds a read failure. They are written by the
+	// drain goroutine and are safe to read only after done is closed.
+	endedAt time.Time
+	eof     bool
+	err     error
+}
+
+// newCapture allocates the pipe for one stream.
+func newCapture() (*capture, error) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	return &capture{r: r, w: w, done: make(chan struct{})}, nil
+}
+
+// writer is the end handed to the child as its stdout or stderr.
+func (c *capture) writer() *os.File { return c.w }
+
+// releaseWriter closes the parent's copy of the write end. It MUST be called
+// right after Start: until it is, atago itself holds the write end open and the
+// read side would never see EOF at all.
+func (c *capture) releaseWriter() {
+	if c.w != nil {
+		_ = c.w.Close()
+		c.w = nil
+	}
+}
+
+// drain reads the stream to EOF in the background.
+func (c *capture) drain() {
+	go func() {
+		defer close(c.done)
+		_, err := io.Copy(&c.buf, c.r)
+		c.endedAt = time.Now()
+		// io.Copy reports EOF as a nil error. Anything else means the loop ended
+		// for a reason other than the stream ending — including forceClose below,
+		// which is how Run stops a drain that would otherwise never finish.
+		c.eof = err == nil
+		c.err = err
+	}()
+}
+
+// waitUntil reports whether the drain finished before deadline.
+func (c *capture) waitUntil(deadline time.Time) bool {
+	select {
+	case <-c.done:
+		return true
+	case <-time.After(time.Until(deadline)):
+		return false
+	}
+}
+
+// forceClose ends a drain that will not finish on its own, by closing the read
+// end under it. The blocked read returns immediately, so the goroutine exits and
+// its buffer becomes safe to read — which is why Run always joins after this
+// rather than reading the buffer out from under a live goroutine.
+func (c *capture) forceClose() { _ = c.r.Close() }
+
+// join blocks until the drain goroutine has returned.
+func (c *capture) join() { <-c.done }
+
+// close releases both ends. Safe to call more than once and after forceClose.
+func (c *capture) close() {
+	c.releaseWriter()
+	_ = c.r.Close()
+}
+
+// String returns the captured bytes. Only valid once the drain has been joined.
+func (c *capture) String() string { return c.buf.String() }
+
+// earlyBy reports how far ahead of exitedAt this stream reached EOF, and whether
+// that gap is large enough to be meaningful. A drain that did not end at a real
+// EOF (a forced close, a read error) reports nothing: the stream did not end, it
+// was cut off, and that is a different fact already reported as a capture
+// failure.
+func (c *capture) earlyBy(exitedAt time.Time) (time.Duration, bool) {
+	if !c.eof || c.endedAt.IsZero() {
+		return 0, false
+	}
+	d := exitedAt.Sub(c.endedAt)
+	if d < earlyEOFMargin {
+		return 0, false
+	}
+	return d, true
+}
+
+// earlyEOF builds the Result's per-stream observation: which streams ended
+// meaningfully before the command did. It returns nil when neither did, so an
+// ordinary command carries no map at all and a failing assertion on it grows no
+// note.
+func earlyEOF(stdout, stderr *capture, exitedAt time.Time) map[string]time.Duration {
+	var out map[string]time.Duration
+	for name, c := range map[string]*capture{"stdout": stdout, "stderr": stderr} {
+		if d, ok := c.earlyBy(exitedAt); ok {
+			if out == nil {
+				out = make(map[string]time.Duration, 2)
+			}
+			out[name] = d
+		}
+	}
+	return out
+}

--- a/internal/runner/cmd/cmd.go
+++ b/internal/runner/cmd/cmd.go
@@ -79,13 +79,56 @@ func (r *Runner) Run(ctx context.Context, run *spec.Run, workdir string) (*runne
 		cmd.Stdin = stdin
 	}
 
-	var stdout, stderr strings.Builder
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	// atago owns the capture pipes rather than assigning a strings.Builder and
+	// letting os/exec create the pipe and the copying goroutine internally. That
+	// is what makes end-of-file observable: os/exec would only ever hand back the
+	// final byte count, so a child that wrote to a handle that was not our pipe
+	// and a child that printed nothing produced the identical observation (#344).
+	stdout, err := newCapture()
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute %q: %w", run.Command, err)
+	}
+	defer stdout.close()
+	stderr, err := newCapture()
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute %q: %w", run.Command, err)
+	}
+	defer stderr.close()
+	cmd.Stdout = stdout.writer()
+	cmd.Stderr = stderr.writer()
 
 	start := time.Now()
-	runErr := cmd.Run()
+	if err := cmd.Start(); err != nil {
+		// Could not start the process at all (not found, permission, ...). Same
+		// message the combined Run() path produced for this case.
+		return nil, fmt.Errorf("failed to execute %q: %w", run.Command, err)
+	}
+	// The child now holds the write ends; drop atago's copies or the read side
+	// never sees EOF at all, and the drains below would never finish.
+	stdout.releaseWriter()
+	stderr.releaseWriter()
+	stdout.drain()
+	stderr.drain()
+
+	runErr := cmd.Wait()
+	exitedAt := time.Now()
 	elapsed := time.Since(start)
+
+	// Wait no longer implies the output is fully read: os/exec waits for pipes it
+	// created, and these are atago's. Join the drains under one shared deadline —
+	// WaitDelay's force-close does not apply here, so a grandchild holding the
+	// pipe would otherwise block forever.
+	deadline := exitedAt.Add(captureDrainGrace)
+	drained := stdout.waitUntil(deadline)
+	drained = stderr.waitUntil(deadline) && drained
+	if !drained {
+		// End the loops so their buffers are ours to read, then join: reading a
+		// buffer a live goroutine is still appending to would be a data race.
+		stdout.forceClose()
+		stderr.forceClose()
+		stdout.join()
+		stderr.join()
+	}
 
 	// A capture that was cut short is classified before ANY of it is persisted or
 	// returned: stdout_to/stderr_to must not write a stream atago only partly
@@ -93,13 +136,24 @@ func (r *Runner) Run(ctx context.Context, run *spec.Run, workdir string) (*runne
 	// A cancel or a step timeout is a different outcome, handled below — the
 	// output a killed command managed to produce IS observable — so ctx state
 	// wins over this check (#339).
-	var captureErr *exec.ExitError
-	if ctx.Err() == nil && runErr != nil && !errors.As(runErr, &captureErr) && cmd.ProcessState != nil {
+	if ctx.Err() == nil {
 		// The process started and exited; what failed is the capture of its
 		// output. Returning the bytes collected so far would present a stream we
 		// only partly read — possibly an empty one — as the observed value, and an
 		// assertion cannot tell that apart from a command that printed nothing.
-		return nil, captureFailure(run.Command, cmd.ProcessState.ExitCode(), runErr)
+		var captureErr *exec.ExitError
+		switch {
+		case !drained:
+			return nil, captureFailure(run.Command, cmd.ProcessState.ExitCode(), errDrainDeadline)
+		case stdout.err != nil:
+			return nil, captureFailure(run.Command, cmd.ProcessState.ExitCode(), stdout.err)
+		case stderr.err != nil:
+			return nil, captureFailure(run.Command, cmd.ProcessState.ExitCode(), stderr.err)
+		case runErr != nil && !errors.As(runErr, &captureErr) && cmd.ProcessState != nil:
+			// Everything else Wait can fail at while the process itself ran fine —
+			// the stdin copy, which os/exec still owns.
+			return nil, captureFailure(run.Command, cmd.ProcessState.ExitCode(), runErr)
+		}
 	}
 
 	// Redirect captured stdout/stderr to workdir-relative files when requested
@@ -116,6 +170,7 @@ func (r *Runner) Run(ctx context.Context, run *spec.Run, workdir string) (*runne
 		Stderr:   []byte(stderr.String()),
 		Duration: elapsed,
 		Workdir:  workdir,
+		EarlyEOF: earlyEOF(stdout, stderr, exitedAt),
 	}
 
 	// A step's own timeout (run.timeout) is an observable outcome, not an error:
@@ -159,7 +214,11 @@ func (r *Runner) Run(ctx context.Context, run *spec.Run, workdir string) (*runne
 // and os/exec force-closes them after WaitDelay rather than waiting forever.
 func captureFailure(command string, exitCode int, err error) error {
 	hint := ""
-	if errors.Is(err, exec.ErrWaitDelay) {
+	// errDrainDeadline is atago's own equivalent of exec.ErrWaitDelay now that it
+	// owns the capture pipes: os/exec's force-close applies only to pipes it
+	// created, so this condition is detected by the drain deadline instead. Same
+	// cause, same advice, same message.
+	if errors.Is(err, exec.ErrWaitDelay) || errors.Is(err, errDrainDeadline) {
 		hint = "; a process it started outlived it and kept the pipes open — declare a long-running program with a `service:` step instead of backgrounding it inside a run step"
 	}
 	return fmt.Errorf("run %q exited with code %d but its output could not be captured: %w%s", command, exitCode, err, hint)

--- a/internal/runner/cmd/cmd_test.go
+++ b/internal/runner/cmd/cmd_test.go
@@ -853,12 +853,19 @@ func TestHelperProcess(t *testing.T) {
 		// process exits — the one signal that tells a lost stream apart from a
 		// silent one (#344). Nothing is printed, so the captured stdout is
 		// empty for the same reason #339's was.
+		//
+		// os.Exit rather than returning: with stdout closed, the testing
+		// package's own shutdown (its result line, and the coverage writer
+		// under `go test -cover`) has nowhere to write and fails the binary
+		// with exit 2, which has nothing to do with what is under test.
 		_ = os.Stdout.Close()
 		time.Sleep(300 * time.Millisecond)
+		os.Exit(0)
 	case "write-then-close-stdout-early":
 		fmt.Println("produced")
 		_ = os.Stdout.Close()
 		time.Sleep(300 * time.Millisecond)
+		os.Exit(0)
 	case "lingering-writer":
 		fmt.Println("produced")
 		child := exec.CommandContext(context.Background(), os.Args[0], "-test.run=TestHelperProcess")

--- a/internal/runner/cmd/cmd_test.go
+++ b/internal/runner/cmd/cmd_test.go
@@ -847,6 +847,18 @@ func TestHelperProcess(t *testing.T) {
 	switch os.Getenv("ATAGO_CMD_HELPER") {
 	case "holder":
 		time.Sleep(10 * time.Second)
+	case "close-stdout-early":
+		// Legal behavior a daemonizing tool exhibits: close stdout, keep
+		// running, exit 0. The read side then sees EOF a full beat before the
+		// process exits — the one signal that tells a lost stream apart from a
+		// silent one (#344). Nothing is printed, so the captured stdout is
+		// empty for the same reason #339's was.
+		_ = os.Stdout.Close()
+		time.Sleep(300 * time.Millisecond)
+	case "write-then-close-stdout-early":
+		fmt.Println("produced")
+		_ = os.Stdout.Close()
+		time.Sleep(300 * time.Millisecond)
 	case "lingering-writer":
 		fmt.Println("produced")
 		child := exec.CommandContext(context.Background(), os.Args[0], "-test.run=TestHelperProcess")
@@ -909,5 +921,101 @@ func TestRun_CaptureFailureIsNotSilentEmptyOutput(t *testing.T) {
 	// ran fine, and saying otherwise sends the reader after the wrong problem.
 	if strings.Contains(err.Error(), "failed to execute") {
 		t.Errorf("error = %q, want it to distinguish a capture failure from a command that could not start", err)
+	}
+}
+
+// TestRun_EarlyEOFIsObserved is the evidence #339 lacked (#344). os/exec closes
+// the parent's copy of the write end right after Start, so from that moment the
+// child is its only holder: EOF on the read end cannot arrive before the child
+// exits unless the child closed its own stdout, or never had atago's pipe at
+// all. atago used to throw that distance away — cmd.Stdout was a strings.Builder
+// and os/exec did the reading — so "the command printed nothing" and "the
+// command's output went somewhere else" produced the identical observation.
+func TestRun_EarlyEOFIsObserved(t *testing.T) {
+	t.Parallel()
+	res, err := New().Run(context.Background(), &spec.Run{
+		Command: helperCommand(),
+		Env:     map[string]string{"ATAGO_CMD_HELPER": "close-stdout-early"},
+	}, t.TempDir())
+	if err != nil {
+		t.Fatalf("Run() error = %v; closing stdout early is legal, not a failure", err)
+	}
+	if res.ExitCode != 0 {
+		t.Errorf("exit code = %d, want 0", res.ExitCode)
+	}
+	d, ok := res.EarlyEOF["stdout"]
+	if !ok {
+		t.Fatalf("stdout's early EOF was not observed: %+v", res.EarlyEOF)
+	}
+	// The helper sleeps 300ms after closing; allow generous slack for a loaded
+	// CI box, but the gap must be real, not noise.
+	if d < 100*time.Millisecond {
+		t.Errorf("observed gap = %s, want at least ~300ms", d)
+	}
+}
+
+// TestRun_NormalCommandHasNoEarlyEOF is the other half of the contract: a
+// command whose stdout simply closes when it exits must carry no observation, or
+// every ordinary failure would grow a phantom note.
+func TestRun_NormalCommandHasNoEarlyEOF(t *testing.T) {
+	t.Parallel()
+	res, err := New().Run(context.Background(), &spec.Run{
+		Command: argvCommand("echo hello", "cmd /c echo hello"),
+	}, t.TempDir())
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if strings.TrimSpace(string(res.Stdout)) != "hello" {
+		t.Errorf("stdout = %q, want hello", res.Stdout)
+	}
+	if len(res.EarlyEOF) != 0 {
+		t.Errorf("a normal command must carry no early-EOF observation: %+v", res.EarlyEOF)
+	}
+}
+
+// TestRun_EarlyEOFKeepsWhatWasWritten: closing stdout early does not discard
+// what the command managed to print first. The bytes and the observation are
+// both real and must both survive.
+func TestRun_EarlyEOFKeepsWhatWasWritten(t *testing.T) {
+	t.Parallel()
+	res, err := New().Run(context.Background(), &spec.Run{
+		Command: helperCommand(),
+		Env:     map[string]string{"ATAGO_CMD_HELPER": "write-then-close-stdout-early"},
+	}, t.TempDir())
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !strings.Contains(string(res.Stdout), "produced") {
+		t.Errorf("stdout = %q, want it to keep the bytes written before the close", res.Stdout)
+	}
+	if _, ok := res.EarlyEOF["stdout"]; !ok {
+		t.Errorf("the observation was lost when bytes were written: %+v", res.EarlyEOF)
+	}
+}
+
+// TestRun_OwnedPipesDoNotLeak: atago creates the capture pipes itself now, so it
+// owns closing them and joining their drain goroutines. A leak here would be
+// invisible per-run and fatal over a 400-scenario suite.
+func TestRun_OwnedPipesDoNotLeak(t *testing.T) {
+	t.Parallel()
+	wd := t.TempDir()
+	r := New()
+	cmdStr := argvCommand("echo hi", "cmd /c echo hi")
+	// Warm up first: the first exec pulls in goroutines that are not per-run.
+	for range 5 {
+		if _, err := r.Run(context.Background(), &spec.Run{Command: cmdStr}, wd); err != nil {
+			t.Fatal(err)
+		}
+	}
+	before := runtime.NumGoroutine()
+	for range 60 {
+		if _, err := r.Run(context.Background(), &spec.Run{Command: cmdStr}, wd); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Give any goroutine that ended on the last run a moment to be reaped.
+	time.Sleep(100 * time.Millisecond)
+	if after := runtime.NumGoroutine(); after > before+10 {
+		t.Errorf("goroutines grew from %d to %d over 60 runs; a drain goroutine is leaking", before, after)
 	}
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -32,6 +32,24 @@ type Result struct {
 	// knob to adjust (#17). Empty when TimedOut is false.
 	TimeoutSource string
 
+	// EarlyEOF records, per stream name ("stdout" / "stderr"), how far ahead of
+	// the command's own exit that stream reached end-of-file.
+	//
+	// atago creates the capture pipes itself and closes the parent's copy of each
+	// write end immediately after Start, so from that moment the child process is
+	// their only holder: EOF on the read end cannot arrive before the child exits
+	// — unless the child closed its own stdout, or never had atago's pipe at all.
+	// That distance is the one piece of evidence separating "the command printed
+	// nothing" from "the command's output went somewhere else", which #339 spent a
+	// day being unreadable for.
+	//
+	// An entry exists only when the gap is large enough to be meaningful (see the
+	// cmd runner's margin), so an ordinary command carries none and the map is
+	// nil. Closing stdout early is legal — a daemonizing tool does it — so this is
+	// only ever a hint on a failure that already happened, never a failure of its
+	// own (#344).
+	EarlyEOF map[string]time.Duration
+
 	// HTTP fields, set only by the http runner (IsHTTP reports which family is
 	// populated, since a zero StatusCode is indistinguishable from "no response").
 	IsHTTP     bool


### PR DESCRIPTION
Closes #344.

## Problem

#343 made the report say `(empty)` instead of dropping the `Actual:` section, and made a capture that was cut short a distinct error. What it could not do is say **why** a stream was empty. `cmd.Stdout` was a `strings.Builder`, so os/exec created the pipe and the copying goroutine internally and atago only ever saw the final byte count. A child that wrote to a handle that was not our pipe (the #339 hypothesis) and a child that printed nothing produced the identical observation: EOF, zero bytes, `nil` error.

There is one signal that separates them, and atago was throwing it away. os/exec closes the parent's copy of the write end immediately after `Start`, so from that moment the child process is its only holder: **EOF on the read end cannot arrive before the child exits** — unless the child closed its own stdout, or never had our handle at all. The distance between "EOF observed" and "process exited" is exactly the evidence #339 lacked.

The reproduction from the issue — a command that closes stdout at t=0 and exits 0 at t=1s — was indistinguishable in the report from a command that simply printed nothing.

## Change

**`internal/runner/cmd/capture.go`** (new) owns one stream end to end: its `os.Pipe`, the goroutine draining it, and the bytes it collected. `Run` now does `Start` → close the parent's write ends → drain → `Wait` → join, instead of `cmd.Run()`.

Owning the pipes means owning what os/exec was doing for us, exactly as the issue's implementation notes say:

- **The parent's write ends are closed right after `Start`**, or the read side never sees EOF at all.
- **`Cmd.WaitDelay`'s force-close applies only to pipes os/exec created**, so the drain gets its own bounded wait — one shared deadline mirroring the existing 2s — and on expiry it synthesizes the same capture failure #343 introduced, with the same message and the same refusal to hand back partial bytes. `errDrainDeadline` stands in for `exec.ErrWaitDelay`, which os/exec no longer produces for these streams; `captureFailure` treats them alike so the `service:` advice a user sees is unchanged.
- On expiry the read ends are **closed under the drains and the goroutines joined**, so no buffer is ever read while a goroutine still appends to it.
- **`configureCancellation`'s `WaitDelay` is untouched** — this change is the capture side only.
- **A passing run returns byte-identical `Stdout`/`Stderr`.**

`Run`'s error classification now distinguishes four capture-side causes (drain deadline, a read failure on either pipe, and everything else `Wait` can fail at while the process itself ran fine — the stdin copy, which os/exec still owns), all funnelling into the same `captureFailure`. A `Start` failure returns the same `failed to execute %q` message the combined `cmd.Run()` path produced.

**`internal/runner/runner.go`**: `Result.EarlyEOF` maps a stream name to how far ahead of the exit it reached EOF, present only when the gap is meaningful — so an ordinary command carries a nil map.

**`internal/assert/assert.go`**: `withEarlyEOFHint` appends to a failing `stdout:`/`stderr:` check:

```
stdout ended 1s before the command exited — its stdout was closed, or was never connected to atago's pipe
```

It composes with #347's counterpart suggestion as a second post-pass, in the order that reads best: what actually failed, then where the text is, then why this stream may be short.

**This is a hint on an existing failure, not a new error.** Closing stdout early is legal — a daemonizing tool does it — so it never fails a step on its own, and a passing check stays green and silent.

### The margin

`earlyEOFMargin = 50ms`, documented where it is defined. EOF and process exit are observed by two different goroutines (the drain's `io.Copy` returning, and `Wait` returning), so on a loaded CI runner they land a few milliseconds apart in either order for a perfectly ordinary command. 50ms is comfortably above that jitter and far below the gap this exists for. A smaller margin would put a phantom note on ordinary failures, which is worse than saying nothing.

## Tests

`internal/runner/cmd/cmd_test.go` (extending the existing `TestHelperProcess` pattern, which re-executes the test binary and works on Windows where `exec 1>&-` does not — two new helper modes close `os.Stdout` and then sleep 300ms):

1. **Early EOF is observed** — the `Result` carries it, `err` is nil, exit code is still 0.
2. **A normal command carries no observation** (`echo hello`).
3. **Writing then closing early keeps the bytes *and* the observation.**
4. **`TestRun_CaptureFailureIsNotSilentEmptyOutput` passes unchanged** — lingering grandchild ⇒ error, no `Result`, no `stdout_to` file. Not edited in this PR.
5. **No goroutine leak** — 60 runs after a warm-up leave the goroutine count flat.

`internal/assert/assert_test.go`: a failing check with the observation renders the hint and keeps its original explanation; an ordinary failure grows no note; one stream does not borrow the other's observation; a passing check stays green and hint-free.

Verified with `go test ./...`, `go test -race` on `internal/runner/cmd` and `internal/assert`, `GOOS=windows go build ./...`, `golangci-lint run` (0 issues), and `make e2e` (466 scenarios: 462 passed, 4 skipped).

## Examples, Cookbook, Pages

None, as the issue specifies: no spec key changes, and the hint appears only on an already-failing step.