### PR TITLE
fix(security): confine a path whose directory component is a symlink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,8 +58,9 @@ and this project follows [Semantic Versioning](https://semver.org/).
   directory — all while the run stayed green. The leaf refusal that was already
   in place saw none of it. Ancestors now face the same containment test the
   declared path does, with the rules `dir:` already follows: a dangling link is
-  judged by its declared target so the answer does not depend on whether that
-  target exists yet, either spelling of a root that itself sits behind a symlink
+  judged by its declared target — to the far end of a chain, since only the end
+  says where a path goes — so the answer does not depend on whether that target
+  exists yet, either spelling of a root that itself sits behind a symlink
   is accepted (macOS puts CI's workdirs behind `/private`), and a link that stays
   inside the root keeps resolving. A path that is merely absent is untouched, so
   `exists: false` still answers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,22 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Every workdir- and spec-scoped path is now checked against a symlink at a
+  DIRECTORY component, not only at the leaf. The containment check was lexical,
+  so it compared path components and could not see that `escape/secret.txt`
+  names a host file once the program under test has run `ln -s /etc escape` —
+  and each path-taking key inherited the hole from the one resolver behind them.
+  A `file:` assertion read the host file into the report and a `size:` bound
+  disclosed its length; `fixture:`, `run.stdout_to`/`stderr_to`, `http.body_to`,
+  and the snapshot writer created files, and whole directory trees, in the host
+  directory — all while the run stayed green. The leaf refusal that was already
+  in place saw none of it. Ancestors now face the same containment test the
+  declared path does, with the rules `dir:` already follows: a dangling link is
+  judged by its declared target so the answer does not depend on whether that
+  target exists yet, either spelling of a root that itself sits behind a symlink
+  is accepted (macOS puts CI's workdirs behind `/private`), and a link that stays
+  inside the root keeps resolving. A path that is merely absent is untouched, so
+  `exists: false` still answers.
 - A `dir:` assertion whose `path:` is a symlink to a directory now reads the
   same tree in every mode. `filepath.WalkDir` lstats its root, so the recursive
   and snapshot modes walked the link itself and saw an empty tree, while the

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-80 suites · 517 scenarios
+80 suites · 520 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -457,9 +457,12 @@
   - [Unix XDG family — write config, read it back, inspect it under the workdir](#scenario-unix-xdg-family--write-config-read-it-back-inspect-it-under-the-workdir)
   - [Windows APPDATA family — write config, read it back, inspect it under the workdir](#scenario-windows-appdata-family--write-config-read-it-back-inspect-it-under-the-workdir)
   - [cwd anchors the run, but sandbox_home stays at the workdir ROOT (Unix)](#scenario-cwd-anchors-the-run-but-sandbox_home-stays-at-the-workdir-root-unix)
-- [atago self-hosting / security](#atago-self-hosting--security) — 3 scenarios
+- [atago self-hosting / security](#atago-self-hosting--security) — 6 scenarios
   - [declared secrets are masked in failure output](#scenario-declared-secrets-are-masked-in-failure-output)
   - [a file assertion path may not escape the scenario workdir](#scenario-a-file-assertion-path-may-not-escape-the-scenario-workdir)
+  - [a file assertion may not read through a symlinked directory](#scenario-a-file-assertion-may-not-read-through-a-symlinked-directory)
+  - [a redirect may not write through a symlinked directory](#scenario-a-redirect-may-not-write-through-a-symlinked-directory)
+  - [a symlinked directory inside the workdir still resolves](#scenario-a-symlinked-directory-inside-the-workdir-still-resolves)
   - [a snapshot path may not escape the spec directory](#scenario-a-snapshot-path-may-not-escape-the-spec-directory)
 - [atago self-hosting / selection](#atago-self-hosting--selection) — 3 scenarios
   - [--filter runs only matching scenarios](#scenario---filter-runs-only-matching-scenarios)
@@ -8887,6 +8890,92 @@ ${atago} run escape.atago.yaml
 #### Then
 - exit code is `1`
 - stdout contains `escapes the scenario workdir`
+### Scenario: a file assertion may not read through a symlinked directory
+_skipped on Windows_
+#### Given
+- Fixture file `link_read.atago.yaml` is created.
+#### Inputs
+_Fixture `link_read.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: inner
+scenarios:
+  - name: read through the link
+    steps:
+      - run:
+          command: ln -s .. escape
+      - assert:
+          file:
+            path: escape/anything.txt
+            exists: false
+```
+#### When
+```shell
+${atago} run link_read.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `escapes the scenario workdir`
+### Scenario: a redirect may not write through a symlinked directory
+_skipped on Windows_
+#### Given
+- Fixture file `link_write.atago.yaml` is created.
+#### Inputs
+_Fixture `link_write.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: inner
+scenarios:
+  - name: write through the link
+    steps:
+      - run:
+          command: ln -s .. escape
+      - run:
+          shell: true
+          command: echo planted
+          stdout_to: escape/planted.txt
+```
+#### When
+```shell
+${atago} run link_write.atago.yaml
+```
+#### Then
+- exit code is `4`
+- stdout contains `escapes the scenario workdir`
+### Scenario: a symlinked directory inside the workdir still resolves
+_skipped on Windows_
+#### Given
+- Fixture file `link_ok.atago.yaml` is created.
+#### Inputs
+_Fixture `link_ok.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: inner
+scenarios:
+  - name: read and write through an in-workdir link
+    steps:
+      - run:
+          command: mkdir real
+      - run:
+          command: ln -s real alias
+      - run:
+          shell: true
+          command: echo through the alias
+          stdout_to: alias/out.txt
+      - assert:
+          file:
+            path: real/out.txt
+            contains: through the alias
+```
+#### When
+```shell
+${atago} run link_ok.atago.yaml
+```
+#### Then
+- exit code is `0`
 ### Scenario: a snapshot path may not escape the spec directory
 #### Given
 - Fixture file `snap_escape.atago.yaml` is created.

--- a/internal/assert/assert_test.go
+++ b/internal/assert/assert_test.go
@@ -1031,6 +1031,42 @@ func TestCheck_File_SymlinkEscapeRejected(t *testing.T) {
 	}
 }
 
+// TestCheck_File_SymlinkedAncestorEscapeRejected is the same disclosure one
+// directory up. The leaf refusal above only sees a link AT the target, so a
+// program under test that turned a directory component into a link — `ln -s /etc
+// escape` — handed the assertion a path that compares as in-workdir and names a
+// host file. The read must be refused, and nothing about the host file may reach
+// the report.
+func TestCheck_File_SymlinkedAncestorEscapeRejected(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is not reliably available on Windows CI")
+	}
+	t.Parallel()
+	workdir := t.TempDir()
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("top-secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(workdir, "escape")); err != nil {
+		t.Fatal(err)
+	}
+	for _, a := range []*spec.Assert{
+		{File: &spec.FileAssert{Path: "escape/secret.txt", Contains: spec.StringList{"top-secret"}}},
+		{File: &spec.FileAssert{Path: "escape/secret.txt", Exists: ptrBool(true)}},
+		// A size bound reads only the metadata, but the size of a host file is a
+		// disclosure too, so it must be refused on the same grounds.
+		{File: &spec.FileAssert{Path: "escape/secret.txt", MinSize: int64p(1)}},
+	} {
+		got := Check(a, nil, Env{Workdir: workdir})
+		if got.OK {
+			t.Errorf("%+v was answered through a symlinked ancestor pointing out of the workdir", a.File)
+		}
+		if strings.Contains(got.Actual, "top-secret") || strings.Contains(string(got.ArtifactActual), "top-secret") {
+			t.Errorf("the out-of-root secret leaked into the result: %+v", got)
+		}
+	}
+}
+
 // TestCheck_Snapshot_TraversalRejected proves a relative snapshot path may not
 // escape the spec directory.
 func TestCheck_Snapshot_TraversalRejected(t *testing.T) {

--- a/internal/assert/dir.go
+++ b/internal/assert/dir.go
@@ -102,7 +102,7 @@ func resolveDirRoot(workdir, declared, dirPath string) (string, error) {
 		// target exists is not a question a spec may put to the filesystem outside
 		// the workdir. Judging it by its declared target keeps the containment
 		// rule from depending on whether the target happens to exist.
-		if target, ok := declaredLinkTarget(dirPath); ok && !withinResolvedWorkdir(workdir, target) {
+		if target, ok := security.LinkTarget(dirPath); ok && !security.WithinResolvedRoot(workdir, target) {
 			return "", escapesWorkdirError(declared, target)
 		}
 		return dirPath, nil
@@ -110,40 +110,10 @@ func resolveDirRoot(workdir, declared, dirPath string) (string, error) {
 	if resolved == dirPath {
 		return dirPath, nil
 	}
-	if !withinResolvedWorkdir(workdir, resolved) {
+	if !security.WithinResolvedRoot(workdir, resolved) {
 		return "", escapesWorkdirError(declared, resolved)
 	}
 	return resolved, nil
-}
-
-// declaredLinkTarget reports where a symlink points, as an absolute path. A
-// relative target resolves against the directory holding the link, the way the
-// kernel would. Anything that is not a symlink reports false.
-func declaredLinkTarget(p string) (string, bool) {
-	target, err := os.Readlink(p)
-	if err != nil {
-		return "", false
-	}
-	if !filepath.IsAbs(target) {
-		target = filepath.Join(filepath.Dir(p), target)
-	}
-	return filepath.Clean(target), true
-}
-
-// withinResolvedWorkdir reports whether p stays inside the scenario workdir.
-//
-// The workdir can itself sit behind a symlink — macOS puts /tmp behind
-// /private/tmp and /var behind /private/var — and p arrives in either spelling:
-// a path EvalSymlinks resolved takes the resolved form, while a dangling link's
-// declared target keeps the form the link was written with. Both spellings name
-// the same directory, so containment holds if either does; a path outside the
-// workdir is inside neither.
-func withinResolvedWorkdir(workdir, p string) bool {
-	if security.WithinRoot(workdir, p) {
-		return true
-	}
-	resolved, err := filepath.EvalSymlinks(workdir)
-	return err == nil && security.WithinRoot(resolved, p)
 }
 
 func escapesWorkdirError(declared, target string) error {

--- a/internal/assert/dir.go
+++ b/internal/assert/dir.go
@@ -102,7 +102,7 @@ func resolveDirRoot(workdir, declared, dirPath string) (string, error) {
 		// target exists is not a question a spec may put to the filesystem outside
 		// the workdir. Judging it by its declared target keeps the containment
 		// rule from depending on whether the target happens to exist.
-		if target, ok := security.LinkTarget(dirPath); ok && !security.WithinResolvedRoot(workdir, target) {
+		if target, escapes := security.LinkChainEscapes(workdir, dirPath); escapes {
 			return "", escapesWorkdirError(declared, target)
 		}
 		return dirPath, nil

--- a/internal/assert/dir_test.go
+++ b/internal/assert/dir_test.go
@@ -160,6 +160,12 @@ func TestCheckDir_DanglingSymlinkedRootJudgedByItsTarget(t *testing.T) {
 			if err := os.Symlink("releases/v3", filepath.Join(wd, "latest")); err != nil {
 				t.Fatal(err)
 			}
+			// A chain: only its far end says where the path goes, so judging the
+			// first hop alone would accept this one — "hop" points at an in-workdir
+			// name, and that name is the link out.
+			if err := os.Symlink("escape", filepath.Join(wd, "hop")); err != nil {
+				t.Fatal(err)
+			}
 			if tc.symlinkedDir {
 				alias := filepath.Join(base, "alias")
 				if err := os.Symlink("real", alias); err != nil {
@@ -170,6 +176,9 @@ func TestCheckDir_DanglingSymlinkedRootJudgedByItsTarget(t *testing.T) {
 
 			if cr := checkDirOK(t, wd, &spec.DirAssert{Path: "escape", Exists: ptrBool(false)}); cr.OK {
 				t.Error("a dangling link out of the workdir must be refused, not answered")
+			}
+			if cr := checkDirOK(t, wd, &spec.DirAssert{Path: "hop", Exists: ptrBool(false)}); cr.OK {
+				t.Error("a dangling chain whose far end leaves the workdir must be refused too")
 			}
 			if cr := checkDirOK(t, wd, &spec.DirAssert{Path: "latest", Exists: ptrBool(false)}); !cr.OK {
 				t.Errorf("a dangling link inside the workdir must still answer: %+v", cr)

--- a/internal/fixture/fixture_test.go
+++ b/internal/fixture/fixture_test.go
@@ -146,6 +146,35 @@ func TestWrite_RefusesToFollowPlantedSymlink(t *testing.T) {
 	}
 }
 
+// TestWrite_RefusesPlantedSymlinkedAncestor is the same TOCTOU one directory up.
+// The leaf refusal above only guards a link AT the destination, so a program
+// under test that made a directory component a link — `ln -s /host/dir escape` —
+// got the fixture to create files, and whole directory trees, outside the
+// workdir while the run stayed green.
+func TestWrite_RefusesPlantedSymlinkedAncestor(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(dir, "escape")); err != nil {
+		t.Skipf("symlink creation unavailable: %v", err) // Windows without privilege
+	}
+	if err := Write(&spec.Fixture{File: "escape/planted.txt", Content: "x"}, dir, ""); err == nil {
+		t.Error("writing through a planted symlinked ancestor should be refused")
+	}
+	// A nested destination is the worse case: the write creates its parents, so an
+	// unguarded fixture builds a directory tree inside the host directory.
+	if err := Write(&spec.Fixture{File: "escape/deep/planted.txt", Content: "x"}, dir, ""); err == nil {
+		t.Error("creating parents through a planted symlinked ancestor should be refused")
+	}
+	entries, err := os.ReadDir(outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("the host directory was written into through the symlink: %v", entries)
+	}
+}
+
 // TestWrite_ModeMtimeRefusesPlantedSymlink is a security regression: a
 // mode/mtime-only fixture operates in place and chmod/chtimes FOLLOW symlinks,
 // so a link the program-under-test planted at the destination must be refused

--- a/internal/security/path.go
+++ b/internal/security/path.go
@@ -34,8 +34,9 @@ func ResolveSpecPath(field, specDir, p string) (string, error) {
 // resolveInRoot resolves p against root and rejects any result that would escape
 // root. A relative path is joined onto root; an absolute path is taken as-is but
 // must still land inside root — so an absolute `${workdir}/out.txt` is allowed
-// while `/etc/passwd` is not. `../` traversal is rejected either way. The
-// returned path is cleaned and ready to hand to the filesystem.
+// while `/etc/passwd` is not. `../` traversal is rejected either way, and so is a
+// path that leaves root through a symlinked directory. The returned path is
+// cleaned and ready to hand to the filesystem.
 func resolveInRoot(field, rootLabel, root, p string) (string, error) {
 	dest := p
 	if filepath.IsAbs(dest) {
@@ -46,7 +47,61 @@ func resolveInRoot(field, rootLabel, root, p string) (string, error) {
 	if !WithinRoot(root, dest) {
 		return "", fmt.Errorf("%s %q escapes the %s", field, p, rootLabel)
 	}
+	if target, escapes := escapingAncestor(root, dest); escapes {
+		return "", fmt.Errorf("%s %q resolves through a symlink to %q, which escapes the %s", field, p, target, rootLabel)
+	}
 	return dest, nil
+}
+
+// escapingAncestor reports where a directory symlink above dest's leaf leads,
+// when that is outside root.
+//
+// WithinRoot is lexical — it compares path components — so it cannot see that
+// `<root>/escape/secret.txt` names a host file once the program under test has
+// made `escape` a link to a host directory. Every path-taking feature inherited
+// that blind spot from this one resolver: a file assertion read the host file
+// into the report, and a fixture, a run.stdout_to, an http.body_to wrote into
+// the host directory, all while the run stayed green. Resolving the ancestors
+// closes it for every caller at once.
+//
+// Only the ancestors are resolved. A link AT the leaf belongs to the read and
+// write helpers, which refuse it by name (ReadFileNoFollow, StatNoFollow,
+// WriteFileNoFollow); resolving it here would take that refusal away from them
+// and would turn a merely absent path into an error, which `exists: false` asks
+// about legitimately.
+func escapingAncestor(root, dest string) (string, bool) {
+	for dir := filepath.Dir(dest); WithinRoot(root, dir); dir = filepath.Dir(dir) {
+		if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+			if WithinResolvedRoot(root, resolved) {
+				return "", false
+			}
+			return resolved, true
+		}
+		// dir does not resolve: it is missing, or it is a link whose target is.
+		// A dangling link still declares where it points, and the program under
+		// test can create that target at any moment, so judging it by its declared
+		// target keeps containment from depending on that timing. Anything else
+		// unresolvable is an absent directory — ordinary, and the caller's own
+		// error to report — so keep walking up to a component that does resolve.
+		if target, ok := LinkTarget(dir); ok && !WithinResolvedRoot(root, target) {
+			return target, true
+		}
+	}
+	return "", false
+}
+
+// LinkTarget reports where a symlink points, as a cleaned path. A relative
+// target resolves against the directory holding the link, the way the kernel
+// resolves it. Anything that is not a symlink reports false.
+func LinkTarget(p string) (string, bool) {
+	target, err := os.Readlink(p)
+	if err != nil {
+		return "", false
+	}
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(filepath.Dir(p), target)
+	}
+	return filepath.Clean(target), true
 }
 
 // confinedFileMode is the mode of every file atago writes on a spec's behalf
@@ -207,4 +262,21 @@ func WithinRoot(root, resolved string) bool {
 		return false
 	}
 	return rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))
+}
+
+// WithinResolvedRoot reports whether p stays inside root, accepting either
+// spelling of a root that itself sits behind a symlink.
+//
+// The root can be reached through a link — macOS puts /tmp behind /private/tmp
+// and /var behind /private/var, which is where CI's scenario workdirs live — and
+// p arrives in either spelling: a path EvalSymlinks resolved takes the resolved
+// form, while a dangling link's declared target keeps the form the link was
+// written with. Both spellings name the same directory, so containment holds if
+// either does; a path genuinely outside the root is inside neither.
+func WithinResolvedRoot(root, p string) bool {
+	if WithinRoot(root, p) {
+		return true
+	}
+	resolved, err := filepath.EvalSymlinks(root)
+	return err == nil && WithinRoot(resolved, p)
 }

--- a/internal/security/path.go
+++ b/internal/security/path.go
@@ -83,17 +83,56 @@ func escapingAncestor(root, dest string) (string, bool) {
 		// target keeps containment from depending on that timing. Anything else
 		// unresolvable is an absent directory — ordinary, and the caller's own
 		// error to report — so keep walking up to a component that does resolve.
-		if target, ok := LinkTarget(dir); ok && !WithinResolvedRoot(root, target) {
+		if target, escapes := LinkChainEscapes(root, dir); escapes {
 			return target, true
 		}
 	}
 	return "", false
 }
 
-// LinkTarget reports where a symlink points, as a cleaned path. A relative
+// maxLinkHops bounds how far a chain of declared symlink targets is followed. A
+// chain this long is a cycle in practice, and the kernel bounds its own
+// resolution the same way (ELOOP after SYMLOOP_MAX hops).
+const maxLinkHops = 40
+
+// LinkChainEscapes reports where the symlink at p leads, when following its
+// declared targets leaves root at any hop. A path that is not a symlink, or
+// whose chain stays inside root the whole way, does not escape.
+//
+// The chain matters because only its far end says where a path really goes:
+// `escape -> alias` with `alias -> /outside` looks in-root for one hop, and a
+// check that stops there accepts a path the program under test completes into a
+// host directory whenever it likes. Every hop is judged, not only the last one —
+// a chain that steps outside and back names a location outside root that the
+// program controls, and the kernel resolves through it.
+//
+// This works on declared targets rather than EvalSymlinks so it answers for a
+// DANGLING chain too, which is the case that matters: whether a target exists
+// yet is a race the program under test wins, so containment must not depend on
+// it. A cycle runs out of hops and reports no escape, which is correct — a
+// cyclic link resolves to nothing on any OS, so it can never reach outside.
+func LinkChainEscapes(root, p string) (string, bool) {
+	target, ok := linkTarget(p)
+	if !ok {
+		return "", false
+	}
+	for range maxLinkHops {
+		if !WithinResolvedRoot(root, target) {
+			return target, true
+		}
+		next, ok := linkTarget(target)
+		if !ok {
+			return "", false
+		}
+		target = next
+	}
+	return "", false
+}
+
+// linkTarget reports where a symlink points, as a cleaned path. A relative
 // target resolves against the directory holding the link, the way the kernel
 // resolves it. Anything that is not a symlink reports false.
-func LinkTarget(p string) (string, bool) {
+func linkTarget(p string) (string, bool) {
 	target, err := os.Readlink(p)
 	if err != nil {
 		return "", false

--- a/internal/security/path_test.go
+++ b/internal/security/path_test.go
@@ -88,6 +88,112 @@ func TestResolve_RelativeRoot(t *testing.T) {
 	}
 }
 
+// TestResolve_AncestorSymlinkMayNotEscapeTheRoot pins the containment rule
+// against a symlink ABOVE the leaf. The check was purely lexical, so a link the
+// program under test planted at a directory component was invisible to it:
+// `<root>/escape/secret.txt` compares as in-root while naming a host file, and
+// every path-taking feature inherited the hole from this one resolver.
+//
+// A link that stays inside the root is ordinary and must keep resolving, and a
+// path that is merely absent must not become an error — `exists: false` asks
+// exactly that question.
+func TestResolve_AncestorSymlinkMayNotEscapeTheRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is not reliably available on Windows CI")
+	}
+	t.Parallel()
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(root, "escape")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(root, "real"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("real", filepath.Join(root, "alias")); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tt := range []struct {
+		name    string
+		in      string
+		wantErr bool
+	}{
+		{name: "through a link out of the root", in: "escape/secret.txt", wantErr: true},
+		{name: "deeper through a link out of the root", in: "escape/sub/secret.txt", wantErr: true},
+		{name: "the link itself is left to the read and write helpers", in: "escape"},
+		{name: "through a link that stays inside the root", in: "alias/out.txt"},
+		{name: "a path that simply does not exist", in: "absent/out.txt"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := ResolveWorkdirPath("assert.file.path", root, tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ResolveWorkdirPath(%q) = nil error; the path names a location outside the root", tt.in)
+				}
+				if !strings.Contains(err.Error(), "symlink") || !strings.Contains(err.Error(), "scenario workdir") {
+					t.Errorf("error %q should say the path resolves through a symlink out of the workdir", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("ResolveWorkdirPath(%q) error = %v; want it accepted", tt.in, err)
+			}
+		})
+	}
+}
+
+// TestResolve_DanglingAncestorJudgedByItsDeclaredTarget keeps the rule from
+// depending on whether a link's target happens to exist yet: a link out of the
+// root that currently dangles still declares where it points, and the program
+// under test can create that target at any moment. A dangling link that stays
+// inside the root is ordinary (a `latest ->` for a release not built yet).
+func TestResolve_DanglingAncestorJudgedByItsDeclaredTarget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is not reliably available on Windows CI")
+	}
+	t.Parallel()
+	root := t.TempDir()
+	if err := os.Symlink(filepath.Join(t.TempDir(), "absent"), filepath.Join(root, "escape")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("releases/v3", filepath.Join(root, "latest")); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ResolveWorkdirPath("fixture path", root, "escape/out.txt"); err == nil {
+		t.Error("a dangling link out of the root must be refused, not written through")
+	}
+	if _, err := ResolveWorkdirPath("fixture path", root, "latest/out.txt"); err != nil {
+		t.Errorf("a dangling link inside the root must still resolve: %v", err)
+	}
+}
+
+// TestResolve_RootBehindASymlink is the macOS spelling case. CI resolves the
+// scenario workdir under /var and /tmp, which sit behind /private, so an
+// ancestor EvalSymlinks resolved comes back in a spelling the root itself is
+// never written with — comparing only the two literal forms refuses a path that
+// never left the root.
+func TestResolve_RootBehindASymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is not reliably available on Windows CI")
+	}
+	t.Parallel()
+	base := t.TempDir()
+	real := filepath.Join(base, "real")
+	if err := os.MkdirAll(filepath.Join(real, "sub"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	alias := filepath.Join(base, "alias")
+	if err := os.Symlink("real", alias); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ResolveWorkdirPath("assert.file.path", alias, "sub/out.txt"); err != nil {
+		t.Errorf("a path inside a workdir reached through a symlink was refused: %v", err)
+	}
+}
+
 // TestReadFileNoFollow verifies a leaf symlink pointing outside the root is
 // refused (issue #16): the untrusted program under test could plant such a link
 // at an assertion/snapshot read target to disclose an arbitrary host file. A

--- a/internal/security/path_test.go
+++ b/internal/security/path_test.go
@@ -170,6 +170,50 @@ func TestResolve_DanglingAncestorJudgedByItsDeclaredTarget(t *testing.T) {
 	}
 }
 
+// TestResolve_DanglingChainJudgedByItsWholeChain closes the one-hop reading of
+// the rule above. Only the END of a chain says where a path goes: `hop ->
+// escape` with `escape -> /outside/absent` looks in-root for one hop, and a
+// check that stops there accepts a path the program under test completes into a
+// host directory at will. A hop that leaves the root is refused wherever in the
+// chain it sits, because the kernel resolves through that location.
+func TestResolve_DanglingChainJudgedByItsWholeChain(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is not reliably available on Windows CI")
+	}
+	t.Parallel()
+	root := t.TempDir()
+	if err := os.Symlink(filepath.Join(t.TempDir(), "absent"), filepath.Join(root, "escape")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("escape", filepath.Join(root, "hop")); err != nil {
+		t.Fatal(err)
+	}
+	// A chain that stays inside the root the whole way is ordinary and must keep
+	// resolving, and a cycle must be answered rather than followed forever.
+	if err := os.Symlink("latest", filepath.Join(root, "current")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("releases/v3", filepath.Join(root, "latest")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("b", filepath.Join(root, "a")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("a", filepath.Join(root, "b")); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ResolveWorkdirPath("fixture path", root, "hop/out.txt"); err == nil {
+		t.Error("a chain whose far end leaves the root must be refused")
+	}
+	if _, err := ResolveWorkdirPath("fixture path", root, "current/out.txt"); err != nil {
+		t.Errorf("a dangling chain that stays inside the root must still resolve: %v", err)
+	}
+	if _, err := ResolveWorkdirPath("fixture path", root, "a/out.txt"); err != nil {
+		t.Errorf("a link cycle inside the root must be answered, not refused: %v", err)
+	}
+}
+
 // TestResolve_RootBehindASymlink is the macOS spelling case. CI resolves the
 // scenario workdir under /var and /tmp, which sit behind /private, so an
 // ancestor EvalSymlinks resolved comes back in a spelling the root itself is

--- a/test/e2e/atago/security.atago.yaml
+++ b/test/e2e/atago/security.atago.yaml
@@ -60,6 +60,98 @@ scenarios:
           stdout:
             contains: "escapes the scenario workdir"
 
+  # The traversal above is lexical and easy to see. A directory symlink the
+  # program under test plants is the same escape with nothing to see: the path
+  # still compares as workdir-relative, and every path-taking key followed it.
+  # Reading is a failed assertion: exists:false would otherwise answer a question
+  # about a directory the spec has no business seeing.
+  - name: a file assertion may not read through a symlinked directory
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: link_read.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: inner
+            scenarios:
+              - name: read through the link
+                steps:
+                  - run:
+                      command: ln -s .. escape
+                  - assert:
+                      file:
+                        path: escape/anything.txt
+                        exists: false
+      - run:
+          command: ${atago} run link_read.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains: "escapes the scenario workdir"
+
+  # Writing is an execution error: the redirect never runs, so no host file is
+  # created for a later assertion to be built on.
+  - name: a redirect may not write through a symlinked directory
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: link_write.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: inner
+            scenarios:
+              - name: write through the link
+                steps:
+                  - run:
+                      command: ln -s .. escape
+                  - run:
+                      shell: true
+                      command: echo planted
+                      stdout_to: escape/planted.txt
+      - run:
+          command: ${atago} run link_write.atago.yaml
+      - assert:
+          exit_code: 4
+          stdout:
+            contains: "escapes the scenario workdir"
+
+  # The other half of the same rule: a link that stays inside the workdir is an
+  # ordinary thing for a program to produce, and both halves must keep working
+  # through it.
+  - name: a symlinked directory inside the workdir still resolves
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: link_ok.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: inner
+            scenarios:
+              - name: read and write through an in-workdir link
+                steps:
+                  - run:
+                      command: mkdir real
+                  - run:
+                      command: ln -s real alias
+                  - run:
+                      shell: true
+                      command: echo through the alias
+                      stdout_to: alias/out.txt
+                  - assert:
+                      file:
+                        path: real/out.txt
+                        contains: through the alias
+      - run:
+          command: ${atago} run link_ok.atago.yaml
+      - assert:
+          exit_code: 0
+
   - name: a snapshot path may not escape the spec directory
     steps:
       - fixture:


### PR DESCRIPTION
## Summary

The containment check behind every workdir- and spec-scoped path is lexical: it compares path components, so it cannot see that `escape/secret.txt` names a host file once the program under test has run `ln -s /etc escape`. Only a symlink at the LEAF was refused (by `ReadFileNoFollow` / `StatNoFollow` / `WriteFileNoFollow`), and every path-taking key inherited the blind spot from the one resolver they share. #427 fixed this for the `dir:` assertion's own root; this is the same defect on the resolver underneath it.

A green run could leave the workdir in both directions. This spec passed, read `secret.txt` from a host directory, and wrote `planted.txt` into it:

```yaml
scenarios:
  - name: read a host file through a symlinked ancestor
    steps:
      - run: { command: ln -s /some/host/dir escape }
      - assert: { file: { path: escape/secret.txt, contains: HOST SECRET } }
  - name: write outside the workdir through a symlinked ancestor
    steps:
      - run: { command: ln -s /some/host/dir escape }
      - run: { shell: true, command: echo planted, stdout_to: escape/planted.txt }
```

Affected: `assert.file` (content, `exists`, and the `size` bounds, which disclose a host file's length), `assert.pdf`, `assert.image.similar_to`, `assert.dir.contains`/`not_contains`, `fixture:`, `run.stdout_to`/`stderr_to`, `run.stdin.file`, `http.body_to`/`body_file`/`files.path`, `store.from.file`, `service.ready.file`, the `cdp` screenshot/upload/download paths, `assert.snapshot`, and `mock` `body_file`. A nested destination is the worst of the write cases: creating the parents builds a whole directory tree inside the host directory.

## Fix

`resolveInRoot` now resolves the path's ancestors and puts them through the same containment test the declared path faces, following the rules `dir:` already established for its root: a dangling link is judged by its declared target, so containment does not depend on whether that target exists yet, and either spelling of a root that itself sits behind a symlink is accepted (macOS puts CI's scenario workdirs behind `/private`). Only the ancestors are resolved — a link at the leaf stays the read and write helpers' business, keeping their wording, and a path that is merely absent is untouched so `exists: false` still answers. A link that stays inside the root keeps resolving, which is ordinary output for a program under test.

The two helpers `dir:` grew for this in #427 move to `internal/security`, so the rule has one implementation for every caller.

## Audit of the same class elsewhere

`changes:` is clean: `filepath.WalkDir` lstats, so a planted directory link is recorded as an entry and never traversed. `--artifacts-dir` is clean: its relative paths are slugs built from the suite, scenario and step, and the root is the operator's own flag rather than a spec-controlled path.

## Tests

`internal/security/path_test.go` covers the resolver (escape, deeper escape, dangling ancestor, in-root link, absent path, and a root behind a symlink), and the boundaries get their own regressions: `internal/assert` for the read and the size disclosure, `internal/fixture` for the write and the parent creation. Each was confirmed to fail before the fix. `test/e2e/atago/security.atago.yaml` adds the user-visible pair — a read refused as a failure, a redirect refused as an execution error — plus the negative case, an in-workdir link that must keep working.

Refs #16, #427


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented file reads, writes, assertions, and output redirects from escaping the permitted working directory through symlinked directories.
  * Correctly handles dangling symlinks and roots accessed through symlink aliases.
  * Preserved valid behavior for symlinks that remain within the allowed directory.

* **Tests**
  * Added end-to-end security coverage for symlink traversal scenarios across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->