### PR TITLE
feat(record): flag a pty send that has no expect before it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- `atago record --pty` now notes in the generated spec's header when a send has
+  no expect before it. The recorder anchors a send on the plain text that
+  preceded it, but a full-screen TUI that redraws with pure cursor addressing
+  prints no text to anchor on, so two sends end up back to back — and on replay
+  they are written as fast as the engine can, where a program that drains
+  typeahead on a mode switch reads the first and drops the second. The comment
+  names the sends (by position) so the author can add an expect or expect_screen
+  before them; a session where every send is anchored is unchanged.
 - `atago record` now anchors an observed stderr the way it has always anchored
   stdout: on its first non-empty line. Only an EMPTY stderr produced an assert
   before, so recording the case a CLI author most wants pinned — a failing run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,10 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- `atago record --pty` now notes in the generated spec's header when a send has
-  no expect before it. The recorder anchors a send on the plain text that
-  preceded it, but a full-screen TUI that redraws with pure cursor addressing
+- `atago record --pty` now notes in the generated spec's header when a send that
+  follows another send has no expect before it (an unanchored first send stays
+  silent, having no prior send to race). The recorder anchors a send on the plain
+  text that preceded it, but a full-screen TUI that redraws with pure cursor addressing
   prints no text to anchor on, so two sends end up back to back — and on replay
   they are written as fast as the engine can, where a program that drains
   typeahead on a mode switch reads the first and drops the second. The comment

