### PR TITLE
test(e2e): gate the skip-vs-expect_fail scenario on env, not a hardcoded OS

### DIFF
--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -3603,6 +3603,7 @@ ${atago} run inner_error.atago.yaml
 ### Scenario: a skip gate still decides on its own
 #### Given
 - Fixture file `inner_skip.atago.yaml` is created.
+- Environment variables are set: ATAGO_E2E_INNER_SKIP.
 #### Inputs
 _Fixture `inner_skip.atago.yaml`:_
 ```text
@@ -3614,7 +3615,7 @@ scenarios:
     expect_fail:
       reason: "only reproducible on plan9"
     skip:
-      os: linux
+      env: ATAGO_E2E_INNER_SKIP
     steps:
       - run:
           command: echo whatever

--- a/test/e2e/atago/expect_fail.atago.yaml
+++ b/test/e2e/atago/expect_fail.atago.yaml
@@ -209,6 +209,12 @@ scenarios:
 
   - name: a skip gate still decides on its own
     steps:
+      # The gate is `skip: env:` rather than `skip: os:` on purpose. A hardcoded
+      # OS only fires on that OS, so the same spec asserted "1 skipped" on Linux
+      # and got "1 xfail" on the scheduled macOS leg. An env gate the outer step
+      # sets itself fires on every host, so the claim under test — a skip gate
+      # decides before expect_fail can classify anything — is the same claim
+      # everywhere.
       - fixture:
           file: inner_skip.atago.yaml
           content: |
@@ -220,7 +226,7 @@ scenarios:
                 expect_fail:
                   reason: "only reproducible on plan9"
                 skip:
-                  os: linux
+                  env: ATAGO_E2E_INNER_SKIP
                 steps:
                   - run:
                       command: echo whatever
@@ -229,6 +235,8 @@ scenarios:
                         contains: nope
       - run:
           command: ${atago} run inner_skip.atago.yaml
+          env:
+            ATAGO_E2E_INNER_SKIP: "1"
       - assert:
           exit_code: 0
           stdout:


### PR DESCRIPTION
## Why

The nightly `CrossPlatformE2E` macOS leg has been failing ([run 31566726534](https://github.com/nao1215/atago/actions/runs/31566726534)):

```
FAILED: atago self-hosting / expected failures / a skip gate still decides on its own
  assert stdout contains "1 skipped"
Actual:
  XFAIL: inner skip / not applicable here
  PASSED  1 scenario: 0 passed, 0 failed, 0 errored, 0 skipped, 1 xfail
```

Nothing is wrong with the product. The scenario writes an inner spec whose gate is
`skip: {os: linux}` and then asserts the inner run reports `1 skipped`. That assertion
only holds on Linux. On macOS the gate does not fire, the scenario runs and fails as its
`expect_fail` declares, and the inner run reports `1 xfail` instead — so the spec asserted
a different thing on each host and went red every night on the scheduled full-suite leg.

## What

- Gate the inner spec on `skip: {env: ATAGO_E2E_INNER_SKIP}`, set by the outer `run` step.
  The gate now fires on every host, so the claim under test — a skip gate decides before
  `expect_fail` can classify anything — is the same claim on Linux, macOS, and Windows.
- Left a comment on the scenario recording why the gate is not `skip: os:`, so the next
  edit does not reintroduce the platform-dependent version.
- Regenerated `doc/e2e/atago.md`, which embeds the fixture content verbatim.

`skip: {os: ...}` takes a single OS, so there is no "skip everywhere" spelling of the
original gate; the env gate is the portable way to state the same precondition.

## Verification

- `go run . run ./test/e2e/atago` → 513 scenarios, 509 passed, 4 skipped
- `./dist/atago doc --out doc/e2e/atago.md ./test/e2e/atago` produces no further diff

The macOS leg is scheduled-only, so I will run `CrossPlatformE2E` on this branch via
`workflow_dispatch` before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test consistency by using an environment variable to control the skip scenario across different operating systems.
  * Continued verifying that skipped tests take precedence over expected-failure handling.
* **Documentation**
  * Updated the skip-gate scenario documentation to reflect the new configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->