### PR TITLE
feat!: a flaky scenario fails the run, with --allow-flaky to opt out

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -72,4 +72,4 @@ jobs:
         # --retry-failed absorbs the inherently racy interactive-pty specs (e.g.
         # sqly's readline REPL over a pty); a recovered scenario is reported as
         # flaky, a real regression still fails after the retries.
-        run: ./dist/atago run --retry-failed 3 "${{ matrix.tool.dir }}"
+        run: ./dist/atago run --retry-failed 3 --allow-flaky "${{ matrix.tool.dir }}"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -80,7 +80,7 @@ jobs:
         # occasionally be lost with no observable signal to expect on. A recovered
         # scenario is reported as flaky, never hidden, and a real regression still
         # fails after the retries.
-        run: ./dist/atago run --retry-failed 3 ./test/e2e/tools/sqly
+        run: ./dist/atago run --retry-failed 3 --allow-flaky ./test/e2e/tools/sqly
 
   # Windows regressions must fail a PR, not surface days later in the daily
   # cross-platform run (#78 follow-up). This job runs the portable subset —
@@ -114,7 +114,7 @@ jobs:
         shell: bash
         run: |
           mapfile -t targets < <(bash scripts/windows_portable_specs.sh)
-          go run . run --retry-failed 1 "${targets[@]}"
+          go run . run --retry-failed 1 --allow-flaky "${targets[@]}"
 
       # Real-world proof that the ConPTY pty runner drives an INTERACTIVE CLI on
       # Windows, not just self-terminating output: sqly's shell is a readline
@@ -132,4 +132,4 @@ jobs:
       # sqly dogfood step above). A recovered scenario is reported as flaky.
       - name: Drive sqly's interactive shell over a Windows pty
         shell: bash
-        run: go run . run --parallel 1 --retry-failed 3 ./test/e2e/tools/sqly/repl_pty.atago.yaml
+        run: go run . run --parallel 1 --retry-failed 3 --allow-flaky ./test/e2e/tools/sqly/repl_pty.atago.yaml

--- a/.github/workflows/thirdparty.yml
+++ b/.github/workflows/thirdparty.yml
@@ -332,4 +332,4 @@ jobs:
         # nothing but load: the TUI suites timed out waiting for a screen that
         # arrives promptly on a quiet machine. A regression still fails both
         # attempts; only a flake is absorbed, and the report names it.
-        run: ./dist/atago run --retry-failed 1 "${{ matrix.program.dir }}"
+        run: ./dist/atago run --retry-failed 1 --allow-flaky "${{ matrix.program.dir }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **A flaky scenario now fails the run.** A scenario that failed and then passed
+  on a `--retry-failed` re-run, or that passed some `--repeat` iterations and
+  failed others, was reported loudly and exited 0. So the two knobs whose whole
+  purpose is to surface instability went green when they found it — `--repeat`'s
+  own help said "any failing iteration fails the run" while a partial failure
+  exited 0 — and a suite could rot without CI ever noticing. Downstream, sqly's
+  runner passed `--retry-failed 3` for the sake of its interactive-pty specs, and
+  that silently extended tolerance to every other spec in the suite: a real
+  nondeterminism bug in filesql, where an LTSV table's column order came out of a
+  map, surfaced there as "flaky, PASSED" rather than as a failure.
+
+  A flaky scenario is still reported as flaky and not as a hard failure — TAP
+  keeps its `ok` point with a diagnostic, junit keeps `flakyFailure` inside a
+  passed testcase, gha keeps its warning — because per scenario the recovery is a
+  fact. What changed is the run-level verdict: the console summary now reads
+  FAILED, matching the exit code, where before the headline and the exit code
+  could disagree.
+
+### Added
+
+- `--allow-flaky` exits 0 when the only problem is flakiness, for a suite whose
+  instability is already known and accepted. atago's own pty scenarios lose
+  keystrokes when their sessions are starved of CPU, so its `dogfood`,
+  `thirdparty`, and pty CI jobs pass it — which puts the tolerance at the command
+  line instead of in a comment beside a flag that granted it invisibly.
+
 ## [0.17.0] - 2026-07-28
 
 A minor release about reach, and about failures that describe themselves.

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ thirdparty: ## Run atago against third-party programs (needs git, caddy, helix, 
 
 dogfood: ## Run atago against real nao1215 CLIs that just need a binary on PATH (gup, sqly, truss)
 	env CGO_ENABLED=0 $(GO_BUILD) $(GO_LDFLAGS) -o ./dist/$(APP) .