--- a/internal/record/pty.go
+++ b/internal/record/pty.go
@@ -81,6 +81,10 @@ func GeneratePTY(rec PTYRecording, opts Options) ([]byte, error) {
 	b.WriteString("# Recorded by `atago record --pty` — a starting point, not a verdict:\n")
 	b.WriteString("# each send replays a burst you typed, and each expect anchors on the\n")
 	b.WriteString("# prompt that preceded it. Tighten the matchers to pin what you care about.\n")
+
+	session, lastOutput, unanchored := renderSession(&rec)
+	writeUnanchoredWarning(&b, unanchored)
+
 	fmt.Fprintf(&b, "suite:\n  name: %s\n\n", yamlScalar(opts.SuiteName))
 	b.WriteString("scenarios:\n")
 	// scenarioLabel, not the raw command: the loader rejects a control character
@@ -100,7 +104,6 @@ func GeneratePTY(rec PTYRecording, opts Options) ([]byte, error) {
 		fmt.Fprintf(&b, "          cols: %d\n", rec.Cols)
 	}
 
-	session, lastOutput := renderSession(&rec)
 	if len(session) > 0 {
 		b.WriteString("          session:\n")
 		for _, line := range session {
@@ -127,21 +130,85 @@ func GeneratePTY(rec PTYRecording, opts Options) ([]byte, error) {
 // each input burst becomes a send, preceded by an expect derived from the last
 // stable line of the output before it. It returns the session lines and the
 // trailing output (after the final input) for the closing assertion (#69).
-func renderSession(rec *PTYRecording) (lines []string, trailingOutput []byte) {
+func renderSession(rec *PTYRecording) (lines []string, trailingOutput []byte, unanchored []int) {
 	var pending []byte
 	secretN := 0
+	sendN := 0
 	for _, seg := range rec.Segments {
 		if seg.Input == nil {
 			pending = append(pending, seg.Output...)
 			continue
 		}
+		hasAnchor := false
 		if anchor := stableLine(pending); anchor != "" {
 			lines = append(lines, fmt.Sprintf("            - expect: %s\n", yamlScalar(regexp.QuoteMeta(anchor))))
+			hasAnchor = true
+		}
+		sendN++
+		// A send with no expect before it is only a replay hazard when another send
+		// precedes it: the two are written back to back and a program that drains
+		// typeahead on a mode switch drops the second. The FIRST send has no prior
+		// send to race, so an anchorless first send is not called out.
+		if sendN > 1 && !hasAnchor {
+			unanchored = append(unanchored, sendN)
 		}
 		lines = append(lines, renderSend(seg, &secretN)...)
 		pending = nil
 	}
-	return lines, pending
+	return lines, pending, unanchored
+}
+
+// writeUnanchoredWarning notes, once in the header, every send that has no
+// expect before it (see renderSession). The list is left empty for the common
+// case — a session where every send is anchored — so nothing is written and the
+// header stays as it was.
+func writeUnanchoredWarning(b *strings.Builder, unanchored []int) {
+	if len(unanchored) == 0 {
+		return
+	}
+	ordinals := make([]string, len(unanchored))
+	for i, n := range unanchored {
+		ordinals[i] = ordinal(n)
+	}
+	verb, subj, them, each := "has", "send", "it", "it is"
+	if len(unanchored) > 1 {
+		verb, subj, them, each = "have", "sends", "them", "each is"
+	}
+	b.WriteString("#\n")
+	fmt.Fprintf(b, "# The %s %s no expect before %s: the program printed no text to anchor\n",
+		joinOrdinals(ordinals)+" "+subj, verb, them)
+	fmt.Fprintf(b, "# on, so on replay %s written right after the send before it. If the\n", each)
+	b.WriteString("# program drops fast input, add an expect or expect_screen before it.\n")
+}
+
+// joinOrdinals renders ["2nd"] as "2nd" and ["2nd","3rd","5th"] as
+// "2nd, 3rd and 5th" so the note reads as a sentence.
+func joinOrdinals(o []string) string {
+	switch len(o) {
+	case 1:
+		return o[0]
+	case 2:
+		return o[0] + " and " + o[1]
+	default:
+		return strings.Join(o[:len(o)-1], ", ") + " and " + o[len(o)-1]
+	}
+}
+
+// ordinal renders 1->"1st", 2->"2nd", 3->"3rd", 4->"4th", handling the 11-13
+// exception (11th, 12th, 13th) the usual way.
+func ordinal(n int) string {
+	suffix := "th"
+	if n%100 < 11 || n%100 > 13 {
+		switch n % 10 {
+		case 1:
+			suffix = "st"
+		case 2:
+			suffix = "nd"
+		case 3:
+			suffix = "rd"
+		}
+	}
+	return fmt.Sprintf("%d%s", n, suffix)
 }
 
 // renderSend renders one input burst as a send entry: an ${env:...} placeholder

--- a/internal/record/pty_test.go
+++ b/internal/record/pty_test.go
@@ -393,6 +393,99 @@ func TestStableLine_PrefersInformativeAnchor(t *testing.T) {
 	}
 }
 
+// TestGeneratePTY_WarnsUnanchoredSends pins the heads-up a generated spec gives
+// when a send has no expect before it. The recorder anchors a send on the plain
+// text that preceded it, but a program that redraws with pure cursor addressing
+// (a full-screen TUI) prints no text to anchor on, so two sends land back to
+// back. On replay they are written as fast as the engine can, and a program that
+// drains typeahead when it switches input mode reads the first and drops the
+// second — a failure with nothing in the spec explaining it. The comment names
+// the sends so the author can add an expect or expect_screen.
+//
+// Only a send that FOLLOWS another send without an anchor is called out: the very
+// first send has no prior send to race, so an anchorless first send is silent.
+func TestGeneratePTY_WarnsUnanchoredSends(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		segments    []PTYSegment
+		wantContain []string
+		wantAbsent  []string
+	}{
+		{
+			// Clear-screen between two inputs: no text to anchor the second send.
+			name: "control-only output between sends is flagged",
+			segments: []PTYSegment{
+				outSeg("Name: "),
+				inSeg("alice\r"),
+				outSeg("\x1b[2J\x1b[H"),
+				inSeg("bob\r"),
+				outSeg("done\r\n"),
+			},
+			wantContain: []string{"no expect", "2nd send"},
+		},
+		{
+			// A real prompt separates every send: nothing to warn about.
+			name: "text between every send is not flagged",
+			segments: []PTYSegment{
+				outSeg("First: "),
+				inSeg("alice\r"),
+				outSeg("Second: "),
+				inSeg("bob\r"),
+				outSeg("done\r\n"),
+			},
+			wantAbsent: []string{"no expect"},
+		},
+		{
+			// The first send has no prompt before it, but it is the first send, so
+			// there is nothing for it to race with — no warning.
+			name: "an anchorless first send alone is not flagged",
+			segments: []PTYSegment{
+				inSeg("alice\r"),
+				outSeg("Second: "),
+				inSeg("bob\r"),
+				outSeg("done\r\n"),
+			},
+			wantAbsent: []string{"no expect"},
+		},
+		{
+			// Two anchorless sends in a row: both the 2nd and 3rd are named.
+			name: "several unanchored sends are all named",
+			segments: []PTYSegment{
+				outSeg("Go: "),
+				inSeg("a\r"),
+				outSeg("\x1b[H"),
+				inSeg("b\r"),
+				outSeg("\x1b[2J"),
+				inSeg("c\r"),
+				outSeg("done\r\n"),
+			},
+			wantContain: []string{"2nd", "3rd send"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := GeneratePTY(PTYRecording{Command: "prog", Segments: tt.segments}, Options{SuiteName: "gen"})
+			if err != nil {
+				t.Fatalf("GeneratePTY: %v", err)
+			}
+			s := string(got)
+			for _, want := range tt.wantContain {
+				if !strings.Contains(s, want) {
+					t.Errorf("generated spec missing %q:\n%s", want, s)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(s, absent) {
+					t.Errorf("generated spec unexpectedly contains %q:\n%s", absent, s)
+				}
+			}
+			loadGenerated(t, got) // the heads-up is a comment; the spec must still load
+		})
+	}
+}
+
 // TestStableLine_AnchorIsRawSubstring is a regression for the pty round-trip law
 // (#30/#69): the anchor an expect/contains is built from must be a verbatim
 // substring of the RAW transcript the replay matches against. Stripping ANSI and


### PR DESCRIPTION
## Summary

Closes #433. `atago record --pty` anchors each send on the plain text that preceded it, so on replay a send waits for the program to reach a known state. A full-screen TUI that redraws with pure cursor addressing prints no text to anchor on, so two sends end up back to back — and on replay they are written as fast as the engine can, where a program that drains typeahead on a mode switch reads the first and drops the second. The generated spec passed its own validation and then failed on a race with nothing in it explaining why.

This is option A from the issue: one note in the generated header, naming the sends. No new spec key, flag, or subcommand.

Example generated output:

```yaml
# Recorded by `atago record --pty` — a starting point, not a verdict:
# each send replays a burst you typed, and each expect anchors on the
# prompt that preceded it. Tighten the matchers to pin what you care about.
#
# The 2nd send has no expect before it: the program printed no text to anchor
# on, so on replay it is written right after the send before it. If the
# program drops fast input, add an expect or expect_screen before it.
suite:
  name: demo
...
```

## Behavior

`renderSession` now reports which sends had no expect before them, and `writeUnanchoredWarning` names them by ordinal. Only a send that FOLLOWS another send is called out: the first send has no prior send to race, so an anchorless first send stays silent. A session where every send is anchored is unchanged, so the common recording is untouched.

## Tests

`TestGeneratePTY_WarnsUnanchoredSends` is a decision table: control-only output between sends is flagged; text between every send is not; an anchorless first send alone is not; several unanchored sends are all named. It was confirmed to fail before the change.

No self-hosted E2E: the warning only fires for a raw-mode TUI redraw with no echoed text, which no always-present POSIX program produces deterministically, and the skill's guidance is to pin non-deterministic behavior at the deterministic layer — which the decision table does.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `atago record --pty` now adds comments identifying sends without a preceding `expect` anchor, including their positions.
  * Sessions with all sends properly anchored remain unchanged.

* **Bug Fixes**
  * Improved visibility into potentially unsynchronized sends, helping authors add the necessary synchronization assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->