### PR TITLE
fix(assert): frame a failing screen assert in display columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,15 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- The box a failing `screen:` assertion draws around the terminal screen is now
+  measured in display columns. It counted bytes first and runes after, and
+  neither is what a terminal draws: a CJK character or an emoji is one rune and
+  two columns, so a Japanese TUI — one of the screens this assertion exists to
+  check — came out with its rows hanging past a border closed half a screen
+  early. Box drawing stays one column, which is what the terminals TUIs run in
+  give it, and the measure ignores the host locale: go-runewidth reads `LANG` at
+  init and would otherwise frame the same screen one way on a CJK machine and
+  another in CI.
 - Every workdir- and spec-scoped path is now checked against a symlink at a
   DIRECTORY component, not only at the leaf. The containment check was lexical,
   so it compared path components and could not see that `escape/secret.txt`

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-80 suites · 520 scenarios
+80 suites · 521 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -578,10 +578,11 @@
   - [a session outlived by its program says so instead of blaming the clock](#scenario-a-session-outlived-by-its-program-says-so-instead-of-blaming-the-clock)
   - [an expect that never matches still reports the pattern, not the quit advice](#scenario-an-expect-that-never-matches-still-reports-the-pattern-not-the-quit-advice)
   - [a timeout that expires before the process starts is still a timeout](#scenario-a-timeout-that-expires-before-the-process-starts-is-still-a-timeout)
-- [atago self-hosting / tui](#atago-self-hosting--tui) — 4 scenarios
+- [atago self-hosting / tui](#atago-self-hosting--tui) — 5 scenarios
   - [a pty step exports a usable TERM by default](#scenario-a-pty-step-exports-a-usable-term-by-default)
   - [an explicit TERM overrides the default](#scenario-an-explicit-term-overrides-the-default)
   - [an expect does not re-match a consumed pattern](#scenario-an-expect-does-not-re-match-a-consumed-pattern)
+  - [a failing screen assert frames a CJK screen squarely](#scenario-a-failing-screen-assert-frames-a-cjk-screen-squarely)
   - [less -X renders a real pager onto the screen](#scenario-less--x-renders-a-real-pager-onto-the-screen)
 - [atago self-hosting / variable resolution semantics](#atago-self-hosting--variable-resolution-semantics) — 7 scenarios
   - [a doubled dollar keeps the braces literal](#scenario-a-doubled-dollar-keeps-the-braces-literal)
@@ -11233,6 +11234,35 @@ ${atago} run inner.atago.yaml
 #### Then
 - exit code is `1`
 - stdout contains `1 failed`
+### Scenario: a failing screen assert frames a CJK screen squarely
+_skipped on Windows_
+#### Given
+- Fixture file `inner.atago.yaml` is created.
+#### Inputs
+_Fixture `inner.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: inner
+scenarios:
+  - name: screen assert that must fail
+    steps:
+      - pty:
+          shell: true
+          command: 'printf "abcdefgh\r\n日本語メニュー\r\n"'
+          rows: 4
+          cols: 20
+      - assert:
+          screen:
+            contains: "NOT ON THIS SCREEN"
+```
+#### When
+```shell
+${atago} run inner.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `| abcdefgh       |`, `| 日本語メニュー |`
 ### Scenario: less -X renders a real pager onto the screen
 _only when `command -v less` succeeds · skipped on Windows_
 #### Given

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/jhump/protoreflect/v2 v2.0.0-beta.2
 	github.com/k1LoW/grpcstub v0.26.5
 	github.com/lib/pq v1.12.3
+	github.com/mattn/go-runewidth v0.0.19
 	github.com/mattn/go-shellwords v1.0.13
 	github.com/nao1215/markdown v0.13.0
 	github.com/ohler55/ojg v1.28.4
@@ -49,7 +50,6 @@ require (
 	github.com/karrick/godirwalk v1.17.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect
-	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 // indirect
 	github.com/olekukonko/errors v1.1.0 // indirect

--- a/internal/assert/assert_test.go
+++ b/internal/assert/assert_test.go
@@ -13,7 +13,8 @@ import (
 	"strings"
 	"testing"
 	"time"
-	"unicode/utf8"
+
+	"github.com/mattn/go-runewidth"
 
 	"github.com/nao1215/atago/internal/fsdelta"
 	"github.com/nao1215/atago/internal/runner"
@@ -1120,29 +1121,78 @@ func TestCheck_File_ExistsUnreadable(t *testing.T) {
 	}
 }
 
-// TestBorderedScreen_MultibyteAligns is a regression test for a width bug in the
-// screen-assert failure box: it measured line width and padding in bytes, so a
-// rendered TUI screen containing box-drawing characters (─│┌, 3 bytes each) or
-// CJK text produced a ragged right border — exactly the screens atago's pty/TUI
-// assertions exist to check. Every framed content row must have the same rune
-// width so the closing "|" column lines up.
+// TestBorderedScreen_MultibyteAligns is a regression test for the width of the
+// screen-assert failure box. It measured lines in bytes first and then in runes,
+// and neither is what a terminal draws: a CJK character or an emoji is one rune
+// and takes TWO columns, so a Japanese TUI — one of the screens this assertion
+// exists to check — still came out with a right border that wanders. The box is
+// read in a terminal, so the only measure that lines it up is display width.
 func TestBorderedScreen_MultibyteAligns(t *testing.T) {
 	t.Parallel()
-	// An ASCII line and a multibyte line of different byte lengths but knowable
-	// rune widths. Byte-based padding would give these rows different rune widths.
-	screen := "abc\n日本\n┌──┐"
-	out := borderedScreen(screen)
-
-	lines := strings.Split(out, "\n")
-	if len(lines) < 3 {
-		t.Fatalf("bordered output has too few lines:\n%s", out)
+	// The expected block is written out in full rather than measured with the
+	// same helper the code under test uses, which would agree with any measure it
+	// picked. Read this in a monospace terminal: every "|" is in one column.
+	//
+	// "日本語" is three runes and six columns, "ok 🎉!" six runes and seven; a
+	// rune-based measure boxes this screen to seven columns instead of nine and
+	// lets both rows spill past the border.
+	for _, tt := range []struct {
+		name   string
+		screen string
+		want   string
+	}{
+		{
+			name:   "a CJK row is the widest",
+			screen: "abc\n日本語",
+			want: "" +
+				"+--------+\n" +
+				"| abc    |\n" +
+				"| 日本語 |\n" +
+				"+--------+",
+		},
+		{
+			name:   "box drawing counts one column, emoji two",
+			screen: "┌───────┐\nok 🎉!\nplain",
+			want: "" +
+				"+-----------+\n" +
+				"| ┌───────┐ |\n" +
+				"| ok 🎉!    |\n" +
+				"| plain     |\n" +
+				"+-----------+",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := borderedScreen(tt.screen); got != tt.want {
+				t.Errorf("borderedScreen(%q) =\n%s\nwant\n%s", tt.screen, got, tt.want)
+			}
+		})
 	}
-	// The top bar sets the box width; every subsequent row (content rows and the
-	// bottom bar) must match it rune-for-rune.
-	want := utf8.RuneCountInString(lines[0])
-	for i, l := range lines {
-		if got := utf8.RuneCountInString(l); got != want {
-			t.Errorf("row %d rune width = %d, want %d (ragged border)\nrow: %q\nfull:\n%s", i, got, want, l, out)
+}
+
+// TestDisplayWidth_IgnoresTheHostLocale pins the measure against go-runewidth's
+// package default, which reads LANG at init and switches ambiguous-width
+// characters to two columns under a CJK locale. Taking that default would frame
+// the same screen one way on a Japanese laptop and another in CI, and box
+// drawing — what a TUI is built from — is exactly the ambiguous class it moves.
+// This test does not run in parallel: it flips that global to prove it is not
+// consulted.
+func TestDisplayWidth_IgnoresTheHostLocale(t *testing.T) {
+	restore := runewidth.DefaultCondition.EastAsianWidth
+	runewidth.DefaultCondition.EastAsianWidth = true
+	t.Cleanup(func() { runewidth.DefaultCondition.EastAsianWidth = restore })
+
+	for _, tt := range []struct {
+		in   string
+		want int
+	}{
+		{in: "abc", want: 3},
+		{in: "┌──┐", want: 4}, // ambiguous: one column in the terminals TUIs run in
+		{in: "日本", want: 4},   // wide, not ambiguous: two columns either way
+		{in: "🎉", want: 2},
+	} {
+		if got := displayWidth(tt.in); got != tt.want {
+			t.Errorf("displayWidth(%q) = %d, want %d (the host locale must not change it)", tt.in, got, tt.want)
 		}
 	}
 }

--- a/internal/assert/screen.go
+++ b/internal/assert/screen.go
@@ -2,7 +2,8 @@ package assert
 
 import (
 	"strings"
-	"unicode/utf8"
+
+	"github.com/mattn/go-runewidth"
 
 	"github.com/nao1215/atago/internal/runner"
 	"github.com/nao1215/atago/internal/spec"
@@ -38,15 +39,17 @@ func checkScreen(sa *spec.ScreenAssert, res *runner.Result, env Env) *CheckResul
 }
 
 // borderedScreen frames the rendered screen so trailing spaces and width are
-// visible in failure output. Width and padding are measured in runes, not bytes:
-// a pty/TUI screen routinely contains box-drawing characters (─│┌, 3 bytes each)
-// and CJK text, and a byte-based measure would pad those rows short and produce a
-// ragged right border in exactly the screens this assertion exists to check.
+// visible in failure output. Width and padding are measured in DISPLAY COLUMNS,
+// which is what the terminal the box is read in actually draws: a pty/TUI screen
+// routinely carries box-drawing characters (─│┌, 3 bytes and 1 column each), CJK
+// text and emoji (1 rune and 2 columns each), and measuring in bytes or in runes
+// pads those rows to the wrong place — a right border that wanders, in exactly
+// the screens this assertion exists to check.
 func borderedScreen(screen string) string {
 	lines := strings.Split(screen, "\n")
 	width := 0
 	for _, l := range lines {
-		if n := utf8.RuneCountInString(l); n > width {
+		if n := displayWidth(l); n > width {
 			width = n
 		}
 	}
@@ -54,8 +57,28 @@ func borderedScreen(screen string) string {
 	bar := "+" + strings.Repeat("-", width+2) + "+"
 	b.WriteString(bar + "\n")
 	for _, l := range lines {
-		b.WriteString("| " + l + strings.Repeat(" ", width-utf8.RuneCountInString(l)) + " |\n")
+		b.WriteString("| " + l + strings.Repeat(" ", width-displayWidth(l)) + " |\n")
 	}
 	b.WriteString(bar)
 	return b.String()
+}
+
+// screenWidth measures display columns with EastAsianWidth off, deliberately
+// rather than by taking the package default.
+//
+// go-runewidth reads the host locale at init and turns that flag ON under a CJK
+// locale, which would make the width of a failure box depend on the developer's
+// LANG — the same screen framed one way on a Japanese laptop and another in CI.
+// A report atago prints has to read the same everywhere. Off is also the right
+// answer: the flag governs the AMBIGUOUS-width characters, which is where box
+// drawing lives (─│┌), and every terminal a TUI is drawn in gives those one
+// column. CJK and emoji are Wide, not ambiguous, so they still count two.
+var screenWidth = &runewidth.Condition{StrictEmojiNeutral: true}
+
+// displayWidth reports how many terminal columns s occupies. A wide character
+// (CJK, emoji) takes two, a combining mark takes none, and everything else takes
+// one — the same table a terminal lays a line out with, so a box drawn to this
+// measure closes where the text ends.
+func displayWidth(s string) int {
+	return screenWidth.StringWidth(s)
 }

--- a/test/e2e/atago/tui.atago.yaml
+++ b/test/e2e/atago/tui.atago.yaml
@@ -67,6 +67,41 @@ scenarios:
           stdout:
             contains: "1 failed"
 
+  # A failing screen assert frames the screen so the reader can see where each
+  # row ends. The frame is drawn in DISPLAY COLUMNS: the Japanese row below is
+  # seven runes and fourteen columns, and measuring it in runes closed the box at
+  # eight and left that row hanging outside it. Both rows must end at the same
+  # "|", which is what the two literals here pin.
+  - name: a failing screen assert frames a CJK screen squarely
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: inner.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: inner
+            scenarios:
+              - name: screen assert that must fail
+                steps:
+                  - pty:
+                      shell: true
+                      command: 'printf "abcdefgh\r\n日本語メニュー\r\n"'
+                      rows: 4
+                      cols: 20
+                  - assert:
+                      screen:
+                        contains: "NOT ON THIS SCREEN"
+      - run:
+          command: ${atago} run inner.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "| abcdefgh       |"
+              - "| 日本語メニュー |"
+
   # A REAL third-party TUI pager: less -X keeps its output on the primary screen,
   # so after quitting the rendered screen still shows the file. (less using the
   # alternate screen would restore a blank primary screen on exit — documented in


### PR DESCRIPTION
## Summary

The box a failing `screen:` assertion draws around the rendered terminal exists so the reader can see what was on screen and where each row ends. It measured lines in bytes first, then in runes, and neither is what a terminal draws: a CJK character or an emoji is one rune and TWO columns. A Japanese TUI — one of the screens this assertion exists to check — came out with its rows hanging past a border closed half a screen early.

Before, for a 20-column pty printing `abcdefgh` and `日本語メニュー`:

```
+----------+
| abcdefgh |
| 日本語メニュー |
+----------+
```

After:

```
+----------------+
| abcdefgh       |
| 日本語メニュー |
+----------------+
```

## Fix

Width and padding come from `go-runewidth`, through an explicit `Condition` rather than the package default. That default reads `LANG` at init and turns `EastAsianWidth` on under a CJK locale, so taking it would frame the same screen one way on a Japanese laptop and another in CI — a report atago prints has to read the same everywhere. Off is also the right answer on the merits: the flag governs the AMBIGUOUS-width class, which is where box drawing lives (`─│┌`), and every terminal a TUI is drawn in gives those one column. CJK and emoji are Wide rather than ambiguous, so they still count two.

`go-runewidth` was already in the build graph via `internal/docgen` -> `nao1215/markdown` -> `tablewriter`; the go.mod change only promotes it from indirect to direct.

Scope is the failure box alone. The screen TEXT is unaffected: vt10x stores one rune per cell with no filler, so `screen: contains: 日本語メニュー` already matched correctly, and that was verified before changing anything.

## Tests

`TestBorderedScreen_MultibyteAligns` now pins the framed block verbatim. The old version measured the output with the same helper the code under test uses, so it agreed with whatever measure that helper picked and passed on the rune measure too — it could not have caught this. `TestDisplayWidth_IgnoresTheHostLocale` flips `runewidth.DefaultCondition.EastAsianWidth` to prove the global is not consulted. Both were confirmed to fail against the old rune measure.

`test/e2e/atago/tui.atago.yaml` adds the user-visible case through the real binary: an inner spec whose `screen:` assert fails on a screen carrying an ASCII row and a Japanese row, with the outer scenario pinning both framed rows so they must end at the same column.
