### PR TITLE
fix(security): bind confined I/O to an os.Root so containment holds at the operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,17 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Every confined read, write, and stat is now bound to an `os.Root` at its
+  containment root, so containment holds at the moment of the operation instead
+  of relying on the pathname check that ran before it. The lexical checks (and
+  the ancestor-symlink resolution added earlier) refuse an escape that is already
+  in place, but a program under test can swap a directory component for a symlink
+  in the window between the check and the read or write; `os.Root` resolves every
+  component through the root's own descriptor and refuses one that leaves the
+  root, closing that race for the file/pdf/image assertions, `fixture:`,
+  `run.stdout_to`/`stderr_to`, `http.body_to`, and the snapshot reader and
+  writer. A symlink at the leaf is still refused outright and a non-regular leaf
+  (a FIFO) is still refused by kind, so the existing contract is unchanged.
 - The box a failing `screen:` assertion draws around the terminal screen is now
   measured in display columns. It counted bytes first and runes after, and
   neither is what a terminal draws: a CJK character or an emoji is one rune and

--- a/internal/assert/count.go
+++ b/internal/assert/count.go
@@ -203,13 +203,14 @@ func location(got string, off int) string {
 // need the bytes in memory to have an opinion about them. A directory fails
 // with the same phrasing exists: uses — a directory has a size, but it is not
 // the file the assertion is about.
-func checkFileSize(f *spec.FileAssert, path string) *CheckResult {
+func checkFileSize(f *spec.FileAssert, root, path string) *CheckResult {
 	desc := fmt.Sprintf("assert file %q size %s", f.Path, sizeBounds(f).phrase())
 	// StatNoFollow, not os.Stat: a program under test can plant a symlink at the
 	// assertion target, and following it would report the size of a host file
 	// outside the workdir — the same disclosure ReadFileNoFollow refuses on the
-	// read path (issue #16).
-	info, err := security.StatNoFollow(path)
+	// read path (issue #16). Binding it to the workdir refuses an ancestor swapped
+	// for a link too (issue #430).
+	info, err := security.StatNoFollow(root, path)
 	if err != nil {
 		return &CheckResult{
 			Desc:     desc,

--- a/internal/assert/file.go
+++ b/internal/assert/file.go
@@ -34,7 +34,7 @@ func checkFile(f *spec.FileAssert, env Env) (out *CheckResult) {
 		}
 	}()
 	read := func(label, p string) ([]byte, *CheckResult) {
-		data, cr := readFile(label, p)
+		data, cr := readFile(label, env.Workdir, p)
 		if cr == nil {
 			fileData = data
 		}
@@ -47,7 +47,7 @@ func checkFile(f *spec.FileAssert, env Env) (out *CheckResult) {
 	// first because a wrong size explains a content mismatch better than the
 	// other way round, and when nothing else is set they are the whole assertion.
 	if f.HasSize() {
-		if cr := checkFileSize(f, path); !cr.OK || !f.HasContentMatcher() {
+		if cr := checkFileSize(f, env.Workdir, path); !cr.OK || !f.HasContentMatcher() {
 			return cr
 		}
 	}
@@ -197,7 +197,7 @@ func checkFile(f *spec.FileAssert, env Env) (out *CheckResult) {
 		}
 		// The comparison file is read plainly (not via read): the failure artifact
 		// is the file under test, and the other file is carried as ArtifactExpected.
-		other, cr := readFile(*f.EqualsFile, otherPath)
+		other, cr := readFile(*f.EqualsFile, env.Workdir, otherPath)
 		if cr != nil {
 			return cr
 		}
@@ -225,7 +225,7 @@ func checkFile(f *spec.FileAssert, env Env) (out *CheckResult) {
 	case f.Snapshot != "":
 		// Read plainly so fileData stays nil: checkSnapshot shapes its own
 		// (normalized) artifact, and the deferred hook must not overwrite it.
-		data, cr := readFile(f.Path, path)
+		data, cr := readFile(f.Path, env.Workdir, path)
 		if cr != nil {
 			return cr
 		}
@@ -236,11 +236,13 @@ func checkFile(f *spec.FileAssert, env Env) (out *CheckResult) {
 	}
 }
 
-func readFile(label, path string) ([]byte, *CheckResult) {
+func readFile(label, root, path string) ([]byte, *CheckResult) {
 	// The program under test may have planted a symlink at the assertion target
 	// pointing outside the workdir; reading through it would disclose an arbitrary
-	// host file into the report/artifacts, so refuse to follow it (issue #16).
-	data, err := security.ReadFileNoFollow(path)
+	// host file into the report/artifacts, so refuse to follow it (issue #16), and
+	// bind the read to the workdir so an ancestor swapped for a link cannot
+	// redirect it either (issue #430).
+	data, err := security.ReadFileNoFollow(root, path)
 	if err != nil {
 		return nil, &CheckResult{
 			Desc:     fmt.Sprintf("assert file %q", label),

--- a/internal/assert/snapshot.go
+++ b/internal/assert/snapshot.go
@@ -20,13 +20,13 @@ func checkSnapshot(desc, label, snapPath string, data []byte, env Env) *CheckRes
 	opt := snapshot.Options{Workdir: env.Workdir, Secrets: env.Secrets, Scrub: env.Scrub}
 
 	if env.UpdateSnapshots {
-		if err := snapshot.Update(path, data, opt); err != nil {
+		if err := snapshot.Update(env.SpecDir, path, data, opt); err != nil {
 			return &CheckResult{Desc: desc, Hint: fmt.Sprintf("could not write snapshot %q: %v", snapPath, err)}
 		}
 		return pass(desc + " (updated)")
 	}
 
-	ok, expected, actual, err := snapshot.Compare(path, data, opt)
+	ok, expected, actual, err := snapshot.Compare(env.SpecDir, path, data, opt)
 	switch {
 	case errors.Is(err, snapshot.ErrMissing):
 		return &CheckResult{

--- a/internal/cli/record.go
+++ b/internal/cli/record.go
@@ -148,8 +148,9 @@ non-goal for now — write those steps by hand.
 		}
 	}
 	if *snap {
-		golden := filepath.Join(filepath.Dir(*out), filepath.FromSlash(opts.SnapshotPath))
-		if err := snapshot.Update(golden, res.Stdout, snapshot.Options{Workdir: workdir}); err != nil {
+		outDir := filepath.Dir(*out)
+		golden := filepath.Join(outDir, filepath.FromSlash(opts.SnapshotPath))
+		if err := snapshot.Update(outDir, golden, res.Stdout, snapshot.Options{Workdir: workdir}); err != nil {
 			fmt.Fprintf(stderr, "atago record: could not write snapshot golden: %v\n", err)
 			return ExitExec
 		}

--- a/internal/fixture/fixture.go
+++ b/internal/fixture/fixture.go
@@ -88,7 +88,7 @@ func Write(f *spec.Fixture, workdir, specDir string) error {
 	// escape) — WriteConfinedFile handles the rest of the policy: the untrusted
 	// program under test may have planted a symlink at dest pointing outside the
 	// workdir, and writing must not follow it (TOCTOU, issue #16).
-	if err := security.WriteConfinedFile(dest, data); err != nil {
+	if err := security.WriteConfinedFile(workdir, dest, data); err != nil {
 		return fmt.Errorf("fixture %q: %w", f.File, err)
 	}
 	if err := applyMode(f, dest); err != nil {

--- a/internal/runner/browser/browser.go
+++ b/internal/runner/browser/browser.go
@@ -154,9 +154,10 @@ func (r *Runner) Run(ctx context.Context, actions []spec.CDPAction, workdir stri
 	// on disk before the scenario's file/image assertions read them (#50).
 	for _, s := range shots {
 		// s.path was confined to the workdir when the task was built; the confined
-		// write creates its parents and refuses to follow a symlink the page under
-		// test may have planted at the target (issue #16).
-		if err := security.WriteConfinedFile(s.path, *s.buf); err != nil {
+		// write creates its parents, refuses to follow a symlink the page under
+		// test may have planted at the target (issue #16), and binds the write to
+		// the workdir so an ancestor swapped for a link cannot redirect it (#430).
+		if err := security.WriteConfinedFile(workdir, s.path, *s.buf); err != nil {
 			return nil, fmt.Errorf("cdp screenshot: writing %q: %w", s.path, err)
 		}
 	}

--- a/internal/security/path.go
+++ b/internal/security/path.go
@@ -1,6 +1,8 @@
 package security
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -66,7 +68,7 @@ func resolveInRoot(field, rootLabel, root, p string) (string, error) {
 //
 // Only the ancestors are resolved. A link AT the leaf belongs to the read and
 // write helpers, which refuse it by name (ReadFileNoFollow, StatNoFollow,
-// WriteFileNoFollow); resolving it here would take that refusal away from them
+// WriteConfinedFile); resolving it here would take that refusal away from them
 // and would turn a merely absent path into an error, which `exists: false` asks
 // about legitimately.
 func escapingAncestor(root, dest string) (string, bool) {
@@ -151,22 +153,47 @@ func linkTarget(p string) (string, bool) {
 // to diverge. run.stdout_to used to write 0o644 for no documented reason (#349).
 const confinedFileMode = 0o600
 
-// WriteConfinedFile creates dest's parent directories and writes data there
-// without following a symlink planted at the leaf. dest must already be
-// containment-checked by ResolveWorkdirPath or ResolveSpecPath — this helper
-// enforces the rest of the policy (create parents, never follow the leaf, one
-// file mode) that every confined write used to spell out for itself.
+// openConfined opens an os.Root at root and returns it with dest expressed as a
+// root-relative path. Binding an operation to the returned *os.Root is what makes
+// containment hold at the moment of the I/O rather than at an earlier pathname
+// check: os.Root resolves every component through the root's own descriptor and
+// refuses one that leaves the root, so an ancestor the program under test swaps
+// for a symlink between the lexical check (resolveInRoot) and the read or write
+// cannot redirect it out of the root (issue #430). The lexical check stays as a
+// fast, spelling-preserving rejection; this is the enforcement.
+//
+// dest was produced by resolveInRoot against this same root, so it shares root's
+// spelling and filepath.Rel yields a clean relative path with no leading "..".
+func openConfined(root, dest string) (*os.Root, string, error) {
+	rel, err := filepath.Rel(root, dest)
+	if err != nil {
+		return nil, "", err
+	}
+	r, err := os.OpenRoot(root)
+	if err != nil {
+		return nil, "", err
+	}
+	return r, rel, nil
+}
+
+// WriteConfinedFile creates dest's parent directories and writes data there,
+// through an os.Root bound to root so no directory component can carry the write
+// out of root, and without following a symlink planted at the leaf. dest must
+// already be containment-checked by ResolveWorkdirPath or ResolveSpecPath, and
+// must lie under root — this helper enforces the rest of the policy (create
+// parents, never follow the leaf, one file mode) that every confined write used
+// to spell out for itself.
 //
 // Parent creation means a spec can name a nested destination (stdout_to:
-// logs/out.txt) without a prior mkdir step; the parent is inside the containment
-// root, so only root-local directories are ever created.
-func WriteConfinedFile(dest string, data []byte) error {
-	if err := os.MkdirAll(filepath.Dir(dest), 0o750); err != nil {
+// logs/out.txt) without a prior mkdir step; the parent is created through the
+// root, so only root-local directories are ever made.
+func WriteConfinedFile(root, dest string, data []byte) error {
+	r, rel, err := openConfined(root, dest)
+	if err != nil {
 		return err
 	}
-	// The program under test may have planted a symlink at dest pointing outside
-	// the containment root; write without following it (issue #16).
-	return WriteFileNoFollow(dest, data, confinedFileMode)
+	defer func() { _ = r.Close() }()
+	return writeConfined(r, rel, dest, data, confinedFileMode)
 }
 
 // WriteWorkdirFile resolves rel against the scenario workdir and writes data
@@ -178,59 +205,67 @@ func WriteWorkdirFile(field, workdir, rel string, data []byte) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err := WriteConfinedFile(dest, data); err != nil {
+	if err := WriteConfinedFile(workdir, dest, data); err != nil {
 		return "", fmt.Errorf("%s: %w", field, err)
 	}
 	return dest, nil
 }
 
-// ReadFileNoFollow reads path but refuses to follow a symlink planted at the
-// leaf. Lexical containment (ResolveWorkdirPath/ResolveSpecPath) proves path is
-// inside its root, but the untrusted program under test may have replaced the
-// leaf with a link pointing outside the root — os.ReadFile would follow it and
-// disclose an arbitrary host file (issue #16). An existing symlink is rejected
-// outright, mirroring WriteFileNoFollow's guard on the write path so every
-// path-taking feature enforces the same rule instead of a plain, link-following
-// os.ReadFile.
-func ReadFileNoFollow(path string) ([]byte, error) {
-	if fi, err := os.Lstat(path); err == nil {
+// ReadFileNoFollow reads dest within root, binding the read to an os.Root so no
+// directory component can redirect it out of root, and refusing a symlink at the
+// leaf. resolveInRoot proves dest is inside root, but the untrusted program under
+// test can swap an ancestor for a symlink after that check — os.Root refuses the
+// escape at the moment of the read instead (issue #430). A symlink AT the leaf is
+// still refused outright: os.Root would follow an in-root one, but atago's rule
+// is that a link the program planted where an output was expected is never read
+// through (issue #16). A non-regular leaf (a FIFO whose open would block the
+// unbounded assert phase) is refused by kind.
+func ReadFileNoFollow(root, dest string) ([]byte, error) {
+	r, rel, err := openConfined(root, dest)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = r.Close() }()
+	if fi, lerr := r.Lstat(rel); lerr == nil {
 		switch {
 		case fi.Mode()&os.ModeSymlink != 0:
-			return nil, fmt.Errorf("refusing to read through the symlink %q (it escapes the scenario root)", path)
+			return nil, fmt.Errorf("refusing to read through the symlink %q (it escapes the scenario root)", dest)
 		case !fi.IsDir() && !fskind.Openable(fi.Mode()):
 			// Opening a named pipe for reading blocks until another process
 			// writes to it, and nothing bounds the assertion phase, so a program
 			// under test that leaves a pipe where a file was expected used to
 			// hang the whole run instead of failing it. A directory is left to
-			// os.ReadFile, whose "is a directory" error already says it.
-			return nil, fmt.Errorf("%q is a %s, not a regular file", path, fskind.Name(fi.Mode()))
+			// r.ReadFile, whose "is a directory" error already says it.
+			return nil, fmt.Errorf("%q is a %s, not a regular file", dest, fskind.Name(fi.Mode()))
 		}
 	}
-	return os.ReadFile(path) //nolint:gosec // path is containment-checked by the caller and Lstat-guarded against a leaf symlink
+	return r.ReadFile(rel)
 }
 
-// StatNoFollow reports a path's metadata without following a symlink planted at
-// the leaf. It is the stat half of ReadFileNoFollow's rule: lexical containment
-// proves the path is inside its root, but the untrusted program under test may
-// have replaced the leaf with a link pointing outside it, and os.Stat would
-// happily report the metadata of whatever the link points at — disclosing the
-// size of an arbitrary host file into the report (issue #16).
-//
-// A leaf symlink is rejected outright rather than resolved, matching the read
-// and write paths, so every path-taking feature enforces one rule.
-func StatNoFollow(path string) (os.FileInfo, error) {
-	fi, err := os.Lstat(path)
+// StatNoFollow reports dest's metadata within root without following a symlink at
+// the leaf. It is the stat half of ReadFileNoFollow's rule, bound to the same
+// os.Root so an ancestor swapped for an escaping symlink is refused at the stat
+// itself (issue #430) rather than disclosing the metadata of a host file (issue
+// #16). A leaf symlink is rejected outright rather than resolved, matching the
+// read and write paths.
+func StatNoFollow(root, dest string) (os.FileInfo, error) {
+	r, rel, err := openConfined(root, dest)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = r.Close() }()
+	fi, err := r.Lstat(rel)
 	if err != nil {
 		return nil, err
 	}
 	if fi.Mode()&os.ModeSymlink != 0 {
-		return nil, fmt.Errorf("refusing to stat through the symlink %q (it escapes the scenario root)", path)
+		return nil, fmt.Errorf("refusing to stat through the symlink %q (it escapes the scenario root)", dest)
 	}
 	return fi, nil
 }
 
-// writeLocks serializes WriteFileNoFollow calls that target the same path.
-// Several parallel scenarios can share one golden file (e.g. matrix rows with an
+// writeLocks serializes confined writes that target the same path. Several
+// parallel scenarios can share one golden file (e.g. matrix rows with an
 // identical snapshot under --update-snapshots); without serialization their
 // writes race in the filesystem — a non-atomic remove/create window on POSIX, or
 // a MoveFileEx sharing violation between concurrent renames on Windows. Keying
@@ -239,53 +274,85 @@ func StatNoFollow(path string) (os.FileInfo, error) {
 // output paths a run touches, and each holds only a mutex pointer (#250).
 var writeLocks sync.Map // dest path -> *sync.Mutex
 
-// WriteFileNoFollow writes data to dest without following a symlink planted at
-// dest. Lexical containment proves dest is inside its root, but the untrusted
-// program under test may have created a link there pointing outside the root;
-// following it on write would escape containment and clobber a host file (TOCTOU,
-// issue #16). An existing symlink is rejected outright.
+// writeConfined writes data to rel through r (an os.Root at the containment root)
+// without following a symlink planted at rel. Every filesystem operation goes
+// through the root's descriptor, so a directory component the program under test
+// turns into a symlink cannot carry the write out of the root (TOCTOU, issue
+// #430), and an existing symlink at the leaf is refused outright (issue #16).
 //
 // The payload is written to a fresh temp file (created O_EXCL, so a planted link
-// is never written through) in dest's own directory and then atomically renamed
-// over dest. os.Rename replaces the destination name without following a link
+// is never written through) in rel's own directory and then atomically renamed
+// over rel. os.Root.Rename replaces the destination name without following a link
 // that may sit there, and the rename is a single filesystem operation, so a
 // reader never observes a torn file. Concurrent writers targeting the same path
 // are additionally serialized on a per-path lock (see writeLocks) so identical
-// writes all succeed and the last one wins deterministically on every OS,
-// instead of colliding in the create window (POSIX) or a rename sharing
-// violation (Windows) (#250). This is portable — unlike O_NOFOLLOW, which is not
-// available on all platforms.
-func WriteFileNoFollow(dest string, data []byte, perm os.FileMode) error {
+// writes all succeed and the last one wins deterministically on every OS, instead
+// of colliding in the create window (POSIX) or a rename sharing violation
+// (Windows) (#250). dest is the absolute path, used only for the lock key and
+// error text.
+func writeConfined(r *os.Root, rel, dest string, data []byte, perm os.FileMode) error {
 	muAny, _ := writeLocks.LoadOrStore(dest, &sync.Mutex{})
 	mu := muAny.(*sync.Mutex) //nolint:errcheck // only *sync.Mutex is ever stored
 	mu.Lock()
 	defer mu.Unlock()
 
-	if fi, err := os.Lstat(dest); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+	if dir := filepath.Dir(rel); dir != "." {
+		if err := r.MkdirAll(dir, 0o750); err != nil {
+			return err
+		}
+	}
+	if fi, err := r.Lstat(rel); err == nil && fi.Mode()&os.ModeSymlink != 0 {
 		return fmt.Errorf("refusing to write through the existing symlink %q (it escapes the scenario root)", dest)
 	}
-	// Create the temp file in dest's directory so the rename stays on one
-	// filesystem (a cross-device rename is not atomic and errors). CreateTemp's
-	// name is unique per call, so concurrent writers never collide on the temp.
-	tmp, err := os.CreateTemp(filepath.Dir(dest), "."+filepath.Base(dest)+".tmp-*")
+	// Create the temp file in rel's directory so the rename stays on one
+	// filesystem (a cross-device rename is not atomic and errors). The random
+	// suffix keeps concurrent writers to different destinations from colliding on
+	// the temp name, and O_EXCL makes a collision an error rather than a reuse.
+	tmpRel, f, err := createTempInRoot(r, rel)
 	if err != nil {
 		return err
 	}
-	tmpName := tmp.Name()
 	// Best-effort cleanup: harmless if the rename already consumed the temp.
-	defer func() { _ = os.Remove(tmpName) }()
-	if err := tmp.Chmod(perm); err != nil {
-		_ = tmp.Close()
+	defer func() { _ = r.Remove(tmpRel) }()
+	if err := f.Chmod(perm); err != nil {
+		_ = f.Close()
 		return err
 	}
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
 		return err
 	}
-	if err := tmp.Close(); err != nil {
+	if err := f.Close(); err != nil {
 		return err
 	}
-	return os.Rename(tmpName, dest)
+	return r.Rename(tmpRel, rel)
+}
+
+// createTempInRoot creates a uniquely named, O_EXCL temp file next to rel within
+// r, returning its root-relative name and the open file. It mirrors os.CreateTemp
+// (random suffix, retry on collision) but through the root descriptor so the temp
+// is created inside the containment root like the final file.
+func createTempInRoot(r *os.Root, rel string) (string, *os.File, error) {
+	dir, base := filepath.Dir(rel), filepath.Base(rel)
+	for range 10000 {
+		var buf [8]byte
+		if _, err := rand.Read(buf[:]); err != nil {
+			return "", nil, err
+		}
+		name := "." + base + ".tmp-" + hex.EncodeToString(buf[:])
+		tmpRel := name
+		if dir != "." {
+			tmpRel = filepath.Join(dir, name)
+		}
+		f, err := r.OpenFile(tmpRel, os.O_RDWR|os.O_CREATE|os.O_EXCL, confinedFileMode)
+		if err == nil {
+			return tmpRel, f, nil
+		}
+		if !os.IsExist(err) {
+			return "", nil, err
+		}
+	}
+	return "", nil, fmt.Errorf("could not create a temp file for %q after many attempts", rel)
 }
 
 // WithinRoot reports whether resolved lies inside root (root itself counts).

--- a/internal/security/path_test.go
+++ b/internal/security/path_test.go
@@ -238,6 +238,67 @@ func TestResolve_RootBehindASymlink(t *testing.T) {
 	}
 }
 
+// TestConfinedIO_EnforcedAtTheOperation proves the confinement is bound to the
+// read, write, and stat themselves, not to an earlier pathname check. Each helper
+// is handed a path whose ANCESTOR is a symlink escaping the root and does NO
+// lexical pre-check of its own here — the os.Root the operation runs through is
+// what refuses the escape (issue #430), so a program under test that swaps an
+// ancestor for a link after the caller's check cannot redirect the I/O. An
+// in-root ancestor link is still followed, and a leaf link is still refused.
+func TestConfinedIO_EnforcedAtTheOperation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is not reliably available on Windows CI")
+	}
+	t.Parallel()
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("top-secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// The program under test plants `escape -> <outside>` inside the root.
+	if err := os.Symlink(outside, filepath.Join(root, "escape")); err != nil {
+		t.Fatal(err)
+	}
+
+	esc := filepath.Join(root, "escape", "secret.txt")
+	if data, err := ReadFileNoFollow(root, esc); err == nil {
+		t.Errorf("ReadFileNoFollow read %q through an escaping ancestor; want refusal", data)
+	}
+	if _, err := StatNoFollow(root, esc); err == nil {
+		t.Error("StatNoFollow reported metadata through an escaping ancestor; want refusal")
+	}
+	if err := WriteConfinedFile(root, filepath.Join(root, "escape", "planted.txt"), []byte("pwned")); err == nil {
+		t.Error("WriteConfinedFile wrote through an escaping ancestor; want refusal")
+	}
+	if _, err := os.Lstat(filepath.Join(outside, "planted.txt")); err == nil {
+		t.Error("a file was created in the host directory through the escaping ancestor")
+	}
+
+	// An in-root ancestor link is ordinary and must keep resolving.
+	if err := os.Mkdir(filepath.Join(root, "real"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "real", "f.txt"), []byte("ok"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("real", filepath.Join(root, "alias")); err != nil {
+		t.Fatal(err)
+	}
+	if data, err := ReadFileNoFollow(root, filepath.Join(root, "alias", "f.txt")); err != nil || string(data) != "ok" {
+		t.Errorf("read through an in-root ancestor link = %q, %v; want %q", data, err, "ok")
+	}
+
+	// A symlink AT the leaf is still refused even when it stays inside the root:
+	// a link the program planted where an output was expected is never read
+	// through (issue #16), independent of where it points.
+	if err := os.Symlink(filepath.Join(root, "real", "f.txt"), filepath.Join(root, "leaf")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadFileNoFollow(root, filepath.Join(root, "leaf")); err == nil {
+		t.Error("ReadFileNoFollow followed an in-root leaf symlink; the leaf must be refused")
+	}
+}
+
 // TestReadFileNoFollow verifies a leaf symlink pointing outside the root is
 // refused (issue #16): the untrusted program under test could plant such a link
 // at an assertion/snapshot read target to disclose an arbitrary host file. A
@@ -253,7 +314,7 @@ func TestReadFileNoFollow(t *testing.T) {
 	if err := os.WriteFile(regular, []byte("in-root"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if got, err := ReadFileNoFollow(regular); err != nil || string(got) != "in-root" {
+	if got, err := ReadFileNoFollow(root, regular); err != nil || string(got) != "in-root" {
 		t.Fatalf("ReadFileNoFollow(regular) = %q, %v; want %q, nil", got, err, "in-root")
 	}
 
@@ -266,7 +327,7 @@ func TestReadFileNoFollow(t *testing.T) {
 	if err := os.Symlink(secret, link); err != nil {
 		t.Fatal(err)
 	}
-	got, err := ReadFileNoFollow(link)
+	got, err := ReadFileNoFollow(root, link)
 	if err == nil {
 		t.Fatalf("ReadFileNoFollow followed the symlink and read %q; want error", got)
 	}
@@ -290,7 +351,8 @@ func TestReadFileNoFollow_RefusesANamedPipe(t *testing.T) {
 		t.Skip("mkfifo not available")
 	}
 	t.Parallel()
-	pipe := filepath.Join(t.TempDir(), "pipe")
+	root := t.TempDir()
+	pipe := filepath.Join(root, "pipe")
 	if out, err := exec.CommandContext(t.Context(), bin, pipe).CombinedOutput(); err != nil {
 		t.Skipf("mkfifo: %v (%s)", err, out)
 	}
@@ -301,7 +363,7 @@ func TestReadFileNoFollow_RefusesANamedPipe(t *testing.T) {
 	}
 	done := make(chan result, 1)
 	go func() {
-		data, err := ReadFileNoFollow(pipe)
+		data, err := ReadFileNoFollow(root, pipe)
 		done <- result{data, err}
 	}()
 	select {
@@ -317,11 +379,11 @@ func TestReadFileNoFollow_RefusesANamedPipe(t *testing.T) {
 	}
 }
 
-// TestWriteFileNoFollow verifies a leaf symlink at the write target is refused
-// (so a redirect/snapshot write cannot clobber a host file through a link the
-// program under test planted), while a fresh write and an overwrite of a plain
-// regular file both succeed.
-func TestWriteFileNoFollow(t *testing.T) {
+// TestWriteConfinedFile_NoFollow verifies a leaf symlink at the write target is
+// refused (so a redirect/snapshot write cannot clobber a host file through a link
+// the program under test planted), while a fresh write and an overwrite of a
+// plain regular file both succeed.
+func TestWriteConfinedFile_NoFollow(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink creation is not reliably available on Windows CI")
 	}
@@ -329,10 +391,10 @@ func TestWriteFileNoFollow(t *testing.T) {
 	root := t.TempDir()
 
 	fresh := filepath.Join(root, "out.txt")
-	if err := WriteFileNoFollow(fresh, []byte("v1"), 0o600); err != nil {
+	if err := WriteConfinedFile(root, fresh, []byte("v1")); err != nil {
 		t.Fatalf("fresh write: %v", err)
 	}
-	if err := WriteFileNoFollow(fresh, []byte("v2"), 0o600); err != nil {
+	if err := WriteConfinedFile(root, fresh, []byte("v2")); err != nil {
 		t.Fatalf("overwrite of regular file: %v", err)
 	}
 	if got, err := os.ReadFile(fresh); err != nil || string(got) != "v2" {
@@ -348,16 +410,16 @@ func TestWriteFileNoFollow(t *testing.T) {
 	if err := os.Symlink(victim, link); err != nil {
 		t.Fatal(err)
 	}
-	if err := WriteFileNoFollow(link, []byte("pwned"), 0o600); err == nil {
-		t.Fatal("WriteFileNoFollow wrote through the symlink; want error")
+	if err := WriteConfinedFile(root, link, []byte("pwned")); err == nil {
+		t.Fatal("WriteConfinedFile wrote through the symlink; want error")
 	}
 	if got, _ := os.ReadFile(victim); string(got) != "original" {
 		t.Errorf("host file was modified through the symlink: %q", got)
 	}
 }
 
-// TestWriteFileNoFollow_ConcurrentIdenticalContent is the regression for #250:
-// several parallel scenarios that share one golden file call WriteFileNoFollow
+// TestWriteConfinedFile_ConcurrentIdenticalContent is the regression for #250:
+// several parallel scenarios that share one golden file call the confined write
 // on the same path with byte-identical content (e.g. matrix rows producing the
 // same output under --update-snapshots). The old non-atomic
 // Lstat→Remove→OpenFile(O_EXCL) sequence raced — one goroutine's Remove hit the
@@ -365,7 +427,7 @@ func TestWriteFileNoFollow(t *testing.T) {
 // another had just created — so an update failed nondeterministically even
 // though every writer produced the same bytes. An atomic write must let every
 // concurrent identical write succeed and leave the expected content behind.
-func TestWriteFileNoFollow_ConcurrentIdenticalContent(t *testing.T) {
+func TestWriteConfinedFile_ConcurrentIdenticalContent(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
 	dest := filepath.Join(root, "shared.golden")
@@ -378,7 +440,7 @@ func TestWriteFileNoFollow_ConcurrentIdenticalContent(t *testing.T) {
 	for i := range writers {
 		wg.Go(func() {
 			<-start // release all goroutines at once to maximize contention
-			errs[i] = WriteFileNoFollow(dest, content, 0o600)
+			errs[i] = WriteConfinedFile(root, dest, content)
 		})
 	}
 	close(start)
@@ -534,10 +596,10 @@ func TestWriteConfinedFile(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
 	dest := filepath.Join(root, "golden", "out.snap")
-	if err := WriteConfinedFile(dest, []byte("v1")); err != nil {
+	if err := WriteConfinedFile(root, dest, []byte("v1")); err != nil {
 		t.Fatalf("first write: %v", err)
 	}
-	if err := WriteConfinedFile(dest, []byte("v2")); err != nil {
+	if err := WriteConfinedFile(root, dest, []byte("v2")); err != nil {
 		t.Fatalf("overwrite: %v", err)
 	}
 	got, err := os.ReadFile(dest)

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -179,11 +179,12 @@ func isComponentBoundary(c byte) bool {
 	return c == '/' || c == '\\' || c <= ' '
 }
 
-// Compare normalizes actual and checks it against the stored snapshot at path.
-// It returns the normalized expected and actual text for diffing. If the
-// snapshot does not exist it returns ErrMissing.
-func Compare(path string, actual []byte, opt Options) (ok bool, expected, actualNorm string, err error) {
-	stored, rerr := security.ReadFileNoFollow(path)
+// Compare normalizes actual and checks it against the stored snapshot at path,
+// which lives under root (the spec directory). It returns the normalized expected
+// and actual text for diffing. If the snapshot does not exist it returns
+// ErrMissing.
+func Compare(root, path string, actual []byte, opt Options) (ok bool, expected, actualNorm string, err error) {
+	stored, rerr := security.ReadFileNoFollow(root, path)
 	if rerr != nil {
 		if os.IsNotExist(rerr) {
 			return false, "", string(Normalize(actual, opt)), ErrMissing
@@ -200,12 +201,14 @@ func Compare(path string, actual []byte, opt Options) (ok bool, expected, actual
 	return expected == actualNorm, expected, actualNorm, nil
 }
 
-// Update writes the normalized actual output to path, creating parent dirs.
-func Update(path string, actual []byte, opt Options) error {
+// Update writes the normalized actual output to path, creating parent dirs. path
+// is confined to root (the spec directory).
+func Update(root, path string, actual []byte, opt Options) error {
 	// path is resolved against the SPEC directory (security.ResolveSpecPath), not
-	// the scenario workdir, so this takes the resolved-path form of the confined
-	// write rather than the workdir-shaped one. The rest of the policy — create
-	// parents, refuse a symlink the program under test may have planted at the
-	// target (issue #16), one file mode — is the same.
-	return security.WriteConfinedFile(path, Normalize(actual, opt))
+	// the scenario workdir, so this passes the spec directory as the confinement
+	// root. The rest of the policy — create parents, refuse a symlink the program
+	// under test may have planted at the target (issue #16), bind the write to the
+	// root so an ancestor swapped for a link cannot redirect it (issue #430), one
+	// file mode — is the same.
+	return security.WriteConfinedFile(root, path, Normalize(actual, opt))
 }

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -219,13 +219,13 @@ func TestCompareAndUpdate(t *testing.T) {
 	path := filepath.Join(dir, "snapshots", "out.txt")
 
 	// Missing snapshot.
-	ok, _, _, err := Compare(path, []byte("hello\n"), Options{})
+	ok, _, _, err := Compare(dir, path, []byte("hello\n"), Options{})
 	if ok || !errors.Is(err, ErrMissing) {
 		t.Fatalf("Compare(missing) = ok %v err %v, want ErrMissing", ok, err)
 	}
 
 	// Update writes the normalized content and creates parent dirs.
-	if err := Update(path, []byte("\x1b[1mhello\x1b[0m\n"), Options{}); err != nil {
+	if err := Update(dir, path, []byte("\x1b[1mhello\x1b[0m\n"), Options{}); err != nil {
 		t.Fatalf("Update() error = %v", err)
 	}
 	stored, _ := os.ReadFile(path)
@@ -234,13 +234,13 @@ func TestCompareAndUpdate(t *testing.T) {
 	}
 
 	// Compare now matches (actual gets normalized too).
-	ok, _, _, err = Compare(path, []byte("\x1b[31mhello\x1b[0m\n"), Options{})
+	ok, _, _, err = Compare(dir, path, []byte("\x1b[31mhello\x1b[0m\n"), Options{})
 	if err != nil || !ok {
 		t.Fatalf("Compare(match) = ok %v err %v, want ok", ok, err)
 	}
 
 	// A real difference fails.
-	ok, exp, act, err := Compare(path, []byte("goodbye\n"), Options{})
+	ok, exp, act, err := Compare(dir, path, []byte("goodbye\n"), Options{})
 	if err != nil || ok {
 		t.Fatalf("Compare(diff) = ok %v err %v, want not ok", ok, err)
 	}
@@ -269,7 +269,7 @@ func TestCompare_CRLFGolden(t *testing.T) {
 	if err := os.WriteFile(path, []byte("hello\r\nworld\r\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	ok, _, _, err := Compare(path, []byte("hello\nworld\n"), Options{})
+	ok, _, _, err := Compare(dir, path, []byte("hello\nworld\n"), Options{})
 	if err != nil {
 		t.Fatalf("Compare error = %v", err)
 	}


### PR DESCRIPTION
## Summary

Closes #430. Every confined read, write, and stat resolved a pathname, checked it stayed inside its containment root, and then handed that same pathname to `os.ReadFile` / `os.Stat` / a temp-create-and-rename. The check and the operation resolve the path twice, and a program under test can swap a directory component for a symlink in the window between them — the check passes on a real directory, and the operation follows the link the program just planted.

The lexical checks and the ancestor-symlink resolution from #429 close every case where the malicious link is already in place when the operation runs (what a spec's own steps produce). This closes the remaining TOCTOU race.

## Fix

The read, write, and stat now run through an `os.Root` opened at the containment root, with the destination expressed relative to it. `os.Root` resolves every path component through the root's own descriptor and refuses one that leaves the root, so containment is enforced by the operation itself rather than by an earlier pathname check. The atomic write keeps its shape — an `O_EXCL` temp in the destination's directory, then `Root.Rename` over the target — now entirely inside the root, and the per-path lock (#250) still serializes concurrent writers to a shared golden.

Sites migrated (all route through the four `security` helpers): the file/pdf/image assertions, `assert.dir` size/stat, `fixture:`, `run.stdout_to`/`stderr_to`, `http.body_to`, the snapshot reader and writer, and CDP screenshots.

## Contract preserved

- A symlink at the leaf is refused outright. `os.Root` would follow an in-root one, but atago's rule is that a link the program planted where an output was expected is never read or written through (#16) — so the leaf is `Lstat`-checked and refused before the operation, independent of where it points.
- A non-regular leaf (a FIFO whose open would block the unbounded assert phase) is refused by kind.
- An in-root ancestor link is still followed.
- The lexical checks (`resolveInRoot`, ancestor resolution) stay as a fast, spelling-preserving first rejection and for the callers that only need the resolved absolute path.

Author-controlled INPUT reads (`store.from.file`, `mock` `body_file`, `http.body_file`/`files.path`) are left as they were: they read committed testdata the spec author supplies, resolve lexically (an escaping ancestor is already refused by #429), and are not the program-under-test TOCTOU concern.

## Tests

`TestConfinedIO_EnforcedAtTheOperation` hands each helper a path whose ANCESTOR is an in-root symlink escaping the root and does no lexical pre-check of its own — the `os.Root` refuses the escape at the read, stat, and write, no host file is created, an in-root ancestor link still resolves, and an in-root leaf link is still refused. It was confirmed to fail against the previous `os.ReadFile(abs)` read (it disclosed the host file and followed the in-root leaf link). Every existing containment test (leaf refusal, FIFO refusal, concurrent identical writes, escape rejection, confined file mode) passes unchanged against the new implementation.

Requires Go 1.24+ for `os.Root` (`Root.Rename`/`Readlink` need 1.25); the module is on Go 1.26. Symlink-planting tests skip on Windows CI as the others do; the read/write/stat paths use `os.Root` on every platform and are covered by the Windows unit-test job.
