### PR TITLE
test(windows): put #339's ConPTY-interference hypothesis under test

### DIFF
--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 446 scenarios
+74 suites · 447 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -364,7 +364,7 @@
   - [console report prints the same counts in its summary line](#scenario-console-report-prints-the-same-counts-in-its-summary-line)
   - [an all-passing run reports a zero-failure suite and exits zero](#scenario-an-all-passing-run-reports-a-zero-failure-suite-and-exits-zero)
   - [an errored step is counted as an error, not a failure, across formats](#scenario-an-errored-step-is-counted-as-an-error-not-a-failure-across-formats)
-- [atago self-hosting / reports](#atago-self-hosting--reports) — 9 scenarios
+- [atago self-hosting / reports](#atago-self-hosting--reports) — 10 scenarios
   - [JUnit report is XML with a testsuite and testcase](#scenario-junit-report-is-xml-with-a-testsuite-and-testcase)
   - [GitHub Actions annotations are emitted on failure](#scenario-github-actions-annotations-are-emitted-on-failure)
   - [TAP report is a numbered TAP 13 stream with ok / not ok points](#scenario-tap-report-is-a-numbered-tap-13-stream-with-ok--not-ok-points)
@@ -374,6 +374,7 @@
   - [a failure against an empty stream reports the stream as empty](#scenario-a-failure-against-an-empty-stream-reports-the-stream-as-empty)
   - [an exit_code failure states that the command printed nothing](#scenario-an-exit_code-failure-states-that-the-command-printed-nothing)
   - [a stdout failure points at stderr when the text is there](#scenario-a-stdout-failure-points-at-stderr-when-the-text-is-there)
+  - [an empty stream that ended early says so in the failure block](#scenario-an-empty-stream-that-ended-early-says-so-in-the-failure-block)
 - [atago self-hosting / rerun-failed](#atago-self-hosting--rerun-failed) — 5 scenarios
   - [a failing run is recorded and rerun-failed selects only it](#scenario-a-failing-run-is-recorded-and-rerun-failed-selects-only-it)
   - [rerun-failed with nothing recorded is a no-op success](#scenario-rerun-failed-with-nothing-recorded-is-a-no-op-success)
@@ -6856,6 +6857,30 @@ ${atago} run wrongstream.atago.yaml
 #### Then
 - exit code is `1`
 - stdout contains `stderr satisfies this assertion (assert `stderr:` instead?)`
+### Scenario: an empty stream that ended early says so in the failure block
+_skipped on Windows_
+#### Given
+- Fixture file `earlyeof.atago.yaml` is created.
+#### Inputs
+_Fixture `earlyeof.atago.yaml`:_
+```text
+version: "1"
+suite: {name: earlyeof}
+scenarios:
+  - name: a command that closes stdout then keeps running
+    steps:
+      - run: {shell: true, command: "exec 1>&-; sleep 1; exit 0"}
+      - assert:
+          exit_code: 0
+          stdout: {contains: "anything"}
+```
+#### When
+```shell
+${atago} run earlyeof.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `before the command exited`, `never connected to atago's pipe`
 ## atago self-hosting / rerun-failed
 Source: `test/e2e/atago/rerun.atago.yaml`
 ### Scenario: a failing run is recorded and rerun-failed selects only it

--- a/internal/conpty/conpty_windows.go
+++ b/internal/conpty/conpty_windows.go
@@ -73,6 +73,18 @@ func CommandLine(command string, shell bool) (string, error) {
 // workDir, with env (nil inherits the parent's environment; a non-nil slice,
 // even empty, starts the child from exactly that set). The returned
 // PseudoConsole must be Closed.
+//
+// Everything below is scoped to the CHILD. Start never calls AllocConsole,
+// AttachConsole, FreeConsole, or SetStdHandle, so atago's own console and
+// standard handles are untouched, and a `run` step executing concurrently in
+// another goroutine cannot have its stdout rebound by a pty step starting up.
+// This was one of the three things #339 listed as worth checking for a Windows
+// capture anomaly seen while pty and nested-run specs shared a parallel batch;
+// it is recorded here so the question is not re-opened from scratch. The
+// remaining handle discipline that keeps the two independent: the pipes below
+// are created with nil SECURITY_ATTRIBUTES (not inheritable), and CreateProcess
+// is called with bInheritHandles=false, so the child reaches its console only
+// through the PSEUDOCONSOLE attribute.
 func Start(commandLine, workDir string, env []string, rows, cols int) (*PseudoConsole, error) {
 	// Two anonymous pipes: one carries parent→child input, the other
 	// child→parent output. CreatePseudoConsole takes the child's ends (inRead,

--- a/internal/runner/ptyrun/ptyrun_windows_test.go
+++ b/internal/runner/ptyrun/ptyrun_windows_test.go
@@ -5,9 +5,11 @@ package ptyrun
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	runnercmd "github.com/nao1215/atago/internal/runner/cmd"
 	"github.com/nao1215/atago/internal/spec"
 )
 
@@ -70,4 +72,89 @@ func TestRun_Windows_ExpectTimeoutAborts(t *testing.T) {
 	if elapsed := time.Since(start); elapsed > 15*time.Second {
 		t.Errorf("session ran %v, want it bounded near the 2s budget (kill did not take)", elapsed)
 	}
+}
+
+// TestRun_Windows_CaptureSurvivesConcurrentConPTYSessions puts #339's leading
+// hypothesis under test.
+//
+// On windows-latest, one scenario of the portable self-hosted subset failed with
+// a nested `atago run` that exited 0 while its stdout came back EMPTY — output
+// the child certainly produced, since a run that exits 0 always prints a PASSED
+// summary. It reproduced once in fourteen runs and never on Linux or macOS. The
+// subset runs that spec alongside pty_portable.atago.yaml at the default
+// parallelism, and attaching a pseudoconsole is a process-global operation on
+// Windows, so a child spawned while a ConPTY is being set up misrouting its
+// handles is the plausible mechanism. Nothing in the CI log proved the two
+// overlapped, so this test forces the overlap that CI only stumbles into.
+//
+// What it asserts is the invariant the flake broke: a command that writes to
+// stdout and exits 0 must never come back with an empty capture. Since #344 the
+// runner can also say WHY a stream is empty — EOF on a capture pipe cannot
+// precede the child's exit unless the child's stdout was not atago's pipe — so
+// an early-EOF observation here would be direct evidence for the hypothesis
+// rather than another unreadable empty string.
+//
+// A green run does not prove the hypothesis wrong (the flake is rare and this
+// forces only tens of overlaps, not thousands). It is a cheap standing guard on
+// the exact interaction, and if it ever fails it hands over the diagnosis.
+func TestRun_Windows_CaptureSurvivesConcurrentConPTYSessions(t *testing.T) {
+	t.Parallel()
+
+	const (
+		ptyWorkers = 3  // concurrent ConPTY sessions being set up and torn down
+		captures   = 40 // captured child processes racing against them
+	)
+	shell := true
+	stop := make(chan struct{})
+	var ptyWG sync.WaitGroup
+
+	// Churn pseudo-consoles for the whole life of the capture loop: the
+	// suspected window is the setup/teardown of a ConPTY, not a session at rest.
+	for range ptyWorkers {
+		ptyWG.Add(1)
+		go func() {
+			defer ptyWG.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				_, _, _ = Run(context.Background(), &spec.PTY{
+					Shell:   &shell,
+					Command: "echo churn",
+					Timeout: "10s",
+					Session: []spec.PTYAction{{Expect: "churn"}},
+				}, t.TempDir(), nil)
+			}
+		}()
+	}
+
+	runner := runnercmd.New()
+	wd := t.TempDir()
+	for i := range captures {
+		res, err := runner.Run(context.Background(), &spec.Run{
+			Command: `cmd /c echo produced`,
+		}, wd)
+		if err != nil {
+			close(stop)
+			ptyWG.Wait()
+			t.Fatalf("capture %d: Run() error = %v", i, err)
+		}
+		if res.ExitCode != 0 {
+			t.Errorf("capture %d: exit code = %d, want 0", i, res.ExitCode)
+		}
+		if !strings.Contains(string(res.Stdout), "produced") {
+			// This is the #339 observation. EarlyEOF, when present, says the
+			// child's stdout was closed or was never connected to atago's pipe.
+			t.Errorf("capture %d: stdout = %q, want it to contain %q (early EOF: %v)",
+				i, res.Stdout, "produced", res.EarlyEOF)
+		}
+		if len(res.EarlyEOF) != 0 {
+			t.Errorf("capture %d: a stream ended before the command exited: %v", i, res.EarlyEOF)
+		}
+	}
+
+	close(stop)
+	ptyWG.Wait()
 }

--- a/test/e2e/atago/reports.atago.yaml
+++ b/test/e2e/atago/reports.atago.yaml
@@ -281,3 +281,32 @@ scenarios:
           exit_code: 1
           stdout:
             contains: "stderr satisfies this assertion (assert `stderr:` instead?)"
+
+  # A stream that came back empty must say why, not just that it was empty. The
+  # capture pipes are atago's own, so EOF on one cannot precede the child's exit
+  # unless the child closed its stdout or never had that pipe — the distinction
+  # #339 spent a day being unreadable for (#344). POSIX-only: `exec 1>&-` closes
+  # a stream from a shell, and cmd.exe has no equivalent.
+  - name: an empty stream that ended early says so in the failure block
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: earlyeof.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: earlyeof}
+            scenarios:
+              - name: a command that closes stdout then keeps running
+                steps:
+                  - run: {shell: true, command: "exec 1>&-; sleep 1; exit 0"}
+                  - assert:
+                      exit_code: 0
+                      stdout: {contains: "anything"}
+      - run: {command: "${atago} run earlyeof.atago.yaml"}
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "before the command exited"
+              - "never connected to atago's pipe"


### PR DESCRIPTION
Refs #339. Read the caveat below before merging expectations onto it: **this does not claim a fix.**

## Where #339 stands

A nested `atago run` on `windows-latest` exited 0 while its stdout came back empty — output the child certainly produced, since a run that exits 0 always prints a `PASSED` summary. It reproduced once in fourteen runs of the portable subset and never on Linux or macOS. The root cause is still unidentified, and no change in this PR claims otherwise.

The issue listed three things worth checking. This PR settles two of them and puts the third under test.

### 1. Can the run-step capture tell "the child wrote nothing" from "the pipe gave us nothing"?

Yes, since #343 and #344. A capture cut short is a distinct error rather than a silent empty string, and the runner now owns its capture pipes, so a stream whose EOF preceded the child's exit is reported as such. This PR adds the end-to-end proof that the attribution survives all the way to the console block a CI log actually shows:

`test/e2e/atago/reports.atago.yaml` — a nested run whose command closes stdout and keeps going, asserting the outer report carries `before the command exited` and `never connected to atago's pipe`. POSIX-only (`skip: {os: windows}`), because `exec 1>&-` closes a stream from a shell and cmd.exe has no equivalent. `doc/e2e/atago.md` regenerated.

The practical effect: if the flake recurs, the failing attempt's report says which of the two it is, instead of needing a re-run to interpret.

### 2. Does `conpty.Start` touch the parent's console state?

**No.** It never calls `AllocConsole`, `AttachConsole`, `FreeConsole`, or `SetStdHandle` — a `grep` over `internal/` finds none of them anywhere in the tree. Everything it does is scoped to the child: the pipes are created with nil `SECURITY_ATTRIBUTES` (not inheritable), `CreateProcess` runs with `bInheritHandles=false`, and the child reaches its console only through the `PSEUDOCONSOLE` attribute. So a `run` step executing concurrently in another goroutine cannot have its stdout rebound by a pty step starting up.

That finding is now written into `Start`'s doc comment, so the question is not re-derived from scratch next time.

### 3. Do concurrent ConPTY sessions interfere with a captured child?

This is the remaining hypothesis, and CI only stumbles into the overlap by luck. `TestRun_Windows_CaptureSurvivesConcurrentConPTYSessions` forces it: three goroutines set up and tear down pseudo-consoles continuously while forty captured children run against them, and every capture must come back with what its command wrote — plus no early-EOF observation, which would be direct evidence for the hypothesis rather than another unreadable empty string.

**A green run does not disprove the hypothesis.** The flake is roughly 1-in-14 across a 240-scenario job, and this forces tens of overlaps, not thousands. It is a cheap standing guard on the exact interaction, and if it ever fails it hands over the diagnosis.

## What is deliberately not changed

The issue floats "running the ConPTY spec outside the parallel batch, if that is what it turns out to be". That condition is not met — the mechanism is unproven — so the workflow is left alone rather than growing an isolation step justified by a guess. `e2e-windows` keeps `--retry-failed 1`, which absorbs the flake and reports a recovery as flaky, exactly as the issue's "Meanwhile" section describes.

I would leave #339 open until the cause is actually identified.

Verified with `go test ./...`, `golangci-lint run` (0 issues), `GOOS=windows go build ./...` plus a Windows test compile, and `make e2e` (467 scenarios: 463 passed, 4 skipped).