### PR TITLE
fix(record): anchor an observed stderr instead of dropping it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- `atago record` now anchors an observed stderr the way it has always anchored
+  stdout: on its first non-empty line. Only an EMPTY stderr produced an assert
+  before, so recording the case a CLI author most wants pinned — a failing run
+  whose whole observable behavior is a diagnostic on stderr — generated a spec
+  that asserted the exit code and silently dropped the message. A first line
+  carrying an escape or a carriage return is still left alone: that is a
+  progress bar or a redrawing status line, and anchoring on one would hand the
+  author a generated spec that is red on arrival.
 - `record --pty` now anchors a generated expect on the latest output run
   carrying a letter or digit, keeping a purely decorative run only as the
   fallback. A full-screen TUI's last painted line is often a decorative rule

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ PASSED  1 scenario: 1 passed, 0 failed, 0 errored, 0 skipped
 ```
 
 `record` runs `git --version` once and writes a spec from what it observed — the
-exit code, the version line on stdout, an empty stderr. `run` replays it. Open
+exit code, the version line on stdout, an empty stderr (a tool that writes a
+diagnostic there gets that first line anchored instead). `run` replays it. Open
 `demo.atago.yaml` and you have a real test you can tighten, not YAML you wrote
 from scratch. (Swap `git --version` for any command you have: `go version`,
 `jq --version`, `ls -la`.)

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-80 suites · 514 scenarios
+80 suites · 515 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -393,10 +393,11 @@
   - [a pty step drives the atago binary directly with no shell](#scenario-a-pty-step-drives-the-atago-binary-directly-with-no-shell)
   - [a pty drives atago running an inner spec to a green result](#scenario-a-pty-drives-atago-running-an-inner-spec-to-a-green-result)
   - [a never-matching expect fails and names the pattern in the transcript](#scenario-a-never-matching-expect-fails-and-names-the-pattern-in-the-transcript)
-- [atago self-hosting / record (spec skeleton from an observed run)](#atago-self-hosting--record-spec-skeleton-from-an-observed-run) — 15 scenarios
+- [atago self-hosting / record (spec skeleton from an observed run)](#atago-self-hosting--record-spec-skeleton-from-an-observed-run) — 16 scenarios
   - [record then run round-trips green](#scenario-record-then-run-round-trips-green)
   - [refusing to overwrite without --force](#scenario-refusing-to-overwrite-without---force)
   - [record --pty refuses an existing --out before driving the session](#scenario-record---pty-refuses-an-existing---out-before-driving-the-session)
+  - [an observed stderr diagnostic is anchored, not dropped](#scenario-an-observed-stderr-diagnostic-is-anchored-not-dropped)
   - [created files become exists asserts (shell mode)](#scenario-created-files-become-exists-asserts-shell-mode)
   - [snapshot mode writes a golden the run then matches](#scenario-snapshot-mode-writes-a-golden-the-run-then-matches)
   - [no command is a usage error](#scenario-no-command-is-a-usage-error)
@@ -7516,6 +7517,21 @@ ${atago} record --pty --out taken.atago.yaml -- echo hi
 - exit code is `3`
 - stderr contains `use --force to overwrite`
 - file `taken.atago.yaml` contains `precious`
+### Scenario: an observed stderr diagnostic is anchored, not dropped
+_skipped on Windows_
+#### When
+```shell
+${atago} record --shell --out diag.atago.yaml -- 'echo "error: unknown flag" >&2; exit 2'
+${atago} run diag.atago.yaml
+```
+#### Then
+- after `${atago} record --shell --out diag.atago.yaml -- 'echo "error: unknown flag" >&2; exit 2'`:
+  - exit code is `0`
+  - file `diag.atago.yaml` contains `exit_code: 2`, `stderr:`, `error: unknown flag`
+  - file `diag.atago.yaml` does not contain `empty: true`
+- after `${atago} run diag.atago.yaml`:
+  - exit code is `0`
+  - stdout contains `1 passed`
 ### Scenario: created files become exists asserts (shell mode)
 _skipped on Windows_
 #### When

--- a/internal/record/record.go
+++ b/internal/record/record.go
@@ -86,10 +86,16 @@ func Generate(obs Observation, opts Options) ([]byte, error) {
 		anchor := maskWorkdir(escapeVarRefs(firstLine(obs.Stdout)), opts.Workdir)
 		fmt.Fprintf(&b, "            contains: %s # first non-empty line, trimmed\n", yamlScalar(anchor))
 	}
-	if len(obs.Stderr) == 0 {
+	switch {
+	case len(obs.Stderr) == 0:
 		b.WriteString("      - assert:\n")
 		b.WriteString("          stderr:\n")
 		b.WriteString("            empty: true\n")
+	case stderrAnchor(obs.Stderr) != "":
+		b.WriteString("      - assert:\n")
+		b.WriteString("          stderr:\n")
+		anchor := maskWorkdir(escapeVarRefs(stderrAnchor(obs.Stderr)), opts.Workdir)
+		fmt.Fprintf(&b, "            contains: %s # first non-empty line, trimmed\n", yamlScalar(anchor))
 	}
 
 	files := obs.CreatedFiles
@@ -175,6 +181,21 @@ func maskWorkdir(s, workdir string) string {
 		return s
 	}
 	return strings.ReplaceAll(s, workdir, "${workdir}")
+}
+
+// stderrAnchor returns the literal a generated stderr assert anchors on: the
+// first non-empty line, unless that line carries an escape or a carriage return.
+// Those are the marks of a progress bar or a redrawing status line — text that
+// differs on the very next run — and anchoring on one would hand the author a
+// generated spec that is red on arrival, which is worse than saying nothing
+// about the stream. A diagnostic, a warning, or a usage line has neither, and is
+// exactly what the author wants pinned.
+func stderrAnchor(stream []byte) string {
+	line := firstLine(stream)
+	if strings.ContainsAny(line, "\x1b\r") {
+		return ""
+	}
+	return line
 }
 
 // firstLine returns the first non-empty line, trimmed.

--- a/internal/record/record_test.go
+++ b/internal/record/record_test.go
@@ -107,6 +107,62 @@ func TestGenerate_EscapesVariableReferences(t *testing.T) {
 	}
 }
 
+// TestGenerate_ObservedStderrIsAnchored pins what a recording says about a
+// stream the tool actually wrote to. Only an EMPTY stderr produced an assert, so
+// recording the case a CLI author most wants pinned — `mytool --bad-flag`, whose
+// whole observable behavior is a diagnostic on stderr — generated a spec that
+// asserted the exit code and nothing else, silently dropping the message. A
+// non-empty stderr now gets the same first-line anchor stdout has always had.
+func TestGenerate_ObservedStderrIsAnchored(t *testing.T) {
+	t.Parallel()
+	out, err := Generate(Observation{
+		Command:  "mytool --bad-flag",
+		ExitCode: 2,
+		Stderr:   []byte("\nerror: unknown flag --bad-flag\nusage: mytool [options]\n"),
+	}, Options{SuiteName: "mytool"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"exit_code: 2",
+		"stderr:",
+		`contains: "error: unknown flag --bad-flag"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("generated spec missing %q:\n%s", want, got)
+		}
+	}
+	// The empty assert belongs only to a stream that really was empty.
+	if strings.Contains(got, "empty: true") {
+		t.Errorf("a non-empty stderr must not be asserted empty:\n%s", got)
+	}
+	if _, lerr := loader.LoadBytes("g.atago.yaml", out); lerr != nil {
+		t.Fatalf("generated spec does not load: %v\n%s", lerr, out)
+	}
+}
+
+// TestGenerate_RedrawingStderrIsNotAnchored keeps the anchor above from turning
+// a progress bar into a failing assertion. A line carrying an escape or a
+// carriage return is a redraw — different on the very next run — so anchoring on
+// one would hand the author a generated spec that is red on arrival, which is
+// worse than saying nothing about the stream.
+func TestGenerate_RedrawingStderrIsNotAnchored(t *testing.T) {
+	t.Parallel()
+	for _, stderr := range []string{
+		"[===>      ] 42%\r[=====>    ] 61%\r",
+		"\x1b[32mbuilding\x1b[0m 3/7",
+	} {
+		out, err := Generate(Observation{Command: "build", ExitCode: 0, Stderr: []byte(stderr)}, Options{SuiteName: "b"})
+		if err != nil {
+			t.Fatalf("Generate(%q): %v", stderr, err)
+		}
+		if got := string(out); strings.Contains(got, "stderr:") {
+			t.Errorf("a redrawing stderr must not be anchored (%q):\n%s", stderr, got)
+		}
+	}
+}
+
 // TestGenerate_EdgeShapes proves generation stays valid across observed
 // shapes: empty output, non-zero exit, noisy stderr, shell mode, file cap,
 // and hostile strings that must not break YAML structure.

