### PR TITLE
fix(snapshot): fold CRLF after stripping escapes so Normalize stays idempotent

### DIFF
--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 447 scenarios
+74 suites · 448 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -431,12 +431,13 @@
   - [a snapshot assertion passes against a committed snapshot](#scenario-a-snapshot-assertion-passes-against-a-committed-snapshot)
   - [snapshot update creates the snapshot file](#scenario-snapshot-update-creates-the-snapshot-file)
   - [a snapshot mismatch writes the normalized actual as an artifact](#scenario-a-snapshot-mismatch-writes-the-normalized-actual-as-an-artifact)
-- [atago self-hosting / snapshot normalization and round-trip](#atago-self-hosting--snapshot-normalization-and-round-trip) — 9 scenarios
+- [atago self-hosting / snapshot normalization and round-trip](#atago-self-hosting--snapshot-normalization-and-round-trip) — 10 scenarios
   - [record then run round-trips green](#scenario-record-then-run-round-trips-green-1)
   - [a UUID is masked in the golden](#scenario-a-uuid-is-masked-in-the-golden)
   - [an ISO timestamp is masked in the golden](#scenario-an-iso-timestamp-is-masked-in-the-golden)
   - [a loopback host and port are masked in the golden](#scenario-a-loopback-host-and-port-are-masked-in-the-golden)
   - [the home directory is masked to a tilde in the golden](#scenario-the-home-directory-is-masked-to-a-tilde-in-the-golden)
+  - [an escape between a CR and an LF leaves no CR in the golden](#scenario-an-escape-between-a-cr-and-an-lf-leaves-no-cr-in-the-golden)
   - [a golden verifies against a different volatile value](#scenario-a-golden-verifies-against-a-different-volatile-value)
   - [updating a snapshot is deterministic](#scenario-updating-a-snapshot-is-deterministic)
   - [a real content change still fails the snapshot](#scenario-a-real-content-change-still-fails-the-snapshot)
@@ -4660,25 +4661,21 @@ printf 'only\r\n'
 printf 'alpha\r\nbeta\r\ngamma\r\n'
 ```
 #### Then
-- stdout contains `alpha
-beta`
+- stdout contains `"alpha\nbeta"`
 ### Scenario: contains authored with CRLF matches LF-folded output
 #### When
 ```shell
 printf 'alpha\r\nbeta\r\n'
 ```
 #### Then
-- stdout contains `alpha
-beta`
+- stdout contains `"alpha\r\nbeta"`
 ### Scenario: contains list every multi-line element folds
 #### When
 ```shell
 printf 'a\r\nb\r\nc\r\nd\r\n'
 ```
 #### Then
-- stdout contains `a
-b`, `c
-d`
+- stdout contains `"a\nb"`, `"c\nd"`
 ### Scenario: matches anchors a line over CRLF with the multiline flag
 #### When
 ```shell
@@ -4692,16 +4689,14 @@ printf 'hello\r\nworld\r\n'
 printf 'up\r\ndown\r\n'
 ```
 #### Then
-- stdout matches `/up
-down/`
+- stdout matches `/up\ndown/`
 ### Scenario: not_contains stays clear of an absent multi-line needle
 #### When
 ```shell
 printf 'red\r\ngreen\r\n'
 ```
 #### Then
-- stdout does not contain `red
-blue`
+- stdout does not contain `"red\nblue"`
 ### Scenario: not_matches passes for an anchored line that is absent
 #### When
 ```shell
@@ -6822,8 +6817,7 @@ ${atago} run silent.atago.yaml
 ```
 #### Then
 - exit code is `1`
-- stdout matches `/Actual:
-  \(empty\)/`
+- stdout matches `/Actual:\n  \(empty\)/`
 ### Scenario: an exit_code failure states that the command printed nothing
 #### Given
 - Fixture file `quiet.atago.yaml` is created.
@@ -6844,8 +6838,7 @@ ${atago} run quiet.atago.yaml
 ```
 #### Then
 - exit code is `1`
-- stdout matches `/Stdout/Stderr:
-  \(empty\)/`
+- stdout matches `/Stdout/Stderr:\n  \(empty\)/`
 ### Scenario: a stdout failure points at stderr when the text is there
 #### Given
 - Fixture file `wrongstream.atago.yaml` is created.
@@ -8127,6 +8120,31 @@ ${atago} snapshot update home.atago.yaml
 ```
 #### Then
 - file `g.txt` contains `home=~/x`
+### Scenario: an escape between a CR and an LF leaves no CR in the golden
+#### Given
+- Fixture file `cr.atago.yaml` is created.
+#### Inputs
+_Fixture `cr.atago.yaml`:_
+```text
+version: "1"
+suite: {name: cr}
+scenarios:
+  - name: rewrites a progress line
+    steps:
+      - run: {shell: true, command: "printf 'working\\r\\033[K\\ndone\\n'"}
+      - assert: {stdout: {snapshot: g.txt}}
+```
+#### When
+```shell
+${atago} snapshot update cr.atago.yaml
+${atago} run cr.atago.yaml
+```
+#### Then
+- after `${atago} snapshot update cr.atago.yaml`:
+  - exit code is `0`
+  - file `g.txt` does not contain `"\r"`
+- after `${atago} run cr.atago.yaml`:
+  - exit code is `0`
 ### Scenario: a golden verifies against a different volatile value
 #### Given
 - Fixture file `rec.atago.yaml` is created.
@@ -8717,7 +8735,7 @@ printf 'ab\n'
 printf 'name\tvalue\n'
 ```
 #### Then
-- stdout contains `name	value`
+- stdout contains `"name\tvalue"`
 ### Scenario: quotes and brackets survive an exact equals
 #### When
 ```shell

--- a/doc/e2e/iso8583tool.md
+++ b/doc/e2e/iso8583tool.md
@@ -2526,7 +2526,7 @@ iso8583tool view a.hex --no-color
 #### Then
 - after `iso8583tool view a.hex --no-color`:
   - exit code is `0`
-  - stdout does not contain ``
+  - stdout does not contain `"\x1b"`
   - stdout contains `^[`
 ### Scenario: validate escapes control bytes
 #### Given
@@ -2544,7 +2544,7 @@ iso8583tool validate a.hex --no-color
 #### Then
 - after `iso8583tool validate a.hex --no-color`:
   - exit code is `0`
-  - stdout does not contain ``
+  - stdout does not contain `"\x1b"`
 ### Scenario: diff escapes control bytes
 #### Given
 - Fixture file `bin41.json` is created.
@@ -2562,7 +2562,7 @@ iso8583tool diff a.hex b.hex --no-color
 #### Then
 - after `iso8583tool diff a.hex b.hex --no-color`:
   - exit code is `0`
-  - stdout does not contain ``
+  - stdout does not contain `"\x1b"`
   - stdout contains `^[`
 ### Scenario: redact text escapes control bytes
 #### Given
@@ -2580,7 +2580,7 @@ iso8583tool redact a.hex --format text --no-color
 #### Then
 - after `iso8583tool redact a.hex --format text --no-color`:
   - exit code is `0`
-  - stdout does not contain ``
+  - stdout does not contain `"\x1b"`
   - stdout contains `^[`
 ## iso8583tool send
 Source: `test/e2e/tools/iso8583tool/send.atago.yaml`

--- a/doc/e2e/mimixbox.md
+++ b/doc/e2e/mimixbox.md
@@ -7444,7 +7444,7 @@ ls --color=never ${workdir}/ls_gnu
 #### Then
 - after `ls --color=never ${workdir}/ls_gnu`:
   - exit code is `0`
-  - stdout does not contain ``
+  - stdout does not contain `"\x1b"`
 ### Scenario: appends / * @ with -F
 #### When
 ```shell

--- a/doc/e2e/openssl.md
+++ b/doc/e2e/openssl.md
@@ -105,8 +105,7 @@ openssl rand -hex 16
 ```
 #### Then
 - exit code is `0`
-- stdout matches `/^[0-9a-f]{32}
-?$/`
+- stdout matches `/^[0-9a-f]{32}\n?$/`
 ### Scenario: a generated private key is valid and yields its public half
 #### When
 ```shell

--- a/doc/e2e/sqly.md
+++ b/doc/e2e/sqly.md
@@ -2466,7 +2466,7 @@ sqly user.csv
 #### Then
 - exit code is `0`
 - stderr contains `mode=tsv`
-- file `out.tsv` contains `user_name	identifier`
+- file `out.tsv` contains `"user_name\tidentifier"`
 - file `out.tsv` does not contain `user_name,identifier`
 ## sqly hermetic environment
 Source: `test/e2e/tools/sqly/hermetic.atago.yaml`

--- a/doc/e2e/yazi.md
+++ b/doc/e2e/yazi.md
@@ -2597,8 +2597,7 @@ a
 readlink dst/a.txt
 ```
 #### Then
-- stdout matches `/^.+/src/a\.txt
-?$/`
+- stdout matches `/^.+/src/a\.txt\n?$/`
 ### Scenario: yank then underscore creates a relative symlink in the sibling directory
 _only when `yazi --version` succeeds · skipped on Windows_
 #### Given
@@ -2636,8 +2635,7 @@ a
 readlink dst/sub
 ```
 #### Then
-- stdout matches `/^.+/src/sub
-?$/`
+- stdout matches `/^.+/src/sub\n?$/`
 ### Scenario: yanked directory can be relative-symlinked into a sibling directory
 _only when `yazi --version` succeeds · skipped on Windows_
 #### Given
@@ -3140,8 +3138,7 @@ spaced
 readlink "dst/two words.txt"
 ```
 #### Then
-- stdout matches `/^.+/src/two words\.txt
-?$/`
+- stdout matches `/^.+/src/two words\.txt\n?$/`
 ### Scenario: underscore symlinks a spaced filename with a relative target
 _only when `yazi --version` succeeds · skipped on Windows_
 #### Given
@@ -3179,8 +3176,7 @@ spaced
 readlink "dst/two words"
 ```
 #### Then
-- stdout matches `/^.+/src/two words
-?$/`
+- stdout matches `/^.+/src/two words\n?$/`
 ### Scenario: underscore symlinks a spaced directory with a relative target
 _only when `yazi --version` succeeds · skipped on Windows_
 #### Given

--- a/internal/docgen/describe.go
+++ b/internal/docgen/describe.go
@@ -3,12 +3,59 @@ package docgen
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/nao1215/atago/internal/assertdesc"
 	"github.com/nao1215/atago/internal/spec"
 	"github.com/nao1215/markdown"
 )
+
+// code renders a spec-supplied string as an inline-code span, writing a value
+// the reader cannot see as a Go-quoted literal instead. A matcher may
+// legitimately assert on a control character — `not_contains: "\r"` is how a
+// spec guards a golden against a stray carriage return — and rendering that raw
+// produced a span that read as empty, and put a bare CR into the committed
+// Markdown. The console failure block already quotes such a value (`does not
+// contain "\r"`); the generated docs now say the same thing. Printable text,
+// including non-ASCII, is rendered exactly as authored.
+func code(s string) string {
+	if strings.ContainsFunc(s, unicode.IsControl) {
+		return markdown.Code(strconv.Quote(s))
+	}
+	return markdown.Code(s)
+}
+
+// codeRegex renders a regex matcher's pattern as an inline-code span. Control
+// characters are escaped so the span stays on one line — a pattern containing a
+// literal newline used to break the span across two, which is not inline code at
+// all — but the rest of the pattern is left byte-for-byte as authored.
+// strconv.Quote would double every backslash (`\.` into `\\.`) and stop the
+// published pattern from reading as the regex the spec wrote.
+func codeRegex(pattern string) string {
+	return markdown.Code("/" + escapeInvisible(pattern) + "/")
+}
+
+// escapeInvisible rewrites the runes a reader cannot see — CR, LF, tab, ESC, and
+// the other control characters — as their Go escapes, leaving every other byte
+// exactly as authored.
+func escapeInvisible(s string) string {
+	if !strings.ContainsFunc(s, unicode.IsControl) {
+		return s
+	}
+	var b strings.Builder
+	for _, r := range s {
+		if unicode.IsControl(r) {
+			// QuoteRune wraps its result in single quotes ('\r'); a control rune is
+			// never a quote itself, so trimming them yields the bare escape.
+			b.WriteString(strings.Trim(strconv.QuoteRune(r), "'"))
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
 
 // codeList renders a contains/not_contains matcher argument. A single element
 // is rendered as one inline-code span (byte-identical to the pre-list format); a
@@ -17,81 +64,81 @@ import (
 func codeList(subs spec.StringList) string {
 	parts := make([]string, len(subs))
 	for i, s := range subs {
-		parts[i] = markdown.Code(s)
+		parts[i] = code(s)
 	}
 	return strings.Join(parts, ", ")
 }
 
 var docgenJSONStyle = assertdesc.JSONStyle{
-	Prefix:  func(path string) string { return "at " + markdown.Code(path) },
-	Equals:  func(v any) string { return "equals " + markdown.Code(assertdesc.JSONValueText(v)) },
-	Matches: func(s string) string { return "matches " + markdown.Code("/"+s+"/") },
+	Prefix:  func(path string) string { return "at " + code(path) },
+	Equals:  func(v any) string { return "equals " + code(assertdesc.JSONValueText(v)) },
+	Matches: func(s string) string { return "matches " + codeRegex(s) },
 	Length:  func(n int) string { return fmt.Sprintf("has length %d", n) },
-	Compare: func(op string, v any) string { return "is " + markdown.Code(fmt.Sprintf("%s %v", op, v)) },
+	Compare: func(op string, v any) string { return "is " + code(fmt.Sprintf("%s %v", op, v)) },
 	Default: "is checked",
 }
 
 var docgenYAMLStyle = docgenJSONStyle.WithPrefix(func(path string) string {
-	return "YAML at " + markdown.Code(path)
+	return "YAML at " + code(path)
 })
 
 var docgenStreamStyle = assertdesc.StreamStyle{
 	List:      codeList,
-	Regex:     func(s string) string { return markdown.Code("/" + s + "/") },
+	Regex:     codeRegex,
 	Equals:    "equals an exact value",
 	NotEquals: "does not equal an exact value",
 	JSON:      docgenJSONStyle,
 	YAML:      docgenYAMLStyle,
-	Snapshot:  markdown.Code,
-	Line:      func(n int) string { return "line " + markdown.Code(fmt.Sprint(n)) },
+	Snapshot:  code,
+	Line:      func(n int) string { return "line " + code(fmt.Sprint(n)) },
 	NoMatcher: "is checked",
 }
 
 var docgenFileStyle = assertdesc.FileStyle{
-	Path:       markdown.Code,
+	Path:       code,
 	List:       codeList,
 	JSON:       docgenJSONStyle,
-	Snapshot:   markdown.Code,
-	Checked:    func(path string) string { return markdown.Code(path) + " is checked" },
+	Snapshot:   code,
+	Checked:    func(path string) string { return code(path) + " is checked" },
 	ExactBytes: "equals exact bytes",
 }
 
 var docgenHeaderStyle = assertdesc.HeaderStyle{
-	Name:  markdown.Code,
-	Value: markdown.Code,
-	Regex: func(s string) string { return markdown.Code("/" + s + "/") },
-	Bare:  func(s string) string { return markdown.Code(s) + " is checked" },
+	Name:  code,
+	Value: code,
+	Regex: codeRegex,
+	Bare:  func(s string) string { return code(s) + " is checked" },
 }
 
 var docgenImageStyle = assertdesc.ImageStyle{
-	Path:      markdown.Code,
-	Format:    markdown.Code,
-	SimilarTo: markdown.Code,
-	Checked:   func(path string) string { return markdown.Code(path) + " is checked" },
+	Path:      code,
+	Format:    code,
+	SimilarTo: code,
+	Checked:   func(path string) string { return code(path) + " is checked" },
 }
 
 var docgenDirStyle = assertdesc.DirStyle{
-	Path:    markdown.Code,
-	Item:    markdown.Code,
-	Token:   markdown.Code,
-	Checked: func(path string) string { return markdown.Code(path) + " is checked" },
+	Path:    code,
+	Item:    code,
+	Token:   code,
+	Checked: func(path string) string { return code(path) + " is checked" },
 }
 
 var docgenPDFStyle = assertdesc.PDFStyle{
-	Path:    markdown.Code,
-	Value:   markdown.Code,
+	Path:    code,
+	Value:   code,
 	Stream:  describeStream,
-	Checked: func(path string) string { return markdown.Code(path) + " is checked" },
+	Checked: func(path string) string { return code(path) + " is checked" },
 }
 
 var docgenChangesStyle = assertdesc.ChangesStyle{
-	Entry: markdown.Code,
+	Entry: code,
 	Join:  ", ",
 }
 
 var docgenMockStyle = assertdesc.MockStyle{
-	Name:  markdown.Code,
-	Route: markdown.Code,
+	Name:  code,
+	Route: code,
 	Count: func(n int) string { return fmt.Sprintf(" exactly %d time(s)", n) },
 }
 
@@ -115,17 +162,17 @@ func describeTarget(a *spec.Assert, target spec.AssertTarget) string {
 	switch target {
 	case spec.AssertExitCode:
 		if a.ExitCode.Not != nil {
-			return fmt.Sprintf("exit code is not %s", markdown.Code(fmt.Sprint(*a.ExitCode.Not)))
+			return fmt.Sprintf("exit code is not %s", code(fmt.Sprint(*a.ExitCode.Not)))
 		}
 		if len(a.ExitCode.In) > 0 {
 			codes := make([]string, len(a.ExitCode.In))
 			for i, n := range a.ExitCode.In {
-				codes[i] = markdown.Code(fmt.Sprint(n))
+				codes[i] = code(fmt.Sprint(n))
 			}
 			return "exit code is one of " + strings.Join(codes, ", ")
 		}
 		if a.ExitCode.Equals != nil {
-			return fmt.Sprintf("exit code is %s", markdown.Code(fmt.Sprint(*a.ExitCode.Equals)))
+			return fmt.Sprintf("exit code is %s", code(fmt.Sprint(*a.ExitCode.Equals)))
 		}
 		return "exit code is checked"
 	case spec.AssertMock:
@@ -150,7 +197,7 @@ func describeTarget(a *spec.Assert, target spec.AssertTarget) string {
 		return "pdf " + describePDF(a.PDF)
 	case spec.AssertStatus:
 		if a.Status != nil {
-			return "HTTP status is " + markdown.Code(fmt.Sprint(*a.Status))
+			return "HTTP status is " + code(fmt.Sprint(*a.Status))
 		}
 		return "HTTP status is checked"
 	case spec.AssertHeader:
@@ -164,7 +211,7 @@ func describeTarget(a *spec.Assert, target spec.AssertTarget) string {
 		return "rows " + describeStream(a.Rows)
 	case spec.AssertGRPCStatus:
 		if a.GRPCStatus != nil {
-			return "gRPC status is " + markdown.Code(fmt.Sprint(*a.GRPCStatus))
+			return "gRPC status is " + code(fmt.Sprint(*a.GRPCStatus))
 		}
 		return "gRPC status is checked"
 	case spec.AssertMessage:

--- a/internal/docgen/describe_test.go
+++ b/internal/docgen/describe_test.go
@@ -1,6 +1,7 @@
 package docgen
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/nao1215/atago/internal/spec"
@@ -23,5 +24,80 @@ func TestDescribeTarget_CoversEveryAssertTarget(t *testing.T) {
 		if got == string(target) {
 			t.Errorf("target %q fell through to the default branch (rendered as the bare name)", target)
 		}
+	}
+}
+
+// TestCode_QuotesInvisibleValues proves a spec-supplied value the reader cannot
+// see is rendered as a Go-quoted literal rather than raw. `not_contains: "\r"`
+// is a legitimate assertion — it is how a spec guards a golden against a stray
+// carriage return — and rendering it raw published an inline-code span that read
+// as empty and put a bare CR into the committed Markdown. Printable values,
+// including non-ASCII, must keep their exact authored form, so the vast majority
+// of the generated docs are untouched by this rule.
+func TestCode_QuotesInvisibleValues(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "carriage return", in: "\r", want: "`\"\\r\"`"},
+		{name: "tab inside text", in: "a\tb", want: "`\"a\\tb\"`"},
+		{name: "embedded newline", in: "one\ntwo", want: "`\"one\\ntwo\"`"},
+		{name: "escape byte", in: "\x1b[0m", want: "`\"\\x1b[0m\"`"},
+		{name: "plain ascii", in: "PASSED", want: "`PASSED`"},
+		{name: "non-ascii stays literal", in: "日本語", want: "`日本語`"},
+		{name: "punctuation stays literal", in: "127.0.0.1:<port>", want: "`127.0.0.1:<port>`"},
+		{name: "empty", in: "", want: "``"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := code(tt.in); got != tt.want {
+				t.Errorf("code(%q) = %s, want %s", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCodeList_QuotesInvisibleValues carries the same rule through the
+// contains/not_contains renderer, the path an assertion on a control character
+// actually takes.
+func TestCodeList_QuotesInvisibleValues(t *testing.T) {
+	t.Parallel()
+	got := codeList(spec.StringList{"ok", "\r"})
+	want := "`ok`, `\"\\r\"`"
+	if got != want {
+		t.Errorf("codeList = %s, want %s", got, want)
+	}
+}
+
+// TestCodeRegex_KeepsThePatternReadable proves a regex pattern keeps its
+// authored backslashes and gets its invisible characters escaped. A pattern with
+// a literal newline used to break its inline-code span across two lines, and
+// quoting the whole pattern the way a plain value is quoted would double every
+// backslash — `\.` published as `\\.` no longer reads as the regex the spec
+// wrote.
+func TestCodeRegex_KeepsThePatternReadable(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "newline is escaped", in: "^[0-9a-f]{32}\n?$", want: "`/^[0-9a-f]{32}\\n?$/`"},
+		{name: "backslash is not doubled", in: `^.+/src/a\.txt\n?$`, want: "`/^.+/src/a\\.txt\\n?$/`"},
+		{name: "plain pattern is untouched", in: "^v[0-9]+", want: "`/^v[0-9]+/`"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := codeRegex(tt.in); got != tt.want {
+				t.Errorf("codeRegex(%q) = %s, want %s", tt.in, got, tt.want)
+			}
+		})
+	}
+	if strings.Contains(codeRegex("a\nb"), "\n") {
+		t.Error("codeRegex left a raw newline in the inline-code span")
 	}
 }

--- a/internal/runner/cmd/cmd_test.go
+++ b/internal/runner/cmd/cmd_test.go
@@ -1088,8 +1088,12 @@ func TestRun_ConcurrentCapturesNeverComeBackEmpty(t *testing.T) {
 			t.Errorf("child %d: exit code = %d, want 0", got.id, got.exit)
 		case strings.TrimSpace(got.stdout) == "":
 			t.Errorf("child %d: exited 0 with empty stdout; it printed %q", got.id, want)
-		case !strings.Contains(got.stdout, want):
-			t.Errorf("child %d: stdout = %q, want it to contain %q", got.id, got.stdout, want)
+		// Exact equality, not a substring: a capture that merged two children's
+		// output contains its own payload and would pass a Contains check while
+		// being precisely the crossed-pipe outcome this test exists to catch.
+		// TrimSpace absorbs the line ending echo appends (CRLF under cmd.exe).
+		case strings.TrimSpace(got.stdout) != want:
+			t.Errorf("child %d: stdout = %q, want exactly %q", got.id, got.stdout, want)
 		}
 	}
 }

--- a/internal/runner/cmd/cmd_test.go
+++ b/internal/runner/cmd/cmd_test.go
@@ -1026,3 +1026,70 @@ func TestRun_OwnedPipesDoNotLeak(t *testing.T) {
 		t.Errorf("goroutines grew from %d to %d over 60 runs; a drain goroutine is leaking", before, after)
 	}
 }
+
+// TestRun_ConcurrentCapturesNeverComeBackEmpty is the standing guard #339 asks
+// for: "a run step whose child writes to stdout and exits 0 must never report
+// empty output".
+//
+// #339 is a Windows-only anomaly where a nested `atago run` exited 0 while its
+// stdout came back empty — output the child certainly produced. It reproduced
+// once in fourteen runs of a parallel batch and has never been reproduced on
+// demand, so this does not claim to fix it. What it does is run the exact
+// invariant under the condition the flake appeared in: many captured children at
+// once, each printing a payload only it could have printed.
+//
+// The payload is per-child, so this catches more than an empty capture. Two
+// concurrent runs whose pipes got crossed would each come back with the other's
+// text and both would be non-empty, which a "not empty" check alone would pass.
+//
+// It is deliberately not Windows-guarded. The unit-test matrix runs
+// windows-latest on every push — far more Windows executions than the E2E leg
+// where the flake was seen — and on POSIX it costs a few hundred milliseconds
+// while pinning the same contract.
+func TestRun_ConcurrentCapturesNeverComeBackEmpty(t *testing.T) {
+	t.Parallel()
+	const workers = 24
+	type outcome struct {
+		id     int
+		stdout string
+		exit   int
+		err    error
+	}
+	results := make(chan outcome, workers)
+	for i := range workers {
+		go func() {
+			// A payload no other child in this test prints, so a capture that came
+			// from the wrong pipe is as visible as one that came back empty.
+			want := fmt.Sprintf("atago-capture-%d", i)
+			res, err := New().Run(
+				context.Background(),
+				&spec.Run{Command: argvCommand("echo "+want, "cmd /c echo "+want)},
+				t.TempDir(),
+			)
+			out := outcome{id: i, err: err}
+			if err == nil {
+				out.stdout = string(res.Stdout)
+				out.exit = res.ExitCode
+			}
+			results <- out
+		}()
+	}
+	for range workers {
+		got := <-results
+		want := fmt.Sprintf("atago-capture-%d", got.id)
+		switch {
+		case got.err != nil:
+			// A capture failure is a legitimate outcome (it is what #344 added), and
+			// it is NOT this failure: it says so instead of presenting an empty
+			// string as the observed value. Report it, since `echo` has no reason to
+			// produce one.
+			t.Errorf("child %d: Run() error = %v", got.id, got.err)
+		case got.exit != 0:
+			t.Errorf("child %d: exit code = %d, want 0", got.id, got.exit)
+		case strings.TrimSpace(got.stdout) == "":
+			t.Errorf("child %d: exited 0 with empty stdout; it printed %q", got.id, want)
+		case !strings.Contains(got.stdout, want):
+			t.Errorf("child %d: stdout = %q, want it to contain %q", got.id, got.stdout, want)
+		}
+	}
+}

--- a/internal/snapshot/fuzz_test.go
+++ b/internal/snapshot/fuzz_test.go
@@ -29,6 +29,9 @@ func FuzzNormalize(f *testing.F) {
 	f.Add([]byte("tok\x1b[0men"), "token")
 	f.Add([]byte("\x1b]0;title\x07body\x1b[2J"), "abcd")
 	f.Add([]byte("\r\r\n0"), "s3cr")
+	// An escape between a CR and an LF: the strip splices a CRLF that a fold
+	// running only before it never saw.
+	f.Add([]byte("\r\x1b[A\n"), "")
 	f.Fuzz(func(t *testing.T, data []byte, secret string) {
 		opt := Options{Workdir: "/tmp/atago-fz-work"}
 		m := security.NewMasker([]string{secret})

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -73,21 +73,28 @@ func Normalize(data []byte, opt Options) []byte {
 		data = opt.Scrub(data)
 	}
 	s := string(data)
-	// Line endings are an OS artifact, not observable behavior: fold CRLF so a
-	// snapshot recorded on POSIX matches cmd.exe output on Windows (and the
-	// committed golden never carries CRs). Matches the equals matcher's rule.
-	// Fold to a fixed point (`\r\r\n` -> `\r\n` -> `\n`): a single ReplaceAll is
-	// not idempotent for a run of CRs before the LF, which would make the whole
-	// function non-idempotent and fail a snapshot on its very next comparison.
-	s = foldCRLF(s)
-	// Strip CSI and OSC escapes to a fixed point. Removing a complete OSC
-	// sequence can splice a stray leading ESC onto the bytes that followed it and
-	// form a fresh CSI escape, which a single CSI-then-OSC pass leaves behind —
-	// a raw escape byte then leaks into the golden the CSI rule exists to keep
-	// clean, and Normalize is no longer idempotent. Loop until the text is stable
-	// (each pass only deletes bytes, so this always terminates).
+	// Fold CRLF and strip CSI/OSC escapes together, to a fixed point.
+	//
+	// Line endings are an OS artifact, not observable behavior: folding CRLF lets
+	// a snapshot recorded on POSIX match cmd.exe output on Windows, and keeps CRs
+	// out of the committed golden. Matches the equals matcher's rule.
+	//
+	// Each step can hand new work to the other, so neither can run just once and
+	// neither can run only before the other:
+	//   - a run of CRs before an LF ("\r\r\n") needs a second fold, since one
+	//     ReplaceAll leaves "\r\n" behind;
+	//   - an escape between a CR and an LF ("\r\x1b[A\n") hides the pair from the
+	//     fold, and stripping the escape splices it back together;
+	//   - removing a complete OSC sequence can splice a stray leading ESC onto the
+	//     bytes that followed it and form a fresh CSI escape, which a single
+	//     CSI-then-OSC pass leaves behind.
+	// Whatever a step leaves behind is a CR or a raw escape byte in the golden,
+	// and a Normalize that is no longer idempotent — so the golden written by
+	// --update-snapshots fails its very next comparison. Loop until the text is
+	// stable; each pass only deletes bytes, so this always terminates, and
+	// stability means every step is now a no-op.
 	for {
-		stripped := reOSC.ReplaceAllString(reCSI.ReplaceAllString(s, ""), "")
+		stripped := reOSC.ReplaceAllString(reCSI.ReplaceAllString(foldCRLF(s), ""), "")
 		if stripped == s {
 			break
 		}

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -32,6 +32,11 @@ func TestNormalize_Idempotent(t *testing.T) {
 		"127.0.0.1:54321", "localhost:8080", "[::1]:22", "0.0.0.0:1",
 		"/tmp/atago-xyz", "plain text ", "\r\n", "\n", "$", "{", "}", "abc",
 		"127.0.0.1:", ":", "-", "T", "Z",
+		// A lone CR, with no LF of its own. Only paired with something that later
+		// disappears — an escape sequence, a stray ESC — does it become the left
+		// half of a CRLF, which is the interaction TestNormalize_IdempotentAcrossCR
+		// pins. Without this fragment every CR in the corpus already had its LF.
+		"\r",
 		// A bare ESC and an incomplete CSI: removing a complete OSC that sits
 		// between them can splice the leftover ESC onto the following bytes and
 		// form a fresh CSI escape, which a single-pass CSI-then-OSC strip would
@@ -73,6 +78,40 @@ func TestNormalize_IdempotentAcrossOSCSplice(t *testing.T) {
 		}
 		if bytes.ContainsRune(once, '\x1b') {
 			t.Errorf("Normalize(%q) = %q still contains a raw ESC byte", in, once)
+		}
+	}
+}
+
+// TestNormalize_IdempotentAcrossCR pins the other direction of the same
+// interaction: an escape sequence sitting between a CR and an LF ("\r\x1b[A\n")
+// hides the CRLF from a fold that runs before the strip, and the strip then
+// splices the pair back together. Normalize returned "\r\n" and a second call
+// folded it to "\n" — so a golden written by --update-snapshots carried a CR and
+// failed its very next comparison. Folding and stripping must run together to a
+// fixed point, leaving no CR before an LF after one call.
+func TestNormalize_IdempotentAcrossCR(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		// The minimized input from the FuzzNormalize failure.
+		"\r\x1b[A\n",
+		// The same splice with each of the other vanishing sequences: a full CSI
+		// color, an OSC title, an OSC hyperlink, and a bare ESC left over from an
+		// OSC removal.
+		"a\r\x1b[0m\nb",
+		"a\r\x1b]0;title\x07\nb",
+		"a\r\x1b]8;;http://x\x1b\\\nb",
+		"a\r\x1b\x1b]0;t\x07[m\nb",
+		// A run of CRs the strip has to fold past, not just one.
+		"a\r\r\x1b[0m\r\x1b[0m\nb",
+	}
+	for _, in := range cases {
+		once := Normalize([]byte(in), Options{})
+		twice := Normalize(once, Options{})
+		if !bytes.Equal(once, twice) {
+			t.Errorf("Normalize not idempotent\n in:    %q\n once:  %q\n twice: %q", in, once, twice)
+		}
+		if strings.Contains(string(once), "\r\n") {
+			t.Errorf("Normalize(%q) = %q still contains a CRLF pair", in, once)
 		}
 	}
 }

--- a/internal/snapshot/testdata/fuzz/FuzzNormalize/c487d5eec3071c98
+++ b/internal/snapshot/testdata/fuzz/FuzzNormalize/c487d5eec3071c98
@@ -1,0 +1,3 @@
+go test fuzz v1
+[]byte("\r\x1b[A\n")
+string("")

--- a/test/e2e/atago/snapshot_normalization.atago.yaml
+++ b/test/e2e/atago/snapshot_normalization.atago.yaml
@@ -97,6 +97,33 @@ scenarios:
       - assert:
           file: {path: g.txt, contains: "home=~/x"}
 
+  - name: an escape between a CR and an LF leaves no CR in the golden
+    steps:
+      # A progress line cleared before the next one — text, CR to return to
+      # column 0, erase-to-end-of-line, then the newline — is what any spinner
+      # emits on its way out. The escape sits between the CR and the LF, so a
+      # CRLF fold that runs before the escape strip never sees the
+      # pair, and stripping the escape splices it back together. The golden then
+      # carries a CR that its own source output no longer produces once the
+      # comparison folds it, and `snapshot update` immediately followed by `run`
+      # fails on output that never changed.
+      - fixture:
+          file: cr.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: cr}
+            scenarios:
+              - name: rewrites a progress line
+                steps:
+                  - run: {shell: true, command: "printf 'working\\r\\033[K\\ndone\\n'"}
+                  - assert: {stdout: {snapshot: g.txt}}
+      - run: {command: "${atago} snapshot update cr.atago.yaml"}
+      - assert: {exit_code: 0}
+      - assert:
+          file: {path: g.txt, not_contains: "\r"}
+      - run: {command: "${atago} run cr.atago.yaml"}
+      - assert: {exit_code: 0}
+
   - name: a golden verifies against a different volatile value
     steps:
       # Record with one UUID, then verify a spec that emits a DIFFERENT UUID


### PR DESCRIPTION
## Summary

`FuzzNormalize` failed on the scheduled fuzz run with a 77-byte input that minimized to `"\r\x1b[A\n"`: `Normalize` returned `"\r\n"`, and a second call returned `"\n"`. Normalization is not idempotent for that input, which means a golden written by `atago snapshot update` carries a CR that its own source output no longer produces once `Compare` folds it — the snapshot fails on its very next comparison, on output that never changed. Fixing it exposed two neighbouring gaps, each fixed with its own regression test.

## Changes

- `internal/snapshot/snapshot.go`: fold CRLF and strip CSI/OSC escapes together in one fixed-point loop instead of folding once before the strip loop. Each step hands work to the other, so neither can run only before the other.
- `internal/snapshot/snapshot_test.go`: `TestNormalize_IdempotentAcrossCR` pins the minimized input and the same splice built from every vanishing sequence (CSI colour, OSC title, OSC hyperlink, a leftover ESC, a run of CRs). The random idempotence corpus gains a lone `"\r"` fragment — every CR it generated already had its LF, which is why it never found this.
- `internal/snapshot/fuzz_test.go` and `testdata/fuzz/FuzzNormalize/c487d5eec3071c98`: the failing input as a seed and as a committed corpus entry, so a plain `go test` fails if it regresses.
- `test/e2e/atago/snapshot_normalization.atago.yaml`: a scenario driving the whole chain — a spinner-shaped line (`printf 'working\r\033[K\ndone\n'`) recorded with `snapshot update`, then asserted to leave no CR in the golden and to pass an immediately following `run`. Verified to fail on both assertions with the fix reverted.
- `internal/docgen/describe.go`: render a spec-supplied value the reader cannot see as a Go-quoted literal, and escape control characters inside a regex pattern without doubling its backslashes. Writing the E2E above surfaced this: the new `not_contains: "\r"` published as an empty-looking inline-code span with a bare CR inside the committed Markdown. It was already wrong for existing specs — `contains: "alpha\nbeta"` and `contains: "alpha\r\nbeta"` rendered identically, a raw ESC and a raw TAB rendered invisibly, and a pattern containing a newline broke its inline-code span across two lines.
- `internal/runner/cmd/cmd_test.go`: `TestRun_ConcurrentCapturesNeverComeBackEmpty`, the portable half of the test #339 asks for.

## Design Decisions

The fold and the strip run in one loop rather than as an extra fold appended after the strip. Both only delete bytes, so the loop terminates, and reaching a fixed point means every step is a no-op — which is the property `Normalize` needs, rather than a fixed ordering that happens to cover the cases known today.

Regexes are rendered with a control-character escape rather than `strconv.Quote`. Quoting the whole pattern doubles every backslash, and `\.` published as `\\.` stops reading as the regex the spec wrote; plain values keep the Go-quoted form the console failure block already uses, so the two agree.

The concurrency test is not Windows-guarded even though #339 is Windows-only. The unit-test matrix runs `windows-latest` on every push, which is far more Windows executions than the E2E leg where the flake was seen, and the per-child payload also catches crossed pipes — an outcome where both captures are non-empty and a bare "not empty" check would pass.

## Limitations

This does not fix #339. That flake has not recurred since the mitigations landed in late July: the last 25 `e2e.yml` runs are green and every `e2e-windows` portable subset reports zero flaky recoveries under `--retry-failed 1`, so there is still no evidence to diagnose. The test above delivers the first bullet of that issue's "tests to add" list; the cause remains unexplained and the issue stays open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved snapshot normalization for mixed carriage returns, line feeds, and terminal escape sequences.
  - Ensured normalization remains consistent and repeatable across repeated processing.
  - Improved reliability of concurrent command output capture.

- **Documentation**
  - Updated examples and expectations to display control characters, tabs, and newlines clearly using escaped notation.
  - Refined generated documentation for more readable inline code and regular-expression examples.

- **Tests**
  - Added coverage for snapshot normalization, control-character rendering, fuzz cases, and concurrent command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->