### PR TITLE
fix(runner): report a timeout that expires before the process starts as a timeout

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -40,5 +40,13 @@ jobs:
         # `.out` package ("FAIL .out [setup failed]"), failing only the Windows
         # legs while the tests themselves pass. Git Bash ships on the windows
         # runner, so the command parses identically across all three OSes.
+        #
+        # -timeout 5m so a hung package explains itself. Go's default is 10m,
+        # which equals this job's timeout-minutes: the runner killed the job at
+        # the same moment Go would have panicked, so a hang left nothing but
+        # "The operation was canceled" and a couple of orphan test binaries in
+        # the cleanup log. No package here takes more than a few seconds, so 5m
+        # only ever fires on a real hang — and then Go dumps every goroutine's
+        # stack with five minutes of job time left to flush it.
         shell: bash
-        run: go test -v -cover -coverprofile=coverage.out ./...
+        run: go test -v -timeout 5m -cover -coverprofile=coverage.out ./...

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-74 suites · 448 scenarios
+74 suites · 449 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -489,7 +489,7 @@
   - [a failing setup errors every scenario and none runs (exit 4)](#scenario-a-failing-setup-errors-every-scenario-and-none-runs-exit-4)
   - [a suite service starts once and its store reaches every scenario](#scenario-a-suite-service-starts-once-and-its-store-reaches-every-scenario)
   - [a failing suite teardown is loud but does not flip the verdict](#scenario-a-failing-suite-teardown-is-loud-but-does-not-flip-the-verdict)
-- [atago self-hosting / step timeouts (suite default + escape hatch)](#atago-self-hosting--step-timeouts-suite-default--escape-hatch) — 10 scenarios
+- [atago self-hosting / step timeouts (suite default + escape hatch)](#atago-self-hosting--step-timeouts-suite-default--escape-hatch) — 11 scenarios
   - [suite.timeout kills a hanging step and the hint names it](#scenario-suitetimeout-kills-a-hanging-step-and-the-hint-names-it)
   - [a step timeout beats the suite timeout and the hint says run.timeout](#scenario-a-step-timeout-beats-the-suite-timeout-and-the-hint-says-runtimeout)
   - [timeout zero disables a short suite bound](#scenario-timeout-zero-disables-a-short-suite-bound)
@@ -500,6 +500,7 @@
   - [an invalid suite.timeout is a load-time error](#scenario-an-invalid-suitetimeout-is-a-load-time-error)
   - [a session outlived by its program says so instead of blaming the clock](#scenario-a-session-outlived-by-its-program-says-so-instead-of-blaming-the-clock)
   - [an expect that never matches still reports the pattern, not the quit advice](#scenario-an-expect-that-never-matches-still-reports-the-pattern-not-the-quit-advice)
+  - [a timeout that expires before the process starts is still a timeout](#scenario-a-timeout-that-expires-before-the-process-starts-is-still-a-timeout)
 - [atago self-hosting / tui](#atago-self-hosting--tui) — 4 scenarios
   - [a pty step exports a usable TERM by default](#scenario-a-pty-step-exports-a-usable-term-by-default)
   - [an explicit TERM overrides the default](#scenario-an-explicit-term-overrides-the-default)
@@ -9165,6 +9166,32 @@ ${atago} run nomatch.atago.yaml
 - exit code is `1`
 - stdout contains `never-going-to-appear`, `never appeared in the terminal transcript`
 - stdout does not contain `send its quit key`
+### Scenario: a timeout that expires before the process starts is still a timeout
+#### Given
+- Fixture file `prestart.atago.yaml` is created.
+#### Inputs
+_Fixture `prestart.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: prestart
+scenarios:
+  - name: the budget is spent before the process exists
+    steps:
+      - run:
+          shell: true
+          command: echo hi
+          timeout: 1ns
+      - assert:
+          exit_code: 0
+```
+#### When
+```shell
+${atago} run prestart.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `timed out`, `run.timeout`, does not contain `failed to execute`
 ## atago self-hosting / tui
 Source: `test/e2e/atago/tui.atago.yaml`
 ### Scenario: a pty step exports a usable TERM by default

--- a/internal/runner/cmd/cmd.go
+++ b/internal/runner/cmd/cmd.go
@@ -99,6 +99,19 @@ func (r *Runner) Run(ctx context.Context, run *spec.Run, workdir string) (*runne
 
 	start := time.Now()
 	if err := cmd.Start(); err != nil {
+		// exec.CommandContext checks the context inside Start, so a deadline or a
+		// cancel can land in the window between building the command and the OS
+		// creating the process — on a loaded machine a short `timeout:` loses that
+		// race outright. Both are the same outcomes the post-Wait paths below
+		// report, and neither is a command that could not be started, so they must
+		// not borrow that message: it would tell a spec author their command is
+		// unrunnable when it merely ran out of time.
+		if res := timedOutBeforeStart(ctx, run, start, workdir); res != nil {
+			return res, nil
+		}
+		if cerr := ctx.Err(); cerr != nil {
+			return nil, fmt.Errorf("run %q canceled: %w", run.Command, cerr)
+		}
 		// Could not start the process at all (not found, permission, ...). Same
 		// message the combined Run() path produced for this case.
 		return nil, fmt.Errorf("failed to execute %q: %w", run.Command, err)
@@ -204,6 +217,30 @@ func (r *Runner) Run(ctx context.Context, run *spec.Run, workdir string) (*runne
 		return nil, fmt.Errorf("failed to execute %q: %w", run.Command, runErr)
 	}
 	return res, nil
+}
+
+// timedOutBeforeStart builds the outcome for a step whose own `timeout:` had
+// already expired when Start ran, so no process ever existed. A step timeout is
+// an observable outcome rather than an error (assertions inspect TimedOut, and
+// the failure hint names the level that supplied the budget, #17), and that must
+// not depend on which side of process creation the deadline happened to land on.
+// ExitCode is -1 because there is no exit status to report, and there are no
+// captured streams because nothing ever wrote to them.
+//
+// It returns nil when the context ended for any other reason, or not at all, so
+// the caller keeps handling a real start failure and a cancel on their own.
+func timedOutBeforeStart(ctx context.Context, run *spec.Run, start time.Time, workdir string) *runner.Result {
+	if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return nil
+	}
+	return &runner.Result{
+		Command:       run.Command,
+		Duration:      time.Since(start),
+		Workdir:       workdir,
+		TimedOut:      true,
+		TimeoutSource: run.TimeoutSource,
+		ExitCode:      -1,
+	}
 }
 
 // captureFailure describes a command that ran to completion while its

--- a/internal/runner/cmd/cmd_test.go
+++ b/internal/runner/cmd/cmd_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -1095,5 +1096,64 @@ func TestRun_ConcurrentCapturesNeverComeBackEmpty(t *testing.T) {
 		case strings.TrimSpace(got.stdout) != want:
 			t.Errorf("child %d: stdout = %q, want exactly %q", got.id, got.stdout, want)
 		}
+	}
+}
+
+// TestRun_TimeoutBeforeStartIsATimeout pins the outcome when a step's own
+// `timeout:` expires before the process could be started at all.
+//
+// exec.CommandContext checks the context inside Start, so on a loaded machine a
+// short timeout can fire in the window between building the command and the OS
+// creating the process. That returned context.DeadlineExceeded from Start, and
+// Run wrapped it in "failed to execute" — the message reserved for a command
+// that could not be started (not found, permission). The result was a spec
+// author being told their command was unrunnable when it had simply run out of
+// time, with no TimedOut flag and no timeout source to point at the budget that
+// killed it. It surfaced as a Windows CI failure of TestRun_Timeout, whose 50ms
+// budget lost the race to Windows process creation.
+//
+// A one-nanosecond timeout makes the race deterministic: the deadline is always
+// already past by the time Start runs.
+func TestRun_TimeoutBeforeStartIsATimeout(t *testing.T) {
+	t.Parallel()
+	res, err := New().Run(context.Background(), &spec.Run{
+		Command:       argvCommand("echo hi", "cmd /c echo hi"),
+		Timeout:       "1ns",
+		TimeoutSource: "step",
+	}, t.TempDir())
+	if err != nil {
+		t.Fatalf("Run() error = %v; an expired step timeout is an observable outcome, not a start failure", err)
+	}
+	if !res.TimedOut {
+		t.Error("TimedOut = false, want true")
+	}
+	if res.TimeoutSource != "step" {
+		t.Errorf("TimeoutSource = %q, want %q — the failure hint names the budget that killed the step", res.TimeoutSource, "step")
+	}
+	if res.ExitCode != -1 {
+		t.Errorf("ExitCode = %d, want -1 (no exit status exists for a process that never ran)", res.ExitCode)
+	}
+	if res.Command != argvCommand("echo hi", "cmd /c echo hi") {
+		t.Errorf("Command = %q, want the command as authored", res.Command)
+	}
+}
+
+// TestRun_ParentCancelBeforeStartIsNotAStartFailure is the same window for a
+// parent-context cancellation (Ctrl-C / suite cancel). It must read as the
+// cancellation it is — the wording issue #30 established for a cancel observed
+// after Wait — rather than claiming the command could not be started.
+func TestRun_ParentCancelBeforeStartIsNotAStartFailure(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := New().Run(ctx, &spec.Run{Command: argvCommand("echo hi", "cmd /c echo hi")}, t.TempDir())
+	if err == nil {
+		t.Fatal("Run() error = nil; a cancelled run must be reported as an error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Run() error = %v, want it to wrap context.Canceled", err)
+	}
+	if strings.Contains(err.Error(), "failed to execute") {
+		t.Errorf("Run() error = %v; a cancel is not a start failure", err)
 	}
 }

--- a/test/e2e/atago/timeouts.atago.yaml
+++ b/test/e2e/atago/timeouts.atago.yaml
@@ -295,3 +295,39 @@ scenarios:
       - assert:
           stdout:
             not_contains: "send its quit key"
+
+  - name: a timeout that expires before the process starts is still a timeout
+    steps:
+      # exec.CommandContext checks the deadline inside Start, so a budget this
+      # small is always already spent by the time the OS would create the
+      # process. atago used to report that as "failed to execute" — the message
+      # for a command that could not be started at all — telling the author their
+      # command was unrunnable when it had merely run out of time. The outcome
+      # must not depend on which side of process creation the deadline lands on,
+      # which is exactly the race a loaded Windows runner loses with a 50ms
+      # budget. No `sleep` here, so unlike its neighbours this runs on every OS.
+      - fixture:
+          file: prestart.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: prestart
+            scenarios:
+              - name: the budget is spent before the process exists
+                steps:
+                  - run:
+                      shell: true
+                      command: echo hi
+                      timeout: 1ns
+                  - assert:
+                      exit_code: 0
+      - run:
+          command: ${atago} run prestart.atago.yaml
+          timeout: 30s
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "timed out"
+              - "run.timeout"
+            not_contains: "failed to execute"


### PR DESCRIPTION
## Summary

`TestRun_Timeout` failed on `windows-latest` on main with `failed to execute "ping -n 6 127.0.0.1": context deadline exceeded`. That is not a flaky test — it is a real reporting bug the Windows leg happened to expose. `exec.CommandContext` checks the context inside `Start`, so a step's own `timeout:` can expire in the window between building the command and the OS creating the process. atago wrapped that in `failed to execute`, the message reserved for a command that could not be started at all, and returned an error instead of a result: the step surfaced as an execution error with exit code 4 rather than a timeout failure with exit code 1, carried no `TimedOut` flag, and named no timeout source. A spec author with a short budget on a loaded machine was told their command was unrunnable when it had merely run out of time.

The second commit is unrelated to that bug and addresses the CI gap that made the preceding hang undiagnosable.

## Changes

- `internal/runner/cmd/cmd.go`: a failed `Start` now classifies the context first. An expired deadline returns the same `TimedOut` result the post-`Wait` path produces (exit code -1, timeout source preserved, no captured streams because nothing ever wrote to them); a cancelled parent returns the `run %q canceled` wording issue #30 established. A genuine start failure — not found, permission — keeps `failed to execute` unchanged.
- `internal/runner/cmd/cmd_test.go`: `TestRun_TimeoutBeforeStartIsATimeout` uses a 1ns budget so the deadline is always already past when `Start` runs, making the race deterministic rather than load-dependent, and `TestRun_ParentCancelBeforeStartIsNotAStartFailure` pins the cancel half.
- `test/e2e/atago/timeouts.atago.yaml`: the same contract through the CLI, asserting the run reports `timed out` and `run.timeout` and never says `failed to execute`. Unlike its neighbours in that spec it needs no `sleep`, so it runs on every OS. Verified to fail with the fix reverted, with exit code 4 instead of 1.
- `.github/workflows/unit_test.yml`: `go test -timeout 5m`. Go's default is 10m, which equals this job's `timeout-minutes`, so the runner killed the job at the same moment Go would have panicked — a hang left nothing but `The operation was canceled` and two orphan test binaries in the cleanup log. No package here takes more than a few seconds, so 5m only ever fires on a real hang, and then Go dumps every goroutine's stack with five minutes of job time left to flush it.

## Design Decisions

The pre-`Start` deadline builds a `Result` rather than reusing the post-`Wait` path, because that path decorates a result that already holds captured output. Here there is no process and no output, and saying so is the point: the fields it sets are the ones a timeout is observable through, and the streams stay empty rather than borrowing anything.

`timeout: 1ns` in both the unit test and the E2E is deliberate. The bug is a race against process creation, and a budget that can never be met turns it into a certainty on every OS instead of something that reproduces only under Windows CI load.

Only the `cmd` runner is affected. The pty runner builds its timeout context after the child is already started, and a service has no step budget, so neither has this window.

## Limitations

The `-timeout` change does not fix the ubuntu hang it exists for — `internal/engine` and `internal/runner/ptyrun` hung once on a leg whose five siblings passed, and it does not reproduce locally at `-count=3`. It makes the next occurrence hand over a stack trace instead of an empty log.