### PR TITLE
docs(cli): add project links to help

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -123,7 +123,8 @@ Commands:
 
 Run "atago <command> --help" for a command's options.
 Start with "atago init" — it writes a runnable example spec.
-Docs and the spec-file reference: https://github.com/nao1215/atago
+Documentation: https://nao1215.github.io/atago/
+GitHub Sponsors: https://github.com/sponsors/nao1215
 `)
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -891,6 +891,14 @@ func TestMain_HelpAndVersionVariants(t *testing.T) {
 		if !strings.Contains(out.String(), "atago <command>") {
 			t.Errorf("%s: usage not on stdout: %q", arg, out.String())
 		}
+		for _, want := range []string{
+			"Documentation: https://nao1215.github.io/atago/",
+			"GitHub Sponsors: https://github.com/sponsors/nao1215",
+		} {
+			if !strings.Contains(out.String(), want) {
+				t.Errorf("%s: help output does not contain %q: %q", arg, want, out.String())
+			}
+		}
 	}
 	for _, arg := range []string{"version", "-version", "--version"} {
 		var out, errb bytes.Buffer


### PR DESCRIPTION
## Summary
Show the hosted documentation and GitHub Sponsors links in atago's top-level help.

## Changes
- replace the repository docs hint with the GitHub Pages URL
- add the GitHub Sponsors URL
- cover all top-level help aliases in the existing CLI test

## Design Decisions
- keep the links as plain URLs so they remain usable in terminal output

## Testing
- `go test ./...`
- `make lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the CLI help output with direct links to Documentation and GitHub Sponsors.
  * Removed the previous “Docs and the spec-file reference” link from the help text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->