### PR TITLE
fix(cli): read a flag written after the spec paths as a flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- A flag written after the spec paths is now read as a flag. `atago run specs/
+  --report json` exited 3 with `cannot access "--report": no such file or
+  directory` — an error about a file nobody typed — because Go's flag package
+  stops parsing at the first non-flag argument, and everything after it became a
+  spec path. "What to run, then how to run it" is the order people reach for
+  first, so the failure landed on a correct-looking command line and named the
+  wrong problem. `run`, `list`, `doc`, `explain`, `manifest`, and `init` now
+  accept flags in any position. `--` still ends flag parsing, which is how a file
+  whose name starts with a dash is addressed; `atago record` is unchanged,
+  because there the trailing arguments are another program's command line and its
+  flags belong to it.
+
 ## [0.18.0] - 2026-07-30
 
 A release about the one verdict atago was getting wrong about itself. `--repeat`

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-80 suites · 508 scenarios
+80 suites · 511 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -435,7 +435,7 @@
   - [retry polls until the condition becomes true](#scenario-retry-polls-until-the-condition-becomes-true)
   - [retry fails the inner spec when until never holds](#scenario-retry-fails-the-inner-spec-when-until-never-holds)
   - [until with a changes target is a load-time error](#scenario-until-with-a-changes-target-is-a-load-time-error)
-- [atago self-hosting / run](#atago-self-hosting--run) — 8 scenarios
+- [atago self-hosting / run](#atago-self-hosting--run) — 11 scenarios
   - [a passing spec exits zero and reports PASS](#scenario-a-passing-spec-exits-zero-and-reports-pass)
   - [a failing assertion exits one and reports the failure](#scenario-a-failing-assertion-exits-one-and-reports-the-failure)
   - [an exit_code failure surfaces the command's stderr](#scenario-an-exit_code-failure-surfaces-the-commands-stderr)
@@ -444,6 +444,9 @@
   - [an exit_code failure falls back to stdout when stderr is silent (windows)](#scenario-an-exit_code-failure-falls-back-to-stdout-when-stderr-is-silent-windows)
   - [a parse error exits with code two](#scenario-a-parse-error-exits-with-code-two)
   - [JSON report is valid JSON with a passed status](#scenario-json-report-is-valid-json-with-a-passed-status)
+  - [a flag after the spec path is still a flag](#scenario-a-flag-after-the-spec-path-is-still-a-flag)
+  - [a flag between two spec paths is still a flag](#scenario-a-flag-between-two-spec-paths-is-still-a-flag)
+  - [a double dash keeps later arguments as paths](#scenario-a-double-dash-keeps-later-arguments-as-paths)
 - [atago self-hosting / sandbox_home (isolated per-OS home)](#atago-self-hosting--sandbox_home-isolated-per-os-home) — 3 scenarios
   - [Unix XDG family — write config, read it back, inspect it under the workdir](#scenario-unix-xdg-family--write-config-read-it-back-inspect-it-under-the-workdir)
   - [Windows APPDATA family — write config, read it back, inspect it under the workdir](#scenario-windows-appdata-family--write-config-read-it-back-inspect-it-under-the-workdir)
@@ -8539,6 +8542,96 @@ ${atago} run --report json ok.atago.yaml
 - stdout at `$.schema_version` equals `1`
 - stdout at `$.suites[0].status` equals `passed`
 - stdout at `$.suites[0].scenarios` has length 1
+### Scenario: a flag after the spec path is still a flag
+#### Given
+- Fixture file `ok.atago.yaml` is created.
+#### Inputs
+_Fixture `ok.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: echo
+    steps:
+      - run:
+          shell: true
+          command: "exit 0"
+      - assert:
+          exit_code: 0
+```
+#### When
+```shell
+${atago} run ok.atago.yaml --report json
+```
+#### Then
+- exit code is `0`
+- stdout at `$.suites[0].status` equals `passed`
+### Scenario: a flag between two spec paths is still a flag
+#### Given
+- Fixture file `ok.atago.yaml` is created.
+- Fixture file `second.atago.yaml` is created.
+#### Inputs
+_Fixture `ok.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: echo
+    steps:
+      - run:
+          shell: true
+          command: "exit 0"
+      - assert:
+          exit_code: 0
+```
+_Fixture `second.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: echo
+    steps:
+      - run:
+          shell: true
+          command: "exit 0"
+      - assert:
+          exit_code: 0
+```
+#### When
+```shell
+${atago} run ok.atago.yaml --report json second.atago.yaml
+```
+#### Then
+- exit code is `0`
+- stdout at `$.suites` has length 2
+### Scenario: a double dash keeps later arguments as paths
+#### Given
+- Fixture file `ok.atago.yaml` is created.
+#### Inputs
+_Fixture `ok.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: sample
+scenarios:
+  - name: echo
+    steps:
+      - run:
+          shell: true
+          command: "exit 0"
+      - assert:
+          exit_code: 0
+```
+#### When
+```shell
+${atago} run -- ok.atago.yaml --report
+```
+#### Then
+- exit code is `3`
+- stderr contains `cannot access "--report"`
 ## atago self-hosting / sandbox_home (isolated per-OS home)
 Source: `test/e2e/atago/sandbox_home.atago.yaml`
 ### Scenario: Unix XDG family — write config, read it back, inspect it under the workdir

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"flag"
 	"fmt"
 	"io"
 
@@ -141,6 +142,43 @@ func wantsHelp(args []string) bool {
 		}
 	}
 	return false
+}
+
+// parseFlagsAnywhere parses args with fs and returns the operands, accepting a
+// flag written after them: `atago run specs/ --report json` means what `atago
+// run --report json specs/` means.
+//
+// The flag package stops at the first non-flag argument, so a trailing flag
+// silently became a spec path and the run died with `cannot access "--report"`
+// — an error about a file nobody typed, for the invocation order most people
+// reach for first (the paths are the subject, the flags are an afterthought).
+// Rather than reordering argv by guessing which flags take a value, this
+// re-enters Parse after each operand, which asks the FlagSet itself.
+//
+// A `--` terminator still ends flag parsing for good: everything after it is an
+// operand even when it looks like a flag, which is the only way to name a file
+// whose name starts with a dash. `atago record` deliberately does NOT use this —
+// there the trailing arguments are another program's command line, and its
+// flags belong to it.
+func parseFlagsAnywhere(fs *flag.FlagSet, args []string) ([]string, error) {
+	var operands []string
+	for {
+		if err := fs.Parse(args); err != nil {
+			return nil, err
+		}
+		rest := fs.Args()
+		if len(rest) == 0 {
+			return operands, nil
+		}
+		// Parse stopped either at an operand or at an explicit `--`. The
+		// terminator is consumed, so it is the last token before what is left;
+		// seeing it there means the caller asked for the rest to stay literal.
+		if consumed := len(args) - len(rest); consumed > 0 && args[consumed-1] == "--" {
+			return append(operands, rest...), nil
+		}
+		operands = append(operands, rest[0])
+		args = rest[1:]
+	}
 }
 
 // snapshotCmd implements `atago snapshot <subcommand>`.

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1059,6 +1059,36 @@ func TestSpecCmds_FlagsAfterPaths(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(dir, "m.json")); err != nil {
 		t.Errorf("manifest --out after the path wrote no file: %v", err)
 	}
+
+	// explain takes no flags of its own today, so --help is what proves it reads
+	// the same parser: a trailing help request prints usage instead of being
+	// collected as a spec path.
+	t.Run("explain help after path", func(t *testing.T) {
+		var out, errb bytes.Buffer
+		if got := Main([]string{"explain", p, "--help"}, &out, &errb); got != ExitOK {
+			t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitOK, errb.String())
+		}
+		if !strings.Contains(out.String(), "Usage: atago explain") {
+			t.Errorf("stdout = %q, want the usage text", out.String())
+		}
+	})
+
+	// init takes one path, so the flag has to be honored without becoming a
+	// second path (which would be rejected as "too many paths").
+	t.Run("init template after path", func(t *testing.T) {
+		target := filepath.Join(dir, "gen.atago.yaml")
+		var out, errb bytes.Buffer
+		if got := Main([]string{"init", target, "--template", "http"}, &out, &errb); got != ExitOK {
+			t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitOK, errb.String())
+		}
+		body, err := os.ReadFile(target) //nolint:gosec // path built from t.TempDir
+		if err != nil {
+			t.Fatalf("init wrote no file: %v", err)
+		}
+		if !strings.Contains(string(body), "type: http") {
+			t.Errorf("generated spec is not the http template:\n%s", body)
+		}
+	})
 }
 
 // TestRunCmd_DoubleDashKeepsPathsLiteral pins the escape hatch that makes the

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1081,7 +1081,7 @@ func TestSpecCmds_FlagsAfterPaths(t *testing.T) {
 		if got := Main([]string{"init", target, "--template", "http"}, &out, &errb); got != ExitOK {
 			t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitOK, errb.String())
 		}
-		body, err := os.ReadFile(target) //nolint:gosec // path built from t.TempDir
+		body, err := os.ReadFile(target)
 		if err != nil {
 			t.Fatalf("init wrote no file: %v", err)
 		}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1022,6 +1022,75 @@ func TestRunCmd_ArgParsingErrors(t *testing.T) {
 	}
 }
 
+// TestSpecCmds_FlagsAfterPaths pins the invocation order every spec-reading
+// subcommand accepts: a flag written AFTER the paths means the same as one
+// written before them. Go's flag package stops at the first non-flag argument,
+// so `atago run specs/ --report json` used to report `cannot access "--report"`
+// — the flag was read as a spec path — which is a shape users type constantly
+// and an error message that names the wrong problem.
+func TestSpecCmds_FlagsAfterPaths(t *testing.T) {
+	dir := t.TempDir()
+	p := writeSpec(t, dir, "ok.atago.yaml", passingSpec)
+	cases := []struct {
+		name     string
+		args     []string
+		wantExit int
+		wantOut  string
+	}{
+		{"run report after path", []string{"run", p, "--report", "json"}, ExitOK, `"schema_version"`},
+		{"run flag between paths", []string{"run", p, "--report", "json", p}, ExitOK, `"schema_version"`},
+		{"run verbose after path", []string{"run", p, "--verbose"}, ExitOK, "exit 0 passes"},
+		{"list json after path", []string{"list", p, "--json"}, ExitOK, `"scenarios"`},
+		{"doc out-dir after path", []string{"doc", p, "--split-by-spec", "--out-dir", filepath.Join(dir, "d")}, ExitOK, ""},
+		{"manifest out after path", []string{"manifest", p, "--out", filepath.Join(dir, "m.json")}, ExitOK, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var out, errb bytes.Buffer
+			if got := Main(c.args, &out, &errb); got != c.wantExit {
+				t.Fatalf("exit = %d, want %d (stderr=%s)", got, c.wantExit, errb.String())
+			}
+			if !strings.Contains(out.String(), c.wantOut) {
+				t.Errorf("stdout = %q, want it to contain %q", out.String(), c.wantOut)
+			}
+		})
+	}
+	// The trailing --out was honored rather than read as a spec path.
+	if _, err := os.Stat(filepath.Join(dir, "m.json")); err != nil {
+		t.Errorf("manifest --out after the path wrote no file: %v", err)
+	}
+}
+
+// TestRunCmd_DoubleDashKeepsPathsLiteral pins the escape hatch that makes the
+// interspersed parsing above safe: everything after `--` is a path, even when it
+// is spelled like a flag. Without it a file legitimately named `--weird` could
+// not be addressed at all.
+func TestRunCmd_DoubleDashKeepsPathsLiteral(t *testing.T) {
+	dir := t.TempDir()
+	p := writeSpec(t, dir, "ok.atago.yaml", passingSpec)
+	var out, errb bytes.Buffer
+	if got := Main([]string{"run", "--", p, "--report"}, &out, &errb); got != ExitConfig {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitConfig, errb.String())
+	}
+	if !strings.Contains(errb.String(), `cannot access "--report"`) {
+		t.Errorf("stderr = %q, want the terminator to make --report a path", errb.String())
+	}
+}
+
+// TestRecordCmd_FlagsAfterCommandStayLiteral guards the one command that must
+// NOT read a later flag as its own: `atago record -- mytool --verbose` records
+// mytool's --verbose, so record keeps the standard "stop at the first operand"
+// parsing.
+func TestRecordCmd_FlagsAfterCommandStayLiteral(t *testing.T) {
+	var out, errb bytes.Buffer
+	if got := Main([]string{"record", "--", "echo", "--out"}, &out, &errb); got != ExitOK {
+		t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitOK, errb.String())
+	}
+	if !strings.Contains(out.String(), "--out") {
+		t.Errorf("stdout = %q, want the recorded command to keep --out", out.String())
+	}
+}
+
 // TestRunCmd_CIFlagAndParallel exercises the --ci and --parallel>1 branches of
 // runCmd (setting NO_COLOR and the shared scenario semaphore).
 func TestRunCmd_CIFlagAndParallel(t *testing.T) {

--- a/internal/cli/doc.go
+++ b/internal/cli/doc.go
@@ -30,7 +30,8 @@ func docCmd(args []string, stdout, stderr io.Writer) int {
 	// explicitly below — to stdout for an explicit --help (so it can be piped),
 	// to stderr for a genuine parse error.
 	fs.Usage = func() {}
-	if err := fs.Parse(args); err != nil {
+	operands, err := parseFlagsAnywhere(fs, args)
+	if err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			printUsage(stdout)
 			return ExitOK
@@ -54,7 +55,7 @@ func docCmd(args []string, stdout, stderr io.Writer) int {
 		return ExitConfig
 	}
 
-	paths, exitCode, ok := specTargets("atago doc", fs.Args(), stderr)
+	paths, exitCode, ok := specTargets("atago doc", operands, stderr)
 	if !ok {
 		return exitCode
 	}

--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -24,7 +24,8 @@ func explainCmd(args []string, stdout, stderr io.Writer) int {
 	// explicitly below — to stdout for an explicit --help (so it can be piped),
 	// to stderr for a genuine parse error.
 	fs.Usage = func() {}
-	if err := fs.Parse(args); err != nil {
+	operands, err := parseFlagsAnywhere(fs, args)
+	if err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			printUsage(stdout)
 			return ExitOK
@@ -33,7 +34,7 @@ func explainCmd(args []string, stdout, stderr io.Writer) int {
 		return ExitConfig
 	}
 
-	paths, exitCode, ok := specTargets("atago explain", fs.Args(), stderr)
+	paths, exitCode, ok := specTargets("atago explain", operands, stderr)
 	if !ok {
 		return exitCode
 	}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -399,7 +399,8 @@ func initCmd(args []string, stdout, stderr io.Writer) int {
 	// explicitly below — to stdout for an explicit --help (so it can be piped),
 	// to stderr for a genuine parse error.
 	fs.Usage = func() {}
-	if err := fs.Parse(args); err != nil {
+	operands, err := parseFlagsAnywhere(fs, args)
+	if err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			printUsage(stdout)
 			return ExitOK
@@ -422,13 +423,13 @@ func initCmd(args []string, stdout, stderr io.Writer) int {
 		return ExitConfig
 	}
 
-	if fs.NArg() > 1 {
-		fmt.Fprintf(stderr, "atago init: too many paths — init writes one spec file, got %d (%s)\n", fs.NArg(), strings.Join(fs.Args(), ", "))
+	if len(operands) > 1 {
+		fmt.Fprintf(stderr, "atago init: too many paths — init writes one spec file, got %d (%s)\n", len(operands), strings.Join(operands, ", "))
 		return ExitConfig
 	}
 	path := defaultInitFilename(*template)
-	if fs.NArg() > 0 {
-		path = fs.Arg(0)
+	if len(operands) > 0 {
+		path = operands[0]
 	}
 
 	if _, err := os.Stat(path); err == nil && !*force {

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -35,7 +35,8 @@ func listCmd(args []string, stdout, stderr io.Writer) int {
 	// explicitly below — to stdout for an explicit --help (so it can be piped),
 	// to stderr for a genuine parse error.
 	fs.Usage = func() {}
-	if err := fs.Parse(args); err != nil {
+	operands, err := parseFlagsAnywhere(fs, args)
+	if err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			printUsage(stdout)
 			return ExitOK
@@ -44,7 +45,7 @@ func listCmd(args []string, stdout, stderr io.Writer) int {
 		return ExitConfig
 	}
 
-	paths, exitCode, ok := specTargets("atago list", fs.Args(), stderr)
+	paths, exitCode, ok := specTargets("atago list", operands, stderr)
 	if !ok {
 		return exitCode
 	}

--- a/internal/cli/manifest.go
+++ b/internal/cli/manifest.go
@@ -28,7 +28,8 @@ func manifestCmd(args []string, stdout, stderr io.Writer) int {
 	// explicitly below — to stdout for an explicit --help (so it can be piped),
 	// to stderr for a genuine parse error.
 	fs.Usage = func() {}
-	if err := fs.Parse(args); err != nil {
+	operands, err := parseFlagsAnywhere(fs, args)
+	if err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			printUsage(stdout)
 			return ExitOK
@@ -37,7 +38,7 @@ func manifestCmd(args []string, stdout, stderr io.Writer) int {
 		return ExitConfig
 	}
 
-	paths, exitCode, ok := specTargets("atago manifest", fs.Args(), stderr)
+	paths, exitCode, ok := specTargets("atago manifest", operands, stderr)
 	if !ok {
 		return exitCode
 	}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -191,7 +191,8 @@ func parseRunFlags(label string, args []string, stdout, stderr io.Writer) (*runO
 		fmt.Fprint(stderr, "Usage: atago run [--report console|json|junit|gha|tap] [--update-snapshots] [--parallel N] [--fail-fast] [--filter S] [--tag T] [--skip-tag T] [--rerun-failed] [--repeat N] [--retry-failed N] [--allow-flaky] [--allow-xpass] [--profile NAME] [--artifacts-dir DIR] [--verbose] [--ci] <path | dir>...\n  (directories are searched recursively)\n")
 		fs.PrintDefaults()
 	}
-	if err := fs.Parse(args); err != nil {
+	operands, err := parseFlagsAnywhere(fs, args)
+	if err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return nil, ExitOK, true
 		}
@@ -208,7 +209,7 @@ func parseRunFlags(label string, args []string, stdout, stderr io.Writer) (*runO
 		return nil, ExitConfig, true
 	}
 
-	paths, exitCode, ok := specTargets(label, fs.Args(), stderr)
+	paths, exitCode, ok := specTargets(label, operands, stderr)
 	if !ok {
 		return nil, exitCode, true
 	}

--- a/test/e2e/atago/run.atago.yaml
+++ b/test/e2e/atago/run.atago.yaml
@@ -220,3 +220,57 @@ scenarios:
             json:
               path: "$.suites[0].scenarios"
               length: 1
+
+  # A flag written after the paths means what it means before them. The order
+  # people reach for first is "what to run, then how to run it", and the flag
+  # package stops parsing at the first path, so this used to die with
+  # `cannot access "--report"` — a complaint about a file nobody named.
+  - name: a flag after the spec path is still a flag
+    steps:
+      - fixture:
+          file: ok.atago.yaml
+          content: &flagorder |
+            version: "1"
+            suite:
+              name: sample
+            scenarios:
+              - name: echo
+                steps:
+                  - run:
+                      shell: true
+                      command: "exit 0"
+                  - assert:
+                      exit_code: 0
+      - run:
+          command: ${atago} run ok.atago.yaml --report json
+      - assert:
+          exit_code: 0
+          stdout:
+            json:
+              path: "$.suites[0].status"
+              equals: passed
+
+  - name: a flag between two spec paths is still a flag
+    steps:
+      - fixture: {file: ok.atago.yaml, content: *flagorder}
+      - fixture: {file: second.atago.yaml, content: *flagorder}
+      - run:
+          command: ${atago} run ok.atago.yaml --report json second.atago.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            json:
+              path: "$.suites"
+              length: 2
+
+  # The escape hatch: after `--` every argument is a path, which is the only way
+  # to name a file whose name starts with a dash.
+  - name: a double dash keeps later arguments as paths
+    steps:
+      - fixture: {file: ok.atago.yaml, content: *flagorder}
+      - run:
+          command: ${atago} run -- ok.atago.yaml --report
+      - assert:
+          exit_code: 3
+          stderr:
+            contains: 'cannot access "--report"'


### PR DESCRIPTION
atago run specs/ --report json exited 3 with `cannot access "--report": no such file or directory`. Go's flag package stops parsing at the first non-flag argument, so every flag after the paths became a spec path and the run died naming a file nobody typed. The same held for list, doc, explain, manifest, and init.

"What to run, then how to run it" is the order people reach for first, so the failure lands on a command line that looks correct while the message points at the wrong problem.

parseFlagsAnywhere re-enters Parse after each operand instead of reordering argv by guessing which flags take a value — the FlagSet itself answers that. A `--` terminator still ends flag parsing, which is the only way to address a file whose name starts with a dash, and there is a test pinning it. `atago record` deliberately keeps the standard parsing: there the trailing arguments are another program's command line, and its flags belong to it.

Covered by unit tests over every affected subcommand and by three self-hosted E2E scenarios in test/e2e/atago/run.atago.yaml (flag after the path, flag between two paths, and the `--` escape hatch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Command-line flags can now appear before, after, or between specification paths for `run`, `list`, `doc`, `explain`, `manifest`, and `init`.
  * Multiple specification paths are supported alongside interspersed flags.
  * `--` continues to treat following arguments as literal paths.

* **Bug Fixes**
  * Improved command-line argument handling while preserving `record` behavior.

* **Documentation**
  * Updated behavior documentation and changelog with the new flag parsing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->