### PR TITLE
fix(pty): let closing the terminal end a drain already inside read(2)

### DIFF
--- a/doc/e2e/mailpit.md
+++ b/doc/e2e/mailpit.md
@@ -24,7 +24,7 @@ Source: `test/e2e/thirdparty/mailpit/mailpit.atago.yaml`
 ### Scenario: the binary reports its version
 #### When
 ```shell
-mailpit version
+mailpit version --no-release-check
 ```
 #### Then
 - exit code is `0`

--- a/internal/record/capture.go
+++ b/internal/record/capture.go
@@ -31,6 +31,21 @@ func resolveCaptureTimeout(d time.Duration) time.Duration {
 	return d
 }
 
+// captureCloseGrace bounds the join with the output reader after the terminal
+// is closed. Closing it is what ends the reader's pending read, so this is a
+// backstop rather than the normal path: a reader that stays blocked anyway must
+// not leave the developer staring at a recorder that never returns.
+const captureCloseGrace = 10 * time.Second
+
+// waitDrained waits for the output reader to finish, but never past
+// captureCloseGrace.
+func waitDrained(done <-chan struct{}) {
+	select {
+	case <-done:
+	case <-time.After(captureCloseGrace):
+	}
+}
+
 // terminalSize returns the invoking terminal's rows/cols, or the pty default
 // (24x80) when out is not a terminal. golang.org/x/term.GetSize reads a POSIX
 // terminal and a Windows console alike, so one helper serves both the POSIX and

--- a/internal/record/capture_test.go
+++ b/internal/record/capture_test.go
@@ -47,6 +47,45 @@ func TestCapturePTY_RecordsOutputAndExit(t *testing.T) {
 	}
 }
 
+// TestCapturePTY_StartFailureDoesNotHang is a regression test for a recorder
+// hang: `atago record --pty -- <not-a-command>` printed its banner and then
+// waited forever. The child never started, so nothing ever wrote to the
+// terminal, and the recorder waited on an output reader whose read could not
+// end while the recorder itself still held the terminal's slave open — closing
+// the master does not interrupt a read already parked in the kernel.
+func TestCapturePTY_StartFailureDoesNotHang(t *testing.T) {
+	inR, inW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("input pipe: %v", err)
+	}
+	defer func() { _ = inR.Close(); _ = inW.Close() }()
+	outR, outW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("output pipe: %v", err)
+	}
+	defer func() { _ = outR.Close(); _ = outW.Close() }()
+	go func() { _, _ = io.Copy(io.Discard, outR) }()
+
+	const missing = "atago-no-such-binary-2a5f1c"
+	errCh := make(chan error, 1)
+	go func() {
+		_, cerr := CapturePTY(missing, false, inR, outW, 30*time.Second)
+		errCh <- cerr
+	}()
+
+	select {
+	case cerr := <-errCh:
+		if cerr == nil {
+			t.Fatal("CapturePTY() error = nil, want the start failure")
+		}
+		if !strings.Contains(cerr.Error(), missing) {
+			t.Errorf("CapturePTY() error = %v, want it to name the command %q", cerr, missing)
+		}
+	case <-time.After(60 * time.Second):
+		t.Fatal("CapturePTY() hung after the child failed to start")
+	}
+}
+
 // TestCapturePTY_NoShellFastExitOutputNotLost covers the same fast-exit path as
 // the macOS CrossPlatformE2E flake, but in the recorder: a no-shell `echo`
 // binary that exits immediately must still leave its output in the recording.

--- a/internal/record/capture_unix.go
+++ b/internal/record/capture_unix.go
@@ -18,11 +18,11 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/creack/pty"
 	"golang.org/x/sys/unix"
 	"golang.org/x/term"
 
 	runnercmd "github.com/nao1215/atago/internal/runner/cmd"
+	"github.com/nao1215/atago/internal/runner/ptyrun"
 )
 
 // captureDrainGrace bounds how long capture waits for the pty's final output to
@@ -55,15 +55,11 @@ func CapturePTY(command string, shell bool, in, out *os.File, timeout time.Durat
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true, Setctty: true}
 
 	rows, cols := terminalSize(out)
