### PR TITLE
fix(record): stop masking raw-mode TUI keystrokes as secrets in --pty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- `record --pty` no longer masks every keystroke of a full-screen TUI session
+  (fzf, vim, htop) as an `${env:ATAGO_SECRET_n}` placeholder. A TUI's raw mode
+  clears ECHO and ICANON together, and the recorder treated ECHO alone as a
+  password prompt, so a recorded TUI session replayed nothing. Secret masking now
+  requires the termios state of an actual password prompt — echo off while
+  canonical (line) input stays on, as with `read -s`, sudo, and ssh — and
+  raw-mode keystrokes are recorded literally, so a recorded TUI session
+  round-trips green.
 - A pty step or `record --pty` no longer loses the output of a command that
   prints and exits at once. macOS discards whatever the terminal still holds the
   moment its last slave handle closes — a read already parked in the kernel comes

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ $ atago run mytool.atago.yaml
 PASSED  1 scenario: 1 passed, 0 failed, 0 errored, 0 skipped (12ms)
 ```
 
-Interactive tools record too: `atago record --pty -- <command>` runs it in a real terminal, lets you drive one session by hand, and writes a `pty:` step that replays your keystrokes as expect/send pairs. It works on Linux, macOS, and Windows (a ConPTY); on POSIX a password prompt becomes an `${env:...}` placeholder automatically, while on Windows — where a ConPTY exposes no echo state — you convert a secret send to `${env:...}` by hand. A `--pty` session is bounded by `--timeout` (default 30s): if the program never exits, atago kills it, writes whatever was captured, and fails instead of hanging forever:
+Interactive tools record too: `atago record --pty -- <command>` runs it in a real terminal, lets you drive one session by hand, and writes a `pty:` step that replays your keystrokes as expect/send pairs. It works on Linux, macOS, and Windows (a ConPTY). On POSIX a password prompt (a line-mode read with echo off) becomes an `${env:...}` placeholder automatically; a TUI's raw mode also disables echo, but its keystrokes are recorded literally. On Windows — where a ConPTY exposes no echo state — you convert a secret send to `${env:...}` by hand. A `--pty` session is bounded by `--timeout` (default 30s): if the program never exits, atago kills it, writes whatever was captured, and fails instead of hanging forever:
 
 ```shell
 $ atago record --pty --out wizard.atago.yaml -- mytool init

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ $ atago run mytool.atago.yaml
 PASSED  1 scenario: 1 passed, 0 failed, 0 errored, 0 skipped (12ms)
 ```
 
-Interactive tools record too: `atago record --pty -- <command>` runs it in a real terminal, lets you drive one session by hand, and writes a `pty:` step that replays your keystrokes as expect/send pairs. It works on Linux, macOS, and Windows (a ConPTY). On POSIX a password prompt (a line-mode read with echo off) becomes an `${env:...}` placeholder automatically; a TUI's raw mode also disables echo, but its keystrokes are recorded literally. On Windows — where a ConPTY exposes no echo state — you convert a secret send to `${env:...}` by hand. A `--pty` session is bounded by `--timeout` (default 30s): if the program never exits, atago kills it, writes whatever was captured, and fails instead of hanging forever:
+Interactive tools record too: `atago record --pty -- <command>` runs it in a real terminal, lets you drive one session by hand, and writes a `pty:` step that replays your keystrokes as expect/send pairs. It works on Linux, macOS, and Windows (a ConPTY). On POSIX a password prompt (a line-mode read with echo off) becomes an `${env:...}` placeholder automatically; a TUI's raw mode also disables echo, but its keystrokes are recorded literally, so convert a password typed into a TUI's own password field to `${env:...}` by hand. On Windows — where a ConPTY exposes no echo state — every secret send needs the same hand conversion. A `--pty` session is bounded by `--timeout` (default 30s): if the program never exits, atago kills it, writes whatever was captured, and fails instead of hanging forever:
 
 ```shell
 $ atago record --pty --out wizard.atago.yaml -- mytool init

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-80 suites · 513 scenarios
+80 suites · 514 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -393,7 +393,7 @@
   - [a pty step drives the atago binary directly with no shell](#scenario-a-pty-step-drives-the-atago-binary-directly-with-no-shell)
   - [a pty drives atago running an inner spec to a green result](#scenario-a-pty-drives-atago-running-an-inner-spec-to-a-green-result)
   - [a never-matching expect fails and names the pattern in the transcript](#scenario-a-never-matching-expect-fails-and-names-the-pattern-in-the-transcript)
-- [atago self-hosting / record (spec skeleton from an observed run)](#atago-self-hosting--record-spec-skeleton-from-an-observed-run) — 14 scenarios
+- [atago self-hosting / record (spec skeleton from an observed run)](#atago-self-hosting--record-spec-skeleton-from-an-observed-run) — 15 scenarios
   - [record then run round-trips green](#scenario-record-then-run-round-trips-green)
   - [refusing to overwrite without --force](#scenario-refusing-to-overwrite-without---force)
   - [record --pty refuses an existing --out before driving the session](#scenario-record---pty-refuses-an-existing---out-before-driving-the-session)
@@ -407,6 +407,7 @@
   - [a prompt with regex metacharacters is escaped in the generated expect](#scenario-a-prompt-with-regex-metacharacters-is-escaped-in-the-generated-expect)
   - [recorded text containing dollar-brace round-trips as literal text](#scenario-recorded-text-containing-dollar-brace-round-trips-as-literal-text)
   - [a recorded secret placeholder replays green with the env set and is guarded when unset](#scenario-a-recorded-secret-placeholder-replays-green-with-the-env-set-and-is-guarded-when-unset)
+  - [a raw-mode (TUI) keystroke is recorded literally, not as a secret](#scenario-a-raw-mode-tui-keystroke-is-recorded-literally-not-as-a-secret)
   - [record --pty of a never-exiting program times out instead of hanging](#scenario-record---pty-of-a-never-exiting-program-times-out-instead-of-hanging)
 - [atago self-hosting / report formats agree on outcomes](#atago-self-hosting--report-formats-agree-on-outcomes) — 7 scenarios
   - [json report carries per-scenario verdicts and a failures array](#scenario-json-report-carries-per-scenario-verdicts-and-a-failures-array)
@@ -7651,6 +7652,19 @@ ${atago} run sec.atago.yaml
 - after `${atago} run sec.atago.yaml`:
   - exit code is `4`
   - stdout contains `ATAGO_SECRET_1 is not set`
+### Scenario: a raw-mode (TUI) keystroke is recorded literally, not as a secret
+_skipped on Windows_
+#### When
+```shell
+# interactive (pty): ${atago} record --pty --out tui.atago.yaml -- sh -c 'stty -icanon -echo min 1 time 0; printf READY; head -c 1 >/dev/null; stty sane; echo BYE'
+${atago} run tui.atago.yaml
+```
+#### Then
+- exit code is `0`
+- file `tui.atago.yaml` contains `- send: "j"`
+- file `tui.atago.yaml` does not contain `ATAGO_SECRET`
+- exit code is `0`
+- stdout contains `1 passed`
 ### Scenario: record --pty of a never-exiting program times out instead of hanging
 _skipped on Windows_
 #### When

--- a/internal/record/capture_termios_linux.go
+++ b/internal/record/capture_termios_linux.go
@@ -5,5 +5,5 @@ package record
 import "golang.org/x/sys/unix"
 
 // ioctlGetTermios is the request that reads a terminal's attributes on Linux,
-// used to check the pty's ECHO flag while recording (#69).
+// used to check the pty's ECHO and ICANON flags while recording (#69).
 const ioctlGetTermios = unix.TCGETS

--- a/internal/record/capture_termios_other.go
+++ b/internal/record/capture_termios_other.go
@@ -5,5 +5,5 @@ package record
 import "golang.org/x/sys/unix"
 
 // ioctlGetTermios is the request that reads a terminal's attributes on Darwin
-// and the BSDs, used to check the pty's ECHO flag while recording (#69).
+// and the BSDs, used to check the pty's ECHO and ICANON flags while recording (#69).
 const ioctlGetTermios = unix.TIOCGETA

--- a/internal/record/capture_test.go
+++ b/internal/record/capture_test.go
@@ -67,6 +67,181 @@ func capturePipes(t *testing.T) (in *os.File, out *os.File) {
 	return inR, outW
 }
 
+// capturePipesMarker is capturePipes plus a synchronization point: its drain
+// scans the output stream for marker and closes the returned channel the first
+// time it appears. A test that must type only AFTER the child has changed the
+// terminal's state (raw mode, echo off) waits on the channel instead of
+// sleeping, so the echo-state tag the recorder attaches to the input is
+// deterministic. It also returns the input pipe's write end so the test can
+// type. The teardown order is the same one capturePipes documents (#406).
+func capturePipesMarker(t *testing.T, marker string) (in, inWrite, out *os.File, seen <-chan struct{}) {
+	t.Helper()
+	inR, inW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("input pipe: %v", err)
+	}
+	outR, outW, err := os.Pipe()
+	if err != nil {
+		_ = inR.Close()
+		_ = inW.Close()
+		t.Fatalf("output pipe: %v", err)
+	}
+	found := make(chan struct{})
+	drained := make(chan struct{})
+	go func() {
+		defer close(drained)
+		var window []byte
+		buf := make([]byte, 4096)
+		notified := false
+		for {
+			n, rerr := outR.Read(buf)
+			if n > 0 && !notified {
+				window = append(window, buf[:n]...)
+				if strings.Contains(string(window), marker) {
+					notified = true
+					close(found)
+				}
+			}
+			if rerr != nil {
+				return
+			}
+		}
+	}()
+	t.Cleanup(func() {
+		_ = outW.Close() // the drain now reaches EOF
+		_ = inR.Close()
+		_ = inW.Close()
+		select {
+		case <-drained:
+			_ = outR.Close()
+		case <-time.After(drainTeardownGrace):
+			t.Errorf("the output drain did not finish %s after its write end closed: "+
+				"something still holds the pipe open, and closing the read end would hang", drainTeardownGrace)
+		}
+	})
+	return inR, inW, outW, found
+}
+
+// waitMarker bounds the wait for a capturePipesMarker channel so a child that
+// never prints its marker fails the test by name instead of wedging it.
+func waitMarker(t *testing.T, seen <-chan struct{}, what string) {
+	t.Helper()
+	select {
+	case <-seen:
+	case <-time.After(15 * time.Second):
+		t.Fatalf("child never printed its %s marker", what)
+	}
+}
+
+// inputSegments collects the input bursts of a recording in order.
+func inputSegments(rec PTYRecording) []PTYSegment {
+	var in []PTYSegment
+	for _, seg := range rec.Segments {
+		if seg.Input != nil {
+			in = append(in, seg)
+		}
+	}
+	return in
+}
+
+// TestCapturePTY_RawModeKeystrokeIsNotSecret is a regression test for recorded
+// TUI sessions: a full-screen program's raw mode (fzf, vim, htop) clears ECHO
+// and ICANON together, and tagging input by ECHO alone turned every keystroke
+// of a recorded TUI session into an ${env:ATAGO_SECRET_n} placeholder — a spec
+// that replays nothing. Only a canonical (line-mode) prompt with echo off is a
+// password prompt; a raw-mode keystroke must be recorded literally.
+func TestCapturePTY_RawModeKeystrokeIsNotSecret(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("stty and termios echo state are POSIX; a ConPTY exposes no echo state at all")
+	}
+	inR, inW, outW, ready := capturePipesMarker(t, "READY")
+
+	// A TUI stand-in: enter raw-ish mode (echo and canonical input both off),
+	// announce READY, read one keystroke, restore the terminal, and exit.
+	const cmd = "stty -icanon -echo min 1 time 0; printf READY; head -c 1 >/dev/null; stty sane; echo BYE"
+	recCh := make(chan PTYRecording, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		rec, err := CapturePTY(cmd, true, inR, outW, 30*time.Second)
+		recCh <- rec
+		errCh <- err
+	}()
+
+	waitMarker(t, ready, "raw-mode")
+	if _, err := inW.WriteString("j"); err != nil {
+		t.Fatalf("typing into the recorder: %v", err)
+	}
+
+	rec := <-recCh
+	if err := <-errCh; err != nil {
+		t.Fatalf("CapturePTY() error = %v", err)
+	}
+	inputs := inputSegments(rec)
+	if len(inputs) != 1 {
+		t.Fatalf("input segments = %d, want 1 (%+v)", len(inputs), rec.Segments)
+	}
+	if inputs[0].EchoOff {
+		t.Errorf("a raw-mode (TUI) keystroke was tagged as secret input")
+	}
+	generated, err := GeneratePTY(rec, Options{SuiteName: "tui"})
+	if err != nil {
+		t.Fatalf("GeneratePTY: %v", err)
+	}
+	if strings.Contains(string(generated), "ATAGO_SECRET") {
+		t.Errorf("a raw-mode (TUI) keystroke was rendered as a secret placeholder:\n%s", generated)
+	}
+	if !strings.Contains(string(generated), `- send: "j"`) {
+		t.Errorf("the recorded keystroke should replay literally:\n%s", generated)
+	}
+}
+
+// TestCapturePTY_CanonicalEchoOffInputIsSecret pins the password half of the
+// same distinction: a canonical prompt that disables echo (read -s, sudo, ssh)
+// must still mask what was typed, before and after the raw-mode fix.
+func TestCapturePTY_CanonicalEchoOffInputIsSecret(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("stty and termios echo state are POSIX; a ConPTY exposes no echo state at all")
+	}
+	inR, inW, outW, ready := capturePipesMarker(t, "Password:")
+
+	const cmd = "stty -echo; printf 'Password: '; read pw; stty echo; echo OK"
+	recCh := make(chan PTYRecording, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		rec, err := CapturePTY(cmd, true, inR, outW, 30*time.Second)
+		recCh <- rec
+		errCh <- err
+	}()
+
+	waitMarker(t, ready, "prompt")
+	const secret = "hunter2-super-secret"
+	if _, err := inW.WriteString(secret + "\n"); err != nil {
+		t.Fatalf("typing into the recorder: %v", err)
+	}
+
+	rec := <-recCh
+	if err := <-errCh; err != nil {
+		t.Fatalf("CapturePTY() error = %v", err)
+	}
+	inputs := inputSegments(rec)
+	if len(inputs) != 1 {
+		t.Fatalf("input segments = %d, want 1 (%+v)", len(inputs), rec.Segments)
+	}
+	if !inputs[0].EchoOff {
+		t.Errorf("a canonical echo-off (password) burst was not tagged as secret")
+	}
+	generated, err := GeneratePTY(rec, Options{SuiteName: "login"})
+	if err != nil {
+		t.Fatalf("GeneratePTY: %v", err)
+	}
+	if strings.Contains(string(generated), secret) {
+		t.Fatalf("SECRET LEAKED into the generated spec:\n%s", generated)
+	}
+	if !strings.Contains(string(generated), "${env:ATAGO_SECRET_1}") {
+		t.Errorf("expected an ${env:...} placeholder for the password:\n%s", generated)
+	}
+}
+
 // TestCapturePTY_RecordsOutputAndExit drives the whole capture path with a
 // self-exiting command and no interactive input: start the child in a real pty
 // (POSIX) / ConPTY (Windows), drain its output into the recording, and reap its

--- a/internal/record/capture_unix.go
+++ b/internal/record/capture_unix.go
@@ -129,7 +129,7 @@ func CapturePTY(command string, shell bool, in, out *os.File, timeout time.Durat
 		for {
 			n, rerr := in.Read(buf)
 			if n > 0 {
-				echoOff := echoDisabled(master)
+				echoOff := secretPromptActive(master)
 				mu.Lock()
 				rec.AppendInput(buf[:n], echoOff)
 				mu.Unlock()
@@ -183,25 +183,30 @@ func CapturePTY(command string, shell bool, in, out *os.File, timeout time.Durat
 	return rec, nil
 }
 
-// echoDisabled reports whether the pty's terminal echo is currently off — the
-// signal of a password prompt, whose typed bytes must not be recorded (#69).
-// Asking through ControlFD rather than master.Fd() is what keeps this poll
-// harmless: Fd() would take the master out of the runtime poller and leave its
-// reads blocking in read(2), where closing the terminal can no longer interrupt
-// them — and this runs on every prompt.
-func echoDisabled(master *os.File) bool {
-	off := false
+// secretPromptActive reports whether the pty is in the termios state of a
+// password prompt — echo off while canonical (line) input stays on, the state
+// read -s, sudo, and ssh put a terminal in — whose typed bytes must not be
+// recorded (#69). ECHO alone is not the signal: a full-screen TUI's raw mode
+// (fzf, vim, htop) clears ECHO and ICANON together, and treating that as
+// secret turned every keystroke of a recorded TUI session into an
+// ${env:ATAGO_SECRET_n} placeholder — a spec that replays nothing. Asking
+// through ControlFD rather than master.Fd() is what keeps this poll harmless:
+// Fd() would take the master out of the runtime poller and leave its reads
+// blocking in read(2), where closing the terminal can no longer interrupt
+// them — and this runs on every keystroke burst.
+func secretPromptActive(master *os.File) bool {
+	secret := false
 	if err := ptyrun.ControlFD(master, func(fd int) error {
 		t, terr := unix.IoctlGetTermios(fd, ioctlGetTermios)
 		if terr != nil {
 			return terr
 		}
-		off = t.Lflag&unix.ECHO == 0
+		secret = t.Lflag&unix.ECHO == 0 && t.Lflag&unix.ICANON != 0
 		return nil
 	}); err != nil {
 		return false
 	}
-	return off
+	return secret
 }
 
 // exitCode extracts a process exit code from cmd.Wait's error (0 on success,

--- a/test/e2e/atago/record.atago.yaml
+++ b/test/e2e/atago/record.atago.yaml
@@ -347,6 +347,43 @@ scenarios:
           stdout:
             contains: "ATAGO_SECRET_1 is not set"
 
+  - name: a raw-mode (TUI) keystroke is recorded literally, not as a secret
+    skip:
+      os: windows
+    steps:
+      # A full-screen TUI's raw mode clears ECHO and ICANON together. Tagging
+      # secret input by ECHO alone turned every keystroke of a recorded TUI
+      # session into an ${env:ATAGO_SECRET_n} placeholder — a spec that replays
+      # nothing. Only a canonical (line-mode) prompt with echo off is a password
+      # prompt; this raw-mode stand-in announces READY after entering raw mode,
+      # reads one keystroke, and exits.
+      - pty:
+          shell: true
+          command: '${atago} record --pty --out tui.atago.yaml -- sh -c ''stty -icanon -echo min 1 time 0; printf READY; head -c 1 >/dev/null; stty sane; echo BYE'''
+          timeout: 20s
+          session:
+            - expect: "READY"
+            - send: "j"
+            - expect: "BYE"
+      - assert:
+          exit_code: 0
+      # The keystroke replays literally; no secret placeholder is generated.
+      - assert:
+          file:
+            path: tui.atago.yaml
+            contains: '- send: "j"'
+      - assert:
+          file:
+            path: tui.atago.yaml
+            not_contains: "ATAGO_SECRET"
+      # The round-trip: replaying the generated spec passes.
+      - run:
+          command: ${atago} run tui.atago.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "1 passed"
+
   - name: record --pty of a never-exiting program times out instead of hanging
     skip:
       os: windows

--- a/website/content/getting-started.md
+++ b/website/content/getting-started.md
@@ -35,7 +35,7 @@ $ atago run mytool.atago.yaml
 PASSED  1 scenario: 1 passed, 0 failed, 0 errored, 0 skipped (12ms)
 ```
 
-Interactive tools record too: `atago record --pty -- <command>` runs it in a real terminal, lets you drive one session by hand, and writes a `pty:` step that replays your keystrokes as expect/send pairs. It works on Linux, macOS, and Windows (a ConPTY); on POSIX a password prompt becomes an `${env:...}` placeholder automatically, while on Windows — where a ConPTY exposes no echo state — you convert a secret send to `${env:...}` by hand. A `--pty` session is bounded by `--timeout` (default 30s): if the program never exits, atago kills it, writes whatever was captured, and fails instead of hanging forever:
+Interactive tools record too: `atago record --pty -- <command>` runs it in a real terminal, lets you drive one session by hand, and writes a `pty:` step that replays your keystrokes as expect/send pairs. It works on Linux, macOS, and Windows (a ConPTY). On POSIX a password prompt (a line-mode read with echo off) becomes an `${env:...}` placeholder automatically; a TUI's raw mode also disables echo, but its keystrokes are recorded literally. On Windows — where a ConPTY exposes no echo state — you convert a secret send to `${env:...}` by hand. A `--pty` session is bounded by `--timeout` (default 30s): if the program never exits, atago kills it, writes whatever was captured, and fails instead of hanging forever:
 
 ```shell
 $ atago record --pty --out wizard.atago.yaml -- mytool init

--- a/website/content/getting-started.md
+++ b/website/content/getting-started.md
@@ -35,7 +35,7 @@ $ atago run mytool.atago.yaml
 PASSED  1 scenario: 1 passed, 0 failed, 0 errored, 0 skipped (12ms)
 ```
 
-Interactive tools record too: `atago record --pty -- <command>` runs it in a real terminal, lets you drive one session by hand, and writes a `pty:` step that replays your keystrokes as expect/send pairs. It works on Linux, macOS, and Windows (a ConPTY). On POSIX a password prompt (a line-mode read with echo off) becomes an `${env:...}` placeholder automatically; a TUI's raw mode also disables echo, but its keystrokes are recorded literally. On Windows — where a ConPTY exposes no echo state — you convert a secret send to `${env:...}` by hand. A `--pty` session is bounded by `--timeout` (default 30s): if the program never exits, atago kills it, writes whatever was captured, and fails instead of hanging forever:
+Interactive tools record too: `atago record --pty -- <command>` runs it in a real terminal, lets you drive one session by hand, and writes a `pty:` step that replays your keystrokes as expect/send pairs. It works on Linux, macOS, and Windows (a ConPTY). On POSIX a password prompt (a line-mode read with echo off) becomes an `${env:...}` placeholder automatically; a TUI's raw mode also disables echo, but its keystrokes are recorded literally, so convert a password typed into a TUI's own password field to `${env:...}` by hand. On Windows — where a ConPTY exposes no echo state — every secret send needs the same hand conversion. A `--pty` session is bounded by `--timeout` (default 30s): if the program never exits, atago kills it, writes whatever was captured, and fails instead of hanging forever:
 
 ```shell
 $ atago record --pty --out wizard.atago.yaml -- mytool init


### PR DESCRIPTION
## Summary

`atago record --pty` treated every keystroke typed into a full-screen TUI (fzf, vim, htop) as password input and replaced it with an `${env:ATAGO_SECRET_n}` placeholder, so a recorded TUI session generated a spec that replays nothing. The recorder decided "secret" from the pty's ECHO flag alone, but a TUI's raw mode clears ECHO and ICANON together — the same signal as a password prompt. Secret masking now requires the termios state of an actual password prompt (echo off while canonical input stays on, as with `read -s`, sudo, and ssh), and raw-mode keystrokes are recorded literally, so a recorded TUI session round-trips green.

## Changes

- `internal/record/capture_unix.go`: rename `echoDisabled` to `secretPromptActive` and require `ECHO == 0 && ICANON != 0` before tagging an input burst as secret.
- `internal/record/capture_termios_linux.go`, `internal/record/capture_termios_other.go`: comment updates for the ICANON read.
- `internal/record/capture_test.go`: two capture-level regression tests — a raw-mode (TUI) keystroke is recorded literally and never rendered as a secret placeholder, and a canonical echo-off prompt still masks what was typed — plus a marker-synchronized pipe helper so the echo-state tag is deterministic.
- `test/e2e/atago/record.atago.yaml`: a self-hosted E2E scenario recording a raw-mode stand-in, asserting the literal send and the round-trip run, with `doc/e2e/atago.md` regenerated.
- `README.md`, `website/content/getting-started.md`: state which prompts are auto-masked and that raw-mode TUI keystrokes are recorded literally.
- `CHANGELOG.md`: Fixed entry.

## Design Decisions

The password/TUI distinction lives in termios: `read -s`, sudo, and ssh disable echo but stay in canonical (line) mode, while a TUI's raw mode clears both flags. Checking ICANON alongside ECHO is the smallest change that separates the two states, keeps the documented POSIX auto-masking promise intact, and needs no new configuration. The regression tests synchronize on a marker the child prints after changing the terminal state instead of sleeping, so the echo-state tag they assert on is deterministic.

## Limitations

A TUI that implements its own password field inside raw mode cannot be detected from termios and is recorded literally; converting such a send to `${env:...}` by hand remains the documented escape hatch (the same one Windows ConPTY recordings already use).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `record --pty` to distinguish password prompts from raw-mode TUI input.
  * Raw-mode keystrokes are now preserved literally and replay successfully.
  * Canonical password input remains masked as environment-based secrets.

* **Documentation**
  * Clarified password-prompt detection and raw-mode recording behavior across guides and reference documentation.
  * Added end-to-end coverage for raw-mode keystroke recording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->