### PR TITLE
fix(pty): keep grapheme clusters whole in screen assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,14 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- A `screen:` assertion now keeps a grapheme cluster whole. The rendered screen
+  stored only the leading rune of each cell, so a ZWJ emoji sequence (a
+  woman-technologist, a flag) rendered as its first emoji and a
+  `screen: contains:` on the real cluster could never match; the `attrs:` matcher
+  compared its query rune-by-rune against one cell per cluster and could not line
+  up either. Cells now carry the full cluster and the matcher compares clusters,
+  so both see complete text. A decomposed base-plus-combining-mark is still
+  reduced to its base by the emulator upstream, which atago does not control.
 - A `screen:` assertion now renders wide characters (CJK, emoji) at their true
   two-column width. The screen emulator stored one column per rune, so a label a
   program positioned with cursor addressing after a Japanese string landed two

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/mattn/go-shellwords v1.0.13
 	github.com/nao1215/markdown v0.13.0
 	github.com/ohler55/ojg v1.28.4
+	github.com/rivo/uniseg v0.4.7
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3
 	golang.org/x/crypto v0.54.0
 	golang.org/x/image v0.44.0
@@ -65,7 +66,6 @@ require (
 	github.com/olekukonko/ll v0.1.4-0.20260115111900-9e59c2286df0 // indirect
 	github.com/olekukonko/tablewriter v1.1.3 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
-	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect

--- a/internal/assert/screenattrs.go
+++ b/internal/assert/screenattrs.go
@@ -3,6 +3,8 @@ package assert
 import (
 	"fmt"
 
+	"github.com/rivo/uniseg"
+
 	"github.com/nao1215/atago/internal/runner"
 	"github.com/nao1215/atago/internal/spec"
 )
@@ -48,7 +50,10 @@ func checkOneScreenAttr(a *spec.ScreenAttr, res *runner.Result) *CheckResult {
 		rows = rows[a.Row-1 : a.Row]
 	}
 
-	text := []rune(a.Text)
+	// Match by grapheme cluster, not by rune: the query text and the screen cells
+	// each hold one cluster per cell, so a ZWJ emoji or a base-plus-combining
+	// sequence lines up cell-for-cluster (#437).
+	text := splitGraphemes(a.Text)
 	if len(text) == 0 {
 		return fail("the entry names no text to check", borderedScreen(string(res.Screen)))
 	}
@@ -57,7 +62,7 @@ func checkOneScreenAttr(a *spec.ScreenAttr, res *runner.Result) *CheckResult {
 	var nearest string
 	for _, row := range rows {
 		for start := 0; start+len(text) <= len(row); start++ {
-			if !runesMatch(row[start:start+len(text)], text) {
+			if !graphemesMatch(row[start:start+len(text)], text) {
 				continue
 			}
 			found = true
@@ -83,14 +88,29 @@ func checkOneScreenAttr(a *spec.ScreenAttr, res *runner.Result) *CheckResult {
 		borderedScreen(string(res.Screen)))
 }
 
-// runesMatch reports whether the cells spell exactly want.
-func runesMatch(cells []runner.ScreenCell, want []rune) bool {
-	for i, r := range want {
-		if cells[i].Rune != r {
+// graphemesMatch reports whether the cells spell exactly want, one cluster per
+// cell.
+func graphemesMatch(cells []runner.ScreenCell, want []string) bool {
+	for i, g := range want {
+		if cells[i].Content != g {
 			return false
 		}
 	}
 	return true
+}
+
+// splitGraphemes breaks s into grapheme clusters, the same unit a screen cell
+// holds, so a query naming a ZWJ emoji or a combining sequence matches one cell
+// rather than being compared rune-by-rune against a single cell.
+func splitGraphemes(s string) []string {
+	var out []string
+	state := -1
+	for len(s) > 0 {
+		var cluster string
+		cluster, s, _, state = uniseg.FirstGraphemeClusterInString(s, state)
+		out = append(out, cluster)
+	}
+	return out
 }
 
 // firstAttrMismatch returns a description of the first way the cells fail the

--- a/internal/assert/screenattrs_test.go
+++ b/internal/assert/screenattrs_test.go
@@ -11,19 +11,37 @@ import (
 // cellsFor builds a one-row screen from a string, applying style to the cells
 // covering want (its first occurrence) and leaving the rest default.
 func cellsFor(text, want string, style func(*runner.ScreenCell)) *runner.Result {
-	runes := []rune(text)
-	row := make([]runner.ScreenCell, len(runes))
-	start := strings.Index(text, want)
-	for i, r := range runes {
-		row[i] = runner.ScreenCell{Rune: r, FG: spec.DefaultScreenColor, BG: spec.DefaultScreenColor + 1}
+	clusters := splitGraphemes(text)
+	row := make([]runner.ScreenCell, len(clusters))
+	for i, g := range clusters {
+		row[i] = runner.ScreenCell{Content: g, FG: spec.DefaultScreenColor, BG: spec.DefaultScreenColor + 1}
 	}
-	if start >= 0 && want != "" {
-		from := len([]rune(text[:start]))
-		for i := from; i < from+len([]rune(want)); i++ {
-			style(&row[i])
+	if want != "" {
+		if from := graphemeIndex(clusters, splitGraphemes(want)); from >= 0 {
+			for i := from; i < from+len(splitGraphemes(want)); i++ {
+				style(&row[i])
+			}
 		}
 	}
 	return &runner.Result{IsPTY: true, Screen: []byte(text), ScreenCells: [][]runner.ScreenCell{row}}
+}
+
+// graphemeIndex returns the cluster index at which sub first appears in clusters,
+// or -1. It mirrors how the matcher slides a cluster window over a row.
+func graphemeIndex(clusters, sub []string) int {
+	for start := 0; start+len(sub) <= len(clusters); start++ {
+		match := true
+		for i, g := range sub {
+			if clusters[start+i] != g {
+				match = false
+				break
+			}
+		}
+		if match {
+			return start
+		}
+	}
+	return -1
 }
 
 // TestCheckScreenAttrs covers the matcher's contract (#382): colors and
@@ -143,13 +161,36 @@ func TestCheckScreenAttrs_AnyOccurrenceSatisfies(t *testing.T) {
 	t.Parallel()
 	// Two "ok"s: the first plain, the second green.
 	row := []runner.ScreenCell{}
-	for _, r := range "ok ok" {
-		row = append(row, runner.ScreenCell{Rune: r, FG: spec.DefaultScreenColor})
+	for _, g := range splitGraphemes("ok ok") {
+		row = append(row, runner.ScreenCell{Content: g, FG: spec.DefaultScreenColor})
 	}
 	row[3].FG, row[4].FG = 2, 2
 	res := &runner.Result{IsPTY: true, Screen: []byte("ok ok"), ScreenCells: [][]runner.ScreenCell{row}}
 
 	if cr := checkScreenAttrs([]spec.ScreenAttr{{Text: "ok", FG: "green"}}, res); !cr.OK {
 		t.Errorf("a later matching occurrence should satisfy the entry: %s", cr.Hint)
+	}
+}
+
+// TestCheckScreenAttrs_GraphemeCluster pins that a query naming a multi-rune
+// grapheme cluster (a ZWJ emoji) matches the single cell that holds it and checks
+// that cell's styling (#437). A rune-by-rune comparison could never line up: the
+// query has several runes, the cell one cluster.
+func TestCheckScreenAttrs_GraphemeCluster(t *testing.T) {
+	t.Parallel()
+	const dev = "\U0001F469\u200d\U0001F4BB" // woman + ZWJ + laptop, one cluster
+	row := []runner.ScreenCell{
+		{Content: "a", FG: spec.DefaultScreenColor},
+		{Content: dev, FG: 1, Bold: true},
+		{Content: "b", FG: spec.DefaultScreenColor},
+	}
+	res := &runner.Result{IsPTY: true, Screen: []byte("a" + dev + "b"), ScreenCells: [][]runner.ScreenCell{row}}
+
+	if cr := checkScreenAttrs([]spec.ScreenAttr{{Text: dev, FG: "red", Bold: boolp(true)}}, res); !cr.OK {
+		t.Errorf("a ZWJ emoji cluster should match its cell and check its style: %s", cr.Hint)
+	}
+	// A wrong style on that cluster must still fail, not be passed over.
+	if cr := checkScreenAttrs([]spec.ScreenAttr{{Text: dev, FG: "green"}}, res); cr.OK {
+		t.Error("a mismatched color on the cluster cell must fail")
 	}
 }

--- a/internal/runner/ptyrun/screen.go
+++ b/internal/runner/ptyrun/screen.go
@@ -134,7 +134,7 @@ func renderScreenCells(transcript []byte, p *spec.PTY, resizes []screenResize) (
 	// A wide character occupies two columns: the first holds the grapheme, the
 	// second is a continuation cell (Width 0). The continuation is dropped so one
 	// logical cell holds one grapheme — the text row reads "日本語", not "日 本 語",
-	// and the attrs matcher keeps matching one cell per rune of its query text.
+	// and the attrs matcher keeps matching one cell per grapheme of its query text.
 	curCols, curRows := term.Width(), term.Height()
 	grid := make([][]runner.ScreenCell, 0, curRows)
 	for y := 0; y < curRows; y++ {
@@ -153,7 +153,7 @@ func renderScreenCells(transcript []byte, p *spec.PTY, resizes []screenResize) (
 	for i, row := range grid {
 		var b strings.Builder
 		for _, c := range row {
-			b.WriteRune(c.Rune)
+			b.WriteString(c.Content)
 		}
 		lines[i] = strings.TrimRight(b.String(), " \t")
 	}
@@ -168,19 +168,18 @@ func renderScreenCells(transcript []byte, p *spec.PTY, resizes []screenResize) (
 }
 
 // glyphCell converts one emulator cell into the cell the assertion layer reads.
-// A cell the program never wrote carries empty content, which renders as a space
-// — matching what the screen shows — and is not a character anyone asserts on.
-// Only the first rune of the grapheme cluster is kept in Rune, so the attrs
-// matcher matches one cell per rune of its query text; the plain-text screen is
-// built from the same runes.
+// The whole grapheme cluster the cell holds is kept — a ZWJ emoji sequence is one
+// cluster in one cell — so the plain-text screen and the attrs matcher both see
+// complete text rather than only the leading rune (#437). A cell the program
+// never wrote carries a space, matching what the screen shows.
 func glyphCell(c *uv.Cell) runner.ScreenCell {
-	r := ' '
-	if c.Content != "" {
-		r, _ = utf8.DecodeRuneInString(c.Content)
+	content := c.Content
+	if content == "" {
+		content = " "
 	}
 	attrs := c.Style.Attrs
 	return runner.ScreenCell{
-		Rune:      r,
+		Content:   content,
 		FG:        colorToIndex(c.Style.Fg),
 		BG:        colorToIndex(c.Style.Bg),
 		Bold:      attrs&uv.AttrBold != 0,

--- a/internal/runner/ptyrun/screen_test.go
+++ b/internal/runner/ptyrun/screen_test.go
@@ -99,6 +99,24 @@ func TestRenderScreen_WideCharactersOccupyTwoColumns(t *testing.T) {
 	}
 }
 
+// TestRenderScreen_PreservesGraphemeClusters is the #437 regression: a grapheme
+// cluster is one cell on the terminal and must render whole. Keeping only the
+// leading rune returned the base emoji alone for a ZWJ sequence, so a screen
+// text match on the real cluster could never succeed. A precomposed accent
+// (U+00E9) is a single rune and was never affected; a DECOMPOSED
+// base-plus-combining-mark is reduced to its base by the emulator upstream,
+// which is out of atago's hands, so it is not asserted here.
+func TestRenderScreen_PreservesGraphemeClusters(t *testing.T) {
+	t.Parallel()
+	// A woman-technologist ZWJ sequence: woman + ZWJ + laptop, one cluster over
+	// one cell.
+	const dev = "\U0001F469\u200d\U0001F4BB"
+	got := RenderScreen([]byte(dev+"\r\n"), &spec.PTY{Rows: 3, Cols: 20})
+	if got != dev {
+		t.Errorf("RenderScreen(%q) = %q, want the whole cluster %q", dev, got, dev)
+	}
+}
+
 // TestRenderScreen_TrailingNormalization proves per-line trailing whitespace
 // and trailing blank rows are stripped so snapshots stay stable.
 func TestRenderScreen_TrailingNormalization(t *testing.T) {
@@ -368,7 +386,7 @@ func TestRenderScreenCells_TracksColorsAndAttributes(t *testing.T) {
 	// to the SGR code.
 	for i, r := range "ERROR" {
 		c := cells[0][i]
-		if c.Rune != r || c.FG != 1 || !c.Bold {
+		if c.Content != string(r) || c.FG != 1 || !c.Bold {
 			t.Errorf("cell (1,%d) = %+v, want %q bold red", i+1, c, r)
 		}
 	}
@@ -384,11 +402,11 @@ func TestRenderScreenCells_TracksColorsAndAttributes(t *testing.T) {
 		}
 	}
 
-	// The alignment law: the text is exactly the cells' runes, row for row.
+	// The alignment law: the text is exactly the cells' content, row for row.
 	for y, line := range strings.Split(text, "\n") {
 		var b strings.Builder
 		for _, c := range cells[y] {
-			b.WriteRune(c.Rune)
+			b.WriteString(c.Content)
 		}
 		if got := strings.TrimRight(b.String(), " \t"); got != line {
 			t.Errorf("row %d: text %q, cells %q", y+1, line, got)

--- a/internal/runner/screencell.go
+++ b/internal/runner/screencell.go
@@ -9,8 +9,11 @@ package runner
 // It lives here rather than in the pty runner because runner.Result carries it
 // and the pty runner imports this package, not the other way round.
 type ScreenCell struct {
-	// Rune is the character drawn in this cell.
-	Rune rune
+	// Content is the grapheme cluster drawn in this cell — usually a single rune,
+	// but a base plus combining marks or a ZWJ emoji sequence is one cluster in
+	// one cell, kept whole so a `screen:` text match or an `attrs:` query naming it
+	// lines up cell-for-cluster (#437).
+	Content string
 	// FG and BG are the emulator's colors: 0..15 for the ANSI palette, 16..255
 	// for the xterm palette, and DefaultColor for "the terminal's own", which is
 	// what makes an uncolored screen assertable.


### PR DESCRIPTION
## Summary

Closes #437. The rendered screen kept only the leading rune of each cell, so a grapheme cluster the terminal draws in one cell — a ZWJ emoji sequence (a woman-technologist, a flag) — rendered as its first emoji alone. A `screen: contains:` on the real cluster could never match, and the `attrs:` matcher compared its query text rune-by-rune against one cell per cluster, so a query naming a cluster could not line up either.

This was raised in review on #436 (the wide-character width fix); it is a distinct concern — how many RUNES a cell's content holds, not how many COLUMNS the cell spans — so it is its own PR.

## Change

- `runner.ScreenCell.Rune rune` becomes `Content string`, the whole grapheme cluster.
- `glyphCell` keeps `uv.Cell.Content` (the emulator already segments a cell into one cluster) instead of decoding only its first rune.
- The plain-text screen is built from `Content`.
- The `attrs:` matcher splits its query text into grapheme clusters (`uniseg`, already in the module graph via x/vt) and matches one cluster per cell, so the alignment law (`text == join(cell content)`) still holds.

ASCII, CJK, and single-rune emoji are one cluster per cell and render exactly as before.

## Known limitation

A decomposed base-plus-combining-mark (`e` + U+0301) is reduced to its base by the x/vt emulator upstream, which atago does not control; a precomposed accent (U+00E9) is a single rune and was never affected. Only the ZWJ case is atago's to fix, and it is fixed.

## Tests

`TestRenderScreen_PreservesGraphemeClusters` renders a ZWJ sequence and asserts the whole cluster survives (confirmed to fail against the previous first-rune render). `TestCheckScreenAttrs_GraphemeCluster` pins that an `attrs:` query naming a ZWJ cluster matches the single cell that holds it and checks its style, and that a wrong style still fails. The existing attrs suite and the screen alignment-law test pass unchanged. Full unit suite, lint, `FuzzRenderScreen` seeds, and `make e2e` (542 scenarios) are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Screen assertions now correctly preserve and compare complete grapheme clusters, including ZWJ emojis and flag emojis.
  * Screen rendering retains multi-character visual symbols within a single cell.
* **Bug Fixes**
  * Improved text and attribute matching for complex emoji and combining-character sequences.
  * Added regression coverage to ensure grapheme clusters render and validate correctly.
* **Documentation**
  * Updated the changelog with the new grapheme-cluster handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->