-	master, tty, err := pty.Open()
+	master, tty, err := ptyrun.OpenTerminal(uint16(rows), uint16(cols)) //nolint:gosec // geometry is bounded by terminalSize
 	if err != nil {
 		return PTYRecording{}, fmt.Errorf("record --pty: start %q: %w", command, err)
 	}
 	defer func() { _ = tty.Close() }()
-	if err := pty.Setsize(master, &pty.Winsize{Rows: uint16(rows), Cols: uint16(cols)}); err != nil { //nolint:gosec // geometry is bounded by terminalSize
-		_ = master.Close()
-		return PTYRecording{}, fmt.Errorf("record --pty: start %q: %w", command, err)
-	}
 	cmd.Stdin = tty
 	cmd.Stdout = tty
 	cmd.Stderr = tty
@@ -102,8 +98,12 @@ func CapturePTY(command string, shell bool, in, out *os.File, timeout time.Durat
 	runtime.Gosched()
 
 	if err := cmd.Start(); err != nil {
+		// Drop atago's own slave handle before waiting: while the recorder still
+		// holds the terminal open the master read has no reason to end, and the
+		// wait below would hang instead of reporting that the child never started.
+		_ = tty.Close()
 		_ = master.Close()
-		<-outDone
+		waitDrained(outDone)
 		return PTYRecording{}, fmt.Errorf("record --pty: start %q: %w", command, err)
 	}
 	_ = tty.Close()
@@ -156,7 +156,7 @@ func CapturePTY(command string, shell bool, in, out *os.File, timeout time.Durat
 	case <-time.After(captureDrainGrace):
 	}
 	_ = master.Close()
-	<-outDone
+	waitDrained(outDone)
 
 	mu.Lock()
 	rec.ExitCode = code

--- a/internal/record/capture_windows.go
+++ b/internal/record/capture_windows.go
@@ -134,7 +134,7 @@ func CapturePTY(command string, shell bool, in, out *os.File, timeout time.Durat
 	case <-time.After(captureDrainGrace):
 	}
 	_ = cpty.Close()
-	<-outDone
+	waitDrained(outDone)
 
 	mu.Lock()
 	rec.ExitCode = code

--- a/internal/runner/ptyrun/ptyrun_unix.go
+++ b/internal/runner/ptyrun/ptyrun_unix.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"runtime"
 	"syscall"
+	"time"
 
 	"github.com/creack/pty"
 
@@ -97,9 +98,10 @@ func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runne
 
 // OpenTerminal opens a pseudo-terminal pair sized rows×cols and hands back a
 // master whose reads the runtime poller owns, so that closing it interrupts a
-// read already in flight. Every POSIX pty atago opens — the pty runner here and
-// the interactive recorder — goes through it, because getting this wrong hangs
-// the process rather than failing it.
+// read already in flight — where the platform lets the poller own it at all.
+// Every POSIX pty atago opens — the pty runner here and the interactive
+// recorder — goes through it, because getting this wrong hangs the process
+// rather than failing it.
 //
 // That last part is the whole reason this helper exists. creack/pty runs its
 // ioctls through (*os.File).Fd(), which is documented to return a blocking
@@ -124,21 +126,43 @@ func OpenTerminal(rows, cols uint16) (master, tty *os.File, err error) {
 		closeBoth()
 		return nil, nil, err
 	}
-	sc, err := master.SyscallConn()
-	if err != nil {
+	if err := adoptMasterReads(master); err != nil {
 		closeBoth()
 		return nil, nil, err
 	}
+	return master, tty, nil
+}
+
+// adoptMasterReads puts the master's reads back under the runtime poller when
+// the poller is in a position to take them, and leaves them blocking when it is
+// not.
+//
+// That condition is not cosmetic. A non-blocking descriptor the poller does not
+// own surfaces EAGAIN straight to the caller, so every read fails instead of
+// waiting and the drain dies on the first one. Which regime a pty master lands
+// in is creack/pty's choice of constructor: on Linux it opens the master with
+// os.OpenFile, which registers the descriptor with the poller, and on macOS it
+// wraps a raw descriptor with os.NewFile, which does not. SetReadDeadline
+// reports that ownership directly — a descriptor the poller does not hold
+// answers os.ErrNoDeadline — so ask it instead of guessing from the platform.
+//
+// Where the answer is no, closing the master cannot interrupt a read already in
+// flight, and waitDrain's bounded join is what keeps that from wedging the run.
+func adoptMasterReads(master *os.File) error {
+	// The zero time means "no deadline": this sets nothing and clears nothing,
+	// it only asks the question.
+	if err := master.SetReadDeadline(time.Time{}); err != nil {
+		return nil //nolint:nilerr // a master the poller does not own is a platform fact, not a failure to open a terminal
+	}
+	sc, err := master.SyscallConn()
+	if err != nil {
+		return err
+	}
 	var setErr error
 	if ctlErr := sc.Control(func(fd uintptr) { setErr = syscall.SetNonblock(int(fd), true) }); ctlErr != nil {
-		closeBoth()
-		return nil, nil, ctlErr
+		return ctlErr
 	}
-	if setErr != nil {
-		closeBoth()
-		return nil, nil, setErr
-	}
-	return master, tty, nil
+	return setErr
 }
 
 // waitExitCode maps a cmd.Wait() error to the observed exit code, mirroring the

--- a/internal/runner/ptyrun/ptyrun_unix.go
+++ b/internal/runner/ptyrun/ptyrun_unix.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"runtime"
 	"syscall"
@@ -51,15 +52,11 @@ func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runne
 	if p.Cols > 0 && p.Cols < 1<<16 {
 		cols = uint16(p.Cols)
 	}
-	master, tty, err := pty.Open()
+	master, tty, err := OpenTerminal(rows, cols)
 	if err != nil {
 		return nil, nil, fmt.Errorf("pty: start %q: %w", p.Command, err)
 	}
 	defer func() { _ = tty.Close() }()
-	if err := pty.Setsize(master, &pty.Winsize{Rows: rows, Cols: cols}); err != nil {
-		_ = master.Close()
-		return nil, nil, fmt.Errorf("pty: start %q: %w", p.Command, err)
-	}
 	cmd.Stdin = tty
 	cmd.Stdout = tty
 	cmd.Stderr = tty
@@ -71,8 +68,11 @@ func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runne
 	// goroutine launches a child that may write and exit immediately.
 	runtime.Gosched()
 	if err := cmd.Start(); err != nil {
-		_ = master.Close()
-		term.waitDrain(func() {}, 0)
+		// Drop atago's own slave handle first: while the parent still holds the
+		// terminal open the master read has no reason to end, and waiting for the
+		// drain would hang instead of surfacing the start failure.
+		_ = tty.Close()
+		term.waitDrain(func() { _ = master.Close() }, 0)
 		return nil, nil, fmt.Errorf("pty: start %q: %w", p.Command, err)
 	}
 	_ = tty.Close()
@@ -93,6 +93,52 @@ func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runne
 		dir:       cmd.Dir,
 	}
 	return driveSession(ctx, p, proc)