--- a/test/e2e/atago/record.atago.yaml
+++ b/test/e2e/atago/record.atago.yaml
@@ -71,6 +71,37 @@ scenarios:
             path: taken.atago.yaml
             contains: precious
 
+  - name: an observed stderr diagnostic is anchored, not dropped
+    skip:
+      os: windows
+    steps:
+      # A failing tool's whole observable behavior is its diagnostic and its exit
+      # code. Only an EMPTY stderr used to produce an assert, so recording this
+      # generated a spec that pinned the exit code and silently dropped the
+      # message — the one thing the author wanted.
+      - run:
+          shell: true
+          command: "${atago} record --shell --out diag.atago.yaml -- 'echo \"error: unknown flag\" >&2; exit 2'"
+      - assert:
+          exit_code: 0
+          file:
+            path: diag.atago.yaml
+            contains:
+              - "exit_code: 2"
+              - "stderr:"
+              - "error: unknown flag"
+      - assert:
+          file:
+            path: diag.atago.yaml
+            not_contains: "empty: true"
+      # The round-trip: replaying the generated spec passes.
+      - run:
+          command: ${atago} run diag.atago.yaml
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "1 passed"
+
   - name: created files become exists asserts (shell mode)
     skip:
       os: windows

--- a/website/content/getting-started.md
+++ b/website/content/getting-started.md
@@ -19,7 +19,7 @@ go run github.com/nao1215/atago@latest run demo.atago.yaml
 PASSED  1 scenario: 1 passed, 0 failed, 0 errored, 0 skipped
 ```
 
-Open `demo.atago.yaml`: `record` captured the exit code, the version line on stdout, and an empty stderr, so you have a real test to tighten rather than YAML written from scratch. Swap `git --version` for any command you have (`go version`, `jq --version`, `ls -la`). Then [install atago](/install/) and point it at your own tool.
+Open `demo.atago.yaml`: `record` captured the exit code, the version line on stdout, and an empty stderr — a tool that writes a diagnostic there gets that first line anchored instead — so you have a real test to tighten rather than YAML written from scratch. Swap `git --version` for any command you have (`go version`, `jq --version`, `ls -la`). Then [install atago](/install/) and point it at your own tool.
 
 ## Start from a real run
 


### PR DESCRIPTION
## Summary

`atago record` asserted on stderr only when the stream was EMPTY, so recording the case a CLI author most wants pinned — a failing run whose whole observable behavior is a diagnostic on stderr — generated a spec that asserted the exit code and silently dropped the message. `atago record -- mytool --bad-flag` produced four lines of YAML that said nothing about `error: unknown flag`. A non-empty stderr now gets the same first-line `contains:` anchor stdout has always had. A first line carrying an escape or a carriage return is still left alone: that is a progress bar or a redrawing status line, different on the very next run, and anchoring on one would hand the author a generated spec that is red on arrival.

## Changes

- `internal/record/record.go`: the stderr branch becomes a switch — `empty: true` for a stream that really was empty, a first-line anchor otherwise — and `stderrAnchor` withholds a redrawing line. The anchor goes through the same `escapeVarRefs` and `maskWorkdir` the stdout anchor does, so it replays verbatim.
- `internal/record/record_test.go`: a diagnostic is anchored and not asserted empty; a progress bar and an ANSI status line produce no stderr assert at all.
- `test/e2e/atago/record.atago.yaml`: the same contract end to end, including the round-trip run, with `doc/e2e/atago.md` regenerated.
- `README.md`, `website/content/getting-started.md`: one clause, where the recorded observables are listed.
- `CHANGELOG.md`: Changed entry.

## Design Decisions

The anchor is the first non-empty line, matching stdout, because a diagnostic's first line is the message and the lines after it are usage or context. Escape and carriage return are the discriminator for "not stable": both mark a stream being repainted rather than written, and neither appears in an ordinary diagnostic, a warning, or a usage line. Withholding the anchor there keeps the existing behavior for progress output rather than trading a silent gap for a false failure.