### PR TITLE
fix(pty): sanitize the live device-query terminal across read boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,16 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- The live terminal that answers a program's device queries during a `pty`
+  session (DA1, cursor-position and status reports) now runs the incoming bytes
+  through the same CSI sanitizer the screen render uses, carried across read
+  boundaries. An oversized count-based sequence (a backward-tab with a
+  billion-step count) would otherwise spin the emulator before it reached a
+  following `\x1b[6n`, and a malformed sequence could abort the rest of a read
+  chunk so a later query went unanswered. Because a read can split a sequence in
+  half, the sanitizer holds an incomplete trailing escape until the next chunk
+  completes it, rather than letting the two halves reassemble inside the emulator
+  where the clamp no longer applies.
 - A `screen:` assertion now keeps a grapheme cluster whole. The rendered screen
   stored only the leading rune of each cell, so a ZWJ emoji sequence (a
   woman-technologist, a flag) rendered as its first emoji and a

--- a/internal/runner/ptyrun/query_sanitize.go
+++ b/internal/runner/ptyrun/query_sanitize.go
@@ -1,0 +1,135 @@
+package ptyrun
+
+// The live device-query terminal (terminal_queries.go) is fed the program's raw
+// output chunk by chunk so it can answer DA1/DSR/CPR probes against the current
+// screen state. Feeding those chunks straight to the emulator has the same two
+// hazards the screen render defends against — an oversized loop-per-count CSI
+// spins the parser, and a malformed CSI can abort the rest of a chunk before a
+// later CPR request is seen — plus one the render does not have: a chunk is an
+// arbitrary read boundary, so a CSI can be SPLIT across two chunks. Sanitizing
+// each chunk on its own cannot bound a split sequence, because the two halves
+// reassemble inside the emulator's stateful parser (issue #438).
+//
+// streamSanitizer closes that by carrying the incomplete trailing escape of one
+// chunk into the next, so a sequence is only handed to the emulator once it is
+// whole and has been through sanitizeTranscriptMarks (which clamps counts and
+// drops malformed sequences).
+
+// maxQueryCarry bounds the incomplete trailing sequence held between chunks. An
+// escape that never terminates — a bare ESC[ with a growing parameter run, an
+// OSC with no ST — would otherwise buffer without limit. A real sequence is tiny;
+// anything past this is adversarial, so it is dropped rather than held or fed on.
+const maxQueryCarry = 4096
+
+// streamSanitizer sanitizes a byte stream delivered in arbitrary chunks, holding
+// an incomplete trailing escape sequence until the chunk that completes it.
+type streamSanitizer struct {
+	carry []byte
+}
+
+// feed returns the sanitized bytes ready to hand to the emulator for this chunk:
+// every complete unit in carry+chunk, sanitized, with any incomplete trailing
+// escape kept back in carry for next time. A trailing escape that grows past
+// maxQueryCarry is dropped, since no legitimate sequence is that long.
+func (s *streamSanitizer) feed(chunk []byte) []byte {
+	buf := chunk
+	if len(s.carry) > 0 {
+		buf = append(s.carry, chunk...)
+		s.carry = nil
+	}
+	split := incompleteEscapeStart(buf)
+	ready, _ := sanitizeTranscriptMarks(buf[:split], nil)
+	switch {
+	case split >= len(buf):
+		s.carry = nil
+	case len(buf)-split > maxQueryCarry:
+		s.carry = nil // drop an over-long, never-terminating escape
+	default:
+		s.carry = append([]byte(nil), buf[split:]...)
+	}
+	return ready
+}
+
+// incompleteEscapeStart returns the index in b where a trailing escape sequence
+// that is not yet complete begins, or len(b) if b ends on a unit boundary. Bytes
+// from that index on must be held until the next chunk completes the sequence, so
+// it is sanitized whole instead of reassembling inside the emulator.
+func incompleteEscapeStart(b []byte) int {
+	i := 0
+	for i < len(b) {
+		if b[i] != 0x1b {
+			i++
+			continue
+		}
+		end, ok := escapeEnd(b, i)
+		if !ok {
+			return i
+		}
+		i = end
+	}
+	return len(b)
+}
+
+// escapeEnd reports where the escape sequence starting at b[i] (an ESC) ends and
+// whether it is complete within b. It is deliberately conservative: when the kind
+// of sequence needs a terminator that has not arrived, it reports incomplete, so
+// the caller holds the bytes rather than risk splitting a sequence.
+func escapeEnd(b []byte, i int) (end int, complete bool) {
+	if i+1 >= len(b) {
+		return i, false // a lone trailing ESC: wait for what follows
+	}
+	switch b[i+1] {
+	case 0x1b:
+		// A second ESC restarts parsing; the first is an inert one-byte unit.
+		return i + 1, true
+	case '[':
+		return csiEnd(b, i+2)
+	case ']', 'P', 'X', '^', '_':
+		// OSC/DCS/SOS/PM/APC string sequences run until ST (ESC \) or BEL.
+		return stringEnd(b, i+2)
+	case '(', ')', '*', '+':
+		// A charset designator takes exactly one more byte.
+		if i+2 >= len(b) {
+			return i, false
+		}
+		return i + 3, true
+	default:
+		// ESC + a single final byte (ESC M, ESC D, ESC c, ...).
+		return i + 2, true
+	}
+}
+
+// csiEnd finds the end of a CSI sequence whose parameter/intermediate bytes start
+// at b[j], i.e. after "ESC [". A final byte in 0x40..0x7e completes it; an ESC
+// aborts it (and starts a new sequence at that ESC); running out of bytes leaves
+// it incomplete.
+func csiEnd(b []byte, j int) (end int, complete bool) {
+	for k := j; k < len(b); k++ {
+		c := b[k]
+		if c == 0x1b {
+			return k, true // aborted CSI; the boundary is the new ESC
+		}
+		if c >= 0x40 && c <= 0x7e {
+			return k + 1, true
+		}
+	}
+	return 0, false
+}
+
+// stringEnd finds the end of a string sequence (OSC/DCS/…) whose data starts at
+// b[j]. BEL or ST (ESC \) terminates it; running out of bytes leaves it
+// incomplete.
+func stringEnd(b []byte, j int) (end int, complete bool) {
+	for k := j; k < len(b); k++ {
+		switch b[k] {
+		case 0x07:
+			return k + 1, true
+		case 0x1b:
+			if k+1 < len(b) && b[k+1] == '\\' {
+				return k + 2, true
+			}
+			return 0, false // ESC with no following byte yet: wait for it
+		}
+	}
+	return 0, false
+}

--- a/internal/runner/ptyrun/query_sanitize.go
+++ b/internal/runner/ptyrun/query_sanitize.go
@@ -123,12 +123,20 @@ func stringEnd(b []byte, j int) (end int, complete bool) {
 	for k := j; k < len(b); k++ {
 		switch b[k] {
 		case 0x07:
-			return k + 1, true
+			return k + 1, true // BEL terminator
 		case 0x1b:
-			if k+1 < len(b) && b[k+1] == '\\' {
-				return k + 2, true
+			switch {
+			case k+1 >= len(b):
+				return 0, false // a lone trailing ESC: wait for what follows
+			case b[k+1] == '\\':
+				return k + 2, true // ST terminator (ESC \)
+			default:
+				// An ESC followed by any other byte ABORTS the string and begins a
+				// new sequence — vt10x exits string parsing here. The string ends at
+				// the ESC (it is not consumed), so scanning resumes at it rather than
+				// holding the rest of the stream and stranding a later query.
+				return k, true
 			}
-			return 0, false // ESC with no following byte yet: wait for it
 		}
 	}
 	return 0, false

--- a/internal/runner/ptyrun/query_sanitize_test.go
+++ b/internal/runner/ptyrun/query_sanitize_test.go
@@ -1,0 +1,87 @@
+package ptyrun
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStreamSanitizer_SplitOversizedCSI is the core #438 case: an oversized
+// count-based CSI split across two chunks must not reach the emulator as two
+// halves that reassemble into a quadrillion-step sequence. The sanitizer holds
+// the incomplete first half and clamps the whole thing once it is complete.
+func TestStreamSanitizer_SplitOversizedCSI(t *testing.T) {
+	t.Parallel()
+	var s streamSanitizer
+
+	// First chunk ends mid-CSI (no final byte): nothing is safe to emit yet.
+	if got := s.feed([]byte("\x1b[8011")); len(got) != 0 {
+		t.Fatalf("first half emitted %q, want nothing held back", got)
+	}
+	// Second chunk completes the CBT. The reassembled 80111111110 count is clamped
+	// to four digits before it reaches the emulator.
+	got := string(s.feed([]byte("1111110Z")))
+	if got != "\x1b[8011Z" {
+		t.Fatalf("completed sequence = %q, want the clamped %q", got, "\x1b[8011Z")
+	}
+}
+
+// TestStreamSanitizer_HoldsAndCompletes covers the ordinary split: a clean CSI
+// broken across chunks is emitted intact once its final byte arrives, and plain
+// text on either side passes straight through.
+func TestStreamSanitizer_HoldsAndCompletes(t *testing.T) {
+	t.Parallel()
+	var s streamSanitizer
+
+	if got := string(s.feed([]byte("ab\x1b[1"))); got != "ab" {
+		t.Fatalf("first chunk = %q, want the plain prefix %q", got, "ab")
+	}
+	if got := string(s.feed([]byte(";31mcd"))); got != "\x1b[1;31mcd" {
+		t.Fatalf("second chunk = %q, want the completed sequence plus text", got)
+	}
+}
+
+// TestStreamSanitizer_DropsNeverEndingEscape pins the buffer bound: an escape
+// that never terminates must not grow the carry without limit; past the cap it
+// is dropped rather than held or fed on.
+func TestStreamSanitizer_DropsNeverEndingEscape(t *testing.T) {
+	t.Parallel()
+	var s streamSanitizer
+
+	// An OSC with no terminator, longer than the carry cap.
+	huge := "\x1b]0;" + strings.Repeat("x", maxQueryCarry+16)
+	if got := s.feed([]byte(huge)); len(got) != 0 {
+		t.Fatalf("an incomplete over-long escape emitted %q, want nothing", got)
+	}
+	// The next ordinary text is emitted normally — the dropped escape did not
+	// wedge the sanitizer.
+	if got := string(s.feed([]byte("hello"))); got != "hello" {
+		t.Fatalf("after dropping the over-long escape, got %q, want %q", got, "hello")
+	}
+}
+
+// TestIncompleteEscapeStart pins where the boundary between complete units and a
+// trailing incomplete escape falls, for the shapes the streaming split depends
+// on.
+func TestIncompleteEscapeStart(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		in   string
+		want int
+	}{
+		{"no escape ends on a boundary", "plain text", len("plain text")},
+		{"complete CSI then boundary", "\x1b[1;31mX", len("\x1b[1;31mX")},
+		{"trailing lone ESC is incomplete", "ab\x1b", 2},
+		{"trailing CSI without final is incomplete", "ab\x1b[12;", 2},
+		{"trailing OSC without terminator is incomplete", "ab\x1b]0;title", 2},
+		{"OSC closed by BEL is complete", "\x1b]0;t\x07", len("\x1b]0;t\x07")},
+		{"OSC closed by ST is complete", "\x1b]0;t\x1b\\", len("\x1b]0;t\x1b\\")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := incompleteEscapeStart([]byte(tc.in)); got != tc.want {
+				t.Errorf("incompleteEscapeStart(%q) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/runner/ptyrun/query_sanitize_test.go
+++ b/internal/runner/ptyrun/query_sanitize_test.go
@@ -76,6 +76,10 @@ func TestIncompleteEscapeStart(t *testing.T) {
 		{"trailing OSC without terminator is incomplete", "ab\x1b]0;title", 2},
 		{"OSC closed by BEL is complete", "\x1b]0;t\x07", len("\x1b]0;t\x07")},
 		{"OSC closed by ST is complete", "\x1b]0;t\x1b\\", len("\x1b]0;t\x1b\\")},
+		// An ESC that is not the start of ST aborts the string; the CSI after it is
+		// a complete unit, so nothing is held.
+		{"OSC aborted by a new escape ends at that escape", "\x1b]x\x1bA\x1b[6n", len("\x1b]x\x1bA\x1b[6n")},
+		{"OSC aborted then trailing incomplete CSI", "\x1b]x\x1bA\x1b[6", len("\x1b]x\x1bA")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/runner/ptyrun/terminal_queries.go
+++ b/internal/runner/ptyrun/terminal_queries.go
@@ -40,7 +40,11 @@ type terminalQueries struct {
 	mu   sync.Mutex
 	term vt10x.Terminal
 	da1  da1Scanner
-	w    io.Writer
+	// sanitize holds an incomplete trailing escape between chunks so a CSI split
+	// across reads is bounded as one sequence instead of reassembling inside
+	// vt10x (#438). Only consume touches it, under mu.
+	sanitize streamSanitizer
+	w        io.Writer
 }
 
 func newTerminalQueries(p *spec.PTY, w io.Writer) *terminalQueries {
@@ -73,7 +77,10 @@ func (t *terminalQueries) resize(rows, cols int) {
 
 func (t *terminalQueries) consume(chunk []byte) {
 	t.mu.Lock()
-	writeQueryTerminal(t.term, chunk)
+	// The emulator sees the sanitized stream (counts clamped, malformed and split
+	// sequences bounded); the DA1 scanner below sees the raw chunk because it must
+	// still recognize a well-formed DA1/DECID request wherever it lands.
+	writeQueryTerminal(t.term, t.sanitize.feed(chunk))
 	t.mu.Unlock()
 	for range t.da1.consume(chunk) {
 		_, _ = t.w.Write([]byte(vt102DA1))

--- a/internal/runner/ptyrun/terminal_queries_test.go
+++ b/internal/runner/ptyrun/terminal_queries_test.go
@@ -89,3 +89,19 @@ func TestTerminalQueries_MalformedCSIStillAnswersCPR(t *testing.T) {
 		t.Fatalf("no cursor-position reply after a malformed CSI: %q", got)
 	}
 }
+
+// TestTerminalQueries_AbortedStringStillAnswersCPR pins that an OSC/string
+// sequence aborted by a new escape (an ESC not followed by ST) does not swallow
+// the rest of the stream: the CPR request after it is still answered. Holding the
+// aborted string in the carry would have stranded the query.
+func TestTerminalQueries_AbortedStringStillAnswersCPR(t *testing.T) {
+	var out bytes.Buffer
+	q := newTerminalQueries(&spec.PTY{Rows: 10, Cols: 40}, &out)
+
+	// OSC "x" aborted by ESC A, then a cursor-position request.
+	q.consume([]byte("\x1b]x\x1bA\x1b[6n"))
+
+	if got := out.String(); !strings.HasSuffix(got, "R") {
+		t.Fatalf("no cursor-position reply after an aborted string sequence: %q", got)
+	}
+}

--- a/internal/runner/ptyrun/terminal_queries_test.go
+++ b/internal/runner/ptyrun/terminal_queries_test.go
@@ -2,6 +2,7 @@ package ptyrun
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/nao1215/atago/internal/spec"
@@ -36,5 +37,55 @@ func TestTerminalQueries_ReplyToDA1AndDSR(t *testing.T) {
 	want := "\x1b[0n\x1b[1;4R" + vt102DA1
 	if got := out.String(); got != want {
 		t.Fatalf("replies = %q, want %q", got, want)
+	}
+}
+
+// TestTerminalQueries_OversizedCSIStillAnswersCPR is the #438 hang regression: a
+// program that emits an enormous count-based CSI just before a cursor-position
+// request must not stall the query terminal on that count — the sanitizer clamps
+// it, so the emulator reaches the `\x1b[6n` and answers it. Running under the
+// test's own deadline is the hang check.
+func TestTerminalQueries_OversizedCSIStillAnswersCPR(t *testing.T) {
+	var out bytes.Buffer
+	q := newTerminalQueries(&spec.PTY{Rows: 10, Cols: 40}, &out)
+
+	// CBT (backward tab) is one of vt10x's loop-per-count handlers; an
+	// eight-billion count would spin it for minutes unclamped.
+	q.consume([]byte("hi\x1b[99999999Z\x1b[6n"))
+
+	if got := out.String(); !strings.HasSuffix(got, "R") || !strings.HasPrefix(got, "\x1b[") {
+		t.Fatalf("no cursor-position reply after an oversized CSI: %q", got)
+	}
+}
+
+// TestTerminalQueries_SplitOversizedCSIStillAnswersCPR is the split variant: the
+// oversized CSI is delivered in two chunks, so a per-chunk sanitizer would let
+// the two halves reassemble inside the emulator and spin. The streaming
+// sanitizer holds the first half, and the cursor-position request in the second
+// chunk is still answered.
+func TestTerminalQueries_SplitOversizedCSIStillAnswersCPR(t *testing.T) {
+	var out bytes.Buffer
+	q := newTerminalQueries(&spec.PTY{Rows: 10, Cols: 40}, &out)
+
+	q.consume([]byte("hi\x1b[8011"))     // ends mid-CSI
+	q.consume([]byte("1111110Z\x1b[6n")) // completes the oversized CBT, then a CPR
+
+	if got := out.String(); !strings.HasSuffix(got, "R") {
+		t.Fatalf("no cursor-position reply after a split oversized CSI: %q", got)
+	}
+}
+
+// TestTerminalQueries_MalformedCSIStillAnswersCPR pins that a malformed sequence
+// does not abort the rest of the chunk: a later CPR request is still answered.
+func TestTerminalQueries_MalformedCSIStillAnswersCPR(t *testing.T) {
+	var out bytes.Buffer
+	q := newTerminalQueries(&spec.PTY{Rows: 10, Cols: 40}, &out)
+
+	// A negative parameter is malformed; a conformant terminal ignores the
+	// sequence, and the CPR after it must still be answered.
+	q.consume([]byte("hi\x1b[-5X\x1b[6n"))
+
+	if got := out.String(); !strings.HasSuffix(got, "R") {
+		t.Fatalf("no cursor-position reply after a malformed CSI: %q", got)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #438. The live terminal that answers a program's device queries during a `pty` session (DA1, DSR, cursor-position reports) was fed the program's raw output with only a `recover` guard — no CSI sanitizing. That predated the x/vt migration (the old `writeTranscript` had the same shape) and was raised in review on #436.

Two hazards the screen render already defends against, plus one it does not:

- An oversized count-based CSI (a backward-tab `\x1b[…Z` with a billion-step count) spins vt10x's loop-per-count handler before `recover` can run — `recover` catches a panic, not a busy loop — so a following `\x1b[6n` is never reached.
- A malformed CSI that panics vt10x aborts the rest of that read chunk, so a CPR/DSR request later in the same chunk goes unanswered and a program waiting on it hangs until its own timeout.
- A read is an arbitrary boundary, so a CSI can be SPLIT across two chunks and reassemble inside vt10x's stateful parser — where a per-chunk sanitizer never sees it whole, the same split-sequence hole `sanitizeTranscriptMarks` was built to avoid for the render.

## Fix

`streamSanitizer` carries the incomplete trailing escape of one chunk into the next, so a sequence reaches the emulator only once it is complete and has been through `sanitizeTranscriptMarks` (counts clamped, malformed sequences dropped). `incompleteEscapeStart` finds where a trailing, not-yet-terminated escape begins — a lone `ESC`, a CSI without its final byte, an OSC/DCS with no ST/BEL — and those bytes are held. An escape that never terminates is bounded: past a 4 KB cap the held bytes are dropped rather than buffered without limit. The DA1 scanner still sees the raw chunk, since it must recognize a well-formed DA1/DECID request wherever it lands.

## Tests

`query_sanitize_test.go` covers the sanitizer: a split oversized CSI is clamped once complete, a clean CSI split across chunks is emitted intact, an over-long never-ending escape is dropped, and `incompleteEscapeStart` is pinned for each shape. `terminal_queries_test.go` adds the integration cases — an oversized CSI, a split oversized CSI, and a malformed CSI, each followed by a cursor-position request that must still be answered. The two oversized cases were confirmed to hang the test (20 s timeout) with the raw feed and pass with the sanitizer. Full unit suite, `-race` on the query path, lint, and `make e2e` (542 scenarios) are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal-query handling for oversized, malformed, and split escape sequences.
  * Prevented invalid input from blocking subsequent cursor-position responses.
  * Preserved incomplete sequences across incoming data chunks and safely discarded never-ending sequences.

* **Documentation**
  * Added changelog documentation for the terminal-query hardening improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->