### PR TITLE
fix(pty): start draining before no-shell fast exits

### DIFF
--- a/internal/record/capture_test.go
+++ b/internal/record/capture_test.go
@@ -47,6 +47,54 @@ func TestCapturePTY_RecordsOutputAndExit(t *testing.T) {
 	}
 }
 
+// TestCapturePTY_NoShellFastExitOutputNotLost covers the same fast-exit path as
+// the macOS CrossPlatformE2E flake, but in the recorder: a no-shell `echo`
+// binary that exits immediately must still leave its output in the recording.
+func TestCapturePTY_NoShellFastExitOutputNotLost(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell:false echo is a POSIX path; windows coverage lives in the ConPTY tests")
+	}
+
+	for i := range 100 {
+		inR, inW, err := os.Pipe()
+		if err != nil {
+			t.Fatalf("iteration %d: input pipe: %v", i, err)
+		}
+		outR, outW, err := os.Pipe()
+		if err != nil {
+			_ = inR.Close()
+			_ = inW.Close()
+			t.Fatalf("iteration %d: output pipe: %v", i, err)
+		}
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			_, _ = io.Copy(io.Discard, outR)
+		}()
+
+		rec, err := CapturePTY("echo capture-marker", false, inR, outW, 30*time.Second)
+		_ = outW.Close()
+		_ = inR.Close()
+		_ = inW.Close()
+		<-done
+		_ = outR.Close()
+
+		if err != nil {
+			t.Fatalf("iteration %d: CapturePTY() error = %v", i, err)
+		}
+		if rec.ExitCode != 0 {
+			t.Fatalf("iteration %d: exit code = %d, want 0", i, rec.ExitCode)
+		}
+		var out strings.Builder
+		for _, seg := range rec.Segments {
+			out.Write(seg.Output)
+		}
+		if !strings.Contains(out.String(), "capture-marker") {
+			t.Fatalf("iteration %d: recording missing the child's output: %q", i, out.String())
+		}
+	}
+}
+
 // TestCapturePTY_TimesOutOnNonExitingChild is the cross-platform backstop for
 // #194: a program that never exits must not hang the recorder forever. It runs
 // a child that ignores stdin and outlives the timeout, and asserts CapturePTY

