### PR TITLE
fix(pty): pair the terminal master with its own slave

### DIFF
--- a/internal/record/capture_unix.go
+++ b/internal/record/capture_unix.go
@@ -169,12 +169,23 @@ func CapturePTY(command string, shell bool, in, out *os.File, timeout time.Durat
 
 // echoDisabled reports whether the pty's terminal echo is currently off — the
 // signal of a password prompt, whose typed bytes must not be recorded (#69).
+// Asking through ControlFD rather than master.Fd() is what keeps this poll
+// harmless: Fd() would take the master out of the runtime poller and leave its
+// reads blocking in read(2), where closing the terminal can no longer interrupt
+// them — and this runs on every prompt.
 func echoDisabled(master *os.File) bool {
-	t, err := unix.IoctlGetTermios(int(master.Fd()), ioctlGetTermios)
-	if err != nil {
+	off := false
+	if err := ptyrun.ControlFD(master, func(fd int) error {
+		t, terr := unix.IoctlGetTermios(fd, ioctlGetTermios)
+		if terr != nil {
+			return terr
+		}
+		off = t.Lflag&unix.ECHO == 0
+		return nil
+	}); err != nil {
 		return false
 	}
-	return t.Lflag&unix.ECHO == 0
+	return off
 }
 
 // exitCode extracts a process exit code from cmd.Wait's error (0 on success,

--- a/internal/record/capture_unix.go
+++ b/internal/record/capture_unix.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"runtime"
 	"sync"
 	"syscall"
 	"time"
@@ -76,10 +75,18 @@ func CapturePTY(command string, shell bool, in, out *os.File, timeout time.Durat
 	}
 
 	// Output: child → developer's screen, recorded verbatim (ANSI intact).
+	//
+	// reading is closed when the goroutine has nothing left to do but read, and
+	// waiting for it below is what puts this reader ahead of the child: creating
+	// a goroutine only makes it runnable, so the runtime.Gosched that used to
+	// stand here guaranteed nothing about a no-shell fast-exit command that
+	// prints and disappears. The pty runner's drain takes the same handoff.
 	outDone := make(chan struct{})
+	reading := make(chan struct{})
 	go func() {
 		defer close(outDone)
 		buf := make([]byte, 4096)
+		close(reading)
 		for {
 			n, rerr := master.Read(buf)
 			if n > 0 {
@@ -93,9 +100,7 @@ func CapturePTY(command string, shell bool, in, out *os.File, timeout time.Durat
 			}
 		}
 	}()
-	// Yield once so the output drain can enter Read before a no-shell fast-exit
-	// command has a chance to print and disappear.
-	runtime.Gosched()
+	<-reading
 
 	if err := cmd.Start(); err != nil {
 		// Drop atago's own slave handle before waiting: while the recorder still

--- a/internal/runner/ptyrun/ptyrun_unix.go
+++ b/internal/runner/ptyrun/ptyrun_unix.go
@@ -60,10 +60,11 @@ func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runne
 	cmd.Stdout = tty
 	cmd.Stderr = tty
 
-	// Post the first Read before the child starts: macOS can otherwise let a
-	// no-shell fast-exit command print and disappear before the drain exists.
-	// startTranscriptDrain does not return until its reader goroutine has
-	// reached that read, so this ordering is an invariant rather than a hope.
+	// Start draining before the child starts: macOS can otherwise let a no-shell
+	// fast-exit command print and disappear before the drain exists.
+	// startTranscriptDrain does not return until its reader goroutine has been
+	// scheduled and has reached its read call — one statement short of a promise
+	// that the read is posted, but as close as user space gets.
 	term := startTranscriptDrain(master, p)
 	if err := cmd.Start(); err != nil {
 		// Drop atago's own slave handle first: while the parent still holds the

--- a/internal/runner/ptyrun/ptyrun_unix.go
+++ b/internal/runner/ptyrun/ptyrun_unix.go
@@ -9,11 +9,8 @@ import (
 	"math"
 	"os"
 	"os/exec"
-	"runtime"
 	"syscall"
 	"time"
-
-	"github.com/creack/pty"
 
 	"github.com/nao1215/atago/internal/runner"
 	runnercmd "github.com/nao1215/atago/internal/runner/cmd"
@@ -22,7 +19,7 @@ import (
 
 // Run executes p.Command inside a POSIX pseudo-terminal in workdir and drives
 // the expect/send session against it via the shared driveSession core. The
-// terminal is a creack/pty master and cleanup kills the whole process group
+// terminal comes from OpenTerminal and cleanup kills the whole process group
 // (Setsid), so a timed-out or aborted session never leaks the child tree.
 func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runner.Result, *ExpectFailure, error) {
 	name, args, err := runnercmd.CommandLine(p.Command, p.Shell != nil && *p.Shell)
@@ -65,10 +62,9 @@ func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runne
 
 	// Post the first Read before the child starts: macOS can otherwise let a
 	// no-shell fast-exit command print and disappear before the drain exists.
+	// startTranscriptDrain does not return until its reader goroutine has
+	// reached that read, so this ordering is an invariant rather than a hope.
 	term := startTranscriptDrain(master, p)
-	// Yield once so the drain goroutine can enter its blocking Read before this
-	// goroutine launches a child that may write and exit immediately.
-	runtime.Gosched()
 	if err := cmd.Start(); err != nil {
 		// Drop atago's own slave handle first: while the parent still holds the
 		// terminal open the master read has no reason to end, and waiting for the
@@ -92,15 +88,15 @@ func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runne
 		// Negative pid signals the whole process group created by Setsid.
 		kill:      func() { _ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL) },
 		closeTerm: func() { _ = master.Close() },
-		// TIOCSWINSZ on the master is the whole mechanism: the kernel records
-		// the new size AND sends SIGWINCH to the terminal's foreground process
-		// group, so the child learns about it exactly as it would from a real
-		// window change (#379).
+		// setTerminalSize's TIOCSWINSZ on the master is the whole mechanism: the
+		// kernel records the new size AND sends SIGWINCH to the terminal's
+		// foreground process group, so the child learns about it exactly as it
+		// would from a real window change (#379).
 		resize: func(rows, cols int) error {
 			if rows < 1 || cols < 1 || rows > math.MaxUint16 || cols > math.MaxUint16 {
 				return fmt.Errorf("size %dx%d is out of range for a terminal", rows, cols)
 			}
-			return pty.Setsize(master, &pty.Winsize{Rows: uint16(rows), Cols: uint16(cols)})
+			return setTerminalSize(master, uint16(rows), uint16(cols))
 		},
 		dir: cmd.Dir,
 		env: env,
@@ -115,18 +111,25 @@ func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runne
 // recorder — goes through it, because getting this wrong hangs the process
 // rather than failing it.
 //
-// That last part is the whole reason this helper exists. creack/pty runs its
-// ioctls through (*os.File).Fd(), which is documented to return a blocking
-// descriptor: os.File hands the descriptor over to the caller and takes it back
-// out of the poller. Reads then park inside read(2), where Close cannot reach
-// them — Go can only mark the file closed and defer the real close(2) until the
-// read returns on its own. A master read ends on its own when the last slave
-// handle goes away, so any surviving handle (a descendant that escaped the
-// process-group kill) left the drain blocked forever. Restoring O_NONBLOCK puts
-// reads back under the poller, where Close unblocks them with fs.ErrClosed —
-// which isSessionEnd already reads as a normal end of session.
+// The pair itself comes from openTerminalPair, which on Linux is atago's own
+// four syscalls rather than creack/pty's: creack/pty can silently report the
+// wrong slave there, and a master paired with a stranger's terminal loses the
+// whole transcript (#385, and the reasoning in terminal_linux.go).
+//
+// The poller part is the other reason this helper exists. An ioctl reached
+// through (*os.File).Fd() — which is how creack/pty sizes a terminal — costs
+// the file its poller: Fd() is documented to return a blocking descriptor, so
+// os.File clears O_NONBLOCK and hands the descriptor over. Reads then park
+// inside read(2), where Close cannot reach them — Go can only mark the file
+// closed and defer the real close(2) until the read returns on its own. A master
+// read ends on its own when the last slave handle goes away, so any surviving
+// handle (a descendant that escaped the process-group kill) left the drain
+// blocked forever. Every ioctl atago performs therefore goes through ControlFD
+// instead, and adoptMasterReads restores O_NONBLOCK on a master that arrived
+// blocking, so that Close unblocks a pending read with fs.ErrClosed — which
+// isSessionEnd already reads as a normal end of session.
 func OpenTerminal(rows, cols uint16) (master, tty *os.File, err error) {
-	master, tty, err = pty.Open()
+	master, tty, err = openTerminalPair()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -134,7 +137,7 @@ func OpenTerminal(rows, cols uint16) (master, tty *os.File, err error) {
 		_ = tty.Close()
 		_ = master.Close()
 	}
-	if err := pty.Setsize(master, &pty.Winsize{Rows: rows, Cols: cols}); err != nil {
+	if err := setTerminalSize(master, rows, cols); err != nil {
 		closeBoth()
 		return nil, nil, err
 	}
@@ -152,9 +155,9 @@ func OpenTerminal(rows, cols uint16) (master, tty *os.File, err error) {
 // That condition is not cosmetic. A non-blocking descriptor the poller does not
 // own surfaces EAGAIN straight to the caller, so every read fails instead of
 // waiting and the drain dies on the first one. Which regime a pty master lands
-// in is creack/pty's choice of constructor: on Linux it opens the master with
-// os.OpenFile, which registers the descriptor with the poller, and on macOS it
-// wraps a raw descriptor with os.NewFile, which does not. SetReadDeadline
+// in is decided by how it was opened: os.OpenFile registers the descriptor with
+// the poller (atago's own Linux path), while creack/pty on macOS wraps a raw
+// descriptor with os.NewFile, which does not. SetReadDeadline
 // reports that ownership directly — a descriptor the poller does not hold
 // answers os.ErrNoDeadline — so ask it instead of guessing from the platform.
 //

--- a/internal/runner/ptyrun/ptyrun_unix_test.go
+++ b/internal/runner/ptyrun/ptyrun_unix_test.go
@@ -189,14 +189,39 @@ func TestOpenTerminal_PairsTheMasterWithItsOwnSlave(t *testing.T) {
 		if _, werr := tty.Write([]byte("atago\n")); werr != nil {
 			t.Fatalf("iteration %d: write to the terminal: %v", i, werr)
 		}
-		buf := make([]byte, 64)
-		n, rerr := master.Read(buf)
-		if rerr != nil {
-			t.Fatalf("iteration %d: read the master: %v", i, rerr)
+		// The read has to be bounded, because the failure this test exists for
+		// does not fail the read — a master with no slave of its own simply never
+		// becomes readable, and an unbounded read would report the whole package
+		// as timing out rather than reporting the mispaired terminal.
+		type readResult struct {
+			data string
+			err  error
 		}
-		if got := string(buf[:n]); !strings.Contains(got, "atago") {
-			t.Fatalf("iteration %d: the master read %q, want the bytes written to its own slave: "+
-				"the pair is not a pair", i, got)
+		done := make(chan readResult, 1)
+		go func() {
+			buf := make([]byte, 64)
+			n, rerr := master.Read(buf)
+			done <- readResult{string(buf[:n]), rerr}
+		}()
+		select {
+		case got := <-done:
+			if got.err != nil {
+				_ = tty.Close()
+				_ = master.Close()
+				t.Fatalf("iteration %d: read the master: %v", i, got.err)
+			}
+			if !strings.Contains(got.data, "atago") {
+				_ = tty.Close()
+				_ = master.Close()
+				t.Fatalf("iteration %d: the master read %q, want the bytes written to its own slave: "+
+					"the pair is not a pair", i, got.data)
+			}
+		case <-time.After(30 * time.Second):
+			// Closing the master is what releases the pending read.
+			_ = master.Close()
+			_ = tty.Close()
+			t.Fatalf("iteration %d: nothing written to the tty ever reached the master: "+
+				"the pair is not a pair", i)
 		}
 		_ = tty.Close()
 		_ = master.Close()

--- a/internal/runner/ptyrun/ptyrun_unix_test.go
+++ b/internal/runner/ptyrun/ptyrun_unix_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/sys/unix"
+
 	runnercmd "github.com/nao1215/atago/internal/runner/cmd"
 	"github.com/nao1215/atago/internal/spec"
 )
@@ -161,6 +163,96 @@ func TestRun_StartFailureDoesNotHang(t *testing.T) {
 	case <-time.After(30 * time.Second):
 		t.Fatal("Run() hung after the child failed to start")
 	}
+}
+
+// TestOpenTerminal_PairsTheMasterWithItsOwnSlave pins the invariant behind
+// #385: the two files OpenTerminal returns must be the two ends of ONE
+// terminal. They were not always — creack/pty's Linux ptsname hands the ioctl
+// its answer buffer as a bare uintptr, and a goroutine stack that moves before
+// the syscall leaves the index reading 0, so atago opened /dev/pts/0 (somebody
+// else's terminal) and paired it with a master that had no slave at all. The
+// child's output then went to that stranger's terminal and the step reported a
+// clean exit 0 with an empty transcript.
+//
+// A byte written to the tty has to come out of the master; nothing else proves
+// the two halves are connected. The loop is there because a wrong pair was
+// never the common case: it is cheap enough to run a batch, and a batch is what
+// makes a still-broken pairing likely to show up here rather than in a pty step.
+func TestOpenTerminal_PairsTheMasterWithItsOwnSlave(t *testing.T) {
+	t.Parallel()
+
+	for i := range 100 {
+		master, tty, err := OpenTerminal(24, 80)
+		if err != nil {
+			t.Fatalf("iteration %d: OpenTerminal: %v", i, err)
+		}
+		if _, werr := tty.Write([]byte("atago\n")); werr != nil {
+			t.Fatalf("iteration %d: write to the terminal: %v", i, werr)
+		}
+		buf := make([]byte, 64)
+		n, rerr := master.Read(buf)
+		if rerr != nil {
+			t.Fatalf("iteration %d: read the master: %v", i, rerr)
+		}
+		if got := string(buf[:n]); !strings.Contains(got, "atago") {
+			t.Fatalf("iteration %d: the master read %q, want the bytes written to its own slave: "+
+				"the pair is not a pair", i, got)
+		}
+		_ = tty.Close()
+		_ = master.Close()
+	}
+}
+
+// TestSetTerminalSize_KeepsTheMasterUnderThePoller pins the other half of the
+// same rule: sizing a terminal must not cost it its poller. creack/pty's
+// Setsize reaches the descriptor through (*os.File).Fd(), which is documented
+// to return it in blocking mode — so a mid-session resize (#379) used to clear
+// O_NONBLOCK on the master and leave the drain parked inside read(2), where
+// closing the terminal can no longer reach it. atago's ioctls go through
+// ControlFD, which borrows the descriptor and leaves the file as it found it.
+func TestSetTerminalSize_KeepsTheMasterUnderThePoller(t *testing.T) {
+	t.Parallel()
+
+	master, tty, err := OpenTerminal(24, 80)
+	if err != nil {
+		t.Fatalf("OpenTerminal: %v", err)
+	}
+	defer func() { _ = tty.Close() }()
+	defer func() { _ = master.Close() }()
+
+	// Whether the poller owns this master at all is a platform fact; only where
+	// it does is there anything for the resize to take away.
+	if err := master.SetReadDeadline(time.Time{}); err != nil {
+		t.Skipf("this platform's pty master is not poller-owned: %v", err)
+	}
+	if err := setTerminalSize(master, 40, 120); err != nil {
+		t.Fatalf("setTerminalSize: %v", err)
+	}
+	if err := master.SetReadDeadline(time.Time{}); err != nil {
+		t.Errorf("after a resize the master is no longer poller-owned (%v): "+
+			"closing it can no longer interrupt the drain's pending read", err)
+	}
+	if !nonblocking(t, master) {
+		t.Error("after a resize the master lost O_NONBLOCK: its reads park in read(2), " +
+			"where Close cannot reach them")
+	}
+}
+
+// nonblocking reports whether f's descriptor still carries O_NONBLOCK.
+func nonblocking(t *testing.T, f *os.File) bool {
+	t.Helper()
+	on := false
+	if err := ControlFD(f, func(fd int) error {
+		flags, ferr := unix.FcntlInt(uintptr(fd), unix.F_GETFL, 0)
+		if ferr != nil {
+			return ferr
+		}
+		on = flags&unix.O_NONBLOCK != 0
+		return nil
+	}); err != nil {
+		t.Fatalf("reading the descriptor's flags: %v", err)
+	}
+	return on
 }
 
 // TestResolveCwd covers cwd resolution for a pty step: empty stays at the

--- a/internal/runner/ptyrun/session_test.go
+++ b/internal/runner/ptyrun/session_test.go
@@ -125,7 +125,7 @@ func (b *blockingPTY) Write(p []byte) (int, error) { return len(p), nil }
 // in hand, and only then lets the read complete.
 //
 // What it deliberately does not assert is that the goroutine is inside Read by
-// the time startTranscriptDrain returns. It is signalled one statement earlier,
+// the time startTranscriptDrain returns. It is signaled one statement earlier,
 // and a test that demanded otherwise would be asserting on the scheduler.
 func TestStartTranscriptDrain_HandsBackARunningReader(t *testing.T) {
 	t.Parallel()

--- a/internal/runner/ptyrun/session_test.go
+++ b/internal/runner/ptyrun/session_test.go
@@ -112,18 +112,22 @@ func (b *blockingPTY) Read([]byte) (int, error) {
 
 func (b *blockingPTY) Write(p []byte) (int, error) { return len(p), nil }
 
-// TestStartTranscriptDrain_HandsBackAReaderThatHasReachedItsFirstRead names the
-// ordering the POSIX runner depends on (#385): Run posts the drain before it
-// starts a child that may print and exit immediately, and that is only worth
-// anything if the reader goroutine has actually reached its read by the time
-// startTranscriptDrain returns. Creating a goroutine only makes it runnable, and
-// the runtime.Gosched that used to stand in for this guaranteed nothing.
+// TestStartTranscriptDrain_HandsBackARunningReader pins what the startup
+// handshake does and does not promise. Run starts the drain before it starts a
+// child that may print and exit immediately, so startTranscriptDrain must not
+// hand back a drain whose reader goroutine has yet to be scheduled — which is
+// all the runtime.Gosched it replaced ever offered.
 //
-// The two halves matter equally. The reader must have got as far as reading —
-// and it must NOT have to finish that read, or a terminal with nothing to say
-// yet (every interactive program, until it prints its prompt) would wedge Run
-// before the child ever started.
-func TestStartTranscriptDrain_HandsBackAReaderThatHasReachedItsFirstRead(t *testing.T) {
+// The other half matters just as much: the reader must NOT have to finish its
+// read first. A terminal with nothing to say yet is every interactive program
+// until it prints its prompt, and waiting for that read would wedge Run before
+// the child ever started. So the test releases nothing until the drain is back
+// in hand, and only then lets the read complete.
+//
+// What it deliberately does not assert is that the goroutine is inside Read by
+// the time startTranscriptDrain returns. It is signalled one statement earlier,
+// and a test that demanded otherwise would be asserting on the scheduler.
+func TestStartTranscriptDrain_HandsBackARunningReader(t *testing.T) {
 	t.Parallel()
 
 	b := &blockingPTY{entered: make(chan struct{}), release: make(chan struct{})}
@@ -143,7 +147,7 @@ func TestStartTranscriptDrain_HandsBackAReaderThatHasReachedItsFirstRead(t *test
 	case <-b.entered:
 	case <-time.After(10 * time.Second):
 		close(b.release)
-		t.Fatal("startTranscriptDrain returned before its reader reached the first read")
+		t.Fatal("the reader goroutine never reached its first read")
 	}
 
 	close(b.release)

--- a/internal/runner/ptyrun/session_test.go
+++ b/internal/runner/ptyrun/session_test.go
@@ -96,6 +96,60 @@ func fakeSession(f *fakePTY, code int) ptyProcess {
 	}
 }
 
+// blockingPTY is a terminal whose first Read never returns until it is
+// released, and which records that the read was entered.
+type blockingPTY struct {
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (b *blockingPTY) Read([]byte) (int, error) {
+	b.once.Do(func() { close(b.entered) })
+	<-b.release
+	return 0, io.EOF
+}
+
+func (b *blockingPTY) Write(p []byte) (int, error) { return len(p), nil }
+
+// TestStartTranscriptDrain_HandsBackAReaderThatHasReachedItsFirstRead names the
+// ordering the POSIX runner depends on (#385): Run posts the drain before it
+// starts a child that may print and exit immediately, and that is only worth
+// anything if the reader goroutine has actually reached its read by the time
+// startTranscriptDrain returns. Creating a goroutine only makes it runnable, and
+// the runtime.Gosched that used to stand in for this guaranteed nothing.
+//
+// The two halves matter equally. The reader must have got as far as reading —
+// and it must NOT have to finish that read, or a terminal with nothing to say
+// yet (every interactive program, until it prints its prompt) would wedge Run
+// before the child ever started.
+func TestStartTranscriptDrain_HandsBackAReaderThatHasReachedItsFirstRead(t *testing.T) {
+	t.Parallel()
+
+	b := &blockingPTY{entered: make(chan struct{}), release: make(chan struct{})}
+	returned := make(chan *transcriptDrain, 1)
+	go func() { returned <- startTranscriptDrain(b, &spec.PTY{}) }()
+
+	var term *transcriptDrain
+	select {
+	case term = <-returned:
+	case <-time.After(10 * time.Second):
+		close(b.release)
+		t.Fatal("startTranscriptDrain never returned: it must hand back the drain when its reader " +
+			"reaches the first read, not when that read completes")
+	}
+
+	select {
+	case <-b.entered:
+	case <-time.After(10 * time.Second):
+		close(b.release)
+		t.Fatal("startTranscriptDrain returned before its reader reached the first read")
+	}
+
+	close(b.release)
+	term.waitDrain(func() {}, 0)
+}
+
 // TestDriveSession_ReadErrorIsNotSilence is the #345 regression. Every read
 // error used to end the drain loop identically, so a transcript lost to a real
 // read failure was indistinguishable from a session that simply ended — and

--- a/internal/runner/ptyrun/terminal_linux.go
+++ b/internal/runner/ptyrun/terminal_linux.go
@@ -1,0 +1,78 @@
+package ptyrun
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// openTerminalPair opens a pseudo-terminal pair the way any POSIX program does:
+// open the multiplexer, ask the kernel which slave belongs to this master,
+// unlock that slave, open it. It exists — instead of a call to creack/pty's
+// Open, which does the same four steps — because of how creack/pty passes the
+// answer buffer to the first ioctl.
+//
+// Its ptsname declares the index as a local variable and hands the ioctl
+// `uintptr(unsafe.Pointer(&n))`, then passes that uintptr down through two
+// ordinary function calls before the syscall happens. A uintptr is a number, not
+// a pointer: it neither keeps the variable alive nor pins it. The Go runtime
+// moves goroutine stacks — it copies them on growth and can shrink them while
+// scanning for the garbage collector — so if the stack moves anywhere in that
+// window, the kernel writes the index into the abandoned stack and the variable
+// still reads its zero value. creack/pty then reports the slave as
+// "/dev/pts/0", which under Linux's flat namespace is some other program's
+// terminal, and hands atago a "pair" whose two halves are not connected.
+//
+// The consequences are exactly the flake in #385, seen roughly once per 10^5
+// pty steps under load and observed directly on Linux 7.0 with the master's
+// real index at 10 and the slave at /dev/pts/0, still held open by a desktop
+// daemon: the child writes its output into that stranger's terminal, the master
+// atago drains never gets a slave at all (so its reads answer EAGAIN forever
+// rather than ending with EIO), the session-end grace elapses, atago closes the
+// master, and the step reports a clean exit 0 with an empty transcript.
+//
+// Doing the ioctl here keeps the conversion inside the syscall call expression,
+// which is the one form the unsafe.Pointer rules guarantee — x/sys/unix marks
+// those wrappers //go:uintptrescapes, so the argument is forced to the heap and
+// stays put for the duration of the call. The index is then always the kernel's
+// answer, never a zero left behind by a stack that moved.
+//
+// macOS is not affected and still goes through creack/pty: its ptsname asks for
+// the name into a heap-allocated slice, and Go's heap does not move.
+func openTerminalPair() (master, tty *os.File, err error) {
+	master, err = os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() {
+		if err != nil {
+			_ = master.Close()
+		}
+	}()
+
+	var index int
+	if ierr := ControlFD(master, func(fd int) error {
+		var gerr error
+		index, gerr = unix.IoctlGetInt(fd, unix.TIOCGPTN)
+		return gerr
+	}); ierr != nil {
+		return nil, nil, fmt.Errorf("asking the kernel which terminal /dev/ptmx just handed out: %w", ierr)
+	}
+	// TIOCSPTLCK with a zero clears the lock the kernel puts on a freshly
+	// allocated slave; until it is cleared, opening the slave fails with EIO.
+	if ierr := ControlFD(master, func(fd int) error {
+		return unix.IoctlSetPointerInt(fd, unix.TIOCSPTLCK, 0)
+	}); ierr != nil {
+		return nil, nil, fmt.Errorf("unlocking terminal /dev/pts/%d: %w", index, ierr)
+	}
+
+	name := "/dev/pts/" + strconv.Itoa(index)
+	tty, err = os.OpenFile(name, os.O_RDWR|syscall.O_NOCTTY, 0) //nolint:gosec // the path is /dev/pts/ plus an integer the kernel just gave us
+	if err != nil {
+		return nil, nil, err
+	}
+	return master, tty, nil
+}

--- a/internal/runner/ptyrun/terminal_linux_test.go
+++ b/internal/runner/ptyrun/terminal_linux_test.go
@@ -1,0 +1,44 @@
+package ptyrun
+
+import (
+	"strconv"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestOpenTerminalPair_SlaveIsTheOneTheKernelNamed states the Linux half of
+// #385 in the kernel's own terms: the slave atago opens must be the slave the
+// master was given, and the only authority on which one that is is TIOCGPTN on
+// the master.
+//
+// creack/pty asks the same question but lets the answer be written into a stack
+// variable it no longer keeps alive across the call, so a stack that moved left
+// the index reading 0 and atago opened /dev/pts/0 — a terminal that belongs to
+// whatever program happens to hold it. Comparing the opened name against a
+// freshly read index says that in one line, and unlike the transcript-level
+// guards it does not need thousands of spawns to have an opinion.
+func TestOpenTerminalPair_SlaveIsTheOneTheKernelNamed(t *testing.T) {
+	t.Parallel()
+
+	for i := range 200 {
+		master, tty, err := openTerminalPair()
+		if err != nil {
+			t.Fatalf("iteration %d: openTerminalPair: %v", i, err)
+		}
+		var index int
+		if ierr := ControlFD(master, func(fd int) error {
+			var gerr error
+			index, gerr = unix.IoctlGetInt(fd, unix.TIOCGPTN)
+			return gerr
+		}); ierr != nil {
+			t.Fatalf("iteration %d: TIOCGPTN on the master: %v", i, ierr)
+		}
+		if want := "/dev/pts/" + strconv.Itoa(index); tty.Name() != want {
+			t.Fatalf("iteration %d: opened %q as the slave, but the master's terminal is %q",
+				i, tty.Name(), want)
+		}
+		_ = tty.Close()
+		_ = master.Close()
+	}
+}

--- a/internal/runner/ptyrun/terminal_posix.go
+++ b/internal/runner/ptyrun/terminal_posix.go
@@ -1,0 +1,17 @@
+//go:build !windows && !linux
+
+package ptyrun
+
+import (
+	"os"
+
+	"github.com/creack/pty"
+)
+
+// openTerminalPair opens a pseudo-terminal pair. Everywhere but Linux this is
+// creack/pty's Open verbatim: the pointer hazard that made Linux need its own
+// copy (see terminal_linux.go) is not present on these platforms, where the
+// slave's name is read into a heap allocation rather than a stack variable.
+func openTerminalPair() (master, tty *os.File, err error) {
+	return pty.Open()
+}

--- a/internal/runner/ptyrun/terminal_unix.go
+++ b/internal/runner/ptyrun/terminal_unix.go
@@ -1,0 +1,42 @@
+//go:build !windows
+
+package ptyrun
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// ControlFD runs fn with f's raw descriptor and returns fn's error, without
+// handing the descriptor over to the caller the way (*os.File).Fd() does.
+//
+// The difference matters for every terminal atago opens. Fd() is documented to
+// return a descriptor in blocking mode: os.File takes the descriptor out of the
+// runtime poller and clears O_NONBLOCK on it, permanently and for every later
+// read. A pty master that has been through Fd() therefore parks its reads inside
+// read(2), where Close cannot reach them — which is the hang OpenTerminal exists
+// to prevent. SyscallConn's Control hands the descriptor to fn for the duration
+// of the call and leaves the file exactly as it found it, so an ioctl (a window
+// size, a termios query) no longer costs the terminal its poller.
+func ControlFD(f *os.File, fn func(fd int) error) error {
+	sc, err := f.SyscallConn()
+	if err != nil {
+		return err
+	}
+	var inner error
+	if cerr := sc.Control(func(fd uintptr) { inner = fn(int(fd)) }); cerr != nil {
+		return cerr
+	}
+	return inner
+}
+
+// setTerminalSize resizes the terminal behind master. TIOCSWINSZ on the master
+// is the whole mechanism: the kernel records the new size AND sends SIGWINCH to
+// the terminal's foreground process group, so the child learns about a
+// mid-session resize exactly as it would from a real window change (#379).
+func setTerminalSize(master *os.File, rows, cols uint16) error {
+	return ControlFD(master, func(fd int) error {
+		return unix.IoctlSetWinsize(fd, unix.TIOCSWINSZ, &unix.Winsize{Row: rows, Col: cols})
+	})
+}

--- a/internal/runner/ptyrun/transcript.go
+++ b/internal/runner/ptyrun/transcript.go
@@ -48,12 +48,17 @@ func startTranscriptDrain(rw io.ReadWriter, p *spec.PTY) *transcriptDrain {
 	queries := newTerminalQueries(p, writerFunc(t.write))
 	var modeScan decsetScanner
 	// reading is closed by the reader goroutine when it has nothing left to do
-	// but read. Waiting for it is what lets the POSIX runner claim that the
-	// first Read is posted before the child starts: creating a goroutine only
-	// makes it runnable, and yielding the processor does not guarantee it was
-	// scheduled, let alone that it got as far as the read. The one gap this
-	// cannot close is the instruction or two between the close and entering the
-	// syscall, which no handshake in user space can.
+	// but read, and startTranscriptDrain waits for it. What that buys is modest
+	// and worth stating exactly: the goroutine has been scheduled and has run
+	// its setup, so the only thing left between it and the terminal is the read
+	// call itself. It is NOT a proof that the read is posted — the goroutine can
+	// still be preempted between this close and entering the syscall, and no
+	// handshake in user space can close that gap.
+	//
+	// It replaces a runtime.Gosched, which promised the same thing and delivered
+	// less: yielding does not guarantee the new goroutine ran at all. Nothing
+	// depends on the stronger reading; the fast-exit transcript loss that made
+	// this look load-bearing was a mispaired terminal (#385), fixed elsewhere.
 	reading := make(chan struct{})
 	go func() {
 		defer close(t.readDone)

--- a/internal/runner/ptyrun/transcript.go
+++ b/internal/runner/ptyrun/transcript.go
@@ -47,6 +47,14 @@ func startTranscriptDrain(rw io.ReadWriter, p *spec.PTY) *transcriptDrain {
 	}
 	queries := newTerminalQueries(p, writerFunc(t.write))
 	var modeScan decsetScanner
+	// reading is closed by the reader goroutine when it has nothing left to do
+	// but read. Waiting for it is what lets the POSIX runner claim that the
+	// first Read is posted before the child starts: creating a goroutine only
+	// makes it runnable, and yielding the processor does not guarantee it was
+	// scheduled, let alone that it got as far as the read. The one gap this
+	// cannot close is the instruction or two between the close and entering the
+	// syscall, which no handshake in user space can.
+	reading := make(chan struct{})
 	go func() {
 		defer close(t.readDone)
 		buf := make([]byte, 4096)
@@ -56,6 +64,7 @@ func startTranscriptDrain(rw io.ReadWriter, p *spec.PTY) *transcriptDrain {
 		// under: a resize recorded while this chunk was in flight belongs after
 		// it, and one recorded before it is applied below, before consume (#379).
 		applied := 0
+		close(reading)
 		for {
 			n, rerr := t.rw.Read(buf)
 			if n > 0 {
@@ -94,6 +103,7 @@ func startTranscriptDrain(rw io.ReadWriter, p *spec.PTY) *transcriptDrain {
 			return
 		}
 	}()
+	<-reading
 	return t
 }
 


### PR DESCRIPTION
Closes #385.

## What was wrong

A pty step could report a clean exit 0 with a **completely empty transcript** —
about once in 340,000 spawns on Linux under load. `TestRun_NoShellFastExitOutputNotLost`
was catching it; nothing was fixing it.

The issue guessed at a drain-start race (`runtime.Gosched` not really
guaranteeing the first `Read` is posted before the child starts). Measuring it
ruled that out: in every captured failure the reader goroutine entered `Read`
1–2µs after being created, well before `cmd.Start`, and then sat there for the
full two-second end-of-session grace.

The real fault is one level down: **the two halves of the terminal were not a
pair.**

`creack/pty`'s Linux `Open` asks the kernel for the slave's index with an ioctl
whose answer buffer it passes as `uintptr(unsafe.Pointer(&n))`, and then hands
that `uintptr` down through two ordinary function calls before the syscall runs:

```go
func ptsname(f *os.File) (string, error) {
	var n _C_uint
	err := ioctl(f, syscall.TIOCGPTN, uintptr(unsafe.Pointer(&n)))
	...
	return "/dev/pts/" + strconv.Itoa(int(n)), nil
}
```

A `uintptr` is a number. It neither keeps `n` alive nor pins it, and the Go
runtime moves goroutine stacks — it copies them on growth and can shrink them
while scanning for the collector. If the stack moves anywhere in that window,
the kernel writes the index into the abandoned stack and `n` still reads `0`, so
the slave is reported as `/dev/pts/0`: under Linux's flat namespace, whatever
terminal happens to hold index 0.

Instrumented capture of a real failure (Linux 7.0):

```
rawread n=0 err=EAGAIN  slave=/dev/pts/0  ptnAtStart=10  ptnAtProbe=10
childpid=1242406 selfpid=1084775 holders=[10430/71(/usr/bin/kded6)]
```

The master's own index was **10**; atago had opened **/dev/pts/0**, still held
open by a desktop daemon. So:

- the child wrote `done` into that stranger's terminal and exited 0;
- atago's master never had a slave at all, so its reads answered `EAGAIN`
  forever instead of ending with `EIO` when the child exited;
- the 2s `drainGrace` elapsed, atago closed the master, and the drain returned
  `file already closed` with an empty transcript.

macOS is not affected: its `ptsname` reads the name into a heap allocation, and
Go's heap does not move.

## The fix

- **Linux opens its own pair** (`terminal_linux.go`), with the pointer
  conversion inside the syscall call expression — the one form the
  `unsafe.Pointer` rules guarantee, and the form `x/sys/unix`'s wrappers use.
  Everything else still goes through `creack/pty`.
- **No atago ioctl reaches through `(*os.File).Fd()` any more.** `Fd()` is
  documented to return a blocking descriptor, so `creack/pty`'s `Setsize` was
  clearing `O_NONBLOCK` on the master: a mid-session `resize` (#379) took the
  terminal out of the runtime poller and left the drain parked inside `read(2)`,
  where closing it can no longer interrupt the read. `ControlFD` borrows the
  descriptor and gives it back unchanged; the recorder's per-prompt echo check
  had the same problem and now uses it too.
- **`startTranscriptDrain` does not return before its reader reaches the first
  read.** That was the invariant the comment in `Run` claimed and
  `runtime.Gosched` did not provide — creating a goroutine only makes it
  runnable. The handshake makes the claim true (bar the instruction or two
  before the syscall, which no user-space handshake can cover), and the comment
  now says so.

## Tests

- `TestOpenTerminal_PairsTheMasterWithItsOwnSlave` — a byte written to the tty
  has to come out of the master. Nothing else proves the halves are connected.
- `TestOpenTerminalPair_SlaveIsTheOneTheKernelNamed` (Linux) — the opened slave
  name must equal `/dev/pts/<TIOCGPTN of the master>`, read the safe way.
- `TestSetTerminalSize_KeepsTheMasterUnderThePoller` — a resize must not cost
  the master `O_NONBLOCK` or its poller. Fails deterministically against the old
  `pty.Setsize` path.
- `TestStartTranscriptDrain_HandsBackAReaderThatHasReachedItsFirstRead` — pins
  both halves of the handshake: the reader must have reached its read, and must
  not have to finish it (a terminal with nothing to say yet would otherwise wedge
  `Run` before the child started).
- `TestRun_NoShellFastExitOutputNotLost` and `TestWaitDrain_ClosingTheMasterEndsTheDrain`
  are unchanged and still pass.

## Measurement

The bug needs volume, so "the test passed" proves nothing. Harness: 24
concurrent copies of the package's fast-exit tests, `-count=20` each — 192,000
pty spawns per round.

| | rounds | pty spawns | empty transcripts |
|---|---:|---:|---:|
| before | 30 | 5,760,000 | **17** |
| after | 12 | 2,304,000 | **0** |

The post-fix rounds also ran 1,728,000 pair-integrity checks from the two new
terminal tests, with no mismatch.

Also green: `go test ./...`, `golangci-lint run` (0 issues), `make e2e` (476
scenarios, 472 passed / 4 skipped), no `doc/` or `site/` drift, and
`GOOS=darwin` / `GOOS=windows` vet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unix terminal handling to preserve output from processes that exit quickly.
  * Fixed terminal resizing behavior while maintaining reliable descriptor polling.
  * Improved terminal echo detection without disrupting runtime polling.

* **Tests**
  * Added regression coverage for terminal pairing, resizing, output preservation, and transcript draining.
  * Added Linux validation for correctly matched terminal devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->