-	./dist/$(APP) run --parallel $(PARALLEL) --retry-failed 3 ./test/e2e/tools/gup ./test/e2e/tools/sqly ./test/e2e/tools/truss
+	./dist/$(APP) run --parallel $(PARALLEL) --retry-failed 3 --allow-flaky ./test/e2e/tools/gup ./test/e2e/tools/sqly ./test/e2e/tools/truss
 
 dogfood-iso8583tool: ## Full iso8583tool e2e (builds latest iso8583tool + its TCP mock; set ISO_REPO)
 	bash ./test/e2e/tools/iso8583tool/run.sh --parallel $(PARALLEL)

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Selection flags compose with any spec: `--filter NAME` (repeatable, and comma-se
 
 ## Use it in CI
 
-Real E2E suites flake (timing, ports, external tools). `--retry-failed N` re-runs failed scenarios in a fresh workdir and reports recovered ones as flaky — green for the exit code, but loud in every report format; silent retries are explicitly a non-goal. `--repeat N` does the opposite job: run each scenario N times to detect flakiness before it reaches CI.
+Real E2E suites flake (timing, ports, external tools). `--retry-failed N` re-runs failed scenarios in a fresh workdir and reports recovered ones as flaky, loud in every report format; silent retries are explicitly a non-goal. A flaky scenario still fails the run, because one whose answer depends on how many times it ran has not been shown to work — pass `--allow-flaky` for a suite whose instability you already know about and accept. `--repeat N` does the opposite job: run each scenario N times to detect flakiness before it reaches CI.
 
 ```shell
 atago run --ci --retry-failed 2 ./specs          # keep CI green, report instability loudly

--- a/README.md
+++ b/README.md
@@ -268,7 +268,8 @@ Selection flags compose with any spec: `--filter NAME` (repeatable, and comma-se
 Real E2E suites flake (timing, ports, external tools). `--retry-failed N` re-runs failed scenarios in a fresh workdir and reports recovered ones as flaky, loud in every report format; silent retries are explicitly a non-goal. A flaky scenario still fails the run, because one whose answer depends on how many times it ran has not been shown to work — pass `--allow-flaky` for a suite whose instability you already know about and accept. `--repeat N` does the opposite job: run each scenario N times to detect flakiness before it reaches CI.
 
 ```shell
-atago run --ci --retry-failed 2 ./specs          # keep CI green, report instability loudly
+atago run --ci --retry-failed 2 ./specs          # retry, report instability loudly, still fail
+atago run --ci --retry-failed 2 --allow-flaky ./specs  # ...and keep CI green when that is accepted
 atago run --repeat 20 --filter "race prone" ./specs   # flake detection
 ```
 

--- a/doc/cookbook.md
+++ b/doc/cookbook.md
@@ -2247,7 +2247,8 @@ other way — it surfaces instability instead of absorbing it:
 
 ```shell
 atago run --repeat 20 flaky.atago.yaml   # run each scenario 20 times; ONE bad iteration fails the run
-atago run --retry-failed 2 ./specs      # retry failures, but a pass-after-fail is REPORTED as flaky, never hidden
+atago run --retry-failed 2 ./specs      # retry failures; a pass-after-fail is REPORTED as flaky and still fails the run
+atago run --retry-failed 2 --allow-flaky ./specs  # ...unless the instability is known and accepted here
 atago run --rerun-failed ./specs        # while bisecting: re-run only what failed last time (from .atago/last-failed.json)
 ```
 

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -3422,16 +3422,21 @@ ${atago} run flaky.atago.yaml
 rm -f seen.txt
 ${atago} run --retry-failed 1 flaky.atago.yaml
 rm -f seen.txt
+${atago} run --retry-failed 1 --allow-flaky flaky.atago.yaml
+rm -f seen.txt
 ${atago} run --retry-failed 1 --report json flaky.atago.yaml
 ```
 #### Then
 - after `${atago} run flaky.atago.yaml`:
   - exit code is `1`
 - after `${atago} run --retry-failed 1 flaky.atago.yaml`:
+  - exit code is `1`
+  - stdout contains `FLAKY:`, `passed after 2 attempts`, `1 flaky`
+- after `${atago} run --retry-failed 1 --allow-flaky flaky.atago.yaml`:
   - exit code is `0`
   - stdout contains `FLAKY:`, `passed after 2 attempts`, `1 flaky`
 - after `${atago} run --retry-failed 1 --report json flaky.atago.yaml`:
-  - exit code is `0`
+  - exit code is `1`
   - stdout contains `"status": "flaky"`, `"attempts": 2`
 ### Scenario: repeat surfaces flakiness that a single run would miss
 _skipped on Windows_
@@ -3482,6 +3487,8 @@ scenarios:
 ```shell
 ${atago} run --repeat 3 green.atago.yaml
 ${atago} run --repeat 3 flaky.atago.yaml
+rm -f seen.txt
+${atago} run --repeat 3 --allow-flaky flaky.atago.yaml
 ${atago} run --repeat 3 broken.atago.yaml
 ```
 #### Then
@@ -3489,6 +3496,9 @@ ${atago} run --repeat 3 broken.atago.yaml
   - exit code is `0`
   - stdout contains `steady: 3/3 passed`
 - after `${atago} run --repeat 3 flaky.atago.yaml`:
+  - exit code is `1`
+  - stdout contains `flaky once: 2/3 passed`, `1 flaky`
+- after `${atago} run --repeat 3 --allow-flaky flaky.atago.yaml`:
   - exit code is `0`
   - stdout contains `flaky once: 2/3 passed`, `1 flaky`
 - after `${atago} run --repeat 3 broken.atago.yaml`:

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -552,26 +552,59 @@ func (errWriter) Write([]byte) (int, error) { return 0, errors.New("boom") }
 func TestExitForSuite_Precedence(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
-		name string
-		res  *engine.SuiteResult
-		want int
+		name       string
+		res        *engine.SuiteResult
+		allowFlaky bool
+		want       int
 	}{
-		{"passed", &engine.SuiteResult{Status: engine.StatusPassed}, ExitOK},
-		{"skipped", &engine.SuiteResult{Status: engine.StatusSkipped}, ExitOK},
-		{"flaky", &engine.SuiteResult{Status: engine.StatusFlaky}, ExitOK},
-		{"failed", &engine.SuiteResult{Status: engine.StatusFailed}, ExitFailures},
-		{"error", &engine.SuiteResult{Status: engine.StatusError}, ExitExec},
-		{"unknown", &engine.SuiteResult{Status: engine.Status("weird")}, ExitInternal},
+		{name: "passed", res: &engine.SuiteResult{Status: engine.StatusPassed}, want: ExitOK},
+		{name: "skipped", res: &engine.SuiteResult{Status: engine.StatusSkipped}, want: ExitOK},
+		// A scenario that needed a retry to pass is unstable, and a suite whose
+		// answer depends on how many times it ran has not been shown to work. It
+		// fails unless the caller says that instability is expected here.
+		// A flaky scenario leaves the suite's status at passed, so these carry a
+		// scenario: the count is what exitForSuite reads.
+		{name: "flaky", res: suiteWithFlake(engine.StatusPassed), want: ExitFailures},
+		{name: "flaky allowed", res: suiteWithFlake(engine.StatusPassed), allowFlaky: true, want: ExitOK},
+		{name: "flaky beside a failure is still a failure", res: suiteWithFlake(engine.StatusFailed), allowFlaky: true, want: ExitFailures},
+		{name: "failed", res: &engine.SuiteResult{Status: engine.StatusFailed}, want: ExitFailures},
+		{name: "failed stays failed when flaky is allowed", res: &engine.SuiteResult{Status: engine.StatusFailed}, allowFlaky: true, want: ExitFailures},
+		{name: "error", res: &engine.SuiteResult{Status: engine.StatusError}, want: ExitExec},
+		{name: "error stays an error when flaky is allowed", res: &engine.SuiteResult{Status: engine.StatusError}, allowFlaky: true, want: ExitExec},
+		{name: "unknown", res: &engine.SuiteResult{Status: engine.Status("weird")}, want: ExitInternal},
 		// A security violation outranks the generic status entirely.
-		{"security over passed", &engine.SuiteResult{Status: engine.StatusPassed, SecurityViolation: true}, ExitSecurity},
-		{"security over error", &engine.SuiteResult{Status: engine.StatusError, SecurityViolation: true}, ExitSecurity},
-		{"security over failed", &engine.SuiteResult{Status: engine.StatusFailed, SecurityViolation: true}, ExitSecurity},
+		{name: "security over passed", res: &engine.SuiteResult{Status: engine.StatusPassed, SecurityViolation: true}, want: ExitSecurity},
+		{name: "security over error", res: &engine.SuiteResult{Status: engine.StatusError, SecurityViolation: true}, want: ExitSecurity},
+		{name: "security over failed", res: &engine.SuiteResult{Status: engine.StatusFailed, SecurityViolation: true}, want: ExitSecurity},
+		{name: "security over allowed flaky", res: &engine.SuiteResult{Status: engine.StatusFlaky, SecurityViolation: true}, allowFlaky: true, want: ExitSecurity},
+		{name: "security over refused flaky", res: suiteWithFlakeAndViolation(), want: ExitSecurity},
 	}
 	for _, c := range cases {
-		if got := exitForSuite(c.res); got != c.want {
+		if got := exitForSuite(c.res, c.allowFlaky); got != c.want {
 			t.Errorf("%s: exitForSuite = %d, want %d", c.name, got, c.want)
 		}
 	}
+}
+
+// suiteWithFlake builds a suite holding one flaky scenario, with the suite's own
+// status set by the caller. The scenario is what matters: worseStatus ranks flaky
+// alongside passed, so a suite is never itself "flaky" just because one of its
+// scenarios was.
+func suiteWithFlake(suiteStatus engine.Status) *engine.SuiteResult {
+	return &engine.SuiteResult{
+		Status: suiteStatus,
+		Scenarios: []engine.ScenarioResult{
+			{Name: "flake", Status: engine.StatusFlaky, Attempts: 2},
+		},
+	}
+}
+
+// suiteWithFlakeAndViolation is suiteWithFlake plus a security breach, so the
+// precedence table can check that the breach wins over the flaky refusal too.
+func suiteWithFlakeAndViolation() *engine.SuiteResult {
+	res := suiteWithFlake(engine.StatusPassed)
+	res.SecurityViolation = true
+	return res
 }
 
 // TestWorseExit_MonotonicAndCommutative exhaustively checks the exit-code

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -43,6 +43,7 @@ type runOptions struct {
 	skipTag         csvFlag
 	artifactsDir    string
 	rerunFailed     bool
+	allowFlaky      bool
 	verbose         bool
 	ci              bool
 	stdout          io.Writer
@@ -151,10 +152,11 @@ func parseRunFlags(label string, args []string, stdout, stderr io.Writer) (*runO
 	artifactsDir := fs.String("artifacts-dir", "", "write deterministic failure artifacts (actual/expected payloads) under DIR for review tooling")
 	rerunFailed := fs.Bool("rerun-failed", false, "run only the scenarios that failed on the previous run (recorded in .atago/last-failed.json)")
 	repeat := fs.Int("repeat", 0, "run each selected scenario N times to surface flakiness; any failing iteration fails the run")
-	retryFailed := fs.Int("retry-failed", 0, "retry failed scenarios up to N times; recovered scenarios are reported as flaky, never hidden")
+	retryFailed := fs.Int("retry-failed", 0, "retry failed scenarios up to N times; a recovered scenario is reported as flaky and still fails the run unless --allow-flaky")
+	allowFlaky := fs.Bool("allow-flaky", false, "exit 0 when the only problem is flakiness; for a suite whose instability is known and accepted")
 	verbose := fs.Bool("verbose", false, "trace every scenario as it finishes: commands, exit codes, captured output, and per-assertion verdicts — for passing scenarios too")
 	fs.Usage = func() {
-		fmt.Fprint(stderr, "Usage: atago run [--report console|json|junit|gha|tap] [--update-snapshots] [--parallel N] [--fail-fast] [--filter S] [--tag T] [--skip-tag T] [--rerun-failed] [--repeat N] [--retry-failed N] [--artifacts-dir DIR] [--verbose] [--ci] <path | dir>...\n  (directories are searched recursively)\n")
+		fmt.Fprint(stderr, "Usage: atago run [--report console|json|junit|gha|tap] [--update-snapshots] [--parallel N] [--fail-fast] [--filter S] [--tag T] [--skip-tag T] [--rerun-failed] [--repeat N] [--retry-failed N] [--allow-flaky] [--artifacts-dir DIR] [--verbose] [--ci] <path | dir>...\n  (directories are searched recursively)\n")
 		fs.PrintDefaults()
 	}
 	if err := fs.Parse(args); err != nil {
@@ -223,6 +225,7 @@ func parseRunFlags(label string, args []string, stdout, stderr io.Writer) (*runO
 		skipTag:         skipTag,
 		artifactsDir:    *artifactsDir,
 		rerunFailed:     *rerunFailed,
+		allowFlaky:      *allowFlaky,
 		verbose:         *verbose,
 		ci:              *ci,
 		stdout:          stdout,
@@ -271,7 +274,7 @@ func finishRun(opts *runOptions, suiteResults []*engine.SuiteResult, loadErrs []
 			continue
 		}
 		results = append(results, suiteResult)
-		exit = worseExit(exit, exitForSuite(suiteResult))
+		exit = worseExit(exit, exitForSuite(suiteResult, opts.allowFlaky))
 	}
 	if progress != nil {
 		progress.Done()
@@ -371,7 +374,7 @@ func finishRun(opts *runOptions, suiteResults []*engine.SuiteResult, loadErrs []
 		}
 	}
 
-	if err := report.Render(opts.stdout, opts.format, results, report.WithLoadFailures(loadFailures), report.WithElapsed(elapsed)); err != nil {
+	if err := report.Render(opts.stdout, opts.format, results, report.WithLoadFailures(loadFailures), report.WithElapsed(elapsed), report.WithAllowFlaky(opts.allowFlaky)); err != nil {
 		fmt.Fprintf(opts.stderr, opts.label+": failed to write report: %v\n", err)
 		return worseExit(exit, ExitInternal)
 	}
@@ -641,7 +644,14 @@ func exitForLoadError(err error) int {
 	return ExitParse
 }
 
-func exitForSuite(res *engine.SuiteResult) int {
+// exitForSuite maps a suite result to an exit code. allowFlaky decides the one
+// status whose severity is a policy rather than a fact: a scenario that needed a
+// retry to pass, or that passed on some iterations and failed on others, has not
+// been shown to work, so a suite holding one fails. --allow-flaky is for a suite
+// with instability the caller already knows about and accepts — atago's own pty
+// scenarios lose keystrokes when their sessions are starved of CPU — and it says
+// so at the command line instead of every run quietly going green.
+func exitForSuite(res *engine.SuiteResult, allowFlaky bool) int {
 	// A security policy violation (e.g. a denied network host) takes precedence
 	// over the generic execution-error code.
 	if res.SecurityViolation {
@@ -649,6 +659,13 @@ func exitForSuite(res *engine.SuiteResult) int {
 	}
 	switch res.Status {
 	case engine.StatusPassed, engine.StatusSkipped, engine.StatusFlaky:
+		// A flaky scenario does not raise the suite's status — worseStatus ranks it
+		// alongside passed, so a suite of one flake and nine passes still reports
+		// passed — which is why the count is what decides here, the same value the
+		// console verdict reads.
+		if !allowFlaky && res.Counts().Flaky > 0 {
+			return ExitFailures
+		}
 		return ExitOK
 	case engine.StatusFailed:
 		return ExitFailures

--- a/internal/engine/attempts.go
+++ b/internal/engine/attempts.go
@@ -32,8 +32,9 @@ func (e *Engine) runScenarioWithPolicy(ctx context.Context, idx int, sc *spec.Sc
 // tell apart (#138): a scenario that failed EVERY iteration is a deterministic
 // bug (StatusFailed, or StatusError when the failures were execution errors),
 // while one that passed some iterations and failed others is unstable, not
-// broken, and folds to StatusFlaky — surfaced with its flake rate but green for
-// the exit code, exactly like a --retry-failed recovery. Collapsing a partial
+// broken, and folds to StatusFlaky — surfaced with its flake rate, and failing
+// the run unless --allow-flaky, exactly like a --retry-failed recovery.
+// Collapsing a partial
 // failure into StatusFailed (the old behavior) erased that distinction, so
 // "3/10 flaked" was indistinguishable from "10/10 is a real bug".
 func (e *Engine) runRepeated(ctx context.Context, idx int, sc *spec.Scenario, rc runConfig) ScenarioResult {

--- a/internal/engine/result.go
+++ b/internal/engine/result.go
@@ -23,9 +23,11 @@ const (
 	// StatusFlaky means the scenario was unstable, not broken: it failed at
 	// least once and passed at least once. Two paths produce it — a
 	// --retry-failed re-run that recovered (#29), or a --repeat run where some
-	// iterations passed and some failed (#138). Either way it is green for the
-	// exit code, but surfaced everywhere (with its attempt count or flake rate)
-	// so instability is never silently hidden.
+	// iterations passed and some failed (#138). Either way it fails the run,
+	// because a scenario whose answer depends on how many times it ran has not
+	// been shown to work; --allow-flaky exits 0 for a suite whose instability the
+	// caller already knows about. It is surfaced everywhere with its attempt count
+	// or flake rate, so the distinction from a deterministic failure is kept.
 	StatusFlaky Status = "flaky"
 )
 

--- a/internal/report/console.go
+++ b/internal/report/console.go
@@ -15,7 +15,7 @@ import (
 
 // writeSummary prints the final tally line. The uppercase status word
 // (PASSED/FAILED) anchors the line and is part of the stable output contract.
-func writeSummary(b *strings.Builder, color bool, c engine.Counts, total int, d time.Duration, hardFail bool, loadFailures int) {
+func writeSummary(b *strings.Builder, color bool, c engine.Counts, total int, d time.Duration, hardFail bool, loadFailures int, allowFlaky bool) {
 	status, code := "PASSED", cGreen
 	// hardFail covers a suite that errored before producing any scenario row (#7):
 	// the counts are all zero, but the verdict must still read FAILED to match the
@@ -23,7 +23,10 @@ func writeSummary(b *strings.Builder, color bool, c engine.Counts, total int, d 
 	// loadFailures covers spec files that could not be parsed/validated (#120):
 	// they run no scenario, so without this the headline would read PASSED while
 	// the process exits non-zero and the dropped file is silently uncounted.
-	if c.Failed > 0 || c.Errored > 0 || hardFail || loadFailures > 0 {
+	// A flaky scenario fails the run for the same reason it is reported at all, so
+	// the verdict follows it unless the caller passed --allow-flaky; the tally's
+	// ", N flaky" tail names it either way.
+	if c.Failed > 0 || c.Errored > 0 || hardFail || loadFailures > 0 || (c.Flaky > 0 && !allowFlaky) {
 		status, code = "FAILED", cRed
 	}
 	plural := "scenarios"

--- a/internal/report/render.go
+++ b/internal/report/render.go
@@ -52,6 +52,11 @@ type renderOptions struct {
 	// in ~1s, not 4s).
 	elapsed    time.Duration
 	hasElapsed bool
+	// allowFlaky mirrors --allow-flaky. A flaky scenario fails the run, so the
+	// summary must read FAILED for one, or the headline contradicts the exit code
+	// the same way a load failure used to. When the caller accepts the
+	// instability, both go back to green together.
+	allowFlaky bool
 }
 
 // WithLoadFailures records how many spec files failed to load for this run, so
@@ -65,6 +70,12 @@ func WithLoadFailures(n int) Option {
 // concurrent (--parallel) suites.
 func WithElapsed(d time.Duration) Option {
 	return func(o *renderOptions) { o.elapsed = d; o.hasElapsed = true }
+}
+
+// WithAllowFlaky records that the caller accepts flakiness for this run, so the
+// summary reads PASSED for a flaky-only run and matches its zero exit code.
+func WithAllowFlaky(allow bool) Option {
+	return func(o *renderOptions) { o.allowFlaky = allow }
 }
 
 // Render writes one or more suite results in the requested format. Console
@@ -101,7 +112,7 @@ func Render(w io.Writer, f Format, results []*engine.SuiteResult, opts ...Option
 		if o.hasElapsed {
 			dur = o.elapsed
 		}
-		writeSummary(&b, color, agg, total, dur, hardFail, o.loadFailures)
+		writeSummary(&b, color, agg, total, dur, hardFail, o.loadFailures, o.allowFlaky)
 		_, err := io.WriteString(w, b.String())
 		return err
 	case FormatJSON:

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -323,10 +323,15 @@ func TestRender_TAP(t *testing.T) {
 }
 
 // flakyResults builds a suite whose single scenario failed once and then passed
-// on retry (#29). atago treats a recovered scenario as green: the process exits 0
-// (exitForSuite), the console verdict stays PASSED, gha warns instead of erroring,
-// and junit records it as a passed testcase. Every report format must agree on
-// that verdict, so a flaky scenario is a pass and never a failure.
+// on retry (#29).
+//
+// Two different questions get two different answers here. Per scenario, the
+// recovery is a fact each format records in its own idiom — a TAP ok point with a
+// diagnostic, junit's flakyFailure inside a passed testcase (the Surefire
+// convention), a gha warning rather than an error — and none of them is a hard
+// failure, because the scenario did pass. At run level the verdict follows the
+// exit code, and a flaky scenario fails the run unless --allow-flaky, so the
+// console summary line reads FAILED where the per-scenario rows do not.
 func flakyResults() []*engine.SuiteResult {
 	return []*engine.SuiteResult{{
 		Suite:    "s1",
@@ -340,11 +345,11 @@ func flakyResults() []*engine.SuiteResult {
 	}}
 }
 
-// TestRender_FlakyIsGreenAcrossFormats is a metamorphic parity check: a scenario
-// that recovered on retry (StatusFlaky) reads as a pass in every report format,
-// matching the exit code and the console verdict. TAP fell through to a `not ok`
-// point, contradicting the green verdict the same run reported everywhere else.
-func TestRender_FlakyIsGreenAcrossFormats(t *testing.T) {
+// TestRender_FlakyIsDistinctFromFailed is a parity check across formats: a
+// scenario that recovered on retry is never rendered as a hard failure, and it is
+// never rendered as an unremarkable pass either. The run-level verdict is checked
+// separately, because that one follows the exit code.
+func TestRender_FlakyIsDistinctFromFailed(t *testing.T) {
 	t.Parallel()
 
 	t.Run("tap marks a flaky scenario ok, not failed", func(t *testing.T) {
@@ -398,18 +403,49 @@ func TestRender_FlakyIsGreenAcrossFormats(t *testing.T) {
 		}
 	})
 
-	t.Run("console verdict stays PASSED with a flaky scenario", func(t *testing.T) {
+	// The run-level verdict has to agree with the exit code, and a flaky scenario
+	// exits non-zero: a headline reading PASSED beside a failing exit code is the
+	// same contradiction a spec-load failure used to produce.
+	t.Run("console verdict reads FAILED for a flaky scenario", func(t *testing.T) {
 		t.Parallel()
 		var b bytes.Buffer
 		if err := Render(&b, FormatConsole, flakyResults()); err != nil {
 			t.Fatal(err)
 		}
 		out := b.String()
-		if strings.Contains(out, "FAILED") {
-			t.Errorf("console verdict flipped to FAILED for a flaky (green) scenario:\n%s", out)
+		if !strings.Contains(out, "FAILED") {
+			t.Errorf("console verdict should read FAILED for a flaky scenario, which fails the run:\n%s", out)
 		}
 		if !strings.Contains(out, "1 flaky") {
 			t.Errorf("console should surface the flaky count:\n%s", out)
+		}
+	})
+
+	t.Run("console verdict reads PASSED when flakiness is allowed", func(t *testing.T) {
+		t.Parallel()
+		var b bytes.Buffer
+		if err := Render(&b, FormatConsole, flakyResults(), WithAllowFlaky(true)); err != nil {
+			t.Fatal(err)
+		}
+		out := b.String()
+		if strings.Contains(out, "FAILED") {
+			t.Errorf("console verdict should read PASSED under --allow-flaky, matching its zero exit code:\n%s", out)
+		}
+		if !strings.Contains(out, "1 flaky") {
+			t.Errorf("--allow-flaky must still surface the flaky count:\n%s", out)
+		}
+	})
+
+	t.Run("a hard failure reads FAILED even when flakiness is allowed", func(t *testing.T) {
+		t.Parallel()
+		results := flakyResults()
+		results[0].Scenarios[0].Status = engine.StatusFailed
+		var b bytes.Buffer
+		if err := Render(&b, FormatConsole, results, WithAllowFlaky(true)); err != nil {
+			t.Fatal(err)
+		}
+		if out := b.String(); !strings.Contains(out, "FAILED") {
+			t.Errorf("--allow-flaky must not soften a real failure:\n%s", out)
 		}
 	})
 }

--- a/test/e2e/atago/flaky.atago.yaml
+++ b/test/e2e/atago/flaky.atago.yaml
@@ -37,10 +37,26 @@ scenarios:
       - run:
           shell: true
           command: rm -f seen.txt
-      # With --retry-failed the recovery is green BUT surfaced: exit 0, an
-      # 'f' progress dot, a FLAKY line, and ", 1 flaky" in the summary.
+      # With --retry-failed the recovery is surfaced — an 'f' progress dot, a
+      # FLAKY line, ", 1 flaky" in the summary — and it still fails the run: a
+      # scenario whose answer depends on how many times it ran has not been
+      # shown to work.
       - run:
           command: ${atago} run --retry-failed 1 flaky.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "FLAKY:"
+              - "passed after 2 attempts"
+              - "1 flaky"
+      # --allow-flaky is for a suite whose instability the caller already knows
+      # about: same report, exit 0.
+      - run:
+          shell: true
+          command: rm -f seen.txt
+      - run:
+          command: ${atago} run --retry-failed 1 --allow-flaky flaky.atago.yaml
       - assert:
           exit_code: 0
           stdout:
@@ -55,7 +71,7 @@ scenarios:
       - run:
           command: ${atago} run --retry-failed 1 --report json flaky.atago.yaml
       - assert:
-          exit_code: 0
+          exit_code: 1
           stdout:
             contains:
               - '"status": "flaky"'
@@ -97,11 +113,24 @@ scenarios:
                       command: "if [ -f '${workdir}/seen.txt' ]; then echo recovered; else touch '${workdir}/seen.txt'; exit 1; fi"
                   - assert:
                       exit_code: 0
-      # A PARTIAL failure (some iterations pass, some fail) is instability, not a
-      # bug: repeat folds it to flaky — green for the exit code but surfaced with
-      # its rate and counted in the summary (#138).
+      # A PARTIAL failure (some iterations pass, some fail) is instability rather
+      # than a bug, so it folds to flaky and is surfaced with its rate (#138) —
+      # and it fails the run, which is what --repeat is for: a knob that exists
+      # to surface flakiness cannot exit 0 when it finds some.
       - run:
           command: ${atago} run --repeat 3 flaky.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "flaky once: 2/3 passed"
+              - "1 flaky"
+      # --allow-flaky takes the same run back to green without hiding the rate.
+      - run:
+          shell: true
+          command: rm -f seen.txt
+      - run:
+          command: ${atago} run --repeat 3 --allow-flaky flaky.atago.yaml
       - assert:
           exit_code: 0
           stdout:


### PR DESCRIPTION
## Summary

A scenario that failed and then passed on a `--retry-failed` re-run, or that passed some `--repeat` iterations and failed others, was reported loudly and exited 0. So the two knobs whose whole purpose is to surface instability went green when they found it.

`--repeat`'s own help already said otherwise:

```
-repeat int
    run each scenario N times to surface flakiness; any failing iteration fails the run
```

A partial failure folded to flaky and exited 0, so the flag did not do what it documented.

## What this cost downstream

sqly's runner passed `--retry-failed 3` for the sake of its interactive-pty specs, and that extended tolerance to every other spec in the suite. filesql built an LTSV table's column list by ranging over a map, so `SELECT *` answered with the columns in a different order on every invocation — and the scenarios written to catch that came out as "flaky, PASSED" rather than as a failure. A suite can rot this way without CI ever saying so.

## What changed, and what did not

A flaky scenario now fails the run. It is **still reported as flaky rather than as a hard failure**: TAP keeps its `ok` point with a diagnostic, junit keeps `flakyFailure` inside a passed testcase (the Surefire convention), gha keeps its warning. Per scenario the recovery is a fact, and each format records it in its own idiom.

What changed is the run-level verdict. The console summary now reads FAILED beside the non-zero exit code, where before the headline and the exit code could disagree — the same contradiction a spec-load failure used to produce, and which that case is already guarded against.

`exitForSuite` reads the flaky **count** rather than the suite's status, because `worseStatus` ranks flaky alongside passed: a suite of one flake and nine passes reports `passed`, so the status never carried the information. That is why the earlier `case StatusFlaky` branch would almost never have fired.

## `--allow-flaky`

For a suite whose instability is known and accepted. atago's own pty scenarios lose keystrokes when their sessions are starved of CPU, so the `dogfood` target and the dogfood, thirdparty, and pty CI jobs pass it. Every one of those call sites already carried a comment explaining that `--retry-failed` was there to absorb known flakiness — the tolerance moves from that comment to the command line, where it is visible in the invocation.

## Tests

`TestExitForSuite_Precedence` covers flaky refused, flaky allowed, a flake beside a real failure under `--allow-flaky`, and security violation winning over both. `TestRender_FlakyIsDistinctFromFailed` (renamed from `TestRender_FlakyIsGreenAcrossFormats`) keeps the per-format parity checks and adds the run-level verdict in both modes. `test/e2e/atago/flaky.atago.yaml` asserts the binary's exit code for `--retry-failed` and `--repeat`, each with and without `--allow-flaky`.

This is a breaking change to exit-code behavior, so the CHANGELOG entry leads with it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `--allow-flaky` option for accepting known flaky test outcomes without failing the run.
  * Flaky scenarios now remain visible in reports while correctly affecting the overall pass/fail result.

* **Bug Fixes**
  * Runs with recovered flaky scenarios now consistently report `FAILED` and return a failure code unless flakiness is explicitly allowed.

* **Documentation**
  * Updated CLI guidance and examples to explain retry, repeat, reporting, and flaky-result behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->