--- a/internal/record/capture_unix.go
+++ b/internal/record/capture_unix.go
@@ -49,15 +49,23 @@ func CapturePTY(command string, shell bool, in, out *os.File, timeout time.Durat
 	// context-aware exec contract without a redundant second deadline.
 	cmd := exec.CommandContext(context.Background(), name, args...) //nolint:gosec // recording the user's declared command is the purpose
 	cmd.Env = os.Environ()
-	// A fresh session so the child owns the pty and a stray descendant does not
-	// keep it open past the child's exit.
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	// A fresh session and controlling terminal so the child owns the pty and a
+	// stray descendant does not keep it open past the child's exit.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true, Setctty: true}
 
 	rows, cols := terminalSize(out)
-	master, err := pty.StartWithSize(cmd, &pty.Winsize{Rows: uint16(rows), Cols: uint16(cols)}) //nolint:gosec // geometry is bounded by terminalSize
+	master, tty, err := pty.Open()
 	if err != nil {
 		return PTYRecording{}, fmt.Errorf("record --pty: start %q: %w", command, err)
 	}
+	defer func() { _ = tty.Close() }()
+	if err := pty.Setsize(master, &pty.Winsize{Rows: uint16(rows), Cols: uint16(cols)}); err != nil { //nolint:gosec // geometry is bounded by terminalSize
+		_ = master.Close()
+		return PTYRecording{}, fmt.Errorf("record --pty: start %q: %w", command, err)
+	}
+	cmd.Stdin = tty
+	cmd.Stdout = tty
+	cmd.Stderr = tty
 	defer func() { _ = master.Close() }()
 
 	rec := PTYRecording{Command: command, Shell: shell, Rows: rows, Cols: cols}
@@ -69,6 +77,32 @@ func CapturePTY(command string, shell bool, in, out *os.File, timeout time.Durat
 	if oldState, rerr := term.MakeRaw(int(in.Fd())); rerr == nil {
 		defer func() { _ = term.Restore(int(in.Fd()), oldState) }()
 	}
+
+	// Output: child → developer's screen, recorded verbatim (ANSI intact).
+	outDone := make(chan struct{})
+	go func() {
+		defer close(outDone)
+		buf := make([]byte, 4096)
+		for {
+			n, rerr := master.Read(buf)
+			if n > 0 {
+				mu.Lock()
+				rec.AppendOutput(buf[:n])
+				mu.Unlock()
+				_, _ = out.Write(buf[:n])
+			}
+			if rerr != nil {
+				return
+			}
+		}
+	}()
+
+	if err := cmd.Start(); err != nil {
+		_ = master.Close()
+		<-outDone
+		return PTYRecording{}, fmt.Errorf("record --pty: start %q: %w", command, err)
+	}
+	_ = tty.Close()
 
 	// Input: developer keystrokes → child. Each Read is one burst; the pty's
 	// current ECHO state tags it as a secret (echo off) or not. This goroutine
@@ -86,25 +120,6 @@ func CapturePTY(command string, shell bool, in, out *os.File, timeout time.Durat
 				if _, werr := master.Write(buf[:n]); werr != nil {
 					return
 				}
-			}
-			if rerr != nil {
-				return
-			}
-		}
-	}()
-
-	// Output: child → developer's screen, recorded verbatim (ANSI intact).
-	outDone := make(chan struct{})
-	go func() {
-		defer close(outDone)
-		buf := make([]byte, 4096)
-		for {
-			n, rerr := master.Read(buf)
-			if n > 0 {
-				mu.Lock()
-				rec.AppendOutput(buf[:n])
-				mu.Unlock()
-				_, _ = out.Write(buf[:n])
 			}
 			if rerr != nil {
 				return

--- a/internal/record/capture_unix.go
+++ b/internal/record/capture_unix.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"sync"
 	"syscall"
 	"time"
@@ -96,6 +97,9 @@ func CapturePTY(command string, shell bool, in, out *os.File, timeout time.Durat
 			}
 		}
 	}()
+	// Yield once so the output drain can enter Read before a no-shell fast-exit
+	// command has a chance to print and disappear.
+	runtime.Gosched()
 
 	if err := cmd.Start(); err != nil {
 		_ = master.Close()

--- a/internal/runner/ptyrun/ptyrun_unix.go
+++ b/internal/runner/ptyrun/ptyrun_unix.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"runtime"
 	"syscall"
 
 	"github.com/creack/pty"
@@ -66,6 +67,9 @@ func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runne
 	// Post the first Read before the child starts: macOS can otherwise let a
 	// no-shell fast-exit command print and disappear before the drain exists.
 	term := startTranscriptDrain(master, p)
+	// Yield once so the drain goroutine can enter its blocking Read before this
+	// goroutine launches a child that may write and exit immediately.
+	runtime.Gosched()
 	if err := cmd.Start(); err != nil {
 		_ = master.Close()
 		term.waitDrain(func() {}, 0)

--- a/internal/runner/ptyrun/ptyrun_unix.go
+++ b/internal/runner/ptyrun/ptyrun_unix.go
@@ -39,9 +39,9 @@ func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runne
 		cmd.Dir = runnercmd.ResolveDir(workdir, p.Cwd)
 	}
 	cmd.Env = env
-	// A fresh process group so cleanup kills the whole tree, mirroring the cmd
-	// runner's teardown discipline.
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	// A fresh session and controlling terminal: the child owns the pty, and
+	// cleanup can still kill the whole tree by the negative process-group pid.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true, Setctty: true}
 
 	rows, cols := uint16(defaultRows), uint16(defaultCols)
 	if p.Rows > 0 && p.Rows < 1<<16 {
@@ -50,10 +50,28 @@ func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runne
 	if p.Cols > 0 && p.Cols < 1<<16 {
 		cols = uint16(p.Cols)
 	}
-	master, err := pty.StartWithSize(cmd, &pty.Winsize{Rows: rows, Cols: cols})
+	master, tty, err := pty.Open()
 	if err != nil {
 		return nil, nil, fmt.Errorf("pty: start %q: %w", p.Command, err)
 	}
+	defer func() { _ = tty.Close() }()
+	if err := pty.Setsize(master, &pty.Winsize{Rows: rows, Cols: cols}); err != nil {
+		_ = master.Close()
+		return nil, nil, fmt.Errorf("pty: start %q: %w", p.Command, err)
+	}
+	cmd.Stdin = tty
+	cmd.Stdout = tty
+	cmd.Stderr = tty
+
+	// Post the first Read before the child starts: macOS can otherwise let a
+	// no-shell fast-exit command print and disappear before the drain exists.
+	term := startTranscriptDrain(master, p)
+	if err := cmd.Start(); err != nil {
+		_ = master.Close()
+		term.waitDrain(func() {}, 0)
+		return nil, nil, fmt.Errorf("pty: start %q: %w", p.Command, err)
+	}
+	_ = tty.Close()
 
 	// Reap exactly once, from one place: probing a zombie with signal 0 keeps
 	// succeeding, so liveness must come from Wait itself. The buffered channel
@@ -62,8 +80,9 @@ func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runne
 	go func() { exitCh <- waitExitCode(cmd.Wait()) }()
 
 	proc := ptyProcess{
-		rw:   master,
-		exit: exitCh,
+		rw:    master,
+		trans: term,
+		exit:  exitCh,
 		// Negative pid signals the whole process group created by Setsid.
 		kill:      func() { _ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL) },
 		closeTerm: func() { _ = master.Close() },

--- a/internal/runner/ptyrun/session.go
+++ b/internal/runner/ptyrun/session.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"sync"
 	"syscall"
 	"time"
 
@@ -32,6 +31,11 @@ type ptyProcess struct {
 	// rw is the terminal master: reads yield the child's output (terminal echo
 	// included, ANSI intact), writes deliver sends to the child.
 	rw io.ReadWriter
+	// trans is an optional already-running terminal drain. The POSIX runner
+	// starts it before the child starts to close fast-exit races; other
+	// backends can leave it nil and let driveSession start the same drain when
+	// the backend cannot start it any earlier.
+	trans *transcriptDrain
 	// exit receives the child's observed exit code exactly once, when the
 	// process is reaped. It must be buffered (cap 1) so the reaper never blocks
 	// waiting for a receiver that a kill path drains later.
@@ -63,116 +67,22 @@ func driveSession(ctx context.Context, p *spec.PTY, proc ptyProcess) (*runner.Re
 	defer cancel()
 
 	start := time.Now()
-	var writeMu sync.Mutex
-	writeTerm := func(b []byte) (int, error) {
-		writeMu.Lock()
-		defer writeMu.Unlock()
-		return proc.rw.Write(b)
+	term := proc.trans
+	if term == nil {
+		term = startTranscriptDrain(proc.rw, p)
 	}
-	queries := newTerminalQueries(p, writerFunc(writeTerm))
-
-	// Transcript accumulator: one goroutine drains the master so the child never
-	// blocks on a full terminal buffer. Reads end when the child exits (EOF/EIO)
-	// or the master is closed.
-	//
-	// readErr holds the error that ended the loop when it is NOT one of those
-	// ends (#345). Every error used to end the loop the same way, so a transcript
-	// lost to a real read failure left exactly the state a completed session
-	// leaves — and every expect_screen/screen/transcript assertion afterwards ran
-	// against a partial transcript atago believed was whole. finish reads it and
-	// refuses to hand back a Result at all, the same call the cmd runner makes
-	// for a cut-short capture (#343).
-	var mu sync.Mutex
-	var transcript []byte
-	var readErr error
-	readDone := make(chan struct{})
-	go func() {
-		defer close(readDone)
-		buf := make([]byte, 4096)
-		for {
-			n, rerr := proc.rw.Read(buf)
-			if n > 0 {
-				mu.Lock()
-				transcript = append(transcript, buf[:n]...)
-				mu.Unlock()
-				queries.consume(buf[:n])
-			}
-			if rerr == nil {
-				continue
-			}
-			// An interrupted read is not an end: resume it, or a signal
-			// arriving mid-read truncates the transcript.
-			if errors.Is(rerr, syscall.EINTR) {
-				continue
-			}
-			if !isSessionEnd(rerr) {
-				mu.Lock()
-				readErr = rerr
-				mu.Unlock()
-			}
-			return
-		}
-	}()
-	snapshot := func() []byte {
-		mu.Lock()
-		defer mu.Unlock()
-		return append([]byte(nil), transcript...)
-	}
-	// tailFrom copies only transcript[from:] under the lock and reports the
-	// transcript's current length; curLen reports the length alone. Together
-	// they let a pending expect skip the poll entirely when nothing new
-	// arrived and copy only the bytes it can still match — a TUI redrawing at
-	// full speed otherwise costs an O(transcript) allocation every 10ms per
-	// expect, pure garbage churn on bytes before matchOffset that no later
-	// expect may ever see again.
-	tailFrom := func(from int) ([]byte, int) {
-		mu.Lock()
-		defer mu.Unlock()
-		if from > len(transcript) {
-			from = len(transcript)
-		}
-		return append([]byte(nil), transcript[from:]...), len(transcript)
-	}
-	curLen := func() int {
-		mu.Lock()
-		defer mu.Unlock()
-		return len(transcript)
-	}
-	screenLen := -1
-	var screenCache []byte
-	currentScreen := func() []byte {
-		mu.Lock()
-		n := len(transcript)
-		if n == screenLen {
-			screen := append([]byte(nil), screenCache...)
-			mu.Unlock()
-			return screen
-		}
-		snap := append([]byte(nil), transcript...)
-		mu.Unlock()
-
-		rendered := []byte(RenderScreen(snap, p))
-
-		mu.Lock()
-		if len(transcript) == n {
-			screenCache = append(screenCache[:0], rendered...)
-			screenLen = n
-		}
-		mu.Unlock()
-		return rendered
-	}
+	writeTerm := term.write
+	snapshot := term.snapshot
+	tailFrom := term.tailFrom
+	curLen := term.curLen
+	currentScreen := term.currentScreen
 
 	finish := func(timedOut bool, code int, ef *ExpectFailure) (*runner.Result, *ExpectFailure, error) {
 		// Drain before closing: a fast-exiting child's final output may still sit
 		// in the pty buffer, and closing the master discards it. Once the last
 		// handle is gone the reader hits EOF and readDone closes on its own;
 		// drainGrace bounds the wait in case a descendant kept the terminal open.
-		select {
-		case <-readDone:
-		case <-time.After(drainGrace):
-		}
-		proc.closeTerm()
-		<-readDone
+		term.waitDrain(proc.closeTerm, drainGrace)
 		tr := snapshot()
 		// A transcript atago knows is incomplete must not become a Result: an
 		// expect_screen compared against missing bytes is a confidently wrong
@@ -185,9 +95,7 @@ func driveSession(ctx context.Context, p *spec.PTY, proc ptyProcess) (*runner.Re
 		// session read error accepted here is by construction one that arrived
 		// after the child exited. That is why the reader can classify on the error
 		// alone without racing the exit.
-		mu.Lock()
-		rerr := readErr
-		mu.Unlock()
+		rerr := term.readError()
 		if rerr != nil {
 			return nil, nil, fmt.Errorf(
 				"pty %q: the terminal transcript is incomplete — reading the terminal failed after %d bytes: %w",
@@ -224,8 +132,7 @@ func driveSession(ctx context.Context, p *spec.PTY, proc ptyProcess) (*runner.Re
 	failHard := func(err error) (*runner.Result, *ExpectFailure, error) {
 		proc.kill()
 		<-proc.exit
-		proc.closeTerm()
-		<-readDone
+		term.waitDrain(proc.closeTerm, 0)
 		return nil, nil, err
 	}
 

--- a/internal/runner/ptyrun/transcript.go
+++ b/internal/runner/ptyrun/transcript.go
@@ -1,0 +1,136 @@
+package ptyrun
+
+import (
+	"errors"
+	"io"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/nao1215/atago/internal/spec"
+)
+
+// transcriptDrain owns the live terminal reader and the accumulated transcript.
+// Starting it before the child starts closes the fast-exit window where a real
+// command can print and exit before atago posts its first Read on the master.
+type transcriptDrain struct {
+	p  *spec.PTY
+	rw io.ReadWriter
+
+	writeMu sync.Mutex
+
+	mu          sync.Mutex
+	transcript  []byte
+	readErr     error
+	readDone    chan struct{}
+	screenLen   int
+	screenCache []byte
+}
+
+func startTranscriptDrain(rw io.ReadWriter, p *spec.PTY) *transcriptDrain {
+	t := &transcriptDrain{
+		p:         p,
+		rw:        rw,
+		readDone:  make(chan struct{}),
+		screenLen: -1,
+	}
+	queries := newTerminalQueries(p, writerFunc(t.write))
+	go func() {
+		defer close(t.readDone)
+		buf := make([]byte, 4096)
+		for {
+			n, rerr := t.rw.Read(buf)
+			if n > 0 {
+				t.mu.Lock()
+				t.transcript = append(t.transcript, buf[:n]...)
+				t.mu.Unlock()
+				queries.consume(buf[:n])
+			}
+			if rerr == nil {
+				continue
+			}
+			// An interrupted read is not an end: resume it, or a signal arriving
+			// mid-read truncates the transcript.
+			if errors.Is(rerr, syscall.EINTR) {
+				continue
+			}
+			if !isSessionEnd(rerr) {
+				t.mu.Lock()
+				t.readErr = rerr
+				t.mu.Unlock()
+			}
+			return
+		}
+	}()
+	return t
+}
+
+func (t *transcriptDrain) write(b []byte) (int, error) {
+	t.writeMu.Lock()
+	defer t.writeMu.Unlock()
+	return t.rw.Write(b)
+}
+
+func (t *transcriptDrain) snapshot() []byte {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return append([]byte(nil), t.transcript...)
+}
+
+// tailFrom copies only transcript[from:] under the lock and reports the
+// transcript's current length; curLen reports the length alone. Together they
+// let a pending expect skip the poll entirely when nothing new arrived and copy
+// only the bytes it can still match.
+func (t *transcriptDrain) tailFrom(from int) ([]byte, int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if from > len(t.transcript) {
+		from = len(t.transcript)
+	}
+	return append([]byte(nil), t.transcript[from:]...), len(t.transcript)
+}
+
+func (t *transcriptDrain) curLen() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.transcript)
+}
+
+func (t *transcriptDrain) currentScreen() []byte {
+	t.mu.Lock()
+	n := len(t.transcript)
+	if n == t.screenLen {
+		screen := append([]byte(nil), t.screenCache...)
+		t.mu.Unlock()
+		return screen
+	}
+	snap := append([]byte(nil), t.transcript...)
+	t.mu.Unlock()
+
+	rendered := []byte(RenderScreen(snap, t.p))
+
+	t.mu.Lock()
+	if len(t.transcript) == n {
+		t.screenCache = append(t.screenCache[:0], rendered...)
+		t.screenLen = n
+	}
+	t.mu.Unlock()
+	return rendered
+}
+
+func (t *transcriptDrain) readError() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.readErr
+}
+
+func (t *transcriptDrain) waitDrain(closeTerm func(), grace time.Duration) {
+	if grace > 0 {
+		select {
+		case <-t.readDone:
+		case <-time.After(grace):
+		}
+	}
+	closeTerm()
+	<-t.readDone
+}


### PR DESCRIPTION
## Summary
- start the PTY transcript drain before launching fast-exit POSIX commands so macOS cannot miss no-shell output
- keep the shared pty session logic on the same drain abstraction and cover the no-shell fast-exit path in recorder tests too
- preserve the existing fuzz fix on main and narrow this PR to the macOS PTY regression introduced by the prior CI follow-up

## Verification
- go test ./internal/runner/ptyrun -count=10
- go test ./internal/record -run 'TestCapturePTY_RecordsOutputAndExit|TestCapturePTY_NoShellFastExitOutputNotLost|TestCapturePTY_TimesOutOnNonExitingChild' -count=10
- go test ./...
- go test ./internal/record -run 'FuzzGenerateRoundTrip/451ec3546aeefa78$'
- go run . run --filter 'record --pty of a no-input command yields a session-less spec that replays green' test/e2e/atago/record.atago.yaml

## CI context
- the original scheduled CrossPlatformE2E failure was on August 1, 2026 in run 30686849386, where the generated `echo.atago.yaml` replay failed because a PTY `echo done` step exited 0 with empty stdout on macOS
- the original scheduled Fuzz failure was on August 3, 2026 in run 30786393269, caused by `contains: !!binary 1803`; that fix is already on `main`, so this PR only repairs the macOS PTY side and waits for CI before merge