### PR TITLE
test: locate entries by index so SA5011 cannot flake the lint gate

### DIFF
--- a/internal/assert/tree_test.go
+++ b/internal/assert/tree_test.go
@@ -143,20 +143,26 @@ func TestWalkTree_DoesNotOpenANamedPipe(t *testing.T) {
 		t.Fatalf("walkTree: %v", got.err)
 	}
 
-	var pipe *treeEntry
+	// Located by index rather than by taking a *treeEntry: a pointer that is
+	// nil-checked and then dereferenced is the shape staticcheck's SA5011 reports
+	// non-deterministically, since knowing t.Fatalf never returns depends on a
+	// cached fact. golangci-lint is an enforced gate, so the flake is not worth
+	// the pointer.
+	found := -1
 	for i := range got.entries {
 		if got.entries[i].rel == "pipe" {
-			pipe = &got.entries[i]
+			found = i
 		}
 	}
-	if pipe == nil {
+	if found < 0 {
 		t.Fatalf("the pipe is missing from the walk: %+v", got.entries)
 	}
+	pipe := got.entries[found]
 	if pipe.kind == "file" {
-		t.Errorf("pipe recorded as a regular file: %+v", *pipe)
+		t.Errorf("pipe recorded as a regular file: %+v", pipe)
 	}
 	if pipe.hash != "" {
-		t.Errorf("pipe was hashed: %+v", *pipe)
+		t.Errorf("pipe was hashed: %+v", pipe)
 	}
 	if line := pipe.manifestLine(); !strings.Contains(line, "pipe") || strings.Contains(line, "sha256:") {
 		t.Errorf("manifest line = %q, want it to name the entry without a hash", line)

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -238,15 +238,21 @@ scenarios:
 		t.Fatalf("load: %v", err)
 	}
 	doc := Build([]Input{{Spec: s, Path: "b.atago.yaml"}})
-	var web *Runner
+	// Located by index rather than by taking a *Runner: a pointer that is
+	// nil-checked and then dereferenced is the shape staticcheck's SA5011 reports
+	// non-deterministically, since knowing t.Fatal never returns depends on a
+	// cached fact. golangci-lint is an enforced gate, so the flake is not worth
+	// the pointer.
+	found := -1
 	for i := range doc.Specs[0].Runners {
 		if doc.Specs[0].Runners[i].Name == "web" {
-			web = &doc.Specs[0].Runners[i]
+			found = i
 		}
 	}
-	if web == nil {
+	if found < 0 {
 		t.Fatal("web runner missing from manifest")
 	}
+	web := doc.Specs[0].Runners[found]
 	if web.Headless == nil || *web.Headless {
 		t.Errorf("manifest headless = %v, want explicit false", web.Headless)
 	}


### PR DESCRIPTION
## Why

`golangci-lint` failed on #416 ([job](https://github.com/nao1215/atago/actions/runs/31583869188/job/94073031074)) with four staticcheck findings:

```
internal/assert/tree_test.go:152:5: SA5011(related information): this check suggests that the pointer can be nil
internal/assert/tree_test.go:155:10: SA5011: possible nil pointer dereference
internal/manifest/manifest_test.go:247:5: SA5011(related information): this check suggests that the pointer can be nil
internal/manifest/manifest_test.go:250:9: SA5011: possible nil pointer dereference
```

Nothing in those tests changed. #416 is a Dependabot bump whose entire diff is `go.mod`/`go.sum`, and the **same PR passed the same gate the day before** ([run 31531137928](https://github.com/nao1215/atago/actions/runs/31531137928)); the second run is just the rebase onto current main. The finding is a false positive that comes and goes.

The pattern it reports is a pointer into a slice that is nil-checked and then dereferenced:

```go
var pipe *treeEntry
for i := range got.entries { ... pipe = &got.entries[i] }
if pipe == nil { t.Fatalf(...) }
if pipe.kind == "file" { ... }   // unreachable when pipe is nil
```

The dereference is unreachable, but seeing that requires knowing `t.Fatalf` does not return — a fact staticcheck reads from its analysis cache. With a cold or partial cache the check fires. Since golangci-lint is an enforced gate, the flake blocks merges at random, on PRs that have nothing to do with the code.

## What

Search by index and use the value, so there is no pointer to nil-check and the finding cannot appear at all:

```go
found := -1
for i := range got.entries { if got.entries[i].rel == "pipe" { found = i } }
if found < 0 { t.Fatalf(...) }
pipe := got.entries[found]
```

`treeEntry` is four strings and `Runner` is a small runner summary, so copying costs nothing and both keep reading exactly as before. `grep` confirms these two are the only places in the tree that take a pointer into a slice inside a test loop, so there is no third site left to flake.

## Verification

- `golangci-lint run ./...` (v2.12.2, same as CI) → 0 issues, warm and cold cache (`GOLANGCI_LINT_CACHE` pointed at an empty dir)
- `go test ./internal/assert/... ./internal/manifest/...` → ok

Once this is on main, #416 needs a rerun (or a Dependabot rebase) to pick it up.