### PR TITLE
docs(website): add comparison and migration guide backed by CI-tested parity suites

### DIFF
--- a/.github/workflows/migration.yml
+++ b/.github/workflows/migration.yml
@@ -1,0 +1,69 @@
+name: MigrationParity
+
+# Proof behind the website's migration guide (/migrate/): the original Bats
+# and ShellSpec suites under test/e2e/migration/{bats,shellspec} and the
+# migrated atago specs beside them describe the same behavior, so all three
+# must pass. The originals run under pinned releases of Bats and ShellSpec —
+# the exact versions the guide says it was verified against — and the
+# migrations run under the freshly built atago binary. If either side stops
+# passing, the guide has drifted from reality and this workflow says so.
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  parity:
+    # Fixed distro for the same reason thirdparty.yml uses one: a pinned tool
+    # comparison must not move when ubuntu-latest rolls over.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: "go.mod"
+
+      - name: Install Bats (pinned)
+        # The release the migration guide is written against. Bump this and
+        # website/content/migrate.md together.
+        run: |
+          git clone --depth 1 --branch v1.14.0 https://github.com/bats-core/bats-core.git "$RUNNER_TEMP/bats-core"
+          sudo "$RUNNER_TEMP/bats-core/install.sh" /usr/local
+
+      - name: Install ShellSpec (pinned)
+        # The release the migration guide is written against. Bump this and
+        # website/content/migrate.md together.
+        run: |
+          git clone --depth 1 --branch 0.28.1 https://github.com/shellspec/shellspec.git "$RUNNER_TEMP/shellspec"
+          sudo make -C "$RUNNER_TEMP/shellspec" install PREFIX=/usr/local
+
+      - name: Run the original Bats suite
+        run: bats test/e2e/migration/bats
+
+      - name: Run the original Bats suite filtered by tag
+        # The selection mapping (test_tags= / --filter-tags <-> tags: / --tag)
+        # must hold under filtering too, not only in a full run.
+        run: bats --filter-tags smoke test/e2e/migration/bats
+
+      - name: Run the original ShellSpec suite
+        working-directory: test/e2e/migration/shellspec
+        run: shellspec
+
+      - name: Build atago
+        run: go build -o ./dist/atago .
+
+      - name: Run the migrated atago specs
+        run: ./dist/atago run ./test/e2e/migration
+
+      - name: Run the migrated atago specs filtered by tag
+        run: ./dist/atago run --tag smoke ./test/e2e/migration

--- a/.github/workflows/migration.yml
+++ b/.github/workflows/migration.yml
@@ -34,17 +34,23 @@ jobs:
           go-version-file: "go.mod"
 
       - name: Install Bats (pinned)
-        # The release the migration guide is written against. Bump this and
-        # website/content/migrate.md together.
+        # Bats-core v1.14.0 — the release the migration guide is written
+        # against, fetched by immutable commit ID because a tag can move.
+        # Bump the SHA, the label, and website/content/migrate.md together.
         run: |
-          git clone --depth 1 --branch v1.14.0 https://github.com/bats-core/bats-core.git "$RUNNER_TEMP/bats-core"
+          git init "$RUNNER_TEMP/bats-core"
+          git -C "$RUNNER_TEMP/bats-core" fetch --depth 1 https://github.com/bats-core/bats-core.git eb7f42f8d608ac693d7a4b67474f6714ea68cfc5
+          git -C "$RUNNER_TEMP/bats-core" checkout --detach eb7f42f8d608ac693d7a4b67474f6714ea68cfc5
           sudo "$RUNNER_TEMP/bats-core/install.sh" /usr/local
 
       - name: Install ShellSpec (pinned)
-        # The release the migration guide is written against. Bump this and
-        # website/content/migrate.md together.
+        # ShellSpec 0.28.1 — the release the migration guide is written
+        # against, fetched by immutable commit ID because a tag can move.
+        # Bump the SHA, the label, and website/content/migrate.md together.
         run: |
-          git clone --depth 1 --branch 0.28.1 https://github.com/shellspec/shellspec.git "$RUNNER_TEMP/shellspec"
+          git init "$RUNNER_TEMP/shellspec"
+          git -C "$RUNNER_TEMP/shellspec" fetch --depth 1 https://github.com/shellspec/shellspec.git 90e48c950239f3b8a9fdfa3e869592872c77b981
+          git -C "$RUNNER_TEMP/shellspec" checkout --detach 90e48c950239f3b8a9fdfa3e869592872c77b981
           sudo make -C "$RUNNER_TEMP/shellspec" install PREFIX=/usr/local
 
       - name: Run the original Bats suite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Two website pages: a [comparison](https://nao1215.github.io/atago/comparison/)
+  with Bats-core v1.14.0, ShellSpec 0.28.1, commander v2.5.0, goss v0.4.10,
+  runn v1.9.4, and venom v1.3.0 (versions stated, sourced from official
+  documentation), and a [migration guide](https://nao1215.github.io/atago/migrate/)
+  mapping Bats and ShellSpec constructs to atago one-to-one. The guide is backed
+  by executable parity suites under `test/e2e/migration/` — the original Bats
+  and ShellSpec tests plus the migrated specs — run by the new MigrationParity
+  workflow under pinned releases of both tools, and drift tests keep every
+  snippet on the guide a verbatim excerpt of a file CI ran.
+
 ### Fixed
 
 - A pty step or `record --pty` no longer loses the output of a command that

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Pick the tool that owns your layer:
 
 If the server or the platform is the system under test, use runn or venom. atago points the other way: the CLI is the product, and HTTP, database, SSH, gRPC, browser, and mock servers appear only as peers your CLI talks to.
 
+A [feature-by-feature comparison](https://nao1215.github.io/atago/comparison/) states the versions compared and its sources, and the [migration guide](https://nao1215.github.io/atago/migrate/) maps Bats and ShellSpec constructs to atago one-to-one — every mapping runs in CI, originals and migrations both.
+
 ## Install
 
 ```shell

--- a/drift_test.go
+++ b/drift_test.go
@@ -695,3 +695,114 @@ func TestExamples_HermeticRunGreen(t *testing.T) {
 		})
 	}
 }
+
+// migrationFenceRe captures each fenced code block in the migration guide with
+// its language tag, so every excerpt can be checked against the file family it
+// claims to come from.
+var migrationFenceRe = regexp.MustCompile("(?s)```([a-z]+)\n(.*?)```")
+
+// migrationSourceFamilies maps a fence language in migrate.md to the committed
+// parity files its excerpts must be verbatim substrings of: ```bash is the Bats
+// suite, ```sh the ShellSpec suite, ```yaml the migrated atago specs. ```shell
+// blocks are free-form command lines and are not checked.
+func migrationSourceFamilies(t *testing.T) map[string][]string {
+	t.Helper()
+	families := map[string][]string{}
+	for lang, glob := range map[string]string{
+		"bash": "test/e2e/migration/bats/*.bats",
+		"sh":   "test/e2e/migration/shellspec/spec/*_spec.sh",
+		"yaml": "test/e2e/migration/*.atago.yaml",
+	} {
+		paths, err := filepath.Glob(glob)
+		if err != nil || len(paths) == 0 {
+			t.Fatalf("glob %s: %v (found %d files)", glob, err, len(paths))
+		}
+		families[lang] = paths
+	}
+	return families
+}
+
+// TestMigrationGuide_SnippetsAreExecutedExcerpts keeps the website's migration
+// guide honest: every Bats, ShellSpec, and atago snippet it shows must be a
+// verbatim excerpt of a committed file under test/e2e/migration/ — the files
+// the MigrationParity workflow actually runs. A snippet edited only in the
+// guide, or a parity file that drifts away from the guide, fails here instead
+// of quietly turning the page into fiction.
+func TestMigrationGuide_SnippetsAreExecutedExcerpts(t *testing.T) {
+	t.Parallel()
+	doc := readDoc(t, "website/content/migrate.md")
+	families := migrationSourceFamilies(t)
+	blocks := migrationFenceRe.FindAllStringSubmatch(doc, -1)
+	if len(blocks) == 0 {
+		t.Fatal("website/content/migrate.md contains no fenced code blocks")
+	}
+	checked := 0
+	for i, m := range blocks {
+		lang, body := m[1], m[2]
+		paths, guarded := families[lang]
+		if !guarded {
+			continue
+		}
+		checked++
+		found := false
+		for _, path := range paths {
+			if strings.Contains(readDoc(t, path), body) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("migrate.md block %d (```%s) is not a verbatim excerpt of any %s parity file:\n%s", i, lang, lang, body)
+		}
+	}
+	if checked == 0 {
+		t.Error("migrate.md has no bats/shellspec/atago snippets to guard; the fence languages may have drifted")
+	}
+}
+
+// TestMigrationGuide_PinsMatchWorkflow keeps the versions the migration guide
+// names in lockstep with the versions the MigrationParity workflow installs.
+// The guide's claim is "verified against Bats-core v1.14.0 and ShellSpec
+// 0.28.1"; that is only true while the workflow pins those same releases.
+func TestMigrationGuide_PinsMatchWorkflow(t *testing.T) {
+	t.Parallel()
+	guide := readDoc(t, "website/content/migrate.md")
+	workflow := readDoc(t, ".github/workflows/migration.yml")
+	for _, pin := range []struct{ name, workflowRef, guideRef string }{
+		{"Bats", "--branch v1.14.0 https://github.com/bats-core/bats-core.git", "Bats-core v1.14.0"},
+		{"ShellSpec", "--branch 0.28.1 https://github.com/shellspec/shellspec.git", "ShellSpec 0.28.1"},
+	} {
+		if !strings.Contains(workflow, pin.workflowRef) {
+			t.Errorf("migration.yml no longer pins %s as %q; update the guide and this test together", pin.name, pin.workflowRef)
+		}
+		if !strings.Contains(guide, pin.guideRef) {
+			t.Errorf("migrate.md no longer names %q; the guide must state the exact release the parity workflow runs", pin.guideRef)
+		}
+	}
+}
+
+// TestMigration_HermeticRunGreen executes every migrated spec behind the
+// migration guide through the real engine, on every platform the unit tests
+// cover — the Linux-only parity workflow proves the Bats/ShellSpec side, this
+// proves the atago side everywhere else. OS-gated scenarios may skip, but
+// nothing may fail or error.
+func TestMigration_HermeticRunGreen(t *testing.T) {
+	t.Parallel()
+	paths, err := filepath.Glob("test/e2e/migration/*.atago.yaml")
+	if err != nil || len(paths) == 0 {
+		t.Fatalf("glob migration specs: %v (found %d files)", err, len(paths))
+	}
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+			s, err := loader.Load(path)
+			if err != nil {
+				t.Fatalf("load: %v", err)
+			}
+			res := engine.New().Run(context.Background(), s, path)
+			if res.Status != engine.StatusPassed && res.Status != engine.StatusSkipped {
+				t.Errorf("status = %s, want passed (or skipped by an OS gate): %+v", res.Status, res.Scenarios)
+			}
+		})
+	}
+}

--- a/drift_test.go
+++ b/drift_test.go
@@ -761,19 +761,23 @@ func TestMigrationGuide_SnippetsAreExecutedExcerpts(t *testing.T) {
 }
 
 // TestMigrationGuide_PinsMatchWorkflow keeps the versions the migration guide
-// names in lockstep with the versions the MigrationParity workflow installs.
-// The guide's claim is "verified against Bats-core v1.14.0 and ShellSpec
-// 0.28.1"; that is only true while the workflow pins those same releases.
+// names in lockstep with what the MigrationParity workflow installs. The
+// workflow fetches by immutable commit ID (a tag can move) and keeps the
+// release label in a comment; the guide's claim "verified against Bats-core
+// v1.14.0 and ShellSpec 0.28.1" is only true while all three stay together.
 func TestMigrationGuide_PinsMatchWorkflow(t *testing.T) {
 	t.Parallel()
 	guide := readDoc(t, "website/content/migrate.md")
 	workflow := readDoc(t, ".github/workflows/migration.yml")
-	for _, pin := range []struct{ name, workflowRef, guideRef string }{
-		{"Bats", "--branch v1.14.0 https://github.com/bats-core/bats-core.git", "Bats-core v1.14.0"},
-		{"ShellSpec", "--branch 0.28.1 https://github.com/shellspec/shellspec.git", "ShellSpec 0.28.1"},
+	for _, pin := range []struct{ name, sha, label, guideRef string }{
+		{"Bats", "eb7f42f8d608ac693d7a4b67474f6714ea68cfc5", "v1.14.0", "Bats-core v1.14.0"},
+		{"ShellSpec", "90e48c950239f3b8a9fdfa3e869592872c77b981", "0.28.1", "ShellSpec 0.28.1"},
 	} {
-		if !strings.Contains(workflow, pin.workflowRef) {
-			t.Errorf("migration.yml no longer pins %s as %q; update the guide and this test together", pin.name, pin.workflowRef)
+		if !strings.Contains(workflow, pin.sha) {
+			t.Errorf("migration.yml no longer pins %s to commit %s; update the SHA, the label comment, and the guide together", pin.name, pin.sha)
+		}
+		if !strings.Contains(workflow, pin.label) {
+			t.Errorf("migration.yml no longer labels the %s pin as %s; the release label must stay next to the commit ID", pin.name, pin.label)
 		}
 		if !strings.Contains(guide, pin.guideRef) {
 			t.Errorf("migrate.md no longer names %q; the guide must state the exact release the parity workflow runs", pin.guideRef)
@@ -784,8 +788,10 @@ func TestMigrationGuide_PinsMatchWorkflow(t *testing.T) {
 // TestMigration_HermeticRunGreen executes every migrated spec behind the
 // migration guide through the real engine, on every platform the unit tests
 // cover — the Linux-only parity workflow proves the Bats/ShellSpec side, this
-// proves the atago side everywhere else. OS-gated scenarios may skip, but
-// nothing may fail or error.
+// proves the atago side everywhere else. Each scenario is checked
+// individually: gated scenarios may skip, but a suite-level "passed" that
+// hides a flaky, xfail, or xpass scenario is not good enough for the suites a
+// guide points at.
 func TestMigration_HermeticRunGreen(t *testing.T) {
 	t.Parallel()
 	paths, err := filepath.Glob("test/e2e/migration/*.atago.yaml")
@@ -801,7 +807,15 @@ func TestMigration_HermeticRunGreen(t *testing.T) {
 			}
 			res := engine.New().Run(context.Background(), s, path)
 			if res.Status != engine.StatusPassed && res.Status != engine.StatusSkipped {
-				t.Errorf("status = %s, want passed (or skipped by an OS gate): %+v", res.Status, res.Scenarios)
+				t.Errorf("status = %s, want passed (or skipped by a gate): %+v", res.Status, res.Scenarios)
+			}
+			if len(res.Scenarios) == 0 {
+				t.Error("spec produced no scenario results")
+			}
+			for _, sc := range res.Scenarios {
+				if sc.Status != engine.StatusPassed && sc.Status != engine.StatusSkipped {
+					t.Errorf("scenario %q: status = %s, want passed or skipped", sc.Name, sc.Status)
+				}
 			}
 		})
 	}

--- a/test/e2e/migration/README.md
+++ b/test/e2e/migration/README.md
@@ -1,0 +1,34 @@
+# Migration parity suites
+
+Backing tests for the website's [migration guide](https://nao1215.github.io/atago/migrate/).
+The same behavior is specified three times:
+
+- `bats/` — the original tests written for [Bats](https://github.com/bats-core/bats-core)
+- `shellspec/` — the original tests written for [ShellSpec](https://github.com/shellspec/shellspec)
+- `*.atago.yaml` — the migrated atago specs, one suite per topic
+
+CI (`.github/workflows/migration.yml`) runs all three: the originals under
+pinned releases of Bats and ShellSpec, the migrations under the freshly built
+atago binary. A mapping shown on the website therefore exists as executable
+code on both sides — if either side stops passing, the guide is wrong and CI
+says so. The hermetic drift test in `drift_test.go` additionally runs the
+atago specs through the engine on every platform the unit tests cover.
+
+The topics mirror the guide's sections:
+
+| Topic | Bats | ShellSpec | atago |
+|-------|------|-----------|-------|
+| exit code, stdout, stderr | `bats/basics.bats` | `shellspec/spec/basics_spec.sh` | `basics.atago.yaml` |
+| setup/teardown → fixtures, JSON | `bats/fixtures.bats` | `shellspec/spec/fixtures_spec.sh` | `fixtures_and_files.atago.yaml` |
+| parameterized tests → matrix | `bats/parameters.bats` | `shellspec/spec/parameters_spec.sh` | `matrix.atago.yaml` |
+| polling → retry | `bats/retry.bats` | `shellspec/spec/retry_spec.sh` | `retry.atago.yaml` |
+| skip and tags | `bats/selection.bats` | `shellspec/spec/selection_spec.sh` | `selection.atago.yaml` |
+| golden files → snapshots | `bats/snapshot.bats` | `shellspec/spec/snapshot_spec.sh` | `snapshot.atago.yaml` |
+
+Run them locally:
+
+```shell
+atago run ./test/e2e/migration                  # the migrated specs
+bats test/e2e/migration/bats                    # needs bats-core >= 1.8.0
+(cd test/e2e/migration/shellspec && shellspec)  # needs shellspec
+```

--- a/test/e2e/migration/bats/basics.bats
+++ b/test/e2e/migration/bats/basics.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+# Original Bats suite for the migration guide. Each @test here maps 1:1 to a
+# scenario in ../basics.atago.yaml; CI runs both (this file under a pinned
+# Bats, the atago spec under the freshly built binary) so the mapping the
+# website shows is executed, not asserted from memory.
+
+# `run -N`, `run !`, and --separate-stderr need Bats >= 1.5.0.
+bats_require_minimum_version 1.5.0
+
+@test "exit code success" {
+  run -0 echo hello
+}
+
+@test "exit code failure" {
+  run ! false
+}
+
+@test "an exact exit code" {
+  run -3 sh -c 'exit 3'
+}
+
+@test "stdout contains" {
+  run echo hello world
+  [[ "$output" == *world* ]]
+}
+
+@test "stdout equals" {
+  run echo exact
+  [ "$output" = "exact" ]
+}
+
+@test "stdout does not contain" {
+  run echo all good
+  [[ "$output" != *panic* ]]
+}
+
+@test "stdout matches a regex" {
+  run echo v1.2.3
+  [[ "$output" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]
+}
+
+@test "stderr contains" {
+  run --separate-stderr sh -c 'echo "warn: heads up" >&2'
+  [[ "$stderr" == *warn* ]]
+}
+
+@test "stderr is empty" {
+  run --separate-stderr echo quiet
+  [ -z "$stderr" ]
+}

--- a/test/e2e/migration/bats/fixtures.bats
+++ b/test/e2e/migration/bats/fixtures.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+# Original Bats suite for the migration guide: setup()/teardown() writing
+# scratch files, and JSON checked by piping through jq. Maps 1:1 to
+# ../fixtures_and_files.atago.yaml, where the same tests become a declarative
+# `fixture:` step (no teardown: every atago scenario gets a fresh temp workdir)
+# and JSONPath matchers (no jq dependency).
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  cd "$BATS_TEST_TMPDIR"
+  printf 'id,name\n1,Alice\n' > input.txt
+}
+
+teardown() {
+  rm -f input.txt output.txt
+}
+
+@test "a seeded input produces the expected output file" {
+  run -0 cp input.txt output.txt
+  [ -f output.txt ]
+  grep -q Alice output.txt
+}
+
+@test "json output asserted via jq, value captured and reused" {
+  run -0 sh -c "printf '%s' '{\"items\":[{\"id\":7,\"name\":\"Alice\"}],\"count\":1}' | jq -r '.items[0].name'"
+  [ "$output" = "Alice" ]
+  first_id="$(printf '%s' '{"items":[{"id":7,"name":"Alice"}],"count":1}' | jq -r '.items[0].id')"
+  run -0 echo "picked $first_id"
+  [[ "$output" == *"picked 7"* ]]
+}

--- a/test/e2e/migration/bats/parameters.bats
+++ b/test/e2e/migration/bats/parameters.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+# Original Bats suite for the migration guide: Bats has no built-in
+# parameterization, so the same test is written once per case (the documented
+# alternative is generating tests with bats_test_function). Maps to the single
+# `matrix:` scenario in ../matrix.atago.yaml, which expands one template into
+# one scenario per row.
+
+bats_require_minimum_version 1.5.0
+
+@test "greets Alice in en" {
+  run -0 echo "hello Alice (en)"
+  [[ "$output" == *Alice* && "$output" == *en* ]]
+}
+
+@test "greets Bob in fr" {
+  run -0 echo "hello Bob (fr)"
+  [[ "$output" == *Bob* && "$output" == *fr* ]]
+}

--- a/test/e2e/migration/bats/retry.bats
+++ b/test/e2e/migration/bats/retry.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+# Original Bats suite for the migration guide: polling is a hand-rolled loop
+# (Bats' own BATS_TEST_RETRIES re-runs the whole test, not the command). Maps
+# to the `run.retry` block in ../retry.atago.yaml, which re-runs the command
+# until an `until:` assertion passes.
+
+bats_require_minimum_version 1.5.0
+
+@test "poll until the command reports ready" {
+  for _ in 1 2 3 4 5; do
+    run echo ready
+    if [[ "$output" == *ready* ]]; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}

--- a/test/e2e/migration/bats/retry.bats
+++ b/test/e2e/migration/bats/retry.bats
@@ -1,14 +1,18 @@
 #!/usr/bin/env bats
 # Original Bats suite for the migration guide: polling is a hand-rolled loop
-# (Bats' own BATS_TEST_RETRIES re-runs the whole test, not the command). Maps
-# to the `run.retry` block in ../retry.atago.yaml, which re-runs the command
-# until an `until:` assertion passes.
+# (Bats' own BATS_TEST_RETRIES re-runs the whole test, not the command). The
+# probed command is stateful, like a service warming up: the first attempt
+# creates a marker and prints "waiting", the second prints "ready" — so the
+# loop genuinely iterates. Maps to the `run.retry` block in
+# ../retry.atago.yaml, which re-runs the command until an `until:` assertion
+# passes.
 
 bats_require_minimum_version 1.5.0
 
 @test "poll until the command reports ready" {
+  marker="$BATS_TEST_TMPDIR/marker"
   for _ in 1 2 3 4 5; do
-    run echo ready
+    run sh -c "if [ -f '$marker' ]; then echo ready; else touch '$marker'; echo waiting; fi"
     if [[ "$output" == *ready* ]]; then
       return 0
     fi

--- a/test/e2e/migration/bats/selection.bats
+++ b/test/e2e/migration/bats/selection.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+# Original Bats suite for the migration guide: `skip` calls and
+# `# bats test_tags=` comments (Bats >= 1.8.0), selected with
+# `bats --filter-tags`. Maps 1:1 to ../selection.atago.yaml, where the same
+# intent becomes declarative `skip:`/`only:` gates and `tags:` selected with
+# `atago run --tag` / `--skip-tag`.
+
+bats_require_minimum_version 1.8.0
+
+@test "runs only where a POSIX filesystem exists" {
+  if [ "$(uname)" = "Windows_NT" ]; then
+    skip "POSIX-only"
+  fi
+  run -0 test -d /
+}
+
+# bats test_tags=smoke
+@test "smoke-tagged, selectable with --filter-tags smoke" {
+  run -0 echo smoke ok
+  [[ "$output" == *ok* ]]
+}
+
+# bats test_tags=slow
+@test "slow-tagged, droppable with --filter-tags !slow" {
+  run -0 echo slow but still green
+}
+
+@test "runs only when an environment variable is set" {
+  if [ -z "${CI_ONLY_UNSET_MARKER:-}" ]; then
+    skip "CI_ONLY_UNSET_MARKER not set"
+  fi
+  run -0 echo would only run in CI
+}
+
+@test "skip decided by a probe command" {
+  if false; then
+    skip "probe matched"
+  fi
+  run -0 echo probe did not match, so we run
+}

--- a/test/e2e/migration/bats/snapshot.bats
+++ b/test/e2e/migration/bats/snapshot.bats
@@ -1,0 +1,13 @@
+#!/usr/bin/env bats
+# Original Bats suite for the migration guide: Bats has no snapshot testing,
+# so the golden compare is hand-rolled with diff against a committed file —
+# and refreshing it after an intended change is a manual edit. Maps to
+# ../snapshot.atago.yaml, where the same golden is a `snapshot:` matcher with
+# normalization and `atago snapshot update`.
+
+bats_require_minimum_version 1.5.0
+
+@test "stdout matches the committed golden file" {
+  run -0 echo "hello from atago"
+  diff <(printf '%s\n' "$output") "$BATS_TEST_DIRNAME/../snapshots/greeting.txt"
+}

--- a/test/e2e/migration/fixtures_and_files.atago.yaml
+++ b/test/e2e/migration/fixtures_and_files.atago.yaml
@@ -10,9 +10,10 @@ version: "1"
 # runn:      no per-CLI file fixtures.
 #
 # atago replaces imperative setup/teardown with a declarative `fixture` step
-# that seeds an input file into the scenario's isolated temp workdir. There is
-# NO teardown to write: every scenario runs in a fresh temp dir that atago
-# removes automatically. `file` assertions inspect what the command produced.
+# that seeds an input file into the scenario's isolated temp workdir. For
+# scratch files there is no teardown to write: every scenario runs in a fresh
+# temp dir that atago removes automatically (`teardown:` steps exist for
+# external state). `file` assertions inspect what the command produced.
 suite:
   name: migration / fixtures — setup files, generated files, JSON
 

--- a/test/e2e/migration/retry.atago.yaml
+++ b/test/e2e/migration/retry.atago.yaml
@@ -7,18 +7,20 @@ version: "1"
 # runn:      `loop:` with `until:` and `interval:` on a step.
 #
 # atago maps these to a `run.retry` block: re-run the command until an `until`
-# assertion passes (or the attempt budget is spent). The command below is
-# deterministic (prints "ready" immediately), so the first attempt satisfies
-# `until` and the scenario passes green without any real waiting.
+# assertion passes (or the attempt budget is spent). The command is stateful,
+# like a service warming up: the first attempt creates a marker file and
+# prints "waiting"; the second sees the marker and prints "ready" — so the
+# retry loop, its interval, and the `until` gate genuinely execute.
 suite:
   name: migration / retry — poll until ready
 
 scenarios:
   - name: retry re-runs the command until until passes
+    skip: { os: windows }        # the marker-file idiom below is POSIX shell
     steps:
       - run:
           shell: true
-          command: echo ready
+          command: "if [ -f marker ]; then echo ready; else touch marker; echo waiting; fi"
           retry:
             times: 5
             interval: 10ms

--- a/test/e2e/migration/shellspec/.shellspec
+++ b/test/e2e/migration/shellspec/.shellspec
@@ -1,0 +1,1 @@
+--format documentation

--- a/test/e2e/migration/shellspec/spec/basics_spec.sh
+++ b/test/e2e/migration/shellspec/spec/basics_spec.sh
@@ -1,0 +1,53 @@
+# Original ShellSpec suite for the migration guide. Each It here maps 1:1 to
+# a scenario in ../../basics.atago.yaml; CI runs both (this file under a
+# pinned ShellSpec, the atago spec under the freshly built binary) so the
+# mapping the website shows is executed, not asserted from memory.
+
+Describe 'migration basics'
+  It 'exit code success'
+    When run echo hello
+    The status should be success
+    The output should include "hello"
+  End
+
+  It 'exit code failure'
+    When run false
+    The status should be failure
+  End
+
+  It 'an exact exit code'
+    When run sh -c 'exit 3'
+    The status should equal 3
+  End
+
+  It 'stdout contains'
+    When run echo hello world
+    The output should include "world"
+  End
+
+  It 'stdout equals'
+    When run echo exact
+    The output should equal "exact"
+  End
+
+  It 'stdout does not contain'
+    When run echo all good
+    The output should not include "panic"
+  End
+
+  It 'stdout matches a pattern'
+    When run echo v1.2.3
+    The output should match pattern 'v[0-9]*.[0-9]*.[0-9]*'
+  End
+
+  It 'stderr contains'
+    When run sh -c 'echo "warn: heads up" >&2'
+    The error should include "warn"
+  End
+
+  It 'stderr is blank'
+    When run echo quiet
+    The output should include "quiet"
+    The error should be blank
+  End
+End

--- a/test/e2e/migration/shellspec/spec/fixtures_spec.sh
+++ b/test/e2e/migration/shellspec/spec/fixtures_spec.sh
@@ -1,0 +1,31 @@
+# Original ShellSpec suite for the migration guide: BeforeEach/AfterEach
+# helpers writing scratch files, and JSON checked by piping through jq. Maps
+# 1:1 to ../../fixtures_and_files.atago.yaml, where the same tests become a
+# declarative `fixture:` step (no cleanup: every atago scenario gets a fresh
+# temp workdir) and JSONPath matchers (no jq dependency).
+
+Describe 'migration fixtures'
+  work="$SHELLSPEC_TMPBASE/migration-fixtures"
+
+  seed_input() {
+    mkdir -p "$work" && printf 'id,name\n1,Alice\n' > "$work/input.txt"
+  }
+  remove_scratch() {
+    rm -rf "$work"
+  }
+
+  BeforeEach 'seed_input'
+  AfterEach 'remove_scratch'
+
+  It 'a seeded input produces the expected output file'
+    When run cp "$work/input.txt" "$work/output.txt"
+    The status should be success
+    The file "$work/output.txt" should be exist
+    The contents of file "$work/output.txt" should include "Alice"
+  End
+
+  It 'json output asserted via jq'
+    When run sh -c "printf '%s' '{\"items\":[{\"id\":7,\"name\":\"Alice\"}],\"count\":1}' | jq -r '.items[0].name'"
+    The output should equal "Alice"
+  End
+End

--- a/test/e2e/migration/shellspec/spec/parameters_spec.sh
+++ b/test/e2e/migration/shellspec/spec/parameters_spec.sh
@@ -1,0 +1,17 @@
+# Original ShellSpec suite for the migration guide: a Parameters block feeding
+# positional $1/$2 into one example. Maps to the single `matrix:` scenario in
+# ../../matrix.atago.yaml, which expands one template into one scenario per
+# row with each key available as ${name}.
+
+Describe 'migration parameters'
+  Parameters
+    Alice en
+    Bob   fr
+  End
+
+  It "greets $1 in $2"
+    When run echo "hello $1 ($2)"
+    The output should include "$1"
+    The output should include "$2"
+  End
+End

--- a/test/e2e/migration/shellspec/spec/retry_spec.sh
+++ b/test/e2e/migration/shellspec/spec/retry_spec.sh
@@ -1,19 +1,28 @@
 # Original ShellSpec suite for the migration guide: polling is a hand-rolled
-# while/sleep loop in a helper function. Maps to the `run.retry` block in
-# ../../retry.atago.yaml, which re-runs the command until an `until:`
-# assertion passes.
+# while/sleep loop in a helper function. The probed command is stateful, like
+# a service warming up: the first attempt creates a marker and prints
+# "waiting", the second prints "ready" — so the loop genuinely iterates. Maps
+# to the `run.retry` block in ../../retry.atago.yaml, which re-runs the
+# command until an `until:` assertion passes.
 
 Describe 'migration retry'
+  marker="$SHELLSPEC_TMPBASE/retry-marker"
+
+  probe() {
+    if [ -f "$marker" ]; then echo ready; else touch "$marker"; echo waiting; fi
+  }
   wait_until_ready() {
     i=0
     while [ "$i" -lt 5 ]; do
-      out=$(echo ready)
+      out=$(probe)
       case $out in (*ready*) return 0 ;; esac
       i=$((i + 1))
       sleep 1
     done
     return 1
   }
+  remove_marker() { rm -f "$marker"; }
+  AfterEach 'remove_marker'
 
   It 'polls until the command reports ready'
     When call wait_until_ready

--- a/test/e2e/migration/shellspec/spec/retry_spec.sh
+++ b/test/e2e/migration/shellspec/spec/retry_spec.sh
@@ -1,0 +1,22 @@
+# Original ShellSpec suite for the migration guide: polling is a hand-rolled
+# while/sleep loop in a helper function. Maps to the `run.retry` block in
+# ../../retry.atago.yaml, which re-runs the command until an `until:`
+# assertion passes.
+
+Describe 'migration retry'
+  wait_until_ready() {
+    i=0
+    while [ "$i" -lt 5 ]; do
+      out=$(echo ready)
+      case $out in (*ready*) return 0 ;; esac
+      i=$((i + 1))
+      sleep 1
+    done
+    return 1
+  }
+
+  It 'polls until the command reports ready'
+    When call wait_until_ready
+    The status should be success
+  End
+End

--- a/test/e2e/migration/shellspec/spec/selection_spec.sh
+++ b/test/e2e/migration/shellspec/spec/selection_spec.sh
@@ -1,0 +1,26 @@
+# Original ShellSpec suite for the migration guide: Skip if guards. Maps 1:1
+# to ../../selection.atago.yaml, where the same intent becomes declarative
+# `skip:`/`only:` gates and `tags:` selected with `atago run --tag` /
+# `--skip-tag`. (ShellSpec's own focusing/tagging lives in fIt/xIt and
+# example tags selected with --tag.)
+
+Describe 'migration selection'
+  It 'runs only where a POSIX filesystem exists'
+    Skip if "no POSIX filesystem" [ ! -d / ]
+    When run test -d /
+    The status should be success
+  End
+
+  It 'runs only when an environment variable is set'
+    Skip if "CI_ONLY_UNSET_MARKER not set" [ -z "${CI_ONLY_UNSET_MARKER:-}" ]
+    When run echo would only run in CI
+    The status should be success
+  End
+
+  It 'skip decided by a probe command'
+    Skip if "probe matched" false
+    When run echo probe did not match, so we run
+    The status should be success
+    The output should include "we run"
+  End
+End

--- a/test/e2e/migration/shellspec/spec/snapshot_spec.sh
+++ b/test/e2e/migration/shellspec/spec/snapshot_spec.sh
@@ -1,0 +1,12 @@
+# Original ShellSpec suite for the migration guide: ShellSpec has no snapshot
+# testing, so the golden compare is hand-rolled against a committed file — and
+# refreshing it after an intended change is a manual edit. Maps to
+# ../../snapshot.atago.yaml, where the same golden is a `snapshot:` matcher
+# with normalization and `atago snapshot update`.
+
+Describe 'migration snapshot'
+  It 'stdout matches the committed golden file'
+    When run echo "hello from atago"
+    The output should equal "$(cat "$SHELLSPEC_PROJECT_ROOT/../snapshots/greeting.txt")"
+  End
+End

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -45,6 +45,8 @@ Pick the tool that owns your layer:
 
 If the server or the platform is the system under test, use runn or venom. atago points the other way: the CLI is the product, and HTTP, database, SSH, gRPC, browser, and mock servers appear only as peers your CLI talks to.
 
+A [feature-by-feature comparison](/comparison/) states the versions compared and its sources, and the [migration guide](/migrate/) maps Bats and ShellSpec constructs to atago one-to-one — every mapping runs in CI, originals and migrations both.
+
 ## Record, don't write
 
 The first spec comes from a real run: `atago record -- <command>` executes the tool once and writes a spec from what it observed — exit code, output, created files. Interactive tools record too: `record --pty` runs in a real terminal, you drive one session by hand, and the keystrokes become a replayable expect/send script, with password prompts masked into `${env:...}` placeholders automatically. Then you edit YAML, not write it from scratch.

--- a/website/content/comparison.md
+++ b/website/content/comparison.md
@@ -1,0 +1,157 @@
+---
+toc: true
+title: Comparison
+description: How atago compares with Bats-core v1.14.0, ShellSpec 0.28.1, commander v2.5.0, goss v0.4.10, runn v1.9.4, and venom v1.3.0 — feature by feature, versions stated, sourced from official documentation.
+---
+
+Every tool here is good software, written by people who understood their
+problem well; several of them shaped how atago thinks about testing. This page
+exists to answer one practical question — *which tool owns which layer* — not
+to rank projects.
+
+Compared releases, checked on **2026-08-14** against each project's official
+documentation and release pages (linked under [Sources](#sources)):
+
+| Tool | Release compared | Released |
+|------|------------------|----------|
+| [atago](https://github.com/nao1215/atago) | v0.19.0 | 2026 |
+| [Bats-core](https://github.com/bats-core/bats-core) | v1.14.0 | 2026-07-21 |
+| [ShellSpec](https://github.com/shellspec/shellspec) | 0.28.1 | 2021-01-11 |
+| [commander](https://github.com/commander-cli/commander) | v2.5.0 | 2023-03-28 |
+| [goss](https://github.com/goss-org/goss) | v0.4.10 | 2026-07-26 |
+| [runn](https://github.com/k1LoW/runn) | v1.9.4 | 2026-06-30 |
+| [venom](https://github.com/ovh/venom) | v1.3.0 | 2026-01-06 |
+
+In the tables below, **—** means the compared release does not provide the
+feature itself, as far as its official documentation shows. If we got
+something wrong, please
+[open an issue](https://github.com/nao1215/atago/issues) — this page is meant
+to stay accurate, not flattering.
+
+## Tools that own a different layer
+
+atago does not compete with these, and where their layer is the system under
+test, they are the better choice:
+
+- **[runn](https://github.com/k1LoW/runn)** owns scenario-based **API
+  testing**. If the system under test is an HTTP/gRPC server, runn's
+  runners, OpenAPI awareness, and Go test-helper integration are built for
+  exactly that. atago points the other way: the CLI is the product, and
+  servers appear only as peers the CLI talks to.
+- **[venom](https://github.com/ovh/venom)** owns **platform integration
+  suites** — one test reaching across HTTP, gRPC, Kafka, AMQP, SQL, Redis,
+  and more through its executor catalog.
+- **[goss](https://github.com/goss-org/goss)** owns **server state
+  validation**: asserting that packages, services, ports, users, and mounts
+  on a host are what they should be, and serving that as a health endpoint.
+  Its `command` resource does check exit status and output, but validating a
+  provisioned machine is a different job from testing a CLI you are
+  developing. (goss is Linux-first; macOS and Windows support is alpha, per
+  its README.)
+
+## The same layer: black-box command testing
+
+Bats, ShellSpec, and commander overlap with atago directly: all four run a
+command and assert on what happened. The tables compare that shared job.
+Columns are atago v0.19.0, Bats-core v1.14.0, ShellSpec 0.28.1, and
+commander v2.5.0.
+
+### Writing and running tests
+
+| | atago | Bats | ShellSpec | commander |
+|---|---|---|---|---|
+| Tests are written in | YAML | Bash | shell DSL (POSIX) | YAML |
+| Ships as | single binary | shell scripts (needs Bash) | shell scripts (needs a POSIX shell) | single binary |
+| System under test | any executable | anything Bash can drive | shell scripts, functions, and commands | any executable |
+| Windows | native, incl. ConPTY terminals | via Bash ports (e.g. Git Bash) | Git Bash, msys2, cygwin | native |
+| Editor completion for the test format | JSON Schema | — | — | — |
+| Record a first test from a real run | `atago record`, incl. `--pty` | — | — | `commander add` |
+| Generate docs from tests | `atago doc` / `explain` / `list` | — | — | — |
+
+### Assertions
+
+| | atago | Bats | ShellSpec | commander |
+|---|---|---|---|---|
+| Exit code | exact, `not:`, `in:` | `run -N`, `run !`, `$status` | `The status should ...` | `exit-code` |
+| stdout / stderr as separate streams | always captured separately | `run --separate-stderr` | `The output` / `The error` | `stdout` / `stderr` |
+| contains / exact / regex | built in | Bash conditionals (richer via [bats-assert](https://github.com/bats-core/bats-assert)) | `include` / `equal` / `match pattern` | `contains` / `exactly` / `lines` / `line-count` / `not-contains` |
+| JSON output | JSONPath matchers built in | via `jq` | via `jq` | GJSON paths built in |
+| YAML output | built in | — | — | — |
+| XML output | — | — | — | XPath built in |
+| Files the command created | `file:` / `dir:` incl. recursive trees, permissions | via [bats-file](https://github.com/bats-core/bats-file) | file/path matchers built in | — (`file` compares output against a file) |
+| Exact set of files a run touched | `changes:` workdir diff | — | — | — |
+| Image / PDF content | format, dimensions, similarity / pages, text | — | — | — |
+| Wall-clock duration bounds | `duration:` | — (`--timing` reports only) | — | `timeout` limit only |
+
+### Interactive terminals and snapshots
+
+| | atago | Bats | ShellSpec | commander |
+|---|---|---|---|---|
+| PTY sessions (expect/send, named keys) | built in, Windows ConPTY too | — | — | — |
+| Asserts on the rendered screen (TUIs) | `screen:` / `expect_screen:` | — | — | — |
+| Snapshot testing with normalization and an update command | `snapshot:` + `atago snapshot update` | — (hand-written `diff`) | — (hand-written compare) | — |
+
+### Environment and test doubles
+
+| | atago | Bats | ShellSpec | commander |
+|---|---|---|---|---|
+| Isolated temp workdir per test | automatic, always | opt-in (`$BATS_TEST_TMPDIR`) | opt-in (`$SHELLSPEC_TMPBASE`) | `dir:` config |
+| Env isolation | `clear_env` / `pass_env` / `sandbox_home` | manual | manual | `inherit-env` toggle |
+| Mock HTTP servers with request asserts | built in | — | — | — |
+| Mock/stub shell functions and commands | — | community patterns (e.g. PATH shims) | built in | — |
+| Background services with readiness probes | built in | — | — | — |
+| Steps on other systems | db / ssh / grpc / browser | — | — | ssh and docker nodes |
+
+### Suite mechanics
+
+| | atago | Bats | ShellSpec | commander |
+|---|---|---|---|---|
+| Parameterized tests | `matrix:` | — (per-case, or `bats_test_function`) | `Parameters` | — |
+| Retry / polling | `retry:` re-runs the command until an assert passes | `$BATS_TEST_RETRIES` re-runs the whole test | — | `retries` + `interval` |
+| Tags and filtering | `tags:`, `--tag` / `--skip-tag` / `--filter` | `# bats test_tags=`, `--filter-tags` (v1.8+) | `--tag`, focus (`fIt`), patterns | test-name filter |
+| Parallel execution | `--parallel`, built in | `--jobs` (needs GNU parallel or rush) | built in | — |
+| A known bug tracked in CI | `expect_fail:` (XFAIL, red on XPASS) | — | `Pending` | — |
+| Flake detection | `--repeat`, `--retry-failed` reports flaky | — | — | — |
+| Coverage of shell scripts | — | — | kcov integration built in | — |
+| Report formats | console / JSON / JUnit / GHA / TAP | pretty / TAP / TAP13 / JUnit | documentation / TAP / JUnit / custom | — |
+
+## Where the others are the better choice
+
+An honest table needs the reverse direction spelled out:
+
+- **Bats** is the standard for testing Bash code, with over a decade of
+  history, active releases, and an ecosystem (bats-assert, bats-file,
+  bats-mock, bats-detik) that atago has no equivalent of. If your tests *are*
+  shell code — sourcing scripts, calling functions — Bats runs them
+  in-process; a black-box runner cannot.
+- **ShellSpec** is the most featureful shell unit-testing framework:
+  function and command mocking, parameterized examples, built-in parallel
+  runs, and kcov coverage. When shell scripts are the product, it is the
+  stronger tool; its released feature set has been stable since 2021.
+- **commander** shares atago's YAML approach in a smaller package, and has
+  XML assertions and a first-class docker execution node, which atago lacks.
+- **goss / runn / venom** own their layers outright, as described
+  [above](#tools-that-own-a-different-layer).
+
+atago is also the youngest project on this page and still pre-1.0. The spec
+format is versioned and every feature ships with a runnable, CI-tested
+example, but the others have years more production mileage — that counts for
+something, and pretending otherwise would defeat the point of this page.
+
+If the table convinced you to try a migration, the
+[migration guide](/migrate/) maps Bats and ShellSpec constructs to atago
+one-to-one — and every mapping on that page runs in CI, originals and
+migrations both.
+
+## Sources
+
+Feature claims come from each project's official documentation for the
+release stated above:
+
+- Bats-core: [writing tests](https://bats-core.readthedocs.io/en/stable/writing-tests.html), [usage](https://bats-core.readthedocs.io/en/stable/usage.html), [releases](https://github.com/bats-core/bats-core/releases)
+- ShellSpec: [shellspec.info](https://shellspec.info/), [README](https://github.com/shellspec/shellspec), [releases](https://github.com/shellspec/shellspec/releases)
+- commander: [README](https://github.com/commander-cli/commander), [releases](https://github.com/commander-cli/commander/releases)
+- goss: [README](https://github.com/goss-org/goss), [releases](https://github.com/goss-org/goss/releases)
+- runn: [README](https://github.com/k1LoW/runn), [releases](https://github.com/k1LoW/runn/releases)
+- venom: [README](https://github.com/ovh/venom), [releases](https://github.com/ovh/venom/releases)
+- atago: the [reference](/reference/) and the [runnable examples](/cookbook/#every-feature-has-a-runnable-spec) behind every claim

--- a/website/content/migrate.md
+++ b/website/content/migrate.md
@@ -1,0 +1,465 @@
+---
+toc: true
+title: Migrating from Bats or ShellSpec
+description: Side-by-side mappings from Bats and ShellSpec tests to atago specs. Every pair on this page is committed to the repository and both sides run in CI, so the guide cannot drift from what actually works.
+---
+
+Bats and ShellSpec are mature, well-designed frameworks, and if they fit your
+suite there is no reason to leave. This guide is for one specific situation:
+the thing under test is a **compiled binary** and the shell code around it
+exists only to run that binary and inspect what happened. That layer is
+atago's job, and the mappings below show what each familiar construct becomes.
+
+Everything on this page is executable. The original Bats and ShellSpec suites
+live at [test/e2e/migration](https://github.com/nao1215/atago/blob/main/test/e2e/migration/)
+next to the migrated atago specs, and the
+[MigrationParity workflow](https://github.com/nao1215/atago/blob/main/.github/workflows/migration.yml)
+runs all three on every push: the originals under pinned **Bats-core v1.14.0**
+and **ShellSpec 0.28.1**, the migrations under the freshly built atago binary.
+A snippet you read here is an excerpt of a file CI ran.
+
+For a feature-by-feature table (including what Bats and ShellSpec do that
+atago does not), see the [comparison](/comparison/).
+
+## The cheat sheet
+
+| Bats | ShellSpec | atago |
+|------|-----------|-------|
+| `run cmd` + `[ "$status" -eq 0 ]` / `run -N` | `When run cmd` + `The status should ...` | `run:` step + `assert: exit_code:` |
+| `[[ "$output" == *x* ]]` / `assert_output --partial` | `The output should include "x"` | `stdout: {contains: x}` |
+| `[ "$output" = "x" ]` / `assert_output` | `The output should equal "x"` | `stdout: {equals: x}` |
+| `[[ "$output" =~ regex ]]` | `The output should match pattern` | `stdout: {matches: regex}` |
+| `run --separate-stderr` + `$stderr` | `The error should include` | `stderr: {contains: ...}` |
+| `setup()` / `teardown()` | `BeforeEach` / `AfterEach` | `fixture:` step; teardown does not exist (fresh temp workdir per scenario) |
+| pipe to `jq` | pipe to `jq` | `stdout: {json: {path: ...}}` |
+| one `@test` per case | `Parameters` block | `matrix:` |
+| retry loop in bash | retry loop in a helper | `run.retry` with `until:` |
+| `skip "reason"` | `Skip if "reason" cmd` | `skip:` / `only:` gates |
+| `# bats test_tags=` + `--filter-tags` | `--tag` | `tags:` + `--tag` / `--skip-tag` |
+| `diff` against a committed file | `should equal "$(cat golden)"` | `snapshot:` + `atago snapshot update` |
+
+## Exit codes, stdout, stderr
+
+The everyday assertions translate one to one. In Bats:
+
+```bash
+@test "an exact exit code" {
+  run -3 sh -c 'exit 3'
+}
+
+@test "stdout contains" {
+  run echo hello world
+  [[ "$output" == *world* ]]
+}
+```
+
+In ShellSpec:
+
+```sh
+  It 'an exact exit code'
+    When run sh -c 'exit 3'
+    The status should equal 3
+  End
+
+  It 'stdout contains'
+    When run echo hello world
+    The output should include "world"
+  End
+```
+
+In atago, each becomes a scenario with a `run:` step and declarative asserts
+([basics.atago.yaml](https://github.com/nao1215/atago/blob/main/test/e2e/migration/basics.atago.yaml)):
+
+```yaml
+  # ShellSpec: The status should equal 3
+  # Bats:      [ "$status" -eq 3 ]
+  - name: an exact exit code maps to exit_code N
+    skip: { os: windows }        # `exit N` phrasing below is POSIX shell
+    steps:
+      - run:
+          shell: true
+          command: "exit 3"
+      - assert:
+          exit_code: 3
+
+  # ShellSpec: The output should include "world"
+  # Bats:      assert_output --partial world
+  # runn:      test: current.res.body contains "world"
+  - name: stdout contains maps to a substring match
+    steps:
+      - run:
+          shell: true
+          command: echo hello world
+      - assert:
+          stdout:
+            contains: world
+```
+
+stderr is a separate stream. Bats needs `run --separate-stderr`; ShellSpec has
+`The error`; atago always captures the two streams independently:
+
+```bash
+@test "stderr contains" {
+  run --separate-stderr sh -c 'echo "warn: heads up" >&2'
+  [[ "$stderr" == *warn* ]]
+}
+```
+
+```yaml
+  # ShellSpec: The error should include "warn"
+  # Bats:      run --separate-stderr; assert_stderr --partial warn
+  - name: stderr contains maps to a stderr substring match
+    skip: { os: windows }        # `>&2` redirect is POSIX-only
+    steps:
+      - run:
+          shell: true
+          command: "echo warn: heads up >&2"
+      - assert:
+          stderr:
+            contains: warn
+```
+
+## setup/teardown become fixtures — and teardown disappears
+
+A Bats `setup()` writes input files and `teardown()` removes them:
+
+```bash
+setup() {
+  cd "$BATS_TEST_TMPDIR"
+  printf 'id,name\n1,Alice\n' > input.txt
+}
+
+teardown() {
+  rm -f input.txt output.txt
+}
+
+@test "a seeded input produces the expected output file" {
+  run -0 cp input.txt output.txt
+  [ -f output.txt ]
+  grep -q Alice output.txt
+}
+```
+
+ShellSpec does the same with `BeforeEach`/`AfterEach` helpers:
+
+```sh
+  seed_input() {
+    mkdir -p "$work" && printf 'id,name\n1,Alice\n' > "$work/input.txt"
+  }
+  remove_scratch() {
+    rm -rf "$work"
+  }
+
+  BeforeEach 'seed_input'
+  AfterEach 'remove_scratch'
+
+  It 'a seeded input produces the expected output file'
+    When run cp "$work/input.txt" "$work/output.txt"
+    The status should be success
+    The file "$work/output.txt" should be exist
+    The contents of file "$work/output.txt" should include "Alice"
+  End
+```
+
+In atago the setup is a declarative `fixture:` step, and there is no teardown
+to write: every scenario runs in its own temp workdir that atago removes
+([fixtures_and_files.atago.yaml](https://github.com/nao1215/atago/blob/main/test/e2e/migration/fixtures_and_files.atago.yaml)):
+
+```yaml
+  # BeforeEach writes input.txt -> fixture step. The command consumes it and
+  # writes an output; we assert on the produced file instead of a teardown rm.
+  - name: a fixture seeds input and a file assertion checks the output
+    skip: { os: windows }        # cp/redirect below are POSIX-only
+    steps:
+      - fixture:
+          file: input.txt
+          content: |
+            id,name
+            1,Alice
+      - run:
+          shell: true
+          command: "cp input.txt output.txt"
+      - assert:
+          file:
+            path: output.txt
+            exists: true
+      - assert:
+          file:
+            path: output.txt
+            contains: Alice
+```
+
+## jq pipelines become JSONPath matchers
+
+Both Bats and ShellSpec suites commonly shell out to `jq`:
+
+```bash
+@test "json output asserted via jq, value captured and reused" {
+  run -0 sh -c "printf '%s' '{\"items\":[{\"id\":7,\"name\":\"Alice\"}],\"count\":1}' | jq -r '.items[0].name'"
+  [ "$output" = "Alice" ]
+  first_id="$(printf '%s' '{"items":[{"id":7,"name":"Alice"}],"count":1}' | jq -r '.items[0].id')"
+  run -0 echo "picked $first_id"
+  [[ "$output" == *"picked 7"* ]]
+}
+```
+
+atago asserts JSON by path without an external tool, and `store:` replaces the
+`var=$(... | jq)` capture:
+
+```yaml
+      - assert:
+          stdout:
+            json:
+              path: "$.items[0].name"
+              equals: Alice
+      - assert:
+          stdout:
+            json:
+              path: "$.count"
+              gte: 1
+      # ShellSpec/Bats would capture with `id=$(... | jq)`. atago's `store`
+      # binds a captured value into ${name} for a later step — declaratively.
+      - store:
+          name: first_id
+          from:
+            stdout:
+              json:
+                path: "$.items[0].id"
+      - run:
+          shell: true
+          command: echo "picked ${first_id}"
+      - assert:
+          stdout:
+            contains: "picked 7"
+```
+
+## Parameterized tests become a matrix
+
+Bats has no built-in parameterization, so the same test is written once per
+case (or generated with `bats_test_function`):
+
+```bash
+@test "greets Alice in en" {
+  run -0 echo "hello Alice (en)"
+  [[ "$output" == *Alice* && "$output" == *en* ]]
+}
+
+@test "greets Bob in fr" {
+  run -0 echo "hello Bob (fr)"
+  [[ "$output" == *Bob* && "$output" == *fr* ]]
+}
+```
+
+ShellSpec's `Parameters` block — a genuinely nice feature — feeds positional
+parameters into one example:
+
+```sh
+  Parameters
+    Alice en
+    Bob   fr
+  End
+
+  It "greets $1 in $2"
+    When run echo "hello $1 ($2)"
+    The output should include "$1"
+    The output should include "$2"
+  End
+```
+
+atago's `matrix:` expands one template scenario into one concrete scenario per
+row, each key available as `${name}`
+([matrix.atago.yaml](https://github.com/nao1215/atago/blob/main/test/e2e/migration/matrix.atago.yaml)):
+
+```yaml
+  - name: "greets ${who} in ${lang}"
+    matrix:
+      - { who: Alice, lang: en }
+      - { who: Bob,   lang: fr }
+    steps:
+      - run:
+          shell: true
+          command: echo "hello ${who} (${lang})"
+      - assert:
+          stdout:
+            contains:
+              - ${who}
+              - ${lang}
+```
+
+## Polling loops become retry
+
+Waiting for an async result is a hand-written loop in shell:
+
+```bash
+@test "poll until the command reports ready" {
+  for _ in 1 2 3 4 5; do
+    run echo ready
+    if [[ "$output" == *ready* ]]; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+```
+
+atago re-runs the command until an `until:` assertion passes, with the
+attempt budget and interval declared
+([retry.atago.yaml](https://github.com/nao1215/atago/blob/main/test/e2e/migration/retry.atago.yaml)):
+
+```yaml
+  - name: retry re-runs the command until until passes
+    steps:
+      - run:
+          shell: true
+          command: echo ready
+          retry:
+            times: 5
+            interval: 10ms
+            until:
+              stdout:
+                contains: ready
+      - assert:
+          stdout:
+            contains: ready
+```
+
+(Bats' own `BATS_TEST_RETRIES` re-runs the whole test on failure — useful, but
+a different tool: it is for flaky tests, not for polling.)
+
+## skip and tags become declarative gates
+
+Bats skips imperatively and tags with comments:
+
+```bash
+# bats test_tags=smoke
+@test "smoke-tagged, selectable with --filter-tags smoke" {
+  run -0 echo smoke ok
+  [[ "$output" == *ok* ]]
+}
+
+# bats test_tags=slow
+@test "slow-tagged, droppable with --filter-tags !slow" {
+  run -0 echo slow but still green
+}
+```
+
+ShellSpec's `Skip if` takes a reason and a probe command:
+
+```sh
+  It 'runs only when an environment variable is set'
+    Skip if "CI_ONLY_UNSET_MARKER not set" [ -z "${CI_ONLY_UNSET_MARKER:-}" ]
+    When run echo would only run in CI
+    The status should be success
+  End
+```
+
+atago's gates are data, so `atago explain` and `atago list` can show them
+without running anything
+([selection.atago.yaml](https://github.com/nao1215/atago/blob/main/test/e2e/migration/selection.atago.yaml)):
+
+```yaml
+  # ShellSpec: Skip if "not linux" ... ; Bats: skip on non-linux
+  # atago: skip: { os: windows } declaratively skips POSIX-only scenarios.
+  - name: skip on an OS maps to skip os
+    skip: { os: windows }
+    steps:
+      - run:
+          shell: true
+          command: "test -d /"        # POSIX filesystem probe
+      - assert:
+          exit_code: 0
+
+  # ShellSpec: fIt / Bats: bats --filter-tags smoke
+  # atago: tag a scenario, then `atago run --tag smoke` to focus on it.
+  - name: a smoke-tagged scenario is selectable with --tag
+    tags: [smoke]
+    steps:
+      - run:
+          shell: true
+          command: echo smoke ok
+      - assert:
+          stdout:
+            contains: ok
+```
+
+The CI parity workflow runs the tag filters too: `bats --filter-tags smoke`
+and `atago run --tag smoke` select the same test on both sides.
+
+## Hand-maintained goldens become snapshots
+
+Neither Bats nor ShellSpec ships snapshot testing, so a golden compare is
+written by hand and refreshed by editing the file:
+
+```bash
+@test "stdout matches the committed golden file" {
+  run -0 echo "hello from atago"
+  diff <(printf '%s\n' "$output") "$BATS_TEST_DIRNAME/../snapshots/greeting.txt"
+}
+```
+
+```sh
+  It 'stdout matches the committed golden file'
+    When run echo "hello from atago"
+    The output should equal "$(cat "$SHELLSPEC_PROJECT_ROOT/../snapshots/greeting.txt")"
+  End
+```
+
+atago's `snapshot:` matcher compares against the same kind of committed file,
+but normalizes ANSI colors, temp paths, UUIDs, timestamps, ports, and CRLF so
+the golden is stable across machines — and `atago snapshot update` refreshes
+every intentionally changed golden in one command
+([snapshot.atago.yaml](https://github.com/nao1215/atago/blob/main/test/e2e/migration/snapshot.atago.yaml)):
+
+```yaml
+  - name: stdout matches a committed snapshot
+    steps:
+      - run:
+          shell: true
+          command: echo hello from atago
+      - assert:
+          stdout:
+            snapshot: snapshots/greeting.txt
+```
+
+## What has no source to migrate from
+
+Some atago features have no Bats/ShellSpec counterpart, so after the port they
+are simply new capability: `pty:` sessions for interactive prompts and TUIs,
+`expect_screen:`/`screen:` asserts on the rendered terminal frame, `changes:`
+for the exact set of files a command touched, `mock_servers:` for offline API
+simulation, `services:` with readiness probes, and `atago record` to turn a
+real run into a first spec. The [cookbook](/cookbook/) has a runnable recipe
+for each.
+
+## What should stay where it is
+
+Migrate the black-box layer, not everything. Bats and ShellSpec remain the
+right tool for what they were built for:
+
+- **Unit tests of shell functions.** Both frameworks run shell code
+  in-process and assert on it directly. atago only ever executes a program,
+  so it cannot see inside your shell scripts.
+- **Mocking shell internals.** ShellSpec's function and command mocks have no
+  atago equivalent — atago's mocks are external HTTP servers, a different
+  axis.
+- **Coverage of shell scripts.** ShellSpec measures kcov coverage for shell
+  code; a black-box runner cannot.
+
+If your repository has both kinds of tests, keeping ShellSpec for the shell
+library and moving the CLI contract tests to atago is a reasonable end state —
+it is exactly how atago's own third-party suites were migrated.
+
+## Migrate incrementally
+
+Both runners coexist happily in one CI job, so port one file at a time:
+
+```shell
+bats test/                       # the suite you are migrating from
+atago run ./specs                # the part that has moved
+```
+
+Start by recording a real run (`atago record -- mytool ...`) instead of
+writing YAML from scratch, then tighten the generated spec with the mappings
+above. [Use it in CI](/ci/) shows the GitHub Actions wiring, including
+`--report junit` if your CI already consumes Bats' JUnit output.

--- a/website/content/migrate.md
+++ b/website/content/migrate.md
@@ -14,7 +14,8 @@ Everything on this page is executable. The original Bats and ShellSpec suites
 live at [test/e2e/migration](https://github.com/nao1215/atago/blob/main/test/e2e/migration/)
 next to the migrated atago specs, and the
 [MigrationParity workflow](https://github.com/nao1215/atago/blob/main/.github/workflows/migration.yml)
-runs all three on every push: the originals under pinned **Bats-core v1.14.0**
+runs all three on every pull request and on every push to `main`: the
+originals under pinned **Bats-core v1.14.0**
 and **ShellSpec 0.28.1**, the migrations under the freshly built atago binary.
 A snippet you read here is an excerpt of a file CI ran.
 
@@ -30,7 +31,7 @@ atago does not), see the [comparison](/comparison/).
 | `[ "$output" = "x" ]` / `assert_output` | `The output should equal "x"` | `stdout: {equals: x}` |
 | `[[ "$output" =~ regex ]]` | `The output should match pattern` | `stdout: {matches: regex}` |
 | `run --separate-stderr` + `$stderr` | `The error should include` | `stderr: {contains: ...}` |
-| `setup()` / `teardown()` | `BeforeEach` / `AfterEach` | `fixture:` step; teardown does not exist (fresh temp workdir per scenario) |
+| `setup()` / `teardown()` | `BeforeEach` / `AfterEach` | `fixture:` step; scratch-file cleanup is automatic (fresh temp workdir per scenario) |
 | pipe to `jq` | pipe to `jq` | `stdout: {json: {path: ...}}` |
 | one `@test` per case | `Parameters` block | `matrix:` |
 | retry loop in bash | retry loop in a helper | `run.retry` with `until:` |
@@ -119,7 +120,7 @@ stderr is a separate stream. Bats needs `run --separate-stderr`; ShellSpec has
             contains: warn
 ```
 
-## setup/teardown become fixtures — and teardown disappears
+## setup/teardown become fixtures — and file cleanup disappears
 
 A Bats `setup()` writes input files and `teardown()` removes them:
 
@@ -161,9 +162,13 @@ ShellSpec does the same with `BeforeEach`/`AfterEach` helpers:
   End
 ```
 
-In atago the setup is a declarative `fixture:` step, and there is no teardown
-to write: every scenario runs in its own temp workdir that atago removes
-([fixtures_and_files.atago.yaml](https://github.com/nao1215/atago/blob/main/test/e2e/migration/fixtures_and_files.atago.yaml)):
+In atago the setup is a declarative `fixture:` step, and for scratch files
+there is no teardown to write: every scenario runs in its own temp workdir
+that atago removes. (`teardown:` steps do exist — they are for external state
+a workdir cannot carry away, like database rows or remote resources; see
+[the cookbook](/cookbook/#clean-up-external-state-even-when-a-step-fails).)
+From
+[fixtures_and_files.atago.yaml](https://github.com/nao1215/atago/blob/main/test/e2e/migration/fixtures_and_files.atago.yaml):
 
 ```yaml
   # BeforeEach writes input.txt -> fixture step. The command consumes it and
@@ -288,12 +293,16 @@ row, each key available as `${name}`
 
 ## Polling loops become retry
 
-Waiting for an async result is a hand-written loop in shell:
+Waiting for an async result is a hand-written loop in shell. The probed
+command here is stateful, like a service warming up — the first attempt
+creates a marker and prints "waiting", the second prints "ready" — so the
+loop genuinely iterates:
 
 ```bash
 @test "poll until the command reports ready" {
+  marker="$BATS_TEST_TMPDIR/marker"
   for _ in 1 2 3 4 5; do
-    run echo ready
+    run sh -c "if [ -f '$marker' ]; then echo ready; else touch '$marker'; echo waiting; fi"
     if [[ "$output" == *ready* ]]; then
       return 0
     fi
@@ -303,16 +312,18 @@ Waiting for an async result is a hand-written loop in shell:
 }
 ```
 
-atago re-runs the command until an `until:` assertion passes, with the
-attempt budget and interval declared
+atago re-runs the same stateful command until an `until:` assertion passes,
+with the attempt budget and interval declared — the first attempt prints
+"waiting", the retry sees "ready"
 ([retry.atago.yaml](https://github.com/nao1215/atago/blob/main/test/e2e/migration/retry.atago.yaml)):
 
 ```yaml
   - name: retry re-runs the command until until passes
+    skip: { os: windows }        # the marker-file idiom below is POSIX shell
     steps:
       - run:
           shell: true
-          command: echo ready
+          command: "if [ -f marker ]; then echo ready; else touch marker; echo waiting; fi"
           retry:
             times: 5
             interval: 10ms

--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -36,6 +36,16 @@ pageRef = "/cookbook"
 weight = 30
 
 [[menus.main]]
+name = "Compare"
+pageRef = "/comparison"
+weight = 38
+
+[[menus.main]]
+name = "Migrate"
+pageRef = "/migrate"
+weight = 42
+
+[[menus.main]]
 name = "CI"
 pageRef = "/ci"
 weight = 50


### PR DESCRIPTION
## Summary

Adds two pages to the documentation site: a feature-by-feature comparison with Bats-core v1.14.0, ShellSpec 0.28.1, commander v2.5.0, goss v0.4.10, runn v1.9.4, and venom v1.3.0 (versions stated, claims sourced from each project's official documentation), and a migration guide mapping Bats and ShellSpec constructs to atago one-to-one. The guide is not prose alone: the original Bats and ShellSpec suites and the migrated atago specs are committed side by side and all three run in CI, so every mapping the site shows is executed.

## Changes

- `website/content/comparison.md` — the comparison page: tools that own a different layer (runn, venom, goss) are conceded up front, the shared black-box layer (Bats, ShellSpec, commander) gets grouped feature tables, and a "where the others are the better choice" section spells out the reverse direction (in-process shell testing, ShellSpec's mocking and kcov coverage, commander's XML asserts and docker node).
- `website/content/migrate.md` — the migration guide: cheat sheet plus side-by-side sections for exit codes/stdout/stderr, setup/teardown → fixtures, jq → JSONPath, parameters → matrix, polling → retry, skip/tags, and hand-maintained goldens → snapshots, ending with what should stay in Bats/ShellSpec.
- `test/e2e/migration/bats/*.bats`, `test/e2e/migration/shellspec/` — the original suites the guide migrates from, mirroring the existing `*.atago.yaml` specs topic by topic; `test/e2e/migration/README.md` documents the layout.
- `.github/workflows/migration.yml` — new MigrationParity workflow: runs the originals under pinned Bats v1.14.0 and ShellSpec 0.28.1 (the releases the guide names), then the migrated specs under the freshly built binary, including a tag-filtered run on both sides.
- `drift_test.go` — three new guards: every bats/sh/yaml snippet in migrate.md must be a verbatim excerpt of a committed parity file, the versions the guide names must match the workflow's pins, and the migrated specs must run green through the engine on every unit-test platform.
- `website/hugo.toml`, `website/content/_index.md`, `README.md`, `CHANGELOG.md` — menu entries and one-sentence links to the new pages.

## Design Decisions

- The migration suites are committed and run rather than quoted, because a migration guide whose examples nobody executes rots silently; the drift tests make the page an index into tested files instead of parallel content.
- Bats and ShellSpec are installed from their release tags at pinned versions in a fixed `ubuntu-24.04` job, following the pinning convention `thirdparty.yml` established, and a drift test keeps the pins and the guide's stated versions in lockstep.
- The comparison concedes ground explicitly (runn/venom/goss own their layers; commander has XML asserts and a docker node atago lacks; Bats/ShellSpec own in-process shell testing) and marks every "—" as "not in the compared release's official documentation", with an invitation to file an issue — the page is meant to stay accurate, not flattering.

## Limitations

- The parity workflow runs on Linux only; the atago side of the mapping is additionally covered cross-platform by the hermetic drift test, but the Bats/ShellSpec originals are only exercised where those tools are canonical.
- Version numbers on the comparison page are a snapshot (checked 2026-08-14) and will need refreshing as upstream projects release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added website pages comparing atago with other command-testing tools and guiding Bats/ShellSpec migrations.
  - Added navigation and README links to the new resources.
  - Documented mappings for assertions, fixtures, retries, snapshots, skips, tags, and incremental migration.

- **Tests**
  - Added executable parity suites covering common migration scenarios.
  - Added automated checks to keep documentation examples and version references aligned with tested behavior.
  - Added CI coverage for original and migrated test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->