### PR TITLE
release: v0.17.0 — install atago on Windows with Scoop

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,6 +61,74 @@ homebrew_casks:
             system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/atago"]
           end
 
+# Scoop distribution for Windows, the one platform CI tests on every push but no
+# package manager could reach. The bucket lives in this repository under
+# `bucket/`, which Scoop accepts the same as a dedicated bucket repository:
+#
+#   scoop bucket add nao1215 https://github.com/nao1215/atago
+#   scoop install nao1215/atago
+#
+# Keeping it here means GoReleaser publishes the manifest with the workflow's
+# built-in GITHUB_TOKEN — there is no cross-repository token to provision, and
+# no second repository whose only content is one generated JSON file. Skipped by
+# `--skip=publish` (release-smoke), so snapshot builds stay hermetic.
+scoops:
+  - name: atago
+    repository:
+      owner: nao1215
+      name: atago
+      branch: main
+    directory: bucket
+    homepage: "https://github.com/nao1215/atago"
+    description: "Tests CLI behavior from plain YAML: exit codes, output, files, snapshots, and interactive terminals (PTY/TUI)"
+    license: MIT
+    commit_msg_template: "chore(scoop): update the bucket manifest for {{ .Tag }}"
+
+# Winget manifests for `winget install nao1215.atago`. Getting into the winget
+# catalog means a pull request to microsoft/winget-pkgs from a fork, which needs
+# a cross-repository token this repository does not hold — so `skip_upload: true`
+# keeps the release self-contained: GoReleaser writes validated manifests under
+# `dist/winget/` from the archives and their checksums, and pushes nothing. The
+# submission itself stays a deliberate manual step against a published tag. The
+# `repository:` block below is the target that step aims at, and is what the
+# release job would use unchanged once `skip_upload` is dropped and a token that
+# can write to the fork is provisioned.
+winget:
+  - name: atago
+    package_identifier: nao1215.atago
+    publisher: Naohiro CHIKAMATSU
+    publisher_url: https://github.com/nao1215
+    publisher_support_url: https://github.com/nao1215/atago/issues/new
+    homepage: "https://github.com/nao1215/atago"
+    short_description: "Tests CLI behavior from plain YAML: exit codes, output, files, snapshots, and interactive terminals (PTY/TUI)"
+    description: |
+      atago runs your actual CLI binary — in any language — and asserts what a
+      user observes: exit codes, stdout and stderr, the files and directories a
+      run creates, snapshots, and interactive terminals driven through a real
+      PTY. Specs are plain YAML, and `atago record` writes the first one from a
+      real run, so there is no test code and no shell DSL to learn.
+    license: MIT
+    license_url: "https://github.com/nao1215/atago/blob/main/LICENSE"
+    copyright: "Copyright (c) 2026 Naohiro CHIKAMATSU"
+    release_notes_url: "https://github.com/nao1215/atago/releases/tag/{{ .Tag }}"
+    tags:
+      - cli
+      - testing
+      - e2e
+      - yaml
+      - tui
+    skip_upload: true
+    repository:
+      owner: nao1215
+      name: winget-pkgs
+      branch: "atago-{{ .Version }}"
+      pull_request:
+        enabled: true
+        base:
+          owner: microsoft
+          name: winget-pkgs
+          branch: master
+
 dockers_v2:
   - images:
       - "ghcr.io/nao1215/atago"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,26 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-07-28
+
+A minor release about reach, and about failures that describe themselves.
+Windows was the one platform CI has always tested and no package manager could
+install from; atago now ships a Scoop bucket, and every tagged release builds
+winget manifests ready to submit. The rest continues what v0.16.0 started: an
+assertion that observed nothing, and a run whose output capture died before its
+process did, now say so instead of leaving the reader to infer it.
+
 ### Added
 
