### PR TITLE
fix(assert): read the same tree in every dir mode when path is a symlink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,8 @@ and this project follows [Semantic Versioning](https://semver.org/).
   and could not see through a link the program under test planted, so a `path:`
   naming a link out of the workdir passed it and the directory outside was
   listed. The resolved path now faces the same containment test, and a link that
-  escapes the workdir is refused.
+  escapes the workdir is refused — a dangling one by its declared target, so the
+  rule does not depend on whether that target happens to exist.
 - `record --pty` no longer masks every keystroke of a full-screen TUI session
   (fzf, vim, htop) as an `${env:ATAGO_SECRET_n}` placeholder. A TUI's raw mode
   clears ECHO and ICANON together, and the recorder treated ECHO alone as a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,18 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- A `dir:` assertion whose `path:` is a symlink to a directory now reads the
+  same tree in every mode. `filepath.WalkDir` lstats its root, so the recursive
+  and snapshot modes walked the link itself and saw an empty tree, while the
+  non-recursive matchers followed it and read the real contents — one assertion
+  giving two answers. The snapshot case was the worst of it: `--update-snapshots`
+  wrote an empty golden, and an empty golden matches an empty walk forever, so
+  the assertion stayed green whatever the directory later held. The same
+  resolution closes the confinement hole underneath: the path check is lexical
+  and could not see through a link the program under test planted, so a `path:`
+  naming a link out of the workdir passed it and the directory outside was
+  listed. The resolved path now faces the same containment test, and a link that
+  escapes the workdir is refused.
 - `record --pty` no longer masks every keystroke of a full-screen TUI session
   (fzf, vim, htop) as an `${env:ATAGO_SECRET_n}` placeholder. A TUI's raw mode
   clears ECHO and ICANON together, and the recorder treated ECHO alone as a

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-80 suites · 514 scenarios
+80 suites · 516 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -101,10 +101,12 @@
   - [explain shows that the command runs more than once](#scenario-explain-shows-that-the-command-runs-more-than-once)
   - [deterministic next to retry is a load error](#scenario-deterministic-next-to-retry-is-a-load-error)
   - [a single run and an unknown observable are load errors](#scenario-a-single-run-and-an-unknown-observable-are-load-errors)
-- [atago self-hosting / dir assertion](#atago-self-hosting--dir-assertion) — 9 scenarios
+- [atago self-hosting / dir assertion](#atago-self-hosting--dir-assertion) — 11 scenarios
   - [directory/tree assertions cover a multi-file generator](#scenario-directorytree-assertions-cover-a-multi-file-generator)
   - [a missing directory can be asserted absent](#scenario-a-missing-directory-can-be-asserted-absent)
   - [a dangling symlink is a present directory entry (membership uses Lstat)](#scenario-a-dangling-symlink-is-a-present-directory-entry-membership-uses-lstat)
+  - [a symlinked directory reads the same in every dir mode](#scenario-a-symlinked-directory-reads-the-same-in-every-dir-mode)
+  - [a dir path that resolves out of the workdir is refused](#scenario-a-dir-path-that-resolves-out-of-the-workdir-is-refused)
   - [a failed dir assert lists what the directory actually holds](#scenario-a-failed-dir-assert-lists-what-the-directory-actually-holds)
   - [a failed count assert lists the entries it counted](#scenario-a-failed-count-assert-lists-the-entries-it-counted)
   - [a failed recursive assert lists the walked tree](#scenario-a-failed-recursive-assert-lists-the-walked-tree)
@@ -2414,6 +2416,49 @@ mkdir -p linkdir && ln -s /nonexistent-target-xyz linkdir/planted
 #### Then
 - exit code is `0`
 - dir `linkdir` contains `planted`, does not contain `never-planted`
+### Scenario: a symlinked directory reads the same in every dir mode
+_skipped on Windows_
+#### When
+```shell
+mkdir -p releases/v2/assets && echo bin > releases/v2/app.bin && echo css > releases/v2/assets/app.css && ln -s releases/v2 latest
+```
+#### Then
+- exit code is `0`
+- dir `latest` contains `app.bin`
+- dir `latest` contains `assets/app.css`, (recursive)
+- dir `latest` has 2 entries, (recursive)
+### Scenario: a dir path that resolves out of the workdir is refused
+_skipped on Windows_
+#### Given
+- Fixture file `escaping.atago.yaml` is created.
+#### Inputs
+_Fixture `escaping.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: escaping dir assert
+scenarios:
+  - name: read outside the workdir through a link
+    steps:
+      - run:
+          shell: true
+          command: ln -s /etc escape
+      - assert:
+          dir:
+            path: escape
+            contains: [hosts]
+```
+#### When
+```shell
+ln -s /etc escape
+${atago} run escaping.atago.yaml
+```
+#### Then
+- after `ln -s /etc escape`:
+  - exit code is `0`
+- after `${atago} run escaping.atago.yaml`:
+  - exit code is `1`
+  - stdout contains `escapes the scenario workdir`
 ### Scenario: a failed dir assert lists what the directory actually holds
 #### Given
 - Fixture file `listing.atago.yaml` is created.

--- a/internal/assert/dir.go
+++ b/internal/assert/dir.go
@@ -130,16 +130,20 @@ func declaredLinkTarget(p string) (string, bool) {
 	return filepath.Clean(target), true
 }
 
-// withinResolvedWorkdir reports whether p stays inside the scenario workdir. The
-// workdir is resolved first: it can itself sit behind a symlink (macOS puts
-// /tmp behind /private/tmp), and testing a resolved path against an unresolved
-// root would reject every path there.
+// withinResolvedWorkdir reports whether p stays inside the scenario workdir.
+//
+// The workdir can itself sit behind a symlink — macOS puts /tmp behind
+// /private/tmp and /var behind /private/var — and p arrives in either spelling:
+// a path EvalSymlinks resolved takes the resolved form, while a dangling link's
+// declared target keeps the form the link was written with. Both spellings name
+// the same directory, so containment holds if either does; a path outside the
+// workdir is inside neither.
 func withinResolvedWorkdir(workdir, p string) bool {
-	root := workdir
-	if r, err := filepath.EvalSymlinks(workdir); err == nil {
-		root = r
+	if security.WithinRoot(workdir, p) {
+		return true
 	}
-	return security.WithinRoot(root, p)
+	resolved, err := filepath.EvalSymlinks(workdir)
+	return err == nil && security.WithinRoot(resolved, p)
 }
 
 func escapesWorkdirError(declared, target string) error {

--- a/internal/assert/dir.go
+++ b/internal/assert/dir.go
@@ -22,6 +22,10 @@ func checkDir(d *spec.DirAssert, env Env) *CheckResult {
 	if err != nil {
 		return &CheckResult{Desc: fmt.Sprintf("assert dir %q", d.Path), Hint: err.Error()}
 	}
+	dirPath, err = resolveDirRoot(env.Workdir, d.Path, dirPath)
+	if err != nil {
+		return &CheckResult{Desc: fmt.Sprintf("assert dir %q", d.Path), Hint: err.Error()}
+	}
 
 	// Existence is checked first: every other constraint needs the directory to be
 	// present and readable. When exists:false is asserted, a missing directory is
@@ -69,6 +73,47 @@ func checkDir(d *spec.DirAssert, env Env) *CheckResult {
 		return cr
 	}
 	return pass(fmt.Sprintf("assert dir %q", d.Path))
+}
+
+// resolveDirRoot follows a symlinked directory path and puts the result through
+// the same containment test the declared path faced.
+//
+// Two defects meet here. filepath.WalkDir Lstats its root, so a `path:` that is
+// itself a symlink to a directory walked as a single non-directory entry:
+// `recursive:` reported an empty tree for a populated directory, and `snapshot:`
+// wrote an empty golden that then matched forever no matter what the directory
+// held — while the non-recursive matchers, whose os.ReadDir does follow the
+// link, read the real contents. One assertion, two answers. And the containment
+// check is lexical, so it cannot see through a link the program under test
+// planted: a `path:` naming a link out of the workdir passed it, and the
+// directory outside was listed despite the confinement this file promises.
+//
+// Resolving the root settles both: every mode reads the same tree, and the tree
+// it reads is inside the workdir. Only the ROOT is resolved — walkTree still
+// records the links inside the tree without traversing them, which is what keeps
+// a link cycle out of the walk.
+func resolveDirRoot(workdir, declared, dirPath string) (string, error) {
+	resolved, rerr := filepath.EvalSymlinks(dirPath)
+	if rerr != nil {
+		// Nothing to resolve (the path is missing, or the link dangles). Not an
+		// error here: the stat in checkDir reports it in the assertion's own words,
+		// and exists:false expects exactly this.
+		return dirPath, nil //nolint:nilerr // the caller's stat gives the better message
+	}
+	if resolved == dirPath {
+		return dirPath, nil
+	}
+	// Resolve the root too before comparing. A scenario workdir can itself sit
+	// behind a symlink (macOS puts /tmp behind /private/tmp), and testing a
+	// resolved path against an unresolved root would reject every path there.
+	root := workdir
+	if r, rerr := filepath.EvalSymlinks(workdir); rerr == nil {
+		root = r
+	}
+	if !security.WithinRoot(root, resolved) {
+		return "", fmt.Errorf("assert.dir.path %q resolves through a symlink to %q, which escapes the scenario workdir", declared, resolved)
+	}
+	return resolved, nil
 }
 
 func checkDirExists(d *spec.DirAssert, info os.FileInfo, statErr error) *CheckResult {

--- a/internal/assert/dir.go
+++ b/internal/assert/dir.go
@@ -95,25 +95,55 @@ func checkDir(d *spec.DirAssert, env Env) *CheckResult {
 func resolveDirRoot(workdir, declared, dirPath string) (string, error) {
 	resolved, rerr := filepath.EvalSymlinks(dirPath)
 	if rerr != nil {
-		// Nothing to resolve (the path is missing, or the link dangles). Not an
-		// error here: the stat in checkDir reports it in the assertion's own words,
-		// and exists:false expects exactly this.
-		return dirPath, nil //nolint:nilerr // the caller's stat gives the better message
+		// Nothing resolvable: the path is missing, or it is a link whose target
+		// is. A missing path is ordinary — the stat in checkDir reports it in the
+		// assertion's own words, and exists:false expects exactly this. A DANGLING
+		// link is different: it still declares where it points, and whether that
+		// target exists is not a question a spec may put to the filesystem outside
+		// the workdir. Judging it by its declared target keeps the containment
+		// rule from depending on whether the target happens to exist.
+		if target, ok := declaredLinkTarget(dirPath); ok && !withinResolvedWorkdir(workdir, target) {
+			return "", escapesWorkdirError(declared, target)
+		}
+		return dirPath, nil
 	}
 	if resolved == dirPath {
 		return dirPath, nil
 	}
-	// Resolve the root too before comparing. A scenario workdir can itself sit
-	// behind a symlink (macOS puts /tmp behind /private/tmp), and testing a
-	// resolved path against an unresolved root would reject every path there.
-	root := workdir
-	if r, rerr := filepath.EvalSymlinks(workdir); rerr == nil {
-		root = r
-	}
-	if !security.WithinRoot(root, resolved) {
-		return "", fmt.Errorf("assert.dir.path %q resolves through a symlink to %q, which escapes the scenario workdir", declared, resolved)
+	if !withinResolvedWorkdir(workdir, resolved) {
+		return "", escapesWorkdirError(declared, resolved)
 	}
 	return resolved, nil
+}
+
+// declaredLinkTarget reports where a symlink points, as an absolute path. A
+// relative target resolves against the directory holding the link, the way the
+// kernel would. Anything that is not a symlink reports false.
+func declaredLinkTarget(p string) (string, bool) {
+	target, err := os.Readlink(p)
+	if err != nil {
+		return "", false
+	}
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(filepath.Dir(p), target)
+	}
+	return filepath.Clean(target), true
+}
+
+// withinResolvedWorkdir reports whether p stays inside the scenario workdir. The
+// workdir is resolved first: it can itself sit behind a symlink (macOS puts
+// /tmp behind /private/tmp), and testing a resolved path against an unresolved
+// root would reject every path there.
+func withinResolvedWorkdir(workdir, p string) bool {
+	root := workdir
+	if r, err := filepath.EvalSymlinks(workdir); err == nil {
+		root = r
+	}
+	return security.WithinRoot(root, p)
+}
+
+func escapesWorkdirError(declared, target string) error {
+	return fmt.Errorf("assert.dir.path %q resolves through a symlink to %q, which escapes the scenario workdir", declared, target)
 }
 
 func checkDirExists(d *spec.DirAssert, info os.FileInfo, statErr error) *CheckResult {

--- a/internal/assert/dir_test.go
+++ b/internal/assert/dir_test.go
@@ -100,6 +100,32 @@ func TestCheckDir_PathConfinement(t *testing.T) {
 	}
 }
 
+// TestCheckDir_SymlinkedRootMayNotEscapeTheWorkdir pins the confinement this
+// assertion documents. The path check is lexical, so it cannot see through a
+// symlink the program under test planted: `path:` pointing at a link out of the
+// workdir passed the check, and os.ReadDir then followed it and listed a
+// directory the spec has no business reading. Resolving the link before the
+// containment test closes that, and an in-workdir link stays allowed.
+func TestCheckDir_SymlinkedRootMayNotEscapeTheWorkdir(t *testing.T) {
+	wd := t.TempDir()
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("s"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(wd, "escape")); err != nil {
+		t.Skipf("symlinks unsupported on this platform: %v", err)
+	}
+	for _, d := range []*spec.DirAssert{
+		{Path: "escape", Contains: []string{"secret.txt"}},
+		{Path: "escape", Recursive: true, Contains: []string{"secret.txt"}},
+		{Path: "escape", Count: ptrInt(1)},
+	} {
+		if cr := checkDirOK(t, wd, d); cr.OK {
+			t.Errorf("reading %+v through a symlink out of the workdir must be rejected", d)
+		}
+	}
+}
+
 // TestCheckDir_BrokenSymlinkMembership pins that contains/not_contains judge
 // membership by the directory entry, not by whether the link target resolves. A
 // dangling symlink is a real dirent, so not_contains must FAIL (the file was

--- a/internal/assert/dir_test.go
+++ b/internal/assert/dir_test.go
@@ -133,21 +133,48 @@ func TestCheckDir_SymlinkedRootMayNotEscapeTheWorkdir(t *testing.T) {
 // which is a question about the filesystem outside the workdir. A dangling link
 // that stays inside (a `latest ->` pointing at a release not built yet) is
 // ordinary and must still answer.
+//
+// It runs the same pair twice: once against the workdir as given, and once
+// against the same directory reached through a symlink. The second spelling is
+// what CI runs on macOS, where /var and /tmp sit behind /private — a dangling
+// link's declared target keeps the unresolved spelling, so comparing it only
+// against the RESOLVED root refused a link that never left the workdir.
 func TestCheckDir_DanglingSymlinkedRootJudgedByItsTarget(t *testing.T) {
-	wd := t.TempDir()
-	outside := filepath.Join(t.TempDir(), "absent")
-	if err := os.Symlink(outside, filepath.Join(wd, "escape")); err != nil {
-		t.Skipf("symlinks unsupported on this platform: %v", err)
-	}
-	if err := os.Symlink("releases/v3", filepath.Join(wd, "latest")); err != nil {
-		t.Fatal(err)
-	}
+	for _, tc := range []struct {
+		name         string
+		symlinkedDir bool
+	}{
+		{name: "workdir as given"},
+		{name: "workdir reached through a symlink", symlinkedDir: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			base := t.TempDir()
+			wd := filepath.Join(base, "real")
+			if err := os.Mkdir(wd, 0o750); err != nil {
+				t.Fatal(err)
+			}
+			outside := filepath.Join(t.TempDir(), "absent")
+			if err := os.Symlink(outside, filepath.Join(wd, "escape")); err != nil {
+				t.Skipf("symlinks unsupported on this platform: %v", err)
+			}
+			if err := os.Symlink("releases/v3", filepath.Join(wd, "latest")); err != nil {
+				t.Fatal(err)
+			}
+			if tc.symlinkedDir {
+				alias := filepath.Join(base, "alias")
+				if err := os.Symlink("real", alias); err != nil {
+					t.Fatal(err)
+				}
+				wd = alias
+			}
 
-	if cr := checkDirOK(t, wd, &spec.DirAssert{Path: "escape", Exists: ptrBool(false)}); cr.OK {
-		t.Error("a dangling link out of the workdir must be refused, not answered")
-	}
-	if cr := checkDirOK(t, wd, &spec.DirAssert{Path: "latest", Exists: ptrBool(false)}); !cr.OK {
-		t.Errorf("a dangling link inside the workdir must still answer: %+v", cr)
+			if cr := checkDirOK(t, wd, &spec.DirAssert{Path: "escape", Exists: ptrBool(false)}); cr.OK {
+				t.Error("a dangling link out of the workdir must be refused, not answered")
+			}
+			if cr := checkDirOK(t, wd, &spec.DirAssert{Path: "latest", Exists: ptrBool(false)}); !cr.OK {
+				t.Errorf("a dangling link inside the workdir must still answer: %+v", cr)
+			}
+		})
 	}
 }
 

--- a/internal/assert/dir_test.go
+++ b/internal/assert/dir_test.go
@@ -126,6 +126,31 @@ func TestCheckDir_SymlinkedRootMayNotEscapeTheWorkdir(t *testing.T) {
 	}
 }
 
+// TestCheckDir_DanglingSymlinkedRootJudgedByItsTarget keeps the containment rule
+// from depending on whether a link's target happens to exist. A dangling link
+// out of the workdir resolves to nothing, so `exists: false` would otherwise
+// pass — and passing tells the spec author that the external path is absent,
+// which is a question about the filesystem outside the workdir. A dangling link
+// that stays inside (a `latest ->` pointing at a release not built yet) is
+// ordinary and must still answer.
+func TestCheckDir_DanglingSymlinkedRootJudgedByItsTarget(t *testing.T) {
+	wd := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "absent")
+	if err := os.Symlink(outside, filepath.Join(wd, "escape")); err != nil {
+		t.Skipf("symlinks unsupported on this platform: %v", err)
+	}
+	if err := os.Symlink("releases/v3", filepath.Join(wd, "latest")); err != nil {
+		t.Fatal(err)
+	}
+
+	if cr := checkDirOK(t, wd, &spec.DirAssert{Path: "escape", Exists: ptrBool(false)}); cr.OK {
+		t.Error("a dangling link out of the workdir must be refused, not answered")
+	}
+	if cr := checkDirOK(t, wd, &spec.DirAssert{Path: "latest", Exists: ptrBool(false)}); !cr.OK {
+		t.Errorf("a dangling link inside the workdir must still answer: %+v", cr)
+	}
+}
+
 // TestCheckDir_BrokenSymlinkMembership pins that contains/not_contains judge
 // membership by the directory entry, not by whether the link target resolves. A
 // dangling symlink is a real dirent, so not_contains must FAIL (the file was

--- a/internal/assert/tree.go
+++ b/internal/assert/tree.go
@@ -64,6 +64,10 @@ func escapeManifestField(s string) string {
 // across platforms. Symlinks are recorded, never traversed; an ignored
 // directory prunes its whole subtree; an entry that is not a regular file is
 // recorded by kind and never opened.
+//
+// dirPath must already have its own symlinks resolved (checkDir does this via
+// resolveDirRoot): filepath.WalkDir Lstats its root, so a root that is still a
+// symlink walks as one non-directory entry and yields an empty tree.
 func walkTree(dirPath string, ignore []string) ([]treeEntry, error) {
 	var out []treeEntry
 	err := filepath.WalkDir(dirPath, func(p string, d fs.DirEntry, err error) error {

--- a/internal/assert/tree_test.go
+++ b/internal/assert/tree_test.go
@@ -310,6 +310,90 @@ func TestCheckDir_SnapshotNewlineNameNoFalseMatch(t *testing.T) {
 	}
 }
 
+// TestCheckDir_SymlinkedRootAgreesAcrossModes is a regression for a dir assert
+// that disagreed with itself. filepath.WalkDir Lstats its root, so a `path:`
+// that is itself a symlink to a directory walked as one non-directory entry and
+// produced an EMPTY tree: `recursive:` reported "(no paths)" for a populated
+// directory while the non-recursive matchers (os.ReadDir follows the link) saw
+// the real contents. A program that publishes a `latest -> releases/v2` link is
+// the ordinary case, and every mode has to read the same tree.
+func TestCheckDir_SymlinkedRootAgreesAcrossModes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating a directory symlink needs elevation on Windows")
+	}
+	t.Parallel()
+	wd := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(wd, "releases", "v2", "assets"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wd, "releases", "v2", "app.bin"), []byte("bin"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wd, "releases", "v2", "assets", "app.css"), []byte("css"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join("releases", "v2"), filepath.Join(wd, "latest")); err != nil {
+		t.Fatal(err)
+	}
+
+	// The non-recursive matchers already read through the link; recursive must
+	// reach the same conclusion, nested path included.
+	if cr := checkDirOK(t, wd, &spec.DirAssert{Path: "latest", Contains: []string{"app.bin"}}); !cr.OK {
+		t.Fatalf("non-recursive contains through a symlinked root failed: %+v", cr)
+	}
+	if cr := checkDirOK(t, wd, &spec.DirAssert{Path: "latest", Recursive: true, Contains: []string{"assets/app.css"}}); !cr.OK {
+		t.Errorf("recursive contains through a symlinked root failed: %+v", cr)
+	}
+	if cr := checkDirOK(t, wd, &spec.DirAssert{Path: "latest", Recursive: true, Count: ptrInt(2)}); !cr.OK {
+		t.Errorf("recursive count through a symlinked root failed: %+v", cr)
+	}
+}
+
+// TestCheckDir_SymlinkedRootSnapshotIsNotEmpty pins the worst symptom of the
+// same defect: --update-snapshots through a symlinked root wrote an EMPTY
+// golden, and an empty golden matches an empty walk forever — so the assertion
+// stayed green no matter what the directory later held. A golden has to describe
+// the tree, and a change to that tree has to break it.
+func TestCheckDir_SymlinkedRootSnapshotIsNotEmpty(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating a directory symlink needs elevation on Windows")
+	}
+	t.Parallel()
+	wd := t.TempDir()
+	specDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(wd, "real"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wd, "real", "inside.txt"), []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("real", filepath.Join(wd, "link")); err != nil {
+		t.Fatal(err)
+	}
+	d := &spec.DirAssert{Path: "link", Snapshot: "link_tree"}
+
+	if cr := checkDir(d, Env{Workdir: wd, SpecDir: specDir, UpdateSnapshots: true}); !cr.OK {
+		t.Fatalf("update through a symlinked root failed: %+v", cr)
+	}
+	golden, err := os.ReadFile(filepath.Join(specDir, "link_tree"))
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if !strings.Contains(string(golden), "inside.txt") {
+		t.Fatalf("golden does not describe the tree behind the link:\n%q", golden)
+	}
+	if cr := checkDir(d, Env{Workdir: wd, SpecDir: specDir}); !cr.OK {
+		t.Fatalf("compare after update failed: %+v", cr)
+	}
+	// The golden must react to the tree it describes.
+	if err := os.WriteFile(filepath.Join(wd, "real", "added.txt"), []byte("more"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if cr := checkDir(d, Env{Workdir: wd, SpecDir: specDir}); cr.OK {
+		t.Error("a file added behind the symlinked root did not break the snapshot")
+	}
+}
+
 // TestCheckDir_SnapshotRoundTrip proves record → green compare → mutation
 // diff naming exactly the changed path (#25).
 func TestCheckDir_SnapshotRoundTrip(t *testing.T) {

--- a/test/e2e/atago/dir.atago.yaml
+++ b/test/e2e/atago/dir.atago.yaml
@@ -51,6 +51,70 @@ scenarios:
             contains: [planted]
             not_contains: [never-planted]
 
+  - name: a symlinked directory reads the same in every dir mode
+    skip: {os: windows}
+    steps:
+      # A program that publishes `latest -> releases/v2` is the ordinary case.
+      # filepath.WalkDir lstats its root, so the recursive and snapshot modes
+      # used to walk the link itself and see an EMPTY tree while the
+      # non-recursive matchers read the real contents — one assertion giving two
+      # answers, and a snapshot golden that stayed green whatever the directory
+      # later held.
+      - run:
+          shell: true
+          command: mkdir -p releases/v2/assets && echo bin > releases/v2/app.bin && echo css > releases/v2/assets/app.css && ln -s releases/v2 latest
+      - assert:
+          exit_code: 0
+      - assert:
+          dir:
+            path: latest
+            contains: [app.bin]
+      - assert:
+          dir:
+            path: latest
+            recursive: true
+            contains: [assets/app.css]
+      - assert:
+          dir:
+            path: latest
+            recursive: true
+            count: 2
+
+  - name: a dir path that resolves out of the workdir is refused
+    skip: {os: windows}
+    steps:
+      # The path check is lexical, so it cannot see through a link the program
+      # under test planted: `path:` naming a link out of the workdir passed it,
+      # and the directory outside was listed anyway. Resolving the root before
+      # the containment test closes that.
+      - run:
+          shell: true
+          command: ln -s /etc escape
+      - assert:
+          exit_code: 0
+      - fixture:
+          file: escaping.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: escaping dir assert
+            scenarios:
+              - name: read outside the workdir through a link
+                steps:
+                  - run:
+                      shell: true
+                      command: ln -s /etc escape
+                  - assert:
+                      dir:
+                        path: escape
+                        contains: [hosts]
+      - run:
+          command: ${atago} run escaping.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains: "escapes the scenario workdir"
+
   - name: a failed dir assert lists what the directory actually holds
     steps:
       - fixture:


### PR DESCRIPTION
## Summary

A `dir:` assertion whose `path:` is a symlink to a directory gave two different answers depending on which matchers were used. `filepath.WalkDir` lstats its root, so the recursive and snapshot modes walked the link itself — one non-directory entry — and concluded the tree was empty, while the non-recursive matchers, whose `os.ReadDir` follows the link, read the real contents. A program publishing `latest -> releases/v2` is the ordinary case for this. The snapshot mode was the worst of it: `--update-snapshots` wrote an empty golden, and an empty golden matches an empty walk forever, so the assertion stayed green no matter what the directory later held. Resolving the root before the walk settles it, and the same resolution closes the confinement hole underneath: the path check is lexical and cannot see through a link the program under test planted, so a `path:` naming a link out of the workdir passed it and the directory outside was listed despite the confinement `checkDir` documents.

## Changes

- `internal/assert/dir.go`: `resolveDirRoot` resolves the asserted directory's own symlinks and puts the result through the same containment test the declared path faced; `checkDir` calls it right after `ResolveWorkdirPath`, so every mode shares one resolved root.
- `internal/assert/tree.go`: `walkTree`'s doc comment states the precondition it silently depended on.
- `internal/assert/tree_test.go`: an in-workdir symlinked root reads the same tree in non-recursive, recursive, and count modes; a snapshot taken through one describes the tree behind the link and breaks when that tree changes.
- `internal/assert/dir_test.go`: a symlink out of the workdir is refused in every mode.
- `test/e2e/atago/dir.atago.yaml`: the same two contracts end to end, with `doc/e2e/atago.md` regenerated.
- `CHANGELOG.md`: Fixed entry.

## Design Decisions

Only the ROOT is resolved. `walkTree` still records the links inside the tree without traversing them, which is what keeps a link cycle out of the walk and what the manifest's `link a -> b` lines describe. The containment test compares against the resolved workdir rather than the declared one, because a scenario workdir can itself sit behind a symlink (macOS puts `/tmp` behind `/private/tmp`) and testing a resolved path against an unresolved root would reject every path there. An unresolvable path — missing, or a dangling link — is left to the stat in `checkDir`, which reports it in the assertion's own words and is what `exists: false` expects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Directory assertions now work correctly when targeting symlinked directories across regular, recursive, count, and snapshot modes.
  * Paths that resolve outside the scenario work directory are rejected for improved safety.
* **Tests**
  * Added coverage for symlink traversal, snapshot behavior, file changes, and workdir escape handling.
* **Documentation**
  * Updated behavior specifications with new symlink-related scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->