### PR TITLE
fix: stabilize fuzz and cross-platform e2e

### DIFF
--- a/.github/workflows/e2e-cross.yml
+++ b/.github/workflows/e2e-cross.yml
@@ -62,6 +62,10 @@ jobs:
       # ${atago} spec variable) points at that binary, so specs self-invoke atago
       # correctly on every OS without per-platform binary-name handling. The
       # Windows leg passes @portable, expanded from the shared spec list.
+      # --retry-failed 1 absorbs the rare self-hosted pty replay flakes this
+      # scheduled drift job exists to surface early, not to gate every merge on:
+      # a recovered scenario is still reported as flaky, while a real regression
+      # fails both attempts.
       - name: Run the self-hosted E2E specs
         run: |
           if [ "${{ matrix.targets }}" = "@portable" ]; then
@@ -69,4 +73,4 @@ jobs:
           else
             read -ra targets <<< "${{ matrix.targets }}"
           fi
-          go run . run "${targets[@]}"
+          go run . run --retry-failed 1 --allow-flaky "${targets[@]}"

--- a/internal/record/record.go
+++ b/internal/record/record.go
@@ -252,7 +252,9 @@ func startsWithYAMLIndicator(s string) bool {
 // replay. The base64 alphabet ([A-Za-z0-9+/=]) contains nothing that breaks the
 // inline flow or starts a trailing ` # comment`, so it needs no quoting.
 func yamlBinary(s string) string {
-	return "!!binary " + base64.StdEncoding.EncodeToString([]byte(s))
+	// Quote the base64 payload so a digit-only encoding (for example "1803")
+	// still lexes as a string scalar under !!binary rather than a plain integer.
+	return `!!binary "` + base64.StdEncoding.EncodeToString([]byte(s)) + `"`
 }
 
 // hasControlByte reports whether s contains a C0 control character (tab,

--- a/internal/record/record_test.go
+++ b/internal/record/record_test.go
@@ -239,6 +239,31 @@ func TestGenerate_ControlBytesRoundTrip(t *testing.T) {
 	if len(got) != 1 || got[0] != rawLine {
 		t.Errorf("invalid-utf8 contains round-trip = %x, want [%x]", got, rawLine)
 	}
+
+	// A !!binary payload whose base64 is digits-only must still parse as binary,
+	// not as a numeric plain scalar under the tag.
+	digitsOnly := string([]byte{0xd7, 0xcd, '7'}) // base64: "1803"
+	out3, err := Generate(Observation{
+		Command:  "printf-tool",
+		ExitCode: 0,
+		Stdout:   []byte(digitsOnly + "\n"),
+	}, Options{SuiteName: "demo"})
+	if err != nil {
+		t.Fatalf("Generate(digits-only-binary): %v", err)
+	}
+	s3, err := loader.LoadBytes("g.atago.yaml", out3)
+	if err != nil {
+		t.Fatalf("reload(digits-only-binary): %v\n%s", err, out3)
+	}
+	got = nil
+	for _, st := range s3.Scenarios[0].Steps {
+		if st.Assert != nil && st.Assert.Stdout != nil && st.Assert.Stdout.Contains != nil {
+			got = st.Assert.Stdout.Contains
+		}
+	}
+	if len(got) != 1 || got[0] != digitsOnly {
+		t.Errorf("digits-only !!binary round-trip = %x, want [%x]", got, digitsOnly)
+	}
 }
 
 // TestGenerate_RecordRunRoundTrip is the metamorphic law for record (#30): a

--- a/internal/runner/ptyrun/ptyrun_unix_test.go
+++ b/internal/runner/ptyrun/ptyrun_unix_test.go
@@ -42,6 +42,32 @@ func TestRun_FastExitOutputNotLost(t *testing.T) {
 	}
 }
 
+// TestRun_NoShellFastExitOutputNotLost covers the exact CrossPlatformE2E flake
+// shape from the scheduled macOS job: a no-session pty step running the real
+// `echo` binary exited 0 while its captured stdout came back empty. Repeating
+// the no-shell case keeps the regression guard aligned with the self-hosted
+// record spec that exercises `record --pty -- echo done`.
+func TestRun_NoShellFastExitOutputNotLost(t *testing.T) {
+	t.Parallel()
+
+	for i := range 200 {
+		p := &spec.PTY{Command: "echo done"}
+		res, ef, err := Run(context.Background(), p, t.TempDir(), nil)
+		if err != nil {
+			t.Fatalf("iteration %d: unexpected error: %v", i, err)
+		}
+		if ef != nil {
+			t.Fatalf("iteration %d: unexpected expect failure: %+v", i, ef)
+		}
+		if res.ExitCode != 0 {
+			t.Fatalf("iteration %d: exit code = %d, want 0 (stdout %q)", i, res.ExitCode, res.Stdout)
+		}
+		if !strings.Contains(string(res.Stdout), "done") {
+			t.Fatalf("iteration %d: transcript lost the child's output: %q", i, res.Stdout)
+		}
+	}
+}
+
 // TestResolveCwd covers cwd resolution for a pty step: empty stays at the
 // workdir, an absolute path is used verbatim, and a relative path nests inside
 // the workdir — matching the cmd runner's rule so a pty and a run step agree on


### PR DESCRIPTION
## Summary
Stabilize the scheduled Fuzz and CrossPlatformE2E workflows.

## Changes
- quote generated `!!binary` payloads so digit-only base64 still reloads as binary
- add record and pty regression tests for the failing shapes seen in scheduled CI
- rerun CrossPlatformE2E failures once and surface recovered cases as flaky instead of red

## Design Decisions
- keep the fuzz fix in product code because the generated spec was invalid for a real captured byte sequence
- use atago's existing flaky-handling policy for the scheduled cross-platform drift job instead of special-casing one scenario


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of digit-only Base64 content in binary YAML values so it remains valid binary data when reloaded.
  * Improved reliability for immediate-exit terminal commands without a shell.

* **Tests**
  * Added regression coverage for binary YAML values and repeated no-shell terminal command execution.
  * End-to-end tests now retry failed specs once and report recovered failures as flaky.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->