+- Scoop distribution for Windows. `scoop bucket add nao1215
+  https://github.com/nao1215/atago`, then `scoop install nao1215/atago`. The
+  bucket is this repository's own [`bucket/`](bucket/) directory — Scoop accepts
+  any git repository with one — so the manifest is published by the release
+  job's built-in token, with no second repository and no second credential to
+  keep alive. Each tagged release also writes winget manifests for
+  `nao1215.atago` under `dist/`; putting them in the winget catalog takes a pull
+  request to microsoft/winget-pkgs and stays a manual step against a published
+  tag.
 - Third-party E2E suite for [fx](https://fx.wtf/), the terminal JSON viewer, in
   `test/e2e/thirdparty/fx`. fx is a filter when it is given a reducer and a
   full-screen viewer when it is not, and both halves are pinned. The filter side

--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ On macOS, Homebrew works too:
 brew install --cask nao1215/tap/atago
 ```
 
+On Windows, [Scoop](https://scoop.sh/) installs it from this repository's own bucket:
+
+```shell
+scoop bucket add nao1215 https://github.com/nao1215/atago
+scoop install nao1215/atago
+```
+
 On Arch Linux, install the [`atago-bin`](https://aur.archlinux.org/packages/atago-bin) package from the AUR:
 
 ```shell

--- a/bucket/README.md
+++ b/bucket/README.md
@@ -1,0 +1,17 @@
+# Scoop bucket
+
+This directory is atago's [Scoop](https://scoop.sh/) bucket. Scoop accepts any
+git repository with a `bucket/` directory, so the manifest lives here rather
+than in a second repository whose only content would be one generated file:
+
+```shell
+scoop bucket add nao1215 https://github.com/nao1215/atago
+scoop install nao1215/atago
+```
+
+`atago.json` is written by GoReleaser on every tagged release — it carries the
+release's Windows archive URLs and their SHA-256 hashes, so it cannot be edited
+by hand without going stale at the next tag. Change
+[`.goreleaser.yml`](../.goreleaser.yml) instead.
+
+The manifest does not exist until the first release that generates it.

--- a/website/content/install.md
+++ b/website/content/install.md
@@ -1,6 +1,6 @@
 ---
 title: Install
-description: Install atago with go install, Homebrew, the AUR, prebuilt binaries for Linux/macOS/Windows, or the setup-atago GitHub Action — and verify what you download.
+description: Install atago with go install, Homebrew, Scoop, the AUR, prebuilt binaries for Linux/macOS/Windows, or the setup-atago GitHub Action — and verify what you download.
 ---
 
 ```shell
@@ -11,6 +11,13 @@ On macOS, Homebrew works too:
 
 ```shell
 brew install --cask nao1215/tap/atago
+```
+
+On Windows, [Scoop](https://scoop.sh/) installs it from atago's own bucket:
+
+```shell
+scoop bucket add nao1215 https://github.com/nao1215/atago
+scoop install nao1215/atago
 ```
 
 On Arch Linux, install the [`atago-bin`](https://aur.archlinux.org/packages/atago-bin) package from the AUR:


### PR DESCRIPTION
## Summary

Windows is the one platform CI tests on every push that no package manager could install from. This release closes that, and stamps `v0.17.0`.

- **Scoop bucket, in this repository.** `scoop bucket add nao1215 https://github.com/nao1215/atago` then `scoop install nao1215/atago`. Scoop accepts any git repository with a `bucket/` directory, so the manifest lives in [`bucket/`](bucket/) instead of a second repository whose only content would be one generated JSON file.
- **winget manifests, generated but not submitted.** Each tagged release writes `nao1215.atago` manifests under `dist/`. Publishing them is a pull request to `microsoft/winget-pkgs`, which stays a manual step against a published tag.

Nix was considered and dropped: GoReleaser's `nix:` publisher targets a self-owned NUR, not nixpkgs itself, so it would cost a release-workflow change and a NUR registration for a channel almost nobody installs from. A manual nixpkgs pull request is the better path later.

## Why the bucket lives here

Publishing to a separate bucket repository needs a cross-repository token. The release job holds exactly one (`TAP_GITHUB_TOKEN`, scoped to the Homebrew tap), and adding another credential to provision and rotate is a real cost for one JSON file. Committing into this repository uses the workflow's built-in `GITHUB_TOKEN`, which already has `contents: write`.

winget cannot avoid that cost — a fork of `microsoft/winget-pkgs` must be written to — so `skip_upload: true` keeps the release green and self-contained. The `repository:` block records the target, so dropping `skip_upload` is all that automating it later takes.

## Verification

- `goreleaser check` against **both** the CI-pinned `v2.16.0` and the local `v2.17.0` (the config uses no field newer than 2.16).
- `make release-smoke`: `bucket/atago.json` carries both Windows architectures with their SHA-256 hashes; the winget installer manifest resolves the `.zip` to a nested portable `atago.exe` aliased to `atago`.
- `go test ./...`, `golangci-lint run` (0 issues), `make docs`, `make site` (no drift), `make e2e` (467 scenarios, 463 passed, 4 skipped).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Windows distribution support through Scoop.
  - Added generation of Winget manifests for Windows package installation.
  - Added release-built Windows artifacts and checksums.

- **Documentation**
  - Updated installation instructions with Scoop setup and installation commands.
  - Expanded the installation guide with Windows instructions and download verification guidance.
  - Added documentation for the project’s Scoop bucket and release-generated manifests.

- **Changelog**
  - Documented the new Windows distribution options and related release updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->