+}
+
+// OpenTerminal opens a pseudo-terminal pair sized rows×cols and hands back a
+// master whose reads the runtime poller owns, so that closing it interrupts a
+// read already in flight. Every POSIX pty atago opens — the pty runner here and
+// the interactive recorder — goes through it, because getting this wrong hangs
+// the process rather than failing it.
+//
+// That last part is the whole reason this helper exists. creack/pty runs its
+// ioctls through (*os.File).Fd(), which is documented to return a blocking
+// descriptor: os.File hands the descriptor over to the caller and takes it back
+// out of the poller. Reads then park inside read(2), where Close cannot reach
+// them — Go can only mark the file closed and defer the real close(2) until the
+// read returns on its own. A master read ends on its own when the last slave
+// handle goes away, so any surviving handle (a descendant that escaped the
+// process-group kill) left the drain blocked forever. Restoring O_NONBLOCK puts
+// reads back under the poller, where Close unblocks them with fs.ErrClosed —
+// which isSessionEnd already reads as a normal end of session.
+func OpenTerminal(rows, cols uint16) (master, tty *os.File, err error) {
+	master, tty, err = pty.Open()
+	if err != nil {
+		return nil, nil, err
+	}
+	closeBoth := func() {
+		_ = tty.Close()
+		_ = master.Close()
+	}
+	if err := pty.Setsize(master, &pty.Winsize{Rows: rows, Cols: cols}); err != nil {
+		closeBoth()
+		return nil, nil, err
+	}
+	sc, err := master.SyscallConn()
+	if err != nil {
+		closeBoth()
+		return nil, nil, err
+	}
+	var setErr error
+	if ctlErr := sc.Control(func(fd uintptr) { setErr = syscall.SetNonblock(int(fd), true) }); ctlErr != nil {
+		closeBoth()
+		return nil, nil, ctlErr
+	}
+	if setErr != nil {
+		closeBoth()
+		return nil, nil, setErr
+	}
+	return master, tty, nil
 }
 
 // waitExitCode maps a cmd.Wait() error to the observed exit code, mirroring the

