### PR TITLE
fix(conpty): let Close end a read already parked in the kernel

### DIFF
--- a/internal/conpty/conpty_windows.go
+++ b/internal/conpty/conpty_windows.go
@@ -289,9 +289,29 @@ func (c *PseudoConsole) Pid() int { return int(c.pid) }
 // Close tears down the pseudo console and every handle exactly once. Closing the
 // pseudo console signals the child that its console went away; a caller that
 // must not let the child linger kills the tree first.
+//
+// CancelIoEx is what actually ends a read already in flight (#406). Read issues
+// a plain synchronous ReadFile on the output pipe, and CloseHandle does NOT
+// abort one that is already parked in the kernel: the reader goroutine stays
+// blocked until the write end goes away on its own, which a surviving conhost —
+// or a descendant that outlived the tree kill — can put off indefinitely. The
+// recorder's bounded join then has to wait out its whole grace on every timed-out
+// capture, and the goroutine leaks for the life of the process holding the pipe
+// handle open. CancelIoEx cancels pending I/O on the handle regardless of which
+// thread issued it (unlike CancelIo, which is limited to the calling thread), so
+// the parked read returns ERROR_OPERATION_ABORTED — which classifyReadError
+// already maps to os.ErrClosed, and which isSessionEnd already reads as a normal
+// end of session. That mapping was written for this case before anything
+// produced it.
+//
+// It runs after ClosePseudoConsole so a reader that can still finish normally
+// sees EOF rather than a cancellation, and before CloseHandle because cancelling
+// I/O on a closed handle is meaningless. A failure is ignored on purpose: there
+// is nothing to cancel when no read is pending, which is the common case.
 func (c *PseudoConsole) Close() error {
 	c.closeOnce.Do(func() {
 		windows.ClosePseudoConsole(c.hpc)
+		_ = windows.CancelIoEx(c.outRead, nil)
 		closeHandles(c.inWrite, c.outRead, c.process)
 		if c.attrList != nil {
 			c.attrList.Delete()

--- a/internal/conpty/conpty_windows.go
+++ b/internal/conpty/conpty_windows.go
@@ -305,7 +305,7 @@ func (c *PseudoConsole) Pid() int { return int(c.pid) }
 // produced it.
 //
 // It runs after ClosePseudoConsole so a reader that can still finish normally
-// sees EOF rather than a cancellation, and before CloseHandle because cancelling
+// sees EOF rather than a cancellation, and before CloseHandle because canceling
 // I/O on a closed handle is meaningless. A failure is ignored on purpose: there
 // is nothing to cancel when no read is pending, which is the common case.
 func (c *PseudoConsole) Close() error {

--- a/internal/conpty/conpty_windows_test.go
+++ b/internal/conpty/conpty_windows_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"testing"
+	"time"
 
 	"golang.org/x/sys/windows"
 )
@@ -80,5 +81,66 @@ func TestReadErrorClassification(t *testing.T) {
 				t.Errorf("a real failure lost its cause: %v does not wrap %v", got, c.err)
 			}
 		})
+	}
+}
+
+// TestClose_ReleasesAPendingRead is the #406 regression, and the one thing the
+// package could not previously do: end a read that is already parked in the
+// kernel.
+//
+// Read issues a plain synchronous ReadFile, and CloseHandle does not abort one
+// that is already in flight — the reader stays blocked until the write end goes
+// away on its own, which a surviving conhost or an escaped descendant can put
+// off indefinitely. In the recorder that showed up twice: every timed-out
+// capture had to wait out its whole drain grace, and the reader goroutine leaked
+// for the life of the process holding the pipe handle open. Close now cancels
+// pending I/O on the handle first.
+//
+// The child is a command that produces nothing and outlives the test, so the
+// read under way is genuinely parked with no data coming: exactly the state the
+// bug needed.
+func TestClose_ReleasesAPendingRead(t *testing.T) {
+	// Repeated because the bug it guards was intermittent in CI: whether a read
+	// is parked at close time depended on timing, so one green iteration proves
+	// less than a handful. Each iteration is a fresh console and costs well
+	// under a second.
+	for i := range 5 {
+		cp, err := Start(`cmd /S /C "ping -n 30 127.0.0.1 > NUL"`, "", nil, 24, 80)
+		if err != nil {
+			t.Fatalf("iteration %d: Start: %v", i, err)
+		}
+
+		// Drain first: the console emits its initial screen setup, and Close has
+		// to interrupt a read waiting for MORE, not one about to return bytes
+		// that are already buffered.
+		readErr := make(chan error, 1)
+		reading := make(chan struct{})
+		go func() {
+			buf := make([]byte, 4096)
+			close(reading)
+			for {
+				if _, rerr := cp.Read(buf); rerr != nil {
+					readErr <- rerr
+					return
+				}
+			}
+		}()
+		<-reading
+		time.Sleep(300 * time.Millisecond) // the setup output drains; the read parks
+
+		start := time.Now()
+		_ = cp.Close()
+		select {
+		case rerr := <-readErr:
+			// os.ErrClosed is what classifyReadError maps a cancelled read to,
+			// and what the recorder already treats as a normal end of session.
+			if !errors.Is(rerr, os.ErrClosed) && !errors.Is(rerr, io.EOF) {
+				t.Errorf("iteration %d: read ended with %v, want os.ErrClosed (cancelled) or io.EOF", i, rerr)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatalf("iteration %d: a read parked in the kernel was still blocked %s after Close: "+
+				"CloseHandle alone does not abort it, so the reader leaks and the recorder waits out its drain grace",
+				i, time.Since(start))
+		}
 	}
 }

--- a/internal/conpty/conpty_windows_test.go
+++ b/internal/conpty/conpty_windows_test.go
@@ -132,10 +132,10 @@ func TestClose_ReleasesAPendingRead(t *testing.T) {
 		_ = cp.Close()
 		select {
 		case rerr := <-readErr:
-			// os.ErrClosed is what classifyReadError maps a cancelled read to,
+			// os.ErrClosed is what classifyReadError maps a canceled read to,
 			// and what the recorder already treats as a normal end of session.
 			if !errors.Is(rerr, os.ErrClosed) && !errors.Is(rerr, io.EOF) {
-				t.Errorf("iteration %d: read ended with %v, want os.ErrClosed (cancelled) or io.EOF", i, rerr)
+				t.Errorf("iteration %d: read ended with %v, want os.ErrClosed (canceled) or io.EOF", i, rerr)
 			}
 		case <-time.After(10 * time.Second):
 			t.Fatalf("iteration %d: a read parked in the kernel was still blocked %s after Close: "+

--- a/internal/record/capture_test.go
+++ b/internal/record/capture_test.go
@@ -10,6 +10,63 @@ import (
 	"time"
 )
 
+// drainTeardownGrace bounds the teardown wait in capturePipes. It is generous —
+// the drain ends as soon as the write end closes — and exists only so a future
+// regression fails one test by name rather than wedging the package.
+const drainTeardownGrace = 30 * time.Second
+
+// capturePipes builds the two pipes a CapturePTY call needs — an input pipe the
+// child reads from and an output pipe standing in for the developer's screen —
+// drains the output so a terminal write never blocks on a full buffer, and
+// registers a teardown that closes them in the ONE order that terminates.
+//
+// The order is the whole point (#406). The drain goroutine sits parked in a
+// read on outR, and on Windows os.Pipe hands back synchronous handles: Close
+// cannot interrupt a read already in the kernel, so (*File).Close waits for the
+// in-flight read to finish before it returns. Closing outR first therefore
+// deadlocks — the read it is waiting for can only end when outW closes, which is
+// the statement that never runs — and that is exactly how this file wedged the
+// whole package on the 5-minute test timeout in CI. Closing the WRITE end first
+// gives the drain EOF; waiting for the drain to exit releases the last reference
+// to outR; only then can outR close. POSIX forgives the wrong order because its
+// pipe fds are poller-owned and Close unblocks a parked read.
+func capturePipes(t *testing.T) (in *os.File, out *os.File) {
+	t.Helper()
+	inR, inW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("input pipe: %v", err)
+	}
+	outR, outW, err := os.Pipe()
+	if err != nil {
+		_ = inR.Close()
+		_ = inW.Close()
+		t.Fatalf("output pipe: %v", err)
+	}
+	drained := make(chan struct{})
+	go func() {
+		defer close(drained)
+		_, _ = io.Copy(io.Discard, outR)
+	}()
+	t.Cleanup(func() {
+		_ = outW.Close() // the drain now reaches EOF
+		_ = inR.Close()
+		_ = inW.Close()
+		select {
+		case <-drained: // and has released its reference to outR
+			_ = outR.Close()
+		case <-time.After(drainTeardownGrace):
+			// Never block here. A drain that will not end means outR.Close()
+			// would wait forever on Windows, and a teardown that hangs takes the
+			// whole PACKAGE down on the go test timeout — which is how one stuck
+			// recorder erased the results of every other test in this package.
+			// Leak the handle and fail this test by name instead.
+			t.Errorf("the output drain did not finish %s after its write end closed: "+
+				"something still holds the pipe open, and closing the read end would hang", drainTeardownGrace)
+		}
+	})
+	return inR, outW
+}
+
 // TestCapturePTY_RecordsOutputAndExit drives the whole capture path with a
 // self-exiting command and no interactive input: start the child in a real pty
 // (POSIX) / ConPTY (Windows), drain its output into the recording, and reap its
@@ -17,18 +74,7 @@ import (
 // otherwise interactive, human-driven `record --pty` — including the Windows
 // ConPTY capture, which has no other test.
 func TestCapturePTY_RecordsOutputAndExit(t *testing.T) {
-	inR, inW, err := os.Pipe() // an empty input pipe: the command needs no keystrokes
-	if err != nil {
-		t.Fatalf("input pipe: %v", err)
-	}
-	defer func() { _ = inR.Close(); _ = inW.Close() }()
-	outR, outW, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("output pipe: %v", err)
-	}
-	defer func() { _ = outR.Close(); _ = outW.Close() }()
-	// Drain the output pipe so the terminal's writes never block on a full buffer.
-	go func() { _, _ = io.Copy(io.Discard, outR) }()
+	inR, outW := capturePipes(t) // an empty input pipe: the command needs no keystrokes
 
 	// shell:true → `sh -c` / `cmd /S /C`, so echo is a builtin on both shells.
 	rec, err := CapturePTY("echo capture-marker", true, inR, outW, 30*time.Second)
@@ -54,17 +100,7 @@ func TestCapturePTY_RecordsOutputAndExit(t *testing.T) {
 // end while the recorder itself still held the terminal's slave open — closing
 // the master does not interrupt a read already parked in the kernel.
 func TestCapturePTY_StartFailureDoesNotHang(t *testing.T) {
-	inR, inW, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("input pipe: %v", err)
-	}
-	defer func() { _ = inR.Close(); _ = inW.Close() }()
-	outR, outW, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("output pipe: %v", err)
-	}
-	defer func() { _ = outR.Close(); _ = outW.Close() }()
-	go func() { _, _ = io.Copy(io.Discard, outR) }()
+	inR, outW := capturePipes(t)
 
 	const missing = "atago-no-such-binary-2a5f1c"
 	errCh := make(chan error, 1)
@@ -141,17 +177,7 @@ func TestCapturePTY_NoShellFastExitOutputNotLost(t *testing.T) {
 // exercises both the POSIX pty process-group kill and the Windows ConPTY tree
 // kill, since that timeout path has no other automated coverage.
 func TestCapturePTY_TimesOutOnNonExitingChild(t *testing.T) {
-	inR, inW, err := os.Pipe() // the child ignores input; the pipe just gives it a stdin
-	if err != nil {
-		t.Fatalf("input pipe: %v", err)
-	}
-	defer func() { _ = inR.Close(); _ = inW.Close() }()
-	outR, outW, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("output pipe: %v", err)
-	}
-	defer func() { _ = outR.Close(); _ = outW.Close() }()
-	go func() { _, _ = io.Copy(io.Discard, outR) }()
+	inR, outW := capturePipes(t) // the child ignores input; the pipe just gives it a stdin
 
 	// A command that ignores stdin and runs far longer than the timeout, so the
 	// only way CapturePTY returns is the timeout firing — not the child exiting.


### PR DESCRIPTION
Closes #406.

## The goroutine dump answered it

The issue asked for the full dump from a failing run, and the first attempt's log (before the re-run overwrote it) had it. It names two separate things, and only one of them is in the product:

```
goroutine 38 [semacquire]:                       ← the test, blocked in Close
internal/poll.(*FD).Close(0x331454fb8480)
  os.(*File).Close(...)
  record.TestCapturePTY_TimesOutOnNonExitingChild.func2()
      capture_test.go:153                        ← defer: outR.Close()

goroutine 39 [syscall]:                          ← the test's own drain, parked
syscall.readFile(0x1f4, ...)
  internal/poll.(*FD).Read(0x331454fb8480, ...)  ← the SAME FD
  io.Copy(io.Discard, outR)
      capture_test.go:154

goroutine 41 [syscall]:                          ← CapturePTY's reader, still parked
  record.CapturePTY.func3()
      capture_windows.go:83                      ← created by a goroutine that already exited
```

`CapturePTY` had already returned — goroutine 40 is gone from the dump. So the title's premise was wrong: the recorder did not hang past its timeout. **The test fixture deadlocked in teardown.**

## 1. The hang: pipe close order

```go
defer func() { _ = outR.Close(); _ = outW.Close() }()
go func() { _, _ = io.Copy(io.Discard, outR) }()
```

The read end closes first while the drain is parked reading it. On Windows `os.Pipe` returns **synchronous** handles, so `Close` cannot interrupt a read already in the kernel — `(*FD).Close` waits on `csema` for the in-flight read, and that read can only end when the *write* end closes, which is the very next statement and never runs. POSIX forgives this because its pipe fds are poller-owned and `Close` evicts a parked read.

That is also why it was intermittent: it deadlocks only when the drain happens to be parked at teardown time.

Three tests had the order wrong; a fourth already had it right. They now share one `capturePipes` helper with the order that terminates — **write end, drain, read end** — and the fourth points at the same rule (it stays inline because a per-iteration `t.Cleanup` would stack 100 deep).

The helper also **bounds** its wait. A teardown that hangs takes the whole *package* down on the go test timeout — that is how one stuck recorder erased every other result in `internal/record` — so it now fails one test by name instead. That is the "own per-test deadline" the issue asked for.

## 2. The product half: a reader that outlives Close

Goroutine 41 is `CapturePTY`'s ConPTY reader, still parked *after* `CapturePTY` returned. `PseudoConsole.Read` issues a plain synchronous `ReadFile`, and `CloseHandle` does not abort one already in flight, so the reader stays blocked until the write end goes away on its own — which a surviving conhost, or a descendant that escaped the tree kill, can put off indefinitely. Consequence: whenever the write end survives, the reader waits out the whole `captureCloseGrace` (10s) and then leaks for the life of the process, holding the pipe handle open. It is conditional rather than constant — in runs where the child's death takes conhost with it, the read ends on its own — which is why the CI timings below are unchanged. What `CancelIoEx` buys is that the outcome no longer depends on that.

`Close` now calls `CancelIoEx(outRead, nil)` before `CloseHandle`. It cancels pending I/O on the handle regardless of which thread issued it (unlike `CancelIo`, which is limited to the calling thread), so the parked read returns `ERROR_OPERATION_ABORTED` — which `classifyReadError` **already** mapped to `os.ErrClosed`, and which `isSessionEnd` already reads as a normal end of session. That mapping was written for this case before anything produced it.

Ordering inside `Close`: after `ClosePseudoConsole` so a reader that can still finish normally sees EOF rather than a cancellation, and before `CloseHandle` because cancelling I/O on a closed handle is meaningless. The error is ignored on purpose — there is nothing to cancel when no read is pending, which is the common case.

This is the same shape as #375 on the POSIX side (creack/pty handed back a blocking descriptor, so `Close` could not interrupt a parked `read(2)`); the issue text guessed at that parallel and it turned out to be right.

## Tests

`TestClose_ReleasesAPendingRead` (Windows) starts a console whose child produces nothing, drains the setup output, waits for the read to park, then closes and requires the read to end. Without `CancelIoEx` it fails after 10s deterministically rather than passing by luck. **It repeats five times on purpose** — whether a read is parked at close time is exactly the timing that made the original failure intermittent, so one green iteration would prove less than a handful.

## Verification on Windows CI

Both Windows unit-test jobs and `e2e-windows` are green, and the new test really ran there rather than skipping:

```
=== RUN   TestClose_ReleasesAPendingRead
--- PASS: TestClose_ReleasesAPendingRead (1.63s)
ok      github.com/nao1215/atago/internal/conpty  1.704s  coverage: 48.2% of statements
=== RUN   TestCapturePTY_TimesOutOnNonExitingChild
--- PASS: TestCapturePTY_TimesOutOnNonExitingChild (1.10s)
ok      github.com/nao1215/atago/internal/record  1.865s  coverage: 91.2% of statements
```

1.63s for five iterations is the interesting number: each `Close` released its parked read effectively immediately. Without the cancellation every iteration would sit on the 10s bound and fail.

The `internal/record` timings are unchanged against a pre-fix Windows run of the same code (`TestCapturePTY_TimesOutOnNonExitingChild` 1.09s → 1.10s, package 1.799s → 1.865s), which is the expected result: on a run where the reader ends on its own, there was never a grace to wait out. The fix removes the dependency on that, and the fixture change removes the deadlock that turned the same package into a 300s timeout.

Locally: `go test ./...`, `golangci-lint run` (0 issues), `GOOS=windows go vet`.
