### PR TITLE
fix(record): anchor generated expects on informative output, not decoration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ and this project follows [Semantic Versioning](https://semver.org/).
   workflow under pinned releases of both tools, and drift tests keep every
   snippet on the guide a verbatim excerpt of a file CI ran.
 
+### Changed
+
+- `record --pty` now anchors a generated expect on the latest output run
+  carrying a letter or digit, keeping a purely decorative run only as the
+  fallback. A full-screen TUI's last painted line is often a decorative rule
+  (fzf's "3/3 ─────" info line, a status bar), so every expect of a recorded
+  fzf session anchored on the same run of box-drawing characters — an anchor
+  that matches any redraw and can release the next send before the state it
+  depends on is on screen. The same recording now anchors on the match counts
+  ("3/3", then "1/3" once the query applied).
+
 ### Fixed
 
 - `record --pty` no longer masks every keystroke of a full-screen TUI session

--- a/internal/record/pty.go
+++ b/internal/record/pty.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/nao1215/atago/internal/buildinfo"
@@ -389,44 +390,65 @@ func endsWithNewline(b []byte) bool {
 	return len(b) > 0 && (b[len(b)-1] == '\r' || b[len(b)-1] == '\n')
 }
 
-// stableLine returns the conservative literal an expect/contains anchors on: the
-// longest run of plain text on the last visible line of the transcript that
-// carries no ANSI sequence or control byte (#69). The returned run is a VERBATIM
-// substring of the raw transcript — ANSI sequences are turned into a delimiter,
-// not stripped and concatenated — so an anchor built from it actually matches the
-// raw pty stdout the replay compares against. Stripping ANSI and joining the
-// visible text (the old behavior) produced an anchor with mid-line color codes
-// removed that was never a substring of the raw output, so a colored prompt made
-// the generated spec fail on replay.
+// stableLine returns the conservative literal an expect/contains anchors on: a
+// run of plain text near the end of the transcript that carries no ANSI
+// sequence or control byte (#69). The returned run is a VERBATIM substring of
+// the raw transcript — ANSI sequences are turned into a delimiter, not stripped
+// and concatenated — so an anchor built from it actually matches the raw pty
+// stdout the replay compares against. Stripping ANSI and joining the visible
+// text (the old behavior) produced an anchor with mid-line color codes removed
+// that was never a substring of the raw output, so a colored prompt made the
+// generated spec fail on replay.
+//
+// Among the candidate runs, the latest one carrying a letter or digit wins. A
+// full-screen TUI's last painted line is often a decorative rule (fzf's
+// "3/3 ─────" info line, a status bar), and the longest run on it is the
+// repeated punctuation — an anchor that matches ANY redraw and says nothing
+// about the state the following send depends on; a recorded fzf session
+// anchored every expect on the same run of box-drawing characters. The
+// decorative run is kept only as the fallback when the output says nothing
+// better.
 func stableLine(output []byte) string {
 	// Replace ANSI/OSC sequences with a NUL so the plain text on either side stays
 	// contiguous and verbatim; fold CR so a redraw does not merge lines.
 	s := ansiPattern.ReplaceAllString(string(output), "\x00")
 	s = strings.ReplaceAll(s, "\r", "\n")
 	best := ""
+	bestInformative := ""
 	for _, line := range strings.Split(s, "\n") {
-		if run := longestPlainRun(line); run != "" {
+		run, informative := plainRuns(line)
+		if run != "" {
 			best = run
 		}
+		if informative != "" {
+			bestInformative = informative
+		}
+	}
+	if bestInformative != "" {
+		return bestInformative
 	}
 	return best
 }
 
-// longestPlainRun returns the longest run of line that contains no C0 control
-// byte (the NUL standing in for an ANSI sequence, a tab, or any other) and no
-// byte that is not valid UTF-8, trimmed of surrounding whitespace. Each such run
+// plainRuns returns the longest run of line that contains no C0 control byte
+// (the NUL standing in for an ANSI sequence, a tab, or any other) and no byte
+// that is not valid UTF-8, trimmed of surrounding whitespace — plus the longest
+// such run that also carries a letter or digit (empty when none does). Each run
 // existed verbatim in the raw output, which is what lets an expect built from it
 // match the replayed transcript. A rune-by-rune scan silently turned an invalid
 // byte into U+FFFD, so a Latin-1 prompt yielded an anchor that appears nowhere in
 // the output and an expect that could never match — the session then hung until
-// its timeout. Such a byte now breaks the run, and the anchor is the longest
-// valid stretch around it.
-func longestPlainRun(line string) string {
-	best := ""
+// its timeout. Such a byte breaks the run, and the anchor is the longest valid
+// stretch around it.
+func plainRuns(line string) (best, bestInformative string) {
 	var cur strings.Builder
 	flush := func() {
-		if t := strings.TrimSpace(cur.String()); len(t) > len(best) {
+		t := strings.TrimSpace(cur.String())
+		if len(t) > len(best) {
 			best = t
+		}
+		if len(t) > len(bestInformative) && hasLetterOrDigit(t) {
+			bestInformative = t
 		}
 		cur.Reset()
 	}
@@ -440,5 +462,16 @@ func longestPlainRun(line string) string {
 		cur.WriteRune(r)
 	}
 	flush()
-	return best
+	return best, bestInformative
+}
+
+// hasLetterOrDigit reports whether s carries at least one letter or digit — the
+// signal that a run describes program state rather than decoration.
+func hasLetterOrDigit(s string) bool {
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsNumber(r) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/record/pty_test.go
+++ b/internal/record/pty_test.go
@@ -347,6 +347,52 @@ func TestStableLine(t *testing.T) {
 	}
 }
 
+// TestStableLine_PrefersInformativeAnchor pins the anchor rule for full-screen
+// TUIs: the last painted line is often a decorative rule (fzf's "3/3 ─────"
+// info line, a status bar), and the longest plain run on it is the repeated
+// punctuation — an anchor that matches ANY redraw and says nothing about the
+// state the following send depends on. A recorded fzf session anchored every
+// expect on the same run of box-drawing characters. The anchor now prefers the
+// latest run carrying a letter or digit, and falls back to the decorative run
+// only when the output has nothing better.
+func TestStableLine_PrefersInformativeAnchor(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			// The count and the rule share the fzf-style info line, split by the
+			// color change: prefer the count over the longer rule.
+			name: "digit run beats a longer box-drawing run on the same line",
+			in:   "apple\r\nbanana\r\n\x1b[33m3/3\x1b[2m ─────────────────\x1b[0m ",
+			want: "3/3",
+		},
+		{
+			// The last plain-bearing line is purely decorative: reach back to the
+			// latest line that says something.
+			name: "an earlier informative line beats a trailing decorative one",
+			in:   "banana\r\n\x1b[2m──────────\x1b[0m ",
+			want: "banana",
+		},
+		{
+			// Nothing informative anywhere: the decorative run is still an anchor.
+			name: "punctuation-only output keeps its run as the fallback",
+			in:   "\x1b[2J\x1b[H> ",
+			want: ">",
+		},
+	}
+	for _, tt := range tests {
+		if got := stableLine([]byte(tt.in)); got != tt.want {
+			t.Errorf("%s: stableLine(%q) = %q, want %q", tt.name, tt.in, got, tt.want)
+		}
+		if got := stableLine([]byte(tt.in)); got != "" && !strings.Contains(tt.in, got) {
+			t.Errorf("%s: stableLine(%q) = %q, which is NOT a substring of the raw transcript", tt.name, tt.in, got)
+		}
+	}
+}
+
 // TestStableLine_AnchorIsRawSubstring is a regression for the pty round-trip law
 // (#30/#69): the anchor an expect/contains is built from must be a verbatim
 // substring of the RAW transcript the replay matches against. Stripping ANSI and


### PR DESCRIPTION
## Summary

A `record --pty` session against a full-screen TUI anchored every generated expect on the same decorative run: fzf's info line ends the redraw, and its longest ANSI-free run is the box-drawing rule, so a recorded session produced `expect: ─────` before every send — an anchor that matches any redraw and can release the next send before the state it depends on is on screen. The anchor now prefers the latest output run carrying a letter or digit, keeping the decorative run only as the fallback when the output has nothing better. The same fzf recording now generates `expect: 3/3` before typing the query and `expect: 1/3` before Enter, so the replay waits for the filter to actually apply, and the round-trip stays green (verified against real fzf).

## Changes

- `internal/record/pty.go`: `stableLine` tracks the latest letter-or-digit-bearing run alongside the longest plain run (`longestPlainRun` becomes `plainRuns`), preferring the informative one; `hasLetterOrDigit` is the discriminator.
- `internal/record/pty_test.go`: `TestStableLine_PrefersInformativeAnchor` pins the three cases — a digit run beating a longer box-drawing run on the same line, an earlier informative line beating a trailing decorative one, and punctuation-only output keeping its run as the fallback — each anchored value proven a verbatim substring of the raw transcript.
- `CHANGELOG.md`: Changed entry.

## Design Decisions

The round-trip law is untouched: every candidate is still a verbatim ANSI-free run of the raw transcript, so a generated expect always matches the replayed stream; only which candidate wins changed. "Carries a letter or digit" (Unicode categories L and N) is the smallest discriminator that separates program state (counts, filenames, prompts) from decoration (rules, borders, cursor markers) without a heuristic list of box-drawing characters.