--- a/internal/runner/ptyrun/ptyrun_unix_test.go
+++ b/internal/runner/ptyrun/ptyrun_unix_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	runnercmd "github.com/nao1215/atago/internal/runner/cmd"
 	"github.com/nao1215/atago/internal/spec"
@@ -65,6 +66,89 @@ func TestRun_NoShellFastExitOutputNotLost(t *testing.T) {
 		if !strings.Contains(string(res.Stdout), "done") {
 			t.Fatalf("iteration %d: transcript lost the child's output: %q", i, res.Stdout)
 		}
+	}
+}
+
+// TestWaitDrain_ClosingTheMasterEndsTheDrain is a regression test for a CI
+// hang: closing the pty master must interrupt the reader even when something
+// else still holds the terminal open.
+//
+// creack/pty performs its ioctls through (*os.File).Fd(), which hands back a
+// blocking descriptor, and a read(2) already parked in the kernel is immune to
+// Close — the descriptor is only really closed once that read returns. So while
+// any slave handle survived (a descendant that escaped the process-group kill,
+// or atago's own tty in the start-failure path) waitDrain blocked forever, and
+// internal/engine and internal/runner/ptyrun both died on the 5m test timeout.
+func TestWaitDrain_ClosingTheMasterEndsTheDrain(t *testing.T) {
+	t.Parallel()
+
+	master, tty, err := OpenTerminal(24, 80)
+	if err != nil {
+		t.Fatalf("OpenTerminal: %v", err)
+	}
+	// Deliberately keep the slave open: this is what makes the master read
+	// block instead of ending with EIO.
+	defer func() { _ = tty.Close() }()
+
+	term := startTranscriptDrain(master, &spec.PTY{})
+	// Park the reader inside read(2) first: a drain closed before its first read
+	// ends on the closed descriptor and would prove nothing. Seeing the written
+	// bytes land in the transcript means the goroutine consumed them and went
+	// back for more.
+	if _, werr := tty.Write([]byte("parked\n")); werr != nil {
+		t.Fatalf("write to the terminal: %v", werr)
+	}
+	deadline := time.Now().Add(10 * time.Second)
+	for term.curLen() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("the drain never read the bytes written to the terminal")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		term.waitDrain(func() { _ = master.Close() }, 0)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("waitDrain never returned after the master was closed while the terminal stayed open")
+	}
+	// Closing the terminal is how atago ends the session, so the drain must not
+	// report it as a lost transcript.
+	if rerr := term.readError(); rerr != nil {
+		t.Errorf("readError() = %v, want nil: atago's own close is a session end, not a read failure", rerr)
+	}
+}
+
+// TestRun_StartFailureDoesNotHang covers the other half of the same hang: when
+// the child cannot be started at all, Run must surface that error instead of
+// waiting on a drain whose read can never end — atago still held the slave.
+func TestRun_StartFailureDoesNotHang(t *testing.T) {
+	t.Parallel()
+
+	p := &spec.PTY{Command: "atago-no-such-binary-2a5f1c"}
+	type outcome struct{ err error }
+	ch := make(chan outcome, 1)
+	go func() {
+		_, _, err := Run(context.Background(), p, t.TempDir(), nil)
+		ch <- outcome{err}
+	}()
+
+	select {
+	case got := <-ch:
+		if got.err == nil {
+			t.Fatal("Run() error = nil, want the start failure")
+		}
+		if !strings.Contains(got.err.Error(), p.Command) {
+			t.Errorf("Run() error = %v, want it to name the command %q", got.err, p.Command)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("Run() hung after the child failed to start")
 	}
 }
 

--- a/internal/runner/ptyrun/ptyrun_unix_test.go
+++ b/internal/runner/ptyrun/ptyrun_unix_test.go
@@ -70,8 +70,8 @@ func TestRun_NoShellFastExitOutputNotLost(t *testing.T) {
 }
 
 // TestWaitDrain_ClosingTheMasterEndsTheDrain is a regression test for a CI
-// hang: closing the pty master must interrupt the reader even when something
-// else still holds the terminal open.
+// hang: waitDrain must return even when something else still holds the terminal
+// open, so that a stuck reader fails a run instead of wedging it.
 //
 // creack/pty performs its ioctls through (*os.File).Fd(), which hands back a
 // blocking descriptor, and a read(2) already parked in the kernel is immune to
@@ -79,6 +79,10 @@ func TestRun_NoShellFastExitOutputNotLost(t *testing.T) {
 // any slave handle survived (a descendant that escaped the process-group kill,
 // or atago's own tty in the start-failure path) waitDrain blocked forever, and
 // internal/engine and internal/runner/ptyrun both died on the 5m test timeout.
+//
+// Where the poller owns the master, closing it ends the read outright, and the
+// test holds that to the stronger standard: it must not take the backstop to
+// get there.
 func TestWaitDrain_ClosingTheMasterEndsTheDrain(t *testing.T) {
 	t.Parallel()
 
@@ -86,6 +90,9 @@ func TestWaitDrain_ClosingTheMasterEndsTheDrain(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenTerminal: %v", err)
 	}
+	// The same question OpenTerminal asks: does closing the master interrupt a
+	// read in flight, or does only the backstop end the wait?
+	pollerOwned := master.SetReadDeadline(time.Time{}) == nil
 	// Deliberately keep the slave open: this is what makes the master read
 	// block instead of ending with EIO.
 	defer func() { _ = tty.Close() }()
@@ -108,6 +115,7 @@ func TestWaitDrain_ClosingTheMasterEndsTheDrain(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	done := make(chan struct{})
+	started := time.Now()
 	go func() {
 		defer close(done)
 		term.waitDrain(func() { _ = master.Close() }, 0)
@@ -115,8 +123,11 @@ func TestWaitDrain_ClosingTheMasterEndsTheDrain(t *testing.T) {
 
 	select {
 	case <-done:
-	case <-time.After(30 * time.Second):
+	case <-time.After(closeGrace + 30*time.Second):
 		t.Fatal("waitDrain never returned after the master was closed while the terminal stayed open")
+	}
+	if elapsed := time.Since(started); pollerOwned && elapsed >= closeGrace {
+		t.Errorf("waitDrain took %s: closing a poller-owned master must end the read outright, not wait out the %s backstop", elapsed, closeGrace)
 	}
 	// Closing the terminal is how atago ends the session, so the drain must not
 	// report it as a lost transcript.

--- a/internal/runner/ptyrun/transcript.go
+++ b/internal/runner/ptyrun/transcript.go
@@ -124,6 +124,12 @@ func (t *transcriptDrain) readError() error {
 	return t.readErr
 }
 
+// closeGrace bounds the join after the terminal is closed. Closing it is what
+// ends the pending read, so this is a backstop rather than the normal path: a
+// reader that stays blocked anyway must not wedge the whole run — a pty drain
+// blocked past a close is how two packages once died on the 5m test timeout.
+const closeGrace = 10 * time.Second
+
 func (t *transcriptDrain) waitDrain(closeTerm func(), grace time.Duration) {
 	if grace > 0 {
 		select {
@@ -132,5 +138,8 @@ func (t *transcriptDrain) waitDrain(closeTerm func(), grace time.Duration) {
 		}
 	}
 	closeTerm()
-	<-t.readDone
+	select {
+	case <-t.readDone:
+	case <-time.After(closeGrace):
+	}
 }

--- a/test/e2e/thirdparty/mailpit/mailpit.atago.yaml
+++ b/test/e2e/thirdparty/mailpit/mailpit.atago.yaml
@@ -43,8 +43,13 @@ runners:
 scenarios:
   - name: the binary reports its version
     steps:
+      # --no-release-check keeps the suite inside the network permission it
+      # declares: plain `mailpit version` asks GitHub for the latest release and
+      # exits 1 when that call fails, so an unauthenticated rate limit (HTTP 403
+      # on a shared CI runner) would fail this scenario for a reason that has
+      # nothing to do with mailpit.
       - run:
-          command: mailpit version
+          command: mailpit version --no-release-check
       - assert:
           exit_code: 0
           stdout:


### PR DESCRIPTION
Fixes both red CI runs:

- [MultiPlatformUnitTest #31127714291](https://github.com/nao1215/atago/actions/runs/31127714291) — `Unit test (ubuntu-latest, 1)` died on the 5m test timeout in two packages.
- [ThirdParty #31155515049](https://github.com/nao1215/atago/actions/runs/31155515049) — the `mailpit` job failed.

## The unit-test hang

`internal/engine` and `internal/runner/ptyrun` both panicked at the 5m timeout with the same stack: the transcript drain parked in `read(2)` on the pty master, and `waitDrain` waiting on it forever *after* closing that master.

```
goroutine 1586 [chan receive, 4 minutes]:
ptyrun.(*transcriptDrain).waitDrain(...)  transcript.go:135   <- <-t.readDone
goroutine 1587 [syscall, 4 minutes]:
syscall.Syscall(0x0, ...)                                     <- read(2), not IO wait
ptyrun.startTranscriptDrain.func1()       transcript.go:42
```

Closing the master cannot end that read. creack/pty runs its ioctls through `(*os.File).Fd()`, which is documented to hand back a **blocking** descriptor: `os.File` gives the descriptor to the caller and takes it back out of the runtime poller. Reads then block inside the kernel, where `Close` cannot reach them — Go can only mark the file closed and defer the real `close(2)` until the read returns on its own. That is why the goroutine sits in `[syscall]` rather than `[IO wait]`.

A master read returns on its own when the last slave handle goes away, so any surviving handle wedges the drain forever. Two of them show up here:

1. a descendant that escaped the process-group kill (`finish` → `waitDrain(closeTerm, drainGrace)`, the engine stack);
2. atago's own `tty`, which `Run` kept open until it returned — the `cmd.Start()` failure path (`ptyrun_unix.go:75`, the ptyrun stack) drained while still holding the slave, which deadlocks every time.

Reproduced outside atago first: with `pty.Open()` alone, a pending read is still blocked 3s after `Close`; restoring `O_NONBLOCK` makes the same read return `file already closed` immediately.

### Fix

`OpenTerminal` opens the pair and restores `O_NONBLOCK` once creack/pty is done with its ioctls, so reads go back under the poller — where `Close` unblocks them with `fs.ErrClosed`, which `isSessionEnd` already reads as a normal end of session. On top of that the start-failure path drops the `tty` before it drains, and `waitDrain` bounds the join after the close so a reader that stays blocked for some other reason fails the run instead of hanging it.

`atago record --pty` opens its own pty and had both hangs too — `atago record --pty -- not-a-command` printed its banner and waited forever. It now goes through the same helper.

Both regression tests fail on `main` (30s guard trips) and pass here.

## The mailpit failure

```
mailpit dev compiled with go1.26.5 on linux/amd64
Error checking for latest release: failed to download file: received status code 403
```

Plain `mailpit version` asks GitHub for the latest release and exits 1 when that call fails; the runner hit the unauthenticated rate limit. The scenario declares `network: allow: [127.0.0.1]`, so reaching GitHub was never what it meant to test — it now passes `--no-release-check`, which mailpit provides for exactly this.

## Verification

- `go test ./...`, `go test -race` on `ptyrun` / `record` / `engine`, `golangci-lint run` — all green
- `go test -count=10 ./internal/runner/ptyrun/` — stable
- `./dist/atago run ./test/e2e/atago` — 445 passed, 4 skipped
- `./dist/atago run ./test/e2e/thirdparty/mailpit` — 5 passed
- `GOOS=windows go build ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented terminal capture and command execution from hanging when processes fail to start or output streams do not close properly.
  * Added bounded waiting during terminal shutdown to ensure operations complete reliably.
  * Preserved captured output while improving terminal cleanup across supported platforms.
  * Updated Mailpit version checks to avoid external release lookups and related failures.

* **Tests**
  * Added regression coverage for startup failures, interrupted output draining, and preserved terminal output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->