### PR TITLE
docs: plain-style pass and CI-setup comparison row

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Documentation: **https://nao1215.github.io/atago/**
 
 ![demo](./doc/img/demo.gif)
 
-## Try it in 30 seconds
+## First run
 
 No install, no fictional binary — if you have Go, paste this. It records a real
 run of a command you already have, then replays it as a test:

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -6,7 +6,7 @@ atago tests real CLI behavior from plain YAML: commands, files, snapshots, servi
 
 ![atago running a spec suite](/img/demo.gif)
 
-## Try it in 30 seconds
+## First run
 
 No install, no fictional binary — if you have Go, paste this. It records a real run of a command you already have, then replays it as a test:
 

--- a/website/content/comparison.md
+++ b/website/content/comparison.md
@@ -9,7 +9,7 @@ problem well; several of them shaped how atago thinks about testing. This page
 exists to answer one practical question — *which tool owns which layer* — not
 to rank projects.
 
-Compared releases, checked on **2026-08-14** against each project's official
+Compared releases, checked on 2026-08-14 against each project's official
 documentation and release pages (linked under [Sources](#sources)):
 
 | Tool | Release compared | Released |
@@ -22,7 +22,7 @@ documentation and release pages (linked under [Sources](#sources)):
 | [runn](https://github.com/k1LoW/runn) | v1.9.4 | 2026-06-30 |
 | [venom](https://github.com/ovh/venom) | v1.3.0 | 2026-01-06 |
 
-In the tables below, **—** means the compared release does not provide the
+In the tables below, — means the compared release does not provide the
 feature itself, as far as its official documentation shows. If we got
 something wrong, please
 [open an issue](https://github.com/nao1215/atago/issues) — this page is meant
@@ -33,16 +33,16 @@ to stay accurate, not flattering.
 atago does not compete with these, and where their layer is the system under
 test, they are the better choice:
 
-- **[runn](https://github.com/k1LoW/runn)** owns scenario-based **API
-  testing**. If the system under test is an HTTP/gRPC server, runn's
+- [runn](https://github.com/k1LoW/runn) owns scenario-based API
+  testing. If the system under test is an HTTP/gRPC server, runn's
   runners, OpenAPI awareness, and Go test-helper integration are built for
   exactly that. atago points the other way: the CLI is the product, and
   servers appear only as peers the CLI talks to.
-- **[venom](https://github.com/ovh/venom)** owns **platform integration
-  suites** — one test reaching across HTTP, gRPC, Kafka, AMQP, SQL, Redis,
+- [venom](https://github.com/ovh/venom) owns platform integration
+  suites — one test reaching across HTTP, gRPC, Kafka, AMQP, SQL, Redis,
   and more through its executor catalog.
-- **[goss](https://github.com/goss-org/goss)** owns **server state
-  validation**: asserting that packages, services, ports, users, and mounts
+- [goss](https://github.com/goss-org/goss) owns server state
+  validation: asserting that packages, services, ports, users, and mounts
   on a host are what they should be, and serving that as a health endpoint.
   Its `command` resource does check exit status and output, but validating a
   provisioned machine is a different job from testing a CLI you are
@@ -119,18 +119,18 @@ commander v2.5.0.
 
 An honest table needs the reverse direction spelled out:
 
-- **Bats** is the standard for testing Bash code, with over a decade of
+- Bats is the standard for testing Bash code, with over a decade of
   history, active releases, and an ecosystem (bats-assert, bats-file,
   bats-mock, bats-detik) that atago has no equivalent of. If your tests *are*
   shell code — sourcing scripts, calling functions — Bats runs them
   in-process; a black-box runner cannot.
-- **ShellSpec** is the most featureful shell unit-testing framework:
+- ShellSpec is the most featureful shell unit-testing framework:
   function and command mocking, parameterized examples, built-in parallel
   runs, and kcov coverage. When shell scripts are the product, it is the
   stronger tool; its released feature set has been stable since 2021.
-- **commander** shares atago's YAML approach in a smaller package, and has
+- commander shares atago's YAML approach in a smaller package, and has
   XML assertions and a first-class docker execution node, which atago lacks.
-- **goss / runn / venom** own their layers outright, as described
+- goss / runn / venom own their layers outright, as described
   [above](#tools-that-own-a-different-layer).
 
 atago is also the youngest project on this page and still pre-1.0. The spec

--- a/website/content/comparison.md
+++ b/website/content/comparison.md
@@ -64,6 +64,7 @@ commander v2.5.0.
 | Ships as | single binary | shell scripts (needs Bash) | shell scripts (needs a POSIX shell) | single binary |
 | System under test | any executable | anything Bash can drive | shell scripts, functions, and commands | any executable |
 | Windows | native, incl. ConPTY terminals | via Bash ports (e.g. Git Bash) | Git Bash, msys2, cygwin | native |
+| CI setup on GitHub Actions | [setup-atago](https://github.com/nao1215/setup-atago): prebuilt binary, checksum-verified, Linux/macOS/Windows | [bats-action](https://github.com/bats-core/bats-action): installs Bats and its libraries | — (install script) | — (binary download) |
 | Editor completion for the test format | JSON Schema | — | — | — |
 | Record a first test from a real run | `atago record`, incl. `--pty` | — | — | `commander add` |
 | Generate docs from tests | `atago doc` / `explain` / `list` | — | — | — |

--- a/website/content/getting-started.md
+++ b/website/content/getting-started.md
@@ -4,7 +4,7 @@ title: Getting started
 description: Record a real run of your CLI, read the spec atago wrote, and keep it as a test — then assert on files, snapshots, interactive prompts, and server peers.
 ---
 
-## Try it in 30 seconds
+## First run
 
 Before installing anything, prove the loop against a command you already have. If you have Go, paste this — it records a real run and replays it as a test:
 

--- a/website/content/migrate.md
+++ b/website/content/migrate.md
@@ -6,7 +6,7 @@ description: Side-by-side mappings from Bats and ShellSpec tests to atago specs.
 
 Bats and ShellSpec are mature, well-designed frameworks, and if they fit your
 suite there is no reason to leave. This guide is for one specific situation:
-the thing under test is a **compiled binary** and the shell code around it
+the thing under test is a compiled binary and the shell code around it
 exists only to run that binary and inspect what happened. That layer is
 atago's job, and the mappings below show what each familiar construct becomes.
 
@@ -15,8 +15,8 @@ live at [test/e2e/migration](https://github.com/nao1215/atago/blob/main/test/e2e
 next to the migrated atago specs, and the
 [MigrationParity workflow](https://github.com/nao1215/atago/blob/main/.github/workflows/migration.yml)
 runs all three on every pull request and on every push to `main`: the
-originals under pinned **Bats-core v1.14.0**
-and **ShellSpec 0.28.1**, the migrations under the freshly built atago binary.
+originals under pinned Bats-core v1.14.0
+and ShellSpec 0.28.1, the migrations under the freshly built atago binary.
 A snippet you read here is an excerpt of a file CI ran.
 
 For a feature-by-feature table (including what Bats and ShellSpec do that
@@ -448,13 +448,13 @@ for each.
 Migrate the black-box layer, not everything. Bats and ShellSpec remain the
 right tool for what they were built for:
 
-- **Unit tests of shell functions.** Both frameworks run shell code
+- Unit tests of shell functions. Both frameworks run shell code
   in-process and assert on it directly. atago only ever executes a program,
   so it cannot see inside your shell scripts.
-- **Mocking shell internals.** ShellSpec's function and command mocks have no
+- Mocking shell internals. ShellSpec's function and command mocks have no
   atago equivalent — atago's mocks are external HTTP servers, a different
   axis.
-- **Coverage of shell scripts.** ShellSpec measures kcov coverage for shell
+- Coverage of shell scripts. ShellSpec measures kcov coverage for shell
   code; a black-box runner cannot.
 
 If your repository has both kinds of tests, keeping ShellSpec for the shell


### PR DESCRIPTION
## Summary

Style pass on the docs plus one comparison addition. The new comparison and migration pages used bold emphasis the prose does not need, the "Try it in 30 seconds" heading reads like boilerplate, and the comparison table was missing CI onboarding — where setup-atago is a real differentiator.

## Changes

- `website/content/comparison.md`, `website/content/migrate.md` — remove all bold emphasis; the drift-guarded version strings ("Bats-core v1.14.0", "ShellSpec 0.28.1") stay intact as plain text.
- `README.md`, `website/content/_index.md`, `website/content/getting-started.md` — rename the "Try it in 30 seconds" heading to "First run"; the no-install detail already lives in the section's first sentence. No anchors referenced the old slug.
- `website/content/comparison.md` — add a "CI setup on GitHub Actions" row: setup-atago (prebuilt binary, checksum-verified, all three OSes) vs Bats' org-maintained bats-action; ShellSpec and commander document script/binary installs, so their cells stay honest dashes.