### PR TITLE
fix(run): let fail-fast and the rerun ledger see every red verdict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- `--fail-fast` now stops for every outcome that fails the run, not just a
+  failed or errored scenario. An XPASS (a known bug that is fixed) and a flaky
+  recovery both decide the exit code, so a run whose verdict was already made
+  kept scheduling scenarios — the flag stopping for one red signal and not
+  another, with nothing in the reports to explain the difference. `--allow-flaky`
+  and `--allow-xpass` make those statuses green again, and then there is nothing
+  to stop for. One predicate now answers the question for the exit code,
+  `--fail-fast`, and the `--rerun-failed` ledger.
+- The `--rerun-failed` ledger records an XPASS. A run whose only red signal was
+  an XPASS wrote no ledger at all, so the follow-up `atago run --rerun-failed`
+  reported "nothing to rerun" and exited 0 — a green answer about a run that
+  failed. Re-running an XPASS reproduces it, which is the outcome that keeps
+  saying "promote this spec" until someone does; under `--allow-xpass` the run
+  is green and the ledger stays empty. A flaky scenario is still not recorded:
+  its re-run most likely passes, and clearing the ledger is not the same as
+  fixing the instability.
+
 ## [0.18.0] - 2026-07-30
 
 A release about the one verdict atago was getting wrong about itself. `--repeat`

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-80 suites · 508 scenarios
+80 suites · 510 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -162,10 +162,12 @@
   - [a signal exit composes with the in matcher alongside normal codes](#scenario-a-signal-exit-composes-with-the-in-matcher-alongside-normal-codes)
   - [a missing command is 127 under the shell](#scenario-a-missing-command-is-127-under-the-shell)
   - [POSIX exit codes wrap modulo 256](#scenario-posix-exit-codes-wrap-modulo-256)
-- [atago self-hosting / expected failures](#atago-self-hosting--expected-failures) — 10 scenarios
+- [atago self-hosting / expected failures](#atago-self-hosting--expected-failures) — 12 scenarios
   - [a known bug that still fails keeps the run green](#scenario-a-known-bug-that-still-fails-keeps-the-run-green)
   - [a known bug that is fixed fails the run so it gets promoted](#scenario-a-known-bug-that-is-fixed-fails-the-run-so-it-gets-promoted)
   - [allow-xpass keeps the run green while the spec is promoted](#scenario-allow-xpass-keeps-the-run-green-while-the-spec-is-promoted)
+  - [fail-fast stops for an xpass and the ledger can rerun it](#scenario-fail-fast-stops-for-an-xpass-and-the-ledger-can-rerun-it)
+  - [an allowed xpass leaves nothing behind to rerun](#scenario-an-allowed-xpass-leaves-nothing-behind-to-rerun)
   - [an execution error is still an error, not an expected failure](#scenario-an-execution-error-is-still-an-error-not-an-expected-failure)
   - [a skip gate still decides on its own](#scenario-a-skip-gate-still-decides-on-its-own)
   - [an expected failure is not retried into a flake](#scenario-an-expected-failure-is-not-retried-into-a-flake)
@@ -3502,6 +3504,75 @@ ${atago} run --allow-xpass --report junit inner_allow.atago.yaml
 - after `${atago} run --allow-xpass --report junit inner_allow.atago.yaml`:
   - exit code is `0`
   - stdout contains `failures="0"`, does not contain `<failure`
+### Scenario: fail-fast stops for an xpass and the ledger can rerun it
+#### Given
+- Fixture file `inner_ff.atago.yaml` is created.
+#### Inputs
+_Fixture `inner_ff.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: inner fail fast
+scenarios:
+  - name: the bug is fixed
+    expect_fail:
+      reason: "used to print nothing at all"
+    steps:
+      - run:
+          command: echo present
+      - assert:
+          stdout:
+            contains: present
+  - name: never reached
+    steps:
+      - run:
+          command: echo later
+      - assert:
+          exit_code: 0
+```
+#### When
+```shell
+${atago} run --fail-fast --parallel 1 --report json inner_ff.atago.yaml
+${atago} run --rerun-failed --report json inner_ff.atago.yaml
+```
+#### Then
+- after `${atago} run --fail-fast --parallel 1 --report json inner_ff.atago.yaml`:
+  - exit code is `1`
+  - stdout at `$.suites[0].scenarios[0].status` equals `xpass`; at `$.suites[0].scenarios[1].status` equals `skipped`
+- after `${atago} run --rerun-failed --report json inner_ff.atago.yaml`:
+  - exit code is `1`
+  - stdout at `$.suites[0].scenarios` has length 1; at `$.suites[0].scenarios[0].status` equals `xpass`
+### Scenario: an allowed xpass leaves nothing behind to rerun
+#### Given
+- Fixture file `inner_allow_ledger.atago.yaml` is created.
+#### Inputs
+_Fixture `inner_allow_ledger.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: inner allow ledger
+scenarios:
+  - name: the bug is fixed
+    expect_fail:
+      reason: "used to crash"
+    steps:
+      - run:
+          command: echo ok
+      - assert:
+          stdout:
+            contains: ok
+```
+#### When
+```shell
+${atago} run --allow-xpass inner_allow_ledger.atago.yaml
+${atago} run --rerun-failed inner_allow_ledger.atago.yaml
+```
+#### Then
+- after `${atago} run --allow-xpass inner_allow_ledger.atago.yaml`:
+  - exit code is `0`
+- after `${atago} run --rerun-failed inner_allow_ledger.atago.yaml`:
+  - exit code is `0`
+  - stderr contains `nothing to rerun`
 ### Scenario: an execution error is still an error, not an expected failure
 #### Given
 - Fixture file `inner_error.atago.yaml` is created.

--- a/internal/cli/features_test.go
+++ b/internal/cli/features_test.go
@@ -17,10 +17,13 @@ import (
 )
 
 // TestCollectFailures_ClassifiesStatuses pins which scenario outcomes are
-// recorded for --rerun-failed: only failed and errored scenarios are, in a
-// deterministic order. A flaky scenario (one that recovered on retry, #29) is
-// green and must NOT be recorded, or the red-green loop would keep re-running a
-// scenario that already passes; passed and skipped are likewise excluded.
+// recorded for --rerun-failed, in a deterministic order: failed and errored
+// scenarios, plus an XPASS, which is what turns an otherwise green run red and
+// would otherwise leave `--rerun-failed` with nothing to do after a red run. A
+// flaky scenario (one that recovered on retry, #29) stays out even though it
+// too fails the run: its rerun most likely passes, which would clear the ledger
+// without anything being fixed. Passed, skipped, and XFAIL are green and
+// excluded.
 func TestCollectFailures_ClassifiesStatuses(t *testing.T) {
 	t.Parallel()
 	results := []*engine.SuiteResult{
@@ -28,21 +31,24 @@ func TestCollectFailures_ClassifiesStatuses(t *testing.T) {
 			{Name: "passes", Status: engine.StatusPassed},
 			{Name: "errs", Status: engine.StatusError},
 			{Name: "flakes", Status: engine.StatusFlaky},
+			{Name: "xfails", Status: engine.StatusXFail},
 		}},
 		{SpecPath: "a.atago.yaml", Scenarios: []engine.ScenarioResult{
 			{Name: "fails", Status: engine.StatusFailed},
 			{Name: "skipped", Status: engine.StatusSkipped},
+			{Name: "xpasses", Status: engine.StatusXPass},
 		}},
 		nil, // a nil suite result (e.g. a spec that failed to load) is skipped
 	}
-	got := collectFailures(results)
+	got := collectFailures(results, false)
 
 	want := []failedEntry{
 		{SpecPath: "b.atago.yaml", Scenario: "errs"},
 		{SpecPath: "a.atago.yaml", Scenario: "fails"},
+		{SpecPath: "a.atago.yaml", Scenario: "xpasses"},
 	}
 	if len(got) != len(want) {
-		t.Fatalf("collectFailures = %+v, want only the failed/errored entries %+v", got, want)
+		t.Fatalf("collectFailures = %+v, want the failed/errored/xpass entries %+v", got, want)
 	}
 	for i := range want {
 		if got[i] != want[i] {
@@ -50,8 +56,18 @@ func TestCollectFailures_ClassifiesStatuses(t *testing.T) {
 		}
 	}
 	for _, e := range got {
-		if e.Scenario == "flakes" || e.Scenario == "passes" || e.Scenario == "skipped" {
+		switch e.Scenario {
+		case "flakes", "passes", "skipped", "xfails":
 			t.Errorf("collectFailures recorded a non-failing scenario %q; the rerun loop would never converge", e.Scenario)
+		}
+	}
+
+	// --allow-xpass makes the XPASS green, and a green run must leave nothing
+	// behind to rerun.
+	allowed := collectFailures(results, true)
+	for _, e := range allowed {
+		if e.Scenario == "xpasses" {
+			t.Error("collectFailures recorded an XPASS the run was told to allow")
 		}
 	}
 }

--- a/internal/cli/rerun.go
+++ b/internal/cli/rerun.go
@@ -230,14 +230,29 @@ func dedupeEntries(in []failedEntry) []failedEntry {
 
 // collectFailures extracts the failing scenario identities from a set of suite
 // results and their spec paths, in a deterministic order.
-func collectFailures(results []*engine.SuiteResult) []failedEntry {
+//
+// An XPASS is recorded: it is what turned an otherwise green run red, so
+// leaving it out meant a red run wrote no ledger at all and the follow-up
+// `--rerun-failed` reported "nothing to rerun" and exited 0 — a green answer to
+// a run that failed. Re-running it reproduces the XPASS, which is the outcome
+// that keeps saying "promote this spec" until someone does. --allow-xpass makes
+// the same run green, and a green run must leave nothing behind.
+//
+// A flaky scenario stays out even though it also fails the run: its re-run most
+// likely passes, and clearing the ledger is not the same as fixing the
+// instability. What is worth re-running and what turns a run red are the same
+// question for every status but that one.
+func collectFailures(results []*engine.SuiteResult, allowXPass bool) []failedEntry {
 	var failed []failedEntry
 	for _, res := range results {
 		if res == nil {
 			continue
 		}
 		for _, sc := range res.Scenarios {
-			if sc.Status == engine.StatusFailed || sc.Status == engine.StatusError {
+			if sc.Status == engine.StatusFlaky {
+				continue
+			}
+			if engine.FailsRun(sc.Status, true, allowXPass) {
 				failed = append(failed, failedEntry{SpecPath: res.SpecPath, Scenario: sc.Name})
 			}
 		}
@@ -349,7 +364,7 @@ func executedScenarioIDs(results []*engine.SuiteResult) map[string]bool {
 	return executed
 }
 
-func updateRerunLedger(label string, stderr io.Writer, results []*engine.SuiteResult) {
+func updateRerunLedger(label string, stderr io.Writer, results []*engine.SuiteResult, allowXPass bool) {
 	prior, perr := loadRerunState()
 	if perr != nil {
 		fmt.Fprintf(stderr, label+": cannot read %s; leaving it untouched: %v\n", rerunStatePath(), perr)
@@ -362,7 +377,7 @@ func updateRerunLedger(label string, stderr io.Writer, results []*engine.SuiteRe
 			preserved = append(preserved, e)
 		}
 	}
-	entries := dedupeEntries(portableEntries(append(collectFailures(results), preserved...)))
+	entries := dedupeEntries(portableEntries(append(collectFailures(results, allowXPass), preserved...)))
 	if err := saveRerunState(entries); err != nil {
 		fmt.Fprintf(stderr, label+": could not update %s: %v\n", rerunStatePath(), err)
 	}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -74,6 +74,8 @@ func runCmd(label string, args []string, stdout, stderr io.Writer) int {
 	eng.UpdateSnapshots = opts.updateSnapshots
 	eng.Parallel = opts.parallel
 	eng.FailFast = opts.failFast
+	eng.AllowFlaky = opts.allowFlaky
+	eng.AllowXPass = opts.allowXPass
 	eng.Repeat = opts.repeat
 	eng.RetryFailed = opts.retryFailed
 	eng.FilterNames = opts.filter
@@ -172,7 +174,7 @@ func parseRunFlags(label string, args []string, stdout, stderr io.Writer) (*runO
 	updateSnapshots := fs.Bool("update-snapshots", false, "create or overwrite snapshot files instead of comparing")
 	ci := fs.Bool("ci", false, "CI-safe defaults: deterministic, no color (sets NO_COLOR), secret masking")
 	parallel := fs.Int("parallel", runtime.NumCPU(), "number of scenarios to run concurrently; scenarios are isolated, each in its own temp dir")
-	failFast := fs.Bool("fail-fast", false, "stop scheduling new scenarios after the first failure")
+	failFast := fs.Bool("fail-fast", false, "stop scheduling new scenarios after the first outcome that fails the run (a failure, an error, an XPASS, or a flake unless allowed)")
 	var filter csvFlag
 	fs.Var(&filter, "filter", "run only scenarios whose name contains any of these comma-separated substrings (repeatable; OR semantics like --tag)")
 	var tag csvFlag
@@ -350,7 +352,7 @@ func finishRun(opts *runOptions, suiteResults []*engine.SuiteResult, loadErrs []
 		if opts.rerunFailed && !opts.selectionActive() {
 			warnUnmatchedRerunEntries(opts.label, opts.stderr, results)
 		}
-		updateRerunLedger(opts.label, opts.stderr, results)
+		updateRerunLedger(opts.label, opts.stderr, results, opts.allowXPass)
 	}
 
 	// Every spec failed to load, or an interrupt skipped every suite before it
@@ -451,7 +453,7 @@ func runSpecs(ctx context.Context, eng *engine.Engine, paths []string) ([]*engin
 			return
 		}
 		suiteResults[i] = eng.Run(ctx, s, p)
-		if eng.FailFast && suiteFailed(suiteResults[i]) {
+		if eng.FailFast && suiteFailed(suiteResults[i], eng.AllowFlaky, eng.AllowXPass) {
 			failStop.Store(true)
 		}
 	}
@@ -504,9 +506,23 @@ func runSpecs(ctx context.Context, eng *engine.Engine, paths []string) ([]*engin
 }
 
 // suiteFailed reports whether a completed suite counts as a failure for
-// --fail-fast: a failed or errored verdict, or a security-policy violation.
-func suiteFailed(res *engine.SuiteResult) bool {
-	return res != nil && (res.Status == engine.StatusFailed || res.Status == engine.StatusError || res.SecurityViolation)
+// --fail-fast across spec files: a security-policy violation, or any scenario
+// whose outcome turns the run red. The suite's own Status is not enough — a
+// flaky recovery and an XPASS both rank green there while failing the run — so
+// the scenarios are consulted with the same predicate the exit code uses.
+func suiteFailed(res *engine.SuiteResult, allowFlaky, allowXPass bool) bool {
+	if res == nil {
+		return false
+	}
+	if res.SecurityViolation {
+		return true
+	}
+	for _, sc := range res.Scenarios {
+		if engine.FailsRun(sc.Status, allowFlaky, allowXPass) {
+			return true
+		}
+	}
+	return false
 }
 
 // specTargets resolves a subcommand's positional arguments into the spec files
@@ -693,21 +709,18 @@ func exitForSuite(res *engine.SuiteResult, allowFlaky, allowXPass bool) int {
 	}
 	switch res.Status {
 	case engine.StatusPassed, engine.StatusSkipped, engine.StatusFlaky, engine.StatusXFail, engine.StatusXPass:
-		// A flaky scenario does not raise the suite's status — worseStatus ranks it
-		// alongside passed, so a suite of one flake and nine passes still reports
-		// passed — which is why the count is what decides here, the same value the
-		// console verdict reads.
-		counts := res.Counts()
-		if !allowFlaky && counts.Flaky > 0 {
-			return ExitFailures
-		}
-		// An XPASS is a fixed bug nobody promoted yet: the scenario documents a
-		// defect that is no longer there, so it must move into the suite that
-		// guards against a regression. Failing the run is what makes that
-		// happen; --allow-xpass is for a caller who wants the warning without
-		// the red build.
-		if !allowXPass && counts.XPass > 0 {
-			return ExitFailures
+		// A flaky scenario and an XPASS do not raise the suite's status —
+		// worseStatus ranks both alongside passed, so a suite of one flake and nine
+		// passes still reports passed — which is why the scenarios are what decide
+		// here. A flake is a scenario whose answer depended on how many times it
+		// ran, and an XPASS is a fixed bug nobody promoted yet; both fail the run
+		// unless the caller accepted them at the command line. engine.FailsRun is
+		// the same predicate --fail-fast consults, so the flag stops for exactly
+		// the outcomes that decide this exit code.
+		for _, sc := range res.Scenarios {
+			if engine.FailsRun(sc.Status, allowFlaky, allowXPass) {
+				return ExitFailures
+			}
 		}
 		return ExitOK
 	case engine.StatusFailed:

--- a/internal/engine/attempts_test.go
+++ b/internal/engine/attempts_test.go
@@ -59,6 +59,49 @@ func TestEngine_RetryFailedRecoversAsFlaky(t *testing.T) {
 	}
 }
 
+// TestEngine_FailFastStopsForAFlakyRecovery pins fail-fast to the run-level
+// verdict for the other status that is green per scenario and red for the run: a
+// recovery on retry fails the run unless --allow-flaky, so --fail-fast must stop
+// scheduling for it too. With the flakiness allowed the verdict is green again
+// and the rest of the suite runs.
+func TestEngine_FailFastStopsForAFlakyRecovery(t *testing.T) {
+	skipOnWindows(t)
+	t.Parallel()
+	cases := []struct {
+		name       string
+		allowFlaky bool
+		wantSecond Status
+	}{
+		{"a flaky recovery stops the run", false, StatusSkipped},
+		{"an allowed flake does not", true, StatusPassed},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			src := flakyOnceSpec(t) + `
+  - name: never
+    steps: [{run: {shell: true, command: echo hi}}, {assert: {exit_code: 0}}]
+`
+			s, err := loader.LoadBytes("t.atago.yaml", []byte(src))
+			if err != nil {
+				t.Fatalf("load: %v", err)
+			}
+			eng := New()
+			eng.Parallel = 1 // deterministic: the first verdict decides the rest
+			eng.RetryFailed = 2
+			eng.FailFast = true
+			eng.AllowFlaky = c.allowFlaky
+			res := eng.Run(context.Background(), s, "t.atago.yaml")
+			if res.Scenarios[0].Status != StatusFlaky {
+				t.Fatalf("scenario[0] = %s, want flaky", res.Scenarios[0].Status)
+			}
+			if res.Scenarios[1].Status != c.wantSecond {
+				t.Errorf("scenario[1] = %s, want %s", res.Scenarios[1].Status, c.wantSecond)
+			}
+		})
+	}
+}
+
 // TestEngine_RetryFailedExhaustedStaysFailed proves exhausted retries keep the
 // failure with the attempt count recorded.
 func TestEngine_RetryFailedExhaustedStaysFailed(t *testing.T) {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -44,10 +44,18 @@ type Engine struct {
 	// < 1 mean sequential execution.
 	Parallel int
 
-	// FailFast stops scheduling new scenarios once one fails or errors.
-	// In-flight scenarios are allowed to finish. With RetryFailed it triggers
-	// only on a FINAL failure (a recovered flaky scenario never trips it).
+	// FailFast stops scheduling new scenarios once one of them turns the run red
+	// (see FailsRun). In-flight scenarios are allowed to finish. With RetryFailed
+	// it triggers only on a FINAL verdict, never on an attempt that still has
+	// retries left.
 	FailFast bool
+
+	// AllowFlaky and AllowXPass carry the run-level policies into the engine, so
+	// FailFast stops for exactly the outcomes that decide the exit code. Without
+	// them the two would disagree: a flaky recovery or an XPASS fails the run,
+	// and fail-fast would keep scheduling scenarios for a verdict already made.
+	AllowFlaky bool
+	AllowXPass bool
 
 	// Repeat runs each selected scenario this many times (#29) to surface
 	// flakiness. The per-iteration statuses are recorded and the fold is
@@ -254,7 +262,7 @@ func (e *Engine) Run(ctx context.Context, s *spec.Spec, specPath string) *SuiteR
 				if e.OnScenario != nil {
 					e.OnScenario(sc)
 				}
-				if e.FailFast && (sc.Status == StatusFailed || sc.Status == StatusError) {
+				if e.FailFast && FailsRun(sc.Status, e.AllowFlaky, e.AllowXPass) {
 					failStop = true
 				}
 				mu.Unlock()

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -671,6 +671,57 @@ scenarios:
 	}
 }
 
+// TestEngine_FailFastCoversEveryFailureLevelStatus pins fail-fast to the same
+// notion of "this run is red" the exit code uses. An XPASS (a known bug that is
+// fixed) and a flaky scenario both fail the run, so --fail-fast has to stop for
+// them too — it stopped only for failed/errored, so a red run kept scheduling
+// work after the verdict was already decided. The allow flags are what make the
+// status green again, and then there is nothing to stop for.
+func TestEngine_FailFastCoversEveryFailureLevelStatus(t *testing.T) {
+	t.Parallel()
+	xpassSrc := `
+version: "1"
+suite:
+  name: ff
+scenarios:
+  - name: fixed bug
+    expect_fail: {reason: "used to print nothing"}
+    steps: [{run: {shell: true, command: echo hi}}, {assert: {exit_code: 0}}]
+  - name: never
+    steps: [{run: {shell: true, command: echo hi}}, {assert: {exit_code: 0}}]
+`
+	cases := []struct {
+		name       string
+		src        string
+		configure  func(*Engine)
+		wantFirst  Status
+		wantSecond Status
+	}{
+		{"xpass stops the run", xpassSrc, func(*Engine) {}, StatusXPass, StatusSkipped},
+		{"an allowed xpass does not", xpassSrc, func(e *Engine) { e.AllowXPass = true }, StatusXPass, StatusPassed},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			s, err := loader.LoadBytes("t.atago.yaml", []byte(c.src))
+			if err != nil {
+				t.Fatalf("load: %v", err)
+			}
+			eng := New()
+			eng.Parallel = 1 // deterministic: the first verdict decides the rest
+			eng.FailFast = true
+			c.configure(eng)
+			res := eng.Run(context.Background(), s, "t.atago.yaml")
+			if res.Scenarios[0].Status != c.wantFirst {
+				t.Fatalf("scenario[0] = %s, want %s", res.Scenarios[0].Status, c.wantFirst)
+			}
+			if res.Scenarios[1].Status != c.wantSecond {
+				t.Errorf("scenario[1] = %s, want %s", res.Scenarios[1].Status, c.wantSecond)
+			}
+		})
+	}
+}
+
 // Regression for issue #30: when the parent context is cancelled mid-scenario
 // (Ctrl-C / suite cancel), the engine step loop must stop rather than keep
 // executing steps and evaluating assertions against a killed result. The

--- a/internal/engine/result.go
+++ b/internal/engine/result.go
@@ -42,6 +42,28 @@ const (
 	StatusFlaky Status = "flaky"
 )
 
+// FailsRun reports whether a finished scenario turns the run red, given the two
+// policies that decide the statuses whose severity is a choice rather than a
+// fact: --allow-flaky and --allow-xpass.
+//
+// It exists so the answer is given in one place. The exit code has always known
+// that a flaky recovery and an XPASS fail the run, but --fail-fast asked a
+// narrower question of its own (failed or errored), so a run whose verdict was
+// already decided kept scheduling scenarios — the flag stopping for one red
+// signal and not another, with nothing in the reports to explain the difference.
+func FailsRun(st Status, allowFlaky, allowXPass bool) bool {
+	switch st {
+	case StatusFailed, StatusError:
+		return true
+	case StatusFlaky:
+		return !allowFlaky
+	case StatusXPass:
+		return !allowXPass
+	default:
+		return false
+	}
+}
+
 // StepResult records what happened for a single step.
 type StepResult struct {
 	Index int

--- a/test/e2e/atago/expect_fail.atago.yaml
+++ b/test/e2e/atago/expect_fail.atago.yaml
@@ -102,6 +102,86 @@ scenarios:
             contains: 'failures="0"'
             not_contains: "<failure"
 
+  # An XPASS decides the run's verdict, so the two things a red verdict drives
+  # have to see it: --fail-fast stops scheduling, and the ledger --rerun-failed
+  # reads knows what to run again. Neither did, so a red run kept working after
+  # the answer was known, and the follow-up rerun reported "nothing to rerun".
+  - name: fail-fast stops for an xpass and the ledger can rerun it
+    steps:
+      - fixture:
+          file: inner_ff.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: inner fail fast
+            scenarios:
+              - name: the bug is fixed
+                expect_fail:
+                  reason: "used to print nothing at all"
+                steps:
+                  - run:
+                      command: echo present
+                  - assert:
+                      stdout:
+                        contains: present
+              - name: never reached
+                steps:
+                  - run:
+                      command: echo later
+                  - assert:
+                      exit_code: 0
+      - run:
+          command: ${atago} run --fail-fast --parallel 1 --report json inner_ff.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            json:
+              - path: "$.suites[0].scenarios[0].status"
+                equals: xpass
+              - path: "$.suites[0].scenarios[1].status"
+                equals: skipped
+      - run:
+          # The ledger holds the xpass, so the shortened loop keeps reporting it
+          # until the spec is promoted.
+          command: ${atago} run --rerun-failed --report json inner_ff.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            json:
+              - path: "$.suites[0].scenarios"
+                length: 1
+              - path: "$.suites[0].scenarios[0].status"
+                equals: xpass
+
+  - name: an allowed xpass leaves nothing behind to rerun
+    steps:
+      - fixture:
+          file: inner_allow_ledger.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: inner allow ledger
+            scenarios:
+              - name: the bug is fixed
+                expect_fail:
+                  reason: "used to crash"
+                steps:
+                  - run:
+                      command: echo ok
+                  - assert:
+                      stdout:
+                        contains: ok
+      - run:
+          command: ${atago} run --allow-xpass inner_allow_ledger.atago.yaml
+      - assert:
+          exit_code: 0
+      - run:
+          command: ${atago} run --rerun-failed inner_allow_ledger.atago.yaml
+      - assert:
+          exit_code: 0
+          stderr:
+            contains: "nothing to rerun"
+
   - name: an execution error is still an error, not an expected failure
     steps:
       - fixture:


### PR DESCRIPTION
The exit code has always known that a flaky recovery and an XPASS fail the run. `--fail-fast` asked a narrower question of its own — failed or errored — so a run whose verdict was already decided kept scheduling scenarios, stopping for one red signal and not another with nothing in the reports to explain why.

The ledger `--rerun-failed` reads had the same gap at the other end: a run whose only red signal was an XPASS wrote no ledger, so the follow-up rerun reported "nothing to rerun" and exited 0 — a green answer about a run that failed. Re-running an XPASS reproduces it, which is what keeps saying "promote this spec" until someone does.

`engine.FailsRun` is now the one predicate the exit code, fail-fast, and the ledger consult, and the engine carries `--allow-flaky`/`--allow-xpass` so an accepted status is green everywhere at once. A flaky scenario stays out of the ledger on purpose: its re-run most likely passes, and clearing the ledger is not the same as fixing the instability.

Covered by engine unit tests (xpass and a deterministic flaky recovery, each with and without its allow flag), the collectFailures classification test, and two self-hosted E2E scenarios in test/e2e/atago/expect_fail.atago.yaml.