### PR TITLE
refactor: decompose four high-complexity linear functions

### DIFF
--- a/internal/assert/assert_test.go
+++ b/internal/assert/assert_test.go
@@ -1053,6 +1053,37 @@ func TestCheck_File_SymlinkEscapeRejected(t *testing.T) {
 	}
 }
 
+// TestCheck_File_SymlinkMetadataNotAnswered closes the metadata half of the
+// leaf-symlink rule: contains/equals already refuse to READ through a workdir
+// symlink pointing outside the root, and file.size refuses to stat through one
+// (checkFileSize uses StatNoFollow), but exists/executable answered via os.Stat
+// — following the link and reporting whether a HOST file exists or carries the
+// execute bit. Both must refuse the symlink the way the read and size paths do,
+// so one assert family never disagrees with itself about the same planted link.
+func TestCheck_File_SymlinkMetadataNotAnswered(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is not reliably available on Windows CI")
+	}
+	t.Parallel()
+	workdir := t.TempDir()
+	secret := filepath.Join(t.TempDir(), "secret.sh")
+	if err := os.WriteFile(secret, []byte("#!/bin/sh\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secret, filepath.Join(workdir, "leak.sh")); err != nil {
+		t.Fatal(err)
+	}
+	for _, a := range []*spec.Assert{
+		{File: &spec.FileAssert{Path: "leak.sh", Exists: ptrBool(true)}},
+		{File: &spec.FileAssert{Path: "leak.sh", Executable: ptrBool(true)}},
+	} {
+		got := Check(a, nil, Env{Workdir: workdir})
+		if got.OK {
+			t.Errorf("%+v was answered through a workdir symlink pointing outside the root", a.File)
+		}
+	}
+}
+
 // TestCheck_File_SymlinkedAncestorEscapeRejected is the same disclosure one
 // directory up. The leaf refusal above only sees a link AT the target, so a
 // program under test that turned a directory component into a link — `ln -s /etc

--- a/internal/assert/file.go
+++ b/internal/assert/file.go
@@ -67,7 +67,7 @@ func checkFile(f *spec.FileAssert, env Env) (out *CheckResult) {
 
 	switch {
 	case f.Exists != nil:
-		return checkFileExists(f, path)
+		return checkFileExists(f, env.Workdir, path)
 
 	case f.Contains != nil:
 		data, cr := read(f.Path, path)
@@ -84,7 +84,7 @@ func checkFile(f *spec.FileAssert, env Env) (out *CheckResult) {
 		return checkFileNotContains(f, data)
 
 	case f.Executable != nil:
-		return checkFileExecutable(f, path)
+		return checkFileExecutable(f, env.Workdir, path)
 
 	case f.Equals != nil:
 		data, cr := read(f.Path, path)
@@ -124,12 +124,18 @@ func checkFile(f *spec.FileAssert, env Env) (out *CheckResult) {
 }
 
 // checkFileExists evaluates exists:true/false against a stat of path.
-func checkFileExists(f *spec.FileAssert, path string) *CheckResult {
+func checkFileExists(f *spec.FileAssert, root, path string) *CheckResult {
 	desc := fmt.Sprintf("assert file %q exists: %t", f.Path, *f.Exists)
-	info, err := os.Stat(path)
+	// StatNoFollow, not os.Stat: a program under test can plant a symlink at the
+	// assertion target, and following it would report whether a host file OUTSIDE
+	// the workdir exists — the metadata twin of the disclosure ReadFileNoFollow
+	// refuses on the read path (issue #16), and the same rule checkFileSize
+	// already applies. Binding it to the workdir refuses an ancestor swapped for
+	// a link too (issue #430).
+	info, err := security.StatNoFollow(root, path)
 	// Only a genuine "not exist" result participates in exists:true/false.
-	// Permission, I/O, and other stat failures are surfaced as an error so
-	// users do not debug a "missing file" that is really unreadable (#39).
+	// Permission, I/O, symlink-refusal, and other stat failures are surfaced as
+	// an error so users do not debug a "missing file" that is really unreadable (#39).
 	if err != nil && !os.IsNotExist(err) {
 		return &CheckResult{
 			Desc:     desc,
@@ -190,9 +196,11 @@ func checkFileNotContains(f *spec.FileAssert, data []byte) *CheckResult {
 }
 
 // checkFileExecutable evaluates executable:true/false against path's mode bits.
-func checkFileExecutable(f *spec.FileAssert, path string) *CheckResult {
+func checkFileExecutable(f *spec.FileAssert, root, path string) *CheckResult {
 	desc := fmt.Sprintf("assert file %q executable: %t", f.Path, *f.Executable)
-	info, statErr := os.Stat(path)
+	// StatNoFollow for the same reason as checkFileExists: the execute bit of a
+	// host file outside the workdir is not this assertion's to report.
+	info, statErr := security.StatNoFollow(root, path)
 	if statErr != nil {
 		return &CheckResult{
 			Desc:     desc,

--- a/internal/assert/file.go
+++ b/internal/assert/file.go
@@ -67,151 +67,38 @@ func checkFile(f *spec.FileAssert, env Env) (out *CheckResult) {
 
 	switch {
 	case f.Exists != nil:
-		desc := fmt.Sprintf("assert file %q exists: %t", f.Path, *f.Exists)
-		info, err := os.Stat(path)
-		// Only a genuine "not exist" result participates in exists:true/false.
-		// Permission, I/O, and other stat failures are surfaced as an error so
-		// users do not debug a "missing file" that is really unreadable (#39).
-		if err != nil && !os.IsNotExist(err) {
-			return &CheckResult{
-				Desc:     desc,
-				Expected: fmt.Sprintf("stat-able file %q", f.Path),
-				Actual:   err.Error(),
-				Hint:     fmt.Sprintf("could not stat file %q: %v", f.Path, err),
-			}
-		}
-		// A directory is not the file this assertion is about. Counting it as one
-		// made `exists: true` pass for a tool that produced a directory where a
-		// file was expected — the assertion's whole job is to catch that.
-		if err == nil && info.IsDir() {
-			return &CheckResult{
-				Desc:     desc,
-				Expected: fmt.Sprintf("file %q exists=%t", f.Path, *f.Exists),
-				Actual:   fmt.Sprintf("%q is a directory", f.Path),
-				Hint:     fmt.Sprintf("%q exists but is a directory, not a file; use a dir: assertion for it", f.Path),
-			}
-		}
-		exists := err == nil
-		if exists == *f.Exists {
-			return pass(desc)
-		}
-		return &CheckResult{
-			Desc:     desc,
-			Expected: fmt.Sprintf("file %q exists=%t", f.Path, *f.Exists),
-			Actual:   fmt.Sprintf("exists=%t", exists),
-			Hint:     fmt.Sprintf("expected file %q to %s", f.Path, existence(*f.Exists)),
-		}
+		return checkFileExists(f, path)
 
 	case f.Contains != nil:
 		data, cr := read(f.Path, path)
 		if cr != nil {
 			return cr
 		}
-		desc := fileContainsDesc(f.Path, f.Contains, true)
-		if sub, idx, missing := firstMissing(string(data), f.Contains); missing {
-			return &CheckResult{
-				Desc:     desc,
-				Expected: fmt.Sprintf("file %q contains %q", f.Path, sub),
-				Actual:   excerpt(string(data)),
-				Hint:     fmt.Sprintf("the substring %q%s was not present in %q", sub, elementLabel(idx, len(f.Contains)), f.Path),
-			}
-		}
-		return pass(desc)
+		return checkFileContains(f, data)
 
 	case f.NotContains != nil:
 		data, cr := read(f.Path, path)
 		if cr != nil {
 			return cr
 		}
-		desc := fileContainsDesc(f.Path, f.NotContains, false)
-		if sub, idx, present := firstPresent(string(data), f.NotContains); present {
-			return &CheckResult{
-				Desc:     desc,
-				Expected: fmt.Sprintf("file %q without %q", f.Path, sub),
-				Actual:   excerpt(string(data)),
-				Hint:     fmt.Sprintf("the substring %q%s was unexpectedly present in %q", sub, elementLabel(idx, len(f.NotContains)), f.Path),
-			}
-		}
-		return pass(desc)
+		return checkFileNotContains(f, data)
 
 	case f.Executable != nil:
-		info, statErr := os.Stat(path)
-		if statErr != nil {
-			return &CheckResult{
-				Desc:     fmt.Sprintf("assert file %q executable: %t", f.Path, *f.Executable),
-				Expected: fmt.Sprintf("readable file %q", f.Path),
-				Actual:   statErr.Error(),
-				Hint:     fmt.Sprintf("could not stat file %q", f.Path),
-			}
-		}
-		desc := fmt.Sprintf("assert file %q executable: %t", f.Path, *f.Executable)
-		// Every directory carries the execute bit, so reading it as "this is an
-		// executable" turned a tool that produced a directory into a passing
-		// executable check.
-		if info.IsDir() {
-			return &CheckResult{
-				Desc:     desc,
-				Expected: fmt.Sprintf("file %q executable=%t", f.Path, *f.Executable),
-				Actual:   fmt.Sprintf("%q is a directory", f.Path),
-				Hint:     fmt.Sprintf("%q is a directory, not an executable file; a directory's execute bit means it can be entered", f.Path),
-			}
-		}
-		isExec := info.Mode().Perm()&0o111 != 0
-		if isExec == *f.Executable {
-			return pass(desc)
-		}
-		return &CheckResult{
-			Desc:     desc,
-			Expected: fmt.Sprintf("file %q executable=%t", f.Path, *f.Executable),
-			Actual:   fmt.Sprintf("executable=%t (mode %s)", isExec, info.Mode().Perm()),
-			Hint:     fmt.Sprintf("expected file %q to %s executable", f.Path, executability(*f.Executable)),
-		}
+		return checkFileExecutable(f, path)
 
 	case f.Equals != nil:
 		data, cr := read(f.Path, path)
 		if cr != nil {
 			return cr
 		}
-		// Byte-exact: no CRLF or trailing-newline normalization, unlike the stdout
-		// equals matcher. A round-trip test needs to prove the bytes are identical.
-		desc := fmt.Sprintf("assert file %q equals exact bytes", f.Path)
-		if string(data) == *f.Equals {
-			return pass(desc)
-		}
-		return &CheckResult{
-			Desc:             desc,
-			Expected:         excerpt(*f.Equals),
-			Actual:           excerpt(string(data)),
-			Hint:             fmt.Sprintf("file %q did not equal the expected bytes exactly (no CRLF/newline normalization)", f.Path),
-			ArtifactExpected: []byte(*f.Equals),
-		}
+		return checkFileEquals(f, data)
 
 	case f.EqualsFile != nil:
 		data, cr := read(f.Path, path)
 		if cr != nil {
 			return cr
 		}
-		otherPath, err := security.ResolveWorkdirPath("assert.file.equals_file", env.Workdir, *f.EqualsFile)
-		if err != nil {
-			return &CheckResult{Desc: fmt.Sprintf("assert file %q equals_file %q", f.Path, *f.EqualsFile), Hint: err.Error()}
-		}
-		// The comparison file is read plainly (not via read): the failure artifact
-		// is the file under test, and the other file is carried as ArtifactExpected.
-		other, cr := readFile(*f.EqualsFile, env.Workdir, otherPath)
-		if cr != nil {
-			return cr
-		}
-		desc := fmt.Sprintf("assert file %q equals file %q", f.Path, *f.EqualsFile)
-		if bytes.Equal(data, other) {
-			return pass(desc)
-		}
-		return &CheckResult{
-			Desc:             desc,
-			Expected:         fmt.Sprintf("bytes identical to %q", *f.EqualsFile),
-			Actual:           excerpt(string(data)),
-			Hint:             fmt.Sprintf("file %q is not byte-identical to %q (no CRLF/newline normalization)", f.Path, *f.EqualsFile),
-			ArtifactExpected: other,
-		}
+		return checkFileEqualsFile(f, data, env)
 
 	case len(f.JSON) > 0:
 		data, cr := read(f.Path, path)
@@ -233,6 +120,150 @@ func checkFile(f *spec.FileAssert, env Env) (out *CheckResult) {
 
 	default:
 		return &CheckResult{Desc: "assert file", Hint: "file assertion must set exists/contains/not_contains/executable/equals/equals_file/json/snapshot"}
+	}
+}
+
+// checkFileExists evaluates exists:true/false against a stat of path.
+func checkFileExists(f *spec.FileAssert, path string) *CheckResult {
+	desc := fmt.Sprintf("assert file %q exists: %t", f.Path, *f.Exists)
+	info, err := os.Stat(path)
+	// Only a genuine "not exist" result participates in exists:true/false.
+	// Permission, I/O, and other stat failures are surfaced as an error so
+	// users do not debug a "missing file" that is really unreadable (#39).
+	if err != nil && !os.IsNotExist(err) {
+		return &CheckResult{
+			Desc:     desc,
+			Expected: fmt.Sprintf("stat-able file %q", f.Path),
+			Actual:   err.Error(),
+			Hint:     fmt.Sprintf("could not stat file %q: %v", f.Path, err),
+		}
+	}
+	// A directory is not the file this assertion is about. Counting it as one
+	// made `exists: true` pass for a tool that produced a directory where a
+	// file was expected — the assertion's whole job is to catch that.
+	if err == nil && info.IsDir() {
+		return &CheckResult{
+			Desc:     desc,
+			Expected: fmt.Sprintf("file %q exists=%t", f.Path, *f.Exists),
+			Actual:   fmt.Sprintf("%q is a directory", f.Path),
+			Hint:     fmt.Sprintf("%q exists but is a directory, not a file; use a dir: assertion for it", f.Path),
+		}
+	}
+	exists := err == nil
+	if exists == *f.Exists {
+		return pass(desc)
+	}
+	return &CheckResult{
+		Desc:     desc,
+		Expected: fmt.Sprintf("file %q exists=%t", f.Path, *f.Exists),
+		Actual:   fmt.Sprintf("exists=%t", exists),
+		Hint:     fmt.Sprintf("expected file %q to %s", f.Path, existence(*f.Exists)),
+	}
+}
+
+// checkFileContains requires every listed substring to appear in data.
+func checkFileContains(f *spec.FileAssert, data []byte) *CheckResult {
+	desc := fileContainsDesc(f.Path, f.Contains, true)
+	if sub, idx, missing := firstMissing(string(data), f.Contains); missing {
+		return &CheckResult{
+			Desc:     desc,
+			Expected: fmt.Sprintf("file %q contains %q", f.Path, sub),
+			Actual:   excerpt(string(data)),
+			Hint:     fmt.Sprintf("the substring %q%s was not present in %q", sub, elementLabel(idx, len(f.Contains)), f.Path),
+		}
+	}
+	return pass(desc)
+}
+
+// checkFileNotContains requires every listed substring to be absent from data.
+func checkFileNotContains(f *spec.FileAssert, data []byte) *CheckResult {
+	desc := fileContainsDesc(f.Path, f.NotContains, false)
+	if sub, idx, present := firstPresent(string(data), f.NotContains); present {
+		return &CheckResult{
+			Desc:     desc,
+			Expected: fmt.Sprintf("file %q without %q", f.Path, sub),
+			Actual:   excerpt(string(data)),
+			Hint:     fmt.Sprintf("the substring %q%s was unexpectedly present in %q", sub, elementLabel(idx, len(f.NotContains)), f.Path),
+		}
+	}
+	return pass(desc)
+}
+
+// checkFileExecutable evaluates executable:true/false against path's mode bits.
+func checkFileExecutable(f *spec.FileAssert, path string) *CheckResult {
+	desc := fmt.Sprintf("assert file %q executable: %t", f.Path, *f.Executable)
+	info, statErr := os.Stat(path)
+	if statErr != nil {
+		return &CheckResult{
+			Desc:     desc,
+			Expected: fmt.Sprintf("readable file %q", f.Path),
+			Actual:   statErr.Error(),
+			Hint:     fmt.Sprintf("could not stat file %q", f.Path),
+		}
+	}
+	// Every directory carries the execute bit, so reading it as "this is an
+	// executable" turned a tool that produced a directory into a passing
+	// executable check.
+	if info.IsDir() {
+		return &CheckResult{
+			Desc:     desc,
+			Expected: fmt.Sprintf("file %q executable=%t", f.Path, *f.Executable),
+			Actual:   fmt.Sprintf("%q is a directory", f.Path),
+			Hint:     fmt.Sprintf("%q is a directory, not an executable file; a directory's execute bit means it can be entered", f.Path),
+		}
+	}
+	isExec := info.Mode().Perm()&0o111 != 0
+	if isExec == *f.Executable {
+		return pass(desc)
+	}
+	return &CheckResult{
+		Desc:     desc,
+		Expected: fmt.Sprintf("file %q executable=%t", f.Path, *f.Executable),
+		Actual:   fmt.Sprintf("executable=%t (mode %s)", isExec, info.Mode().Perm()),
+		Hint:     fmt.Sprintf("expected file %q to %s executable", f.Path, executability(*f.Executable)),
+	}
+}
+
+// checkFileEquals compares data to the expected literal byte-exactly: no CRLF
+// or trailing-newline normalization, unlike the stdout equals matcher. A
+// round-trip test needs to prove the bytes are identical.
+func checkFileEquals(f *spec.FileAssert, data []byte) *CheckResult {
+	desc := fmt.Sprintf("assert file %q equals exact bytes", f.Path)
+	if string(data) == *f.Equals {
+		return pass(desc)
+	}
+	return &CheckResult{
+		Desc:             desc,
+		Expected:         excerpt(*f.Equals),
+		Actual:           excerpt(string(data)),
+		Hint:             fmt.Sprintf("file %q did not equal the expected bytes exactly (no CRLF/newline normalization)", f.Path),
+		ArtifactExpected: []byte(*f.Equals),
+	}
+}
+
+// checkFileEqualsFile compares data byte-exactly to another workdir file.
+func checkFileEqualsFile(f *spec.FileAssert, data []byte, env Env) *CheckResult {
+	otherPath, err := security.ResolveWorkdirPath("assert.file.equals_file", env.Workdir, *f.EqualsFile)
+	if err != nil {
+		return &CheckResult{Desc: fmt.Sprintf("assert file %q equals_file %q", f.Path, *f.EqualsFile), Hint: err.Error()}
+	}
+	// The comparison file is read plainly (not via checkFile's read): the failure
+	// artifact is the file under test, and the other file is carried as
+	// ArtifactExpected.
+	other, cr := readFile(*f.EqualsFile, env.Workdir, otherPath)
+	if cr != nil {
+		return cr
+	}
+	desc := fmt.Sprintf("assert file %q equals file %q", f.Path, *f.EqualsFile)
+	if bytes.Equal(data, other) {
+		return pass(desc)
+	}
+	return &CheckResult{
+		Desc:             desc,
+		Expected:         fmt.Sprintf("bytes identical to %q", *f.EqualsFile),
+		Actual:           excerpt(string(data)),
+		Hint:             fmt.Sprintf("file %q is not byte-identical to %q (no CRLF/newline normalization)", f.Path, *f.EqualsFile),
+		ArtifactExpected: other,
 	}
 }
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -156,7 +156,7 @@ func runCmd(label string, args []string, stdout, stderr io.Writer) int {
 	suiteResults, loadErrs := runSpecs(ctx, eng, paths)
 	elapsed := time.Since(start)
 
-	return finishRun(opts, suiteResults, loadErrs, progress, elapsed, ctx)
+	return finishRun(ctx, opts, suiteResults, loadErrs, progress, elapsed)
 }
 
 // parseRunFlags parses and validates `atago run`'s flags into a runOptions. The

--- a/internal/cli/run_finish.go
+++ b/internal/cli/run_finish.go
@@ -10,32 +10,73 @@ import (
 	"github.com/nao1215/atago/internal/report"
 )
 
-func finishRun(opts *runOptions, suiteResults []*engine.SuiteResult, loadErrs []error, progress *report.Progress, elapsed time.Duration, ctx context.Context) int {
-	failIncomplete := func() int {
-		if progress != nil {
-			progress.Done()
-		}
-		fmt.Fprintln(opts.stderr, opts.label+": internal error: incomplete run results")
-		return ExitInternal
-	}
-
+func finishRun(ctx context.Context, opts *runOptions, suiteResults []*engine.SuiteResult, loadErrs []error, progress *report.Progress, elapsed time.Duration) int {
 	if len(suiteResults) != len(opts.paths) || len(loadErrs) != len(opts.paths) {
-		return failIncomplete()
+		return failIncomplete(opts, progress)
+	}
+	results, exit, loadFailures, ok := collectSuiteExits(opts, suiteResults, loadErrs)
+	if !ok {
+		return failIncomplete(opts, progress)
+	}
+	if progress != nil {
+		progress.Done()
 	}
 
-	results := make([]*engine.SuiteResult, 0, len(opts.paths))
-	exit := ExitOK
-	loadFailures := 0
+	exit = worseExit(exit, settleRerunLedger(ctx, opts, results))
+
+	// Every spec failed to load, or an interrupt skipped every suite before it
+	// produced a result. Don't print a misleading "0 scenarios" report — but a run
+	// that was interrupted before completing must never exit 0.
+	if len(results) == 0 {
+		if ctx.Err() != nil {
+			fmt.Fprintln(opts.stderr, opts.label+": interrupted")
+			return worseExit(exit, ExitExec)
+		}
+		return exit
+	}
+
+	exit = worseExit(exit, emptySelectionExit(ctx, opts, results))
+
+	if err := report.Render(opts.stdout, opts.format, results, report.WithLoadFailures(loadFailures), report.WithElapsed(elapsed), report.WithAllowFlaky(opts.allowFlaky), report.WithAllowXPass(opts.allowXPass)); err != nil {
+		fmt.Fprintf(opts.stderr, opts.label+": failed to write report: %v\n", err)
+		return worseExit(exit, ExitInternal)
+	}
+	// An interrupted run never reports success, even in the rare case where the
+	// signal landed between scenarios and every scheduled one was skipped: the run
+	// did not complete, so the exit code is at least an execution error (4).
+	if ctx.Err() != nil {
+		fmt.Fprintln(opts.stderr, opts.label+": interrupted")
+		exit = worseExit(exit, ExitExec)
+	}
+	return exit
+}
+
+// failIncomplete reports a result/path bookkeeping mismatch — a bug in atago,
+// never in the spec — and returns the internal-error exit code.
+func failIncomplete(opts *runOptions, progress *report.Progress) int {
+	if progress != nil {
+		progress.Done()
+	}
+	fmt.Fprintln(opts.stderr, opts.label+": internal error: incomplete run results")
+	return ExitInternal
+}
+
+// collectSuiteExits pairs each spec path with its load error or suite result,
+// printing load failures and folding every outcome into one exit code. ok is
+// false when the slices run dry early (a bookkeeping bug the caller reports).
+func collectSuiteExits(opts *runOptions, suiteResults []*engine.SuiteResult, loadErrs []error) (results []*engine.SuiteResult, exit, loadFailures int, ok bool) {
+	results = make([]*engine.SuiteResult, 0, len(opts.paths))
+	exit = ExitOK
 	remainingResults := suiteResults
 	remainingLoadErrs := loadErrs
 	for range opts.paths {
 		loadErr, nextLoadErrs, ok := shiftSlice(remainingLoadErrs)
 		if !ok {
-			return failIncomplete()
+			return nil, 0, 0, false
 		}
 		suiteResult, nextResults, ok := shiftSlice(remainingResults)
 		if !ok {
-			return failIncomplete()
+			return nil, 0, 0, false
 		}
 		remainingLoadErrs = nextLoadErrs
 		remainingResults = nextResults
@@ -53,10 +94,14 @@ func finishRun(opts *runOptions, suiteResults []*engine.SuiteResult, loadErrs []
 		results = append(results, suiteResult)
 		exit = worseExit(exit, exitForSuite(suiteResult, opts.allowFlaky, opts.allowXPass))
 	}
-	if progress != nil {
-		progress.Done()
-	}
+	return results, exit, loadFailures, true
+}
 
+// settleRerunLedger updates the last-failed ledger for a later `--rerun-failed`
+// (#64) and returns the exit contribution of a --rerun-failed that matched
+// nothing. The preservation invariants live with the ledger primitives in
+// rerun.go.
+func settleRerunLedger(ctx context.Context, opts *runOptions, results []*engine.SuiteResult) int {
 	// Scenarios that actually executed. A Select can exclude every scenario in a
 	// loaded suite — most importantly a --rerun-failed whose recorded scenario
 	// names no longer exist in the specs (renamed or removed while still broken).
@@ -72,20 +117,17 @@ func finishRun(opts *runOptions, suiteResults []*engine.SuiteResult, loadErrs []
 	// (already printed) are the real story, not a "renamed or removed" scenario.
 	// An active --filter/--tag/--skip-tag is excluded here: when the user's own
 	// selection is why nothing ran, blaming a rename/removal is wrong (and
-	// contradicts the selection warning below). The excluded failures are still
-	// preserved into the ledger via rerunPreserved above, so no work is lost.
-	rerunMatchedNothing := opts.rerunFailed && !opts.selectionActive() && len(results) > 0 && ranScenarios == 0 && ctx.Err() == nil
-	if rerunMatchedNothing {
+	// contradicts the empty-selection warning). The excluded failures are still
+	// preserved into the ledger via rerunPreserved, so no work is lost.
+	if opts.rerunFailed && !opts.selectionActive() && len(results) > 0 && ranScenarios == 0 && ctx.Err() == nil {
 		fmt.Fprintln(opts.stderr, opts.label+": warning: no recorded failing scenarios matched the current specs (renamed or removed?); the recorded failures were kept, not cleared")
-		exit = worseExit(exit, ExitConfig)
+		return ExitConfig
 	}
 
-	// Update the last-failed ledger for a later `--rerun-failed` (#64); the
-	// preservation invariants live with the ledger primitives in rerun.go. The
-	// ledger is left untouched when no suite loaded (prior state stays intact)
-	// and when a --rerun-failed matched nothing (its unmapped failures must
-	// survive).
-	if len(results) > 0 && !rerunMatchedNothing {
+	// The ledger is left untouched when no suite loaded (prior state stays
+	// intact); the matched-nothing case above returned before reaching here so
+	// its unmapped failures survive.
+	if len(results) > 0 {
 		// A --rerun-failed that matched only SOME of the recorded failures is the
 		// quiet version of the case above: the run reports fewer scenarios than
 		// were recorded, which reads as "the others are fixed". Say so before the
@@ -95,74 +137,55 @@ func finishRun(opts *runOptions, suiteResults []*engine.SuiteResult, loadErrs []
 		}
 		updateRerunLedger(opts.label, opts.stderr, results, opts.allowXPass)
 	}
+	return ExitOK
+}
 
-	// Every spec failed to load, or an interrupt skipped every suite before it
-	// produced a result. Don't print a misleading "0 scenarios" report — but a run
-	// that was interrupted before completing must never exit 0.
-	if len(results) == 0 {
-		if ctx.Err() != nil {
-			fmt.Fprintln(opts.stderr, opts.label+": interrupted")
-			return worseExit(exit, ExitExec)
-		}
-		return exit
+// emptySelectionExit handles a selection that matches nothing: interactively
+// this still exits 0 (nothing ran, nothing failed) but stays loud; under --ci
+// it is a hard config error so a typo'd --filter/--tag/--skip-tag cannot
+// silently disable the whole suite in a pipeline forever.
+func emptySelectionExit(ctx context.Context, opts *runOptions, results []*engine.SuiteResult) int {
+	if !opts.selectionActive() {
+		return ExitOK
 	}
-
-	// A selection that matches nothing: interactively this still exits 0 (nothing
-	// ran, nothing failed) but stays loud; under --ci it is a hard config error so
-	// a typo'd --filter/--tag/--skip-tag cannot silently disable the whole suite in
-	// a pipeline forever.
-	if opts.selectionActive() {
-		total := 0
-		for _, r := range results {
-			total += len(r.Scenarios)
-		}
-		// total == 0 here can only mean the selectors excluded every scenario, never
-		// that the specs were empty: the loader rejects a spec with no scenarios, and
-		// a selected-but-skipped scenario (os gate, skip step) still appears in
-		// res.Scenarios. So this is precisely the "selectors filtered everything"
-		// case the task must fail on, not "the specs had nothing to run".
-		if total == 0 && ctx.Err() == nil {
-			var sel []string
-			if len(opts.filter) > 0 {
-				sel = append(sel, fmt.Sprintf("--filter %q", strings.Join(opts.filter, ",")))
-			}
-			if len(opts.tag) > 0 {
-				sel = append(sel, fmt.Sprintf("--tag %q", strings.Join(opts.tag, ",")))
-			}
-			if len(opts.skipTag) > 0 {
-				sel = append(sel, fmt.Sprintf("--skip-tag %q", strings.Join(opts.skipTag, ",")))
-			}
-			tagActive := len(opts.tag) > 0 || len(opts.skipTag) > 0
-			// The note is selector-aware: --filter matches names by case-sensitive
-			// substring, but --tag/--skip-tag compare tags for EXACT equality
-			// (engine.hasAnyTag uses ==). A single "substring" note for tags would send
-			// users fixing the wrong thing, so name each selector's real rule.
-			note := selectorNoMatchNote(len(opts.filter) > 0, tagActive)
-			if opts.ci {
-				fmt.Fprintf(opts.stderr, opts.label+": no scenarios matched %s under --ci; refusing to exit 0 (an empty selection would silently disable the suite). %s. Run `atago list` to see available scenarios and tags.\n", strings.Join(sel, " "), note)
-				exit = worseExit(exit, ExitConfig)
-			} else {
-				hint := note
-				if tagActive {
-					hint += "; run `atago list` to see the available tags"
-				}
-				fmt.Fprintf(opts.stderr, opts.label+": warning: no scenarios matched %s (%s)\n", strings.Join(sel, " "), hint)
-			}
-		}
+	total := 0
+	for _, r := range results {
+		total += len(r.Scenarios)
 	}
-
-	if err := report.Render(opts.stdout, opts.format, results, report.WithLoadFailures(loadFailures), report.WithElapsed(elapsed), report.WithAllowFlaky(opts.allowFlaky), report.WithAllowXPass(opts.allowXPass)); err != nil {
-		fmt.Fprintf(opts.stderr, opts.label+": failed to write report: %v\n", err)
-		return worseExit(exit, ExitInternal)
+	// total == 0 here can only mean the selectors excluded every scenario, never
+	// that the specs were empty: the loader rejects a spec with no scenarios, and
+	// a selected-but-skipped scenario (os gate, skip step) still appears in
+	// res.Scenarios. So this is precisely the "selectors filtered everything"
+	// case the task must fail on, not "the specs had nothing to run".
+	if total > 0 || ctx.Err() != nil {
+		return ExitOK
 	}
-	// An interrupted run never reports success, even in the rare case where the
-	// signal landed between scenarios and every scheduled one was skipped: the run
-	// did not complete, so the exit code is at least an execution error (4).
-	if ctx.Err() != nil {
-		fmt.Fprintln(opts.stderr, opts.label+": interrupted")
-		exit = worseExit(exit, ExitExec)
+	var sel []string
+	if len(opts.filter) > 0 {
+		sel = append(sel, fmt.Sprintf("--filter %q", strings.Join(opts.filter, ",")))
 	}
-	return exit
+	if len(opts.tag) > 0 {
+		sel = append(sel, fmt.Sprintf("--tag %q", strings.Join(opts.tag, ",")))
+	}
+	if len(opts.skipTag) > 0 {
+		sel = append(sel, fmt.Sprintf("--skip-tag %q", strings.Join(opts.skipTag, ",")))
+	}
+	tagActive := len(opts.tag) > 0 || len(opts.skipTag) > 0
+	// The note is selector-aware: --filter matches names by case-sensitive
+	// substring, but --tag/--skip-tag compare tags for EXACT equality
+	// (engine.hasAnyTag uses ==). A single "substring" note for tags would send
+	// users fixing the wrong thing, so name each selector's real rule.
+	note := selectorNoMatchNote(len(opts.filter) > 0, tagActive)
+	if opts.ci {
+		fmt.Fprintf(opts.stderr, opts.label+": no scenarios matched %s under --ci; refusing to exit 0 (an empty selection would silently disable the suite). %s. Run `atago list` to see available scenarios and tags.\n", strings.Join(sel, " "), note)
+		return ExitConfig
+	}
+	hint := note
+	if tagActive {
+		hint += "; run `atago list` to see the available tags"
+	}
+	fmt.Fprintf(opts.stderr, opts.label+": warning: no scenarios matched %s (%s)\n", strings.Join(sel, " "), hint)
+	return ExitOK
 }
 
 func shiftSlice[T any](values []T) (T, []T, bool) {

--- a/internal/cli/run_split_test.go
+++ b/internal/cli/run_split_test.go
@@ -124,7 +124,7 @@ func TestFinishRun_RerunMatchedNothingKeepsLedger(t *testing.T) {
 			Status:   engine.StatusPassed,
 		}}
 
-		if got := finishRun(opts, suiteResults, []error{nil}, nil, 5*time.Millisecond, context.Background()); got != ExitConfig {
+		if got := finishRun(context.Background(), opts, suiteResults, []error{nil}, nil, 5*time.Millisecond); got != ExitConfig {
 			t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitConfig, errb.String())
 		}
 		if !strings.Contains(errb.String(), "no recorded failing scenarios matched the current specs") {
@@ -160,7 +160,7 @@ func TestFinishRun_CIEmptySelectionExitsConfig(t *testing.T) {
 			Status:   engine.StatusPassed,
 		}}
 
-		if got := finishRun(opts, suiteResults, []error{nil}, nil, 5*time.Millisecond, context.Background()); got != ExitConfig {
+		if got := finishRun(context.Background(), opts, suiteResults, []error{nil}, nil, 5*time.Millisecond); got != ExitConfig {
 			t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitConfig, errb.String())
 		}
 		s := errb.String()
@@ -185,7 +185,7 @@ func TestFinishRun_InterruptedWithoutResultsSkipsReport(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	if got := finishRun(opts, []*engine.SuiteResult{nil}, []error{nil}, nil, 5*time.Millisecond, ctx); got != ExitExec {
+	if got := finishRun(ctx, opts, []*engine.SuiteResult{nil}, []error{nil}, nil, 5*time.Millisecond); got != ExitExec {
 		t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitExec, errb.String())
 	}
 	if out.Len() != 0 {
@@ -206,11 +206,11 @@ func TestFinishRun_IncompleteResultSlicesReturnInternal(t *testing.T) {
 		stderr: &errb,
 	}
 
-	if got := finishRun(opts, []*engine.SuiteResult{{
+	if got := finishRun(context.Background(), opts, []*engine.SuiteResult{{
 		Suite:    "one",
 		SpecPath: "one.atago.yaml",
 		Status:   engine.StatusPassed,
-	}}, []error{nil}, nil, 5*time.Millisecond, context.Background()); got != ExitInternal {
+	}}, []error{nil}, nil, 5*time.Millisecond); got != ExitInternal {
 		t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitInternal, errb.String())
 	}
 	if out.Len() != 0 {
@@ -243,7 +243,7 @@ func TestFinishRun_ReportWriteFailureReturnsInternal(t *testing.T) {
 			}},
 		}}
 
-		if got := finishRun(opts, suiteResults, []error{nil}, nil, 5*time.Millisecond, context.Background()); got != ExitInternal {
+		if got := finishRun(context.Background(), opts, suiteResults, []error{nil}, nil, 5*time.Millisecond); got != ExitInternal {
 			t.Fatalf("exit = %d, want %d (stderr=%s)", got, ExitInternal, errb.String())
 		}
 		if !strings.Contains(errb.String(), "failed to write report: boom") {

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -85,25 +85,7 @@ func explainSuiteBlock(b *strings.Builder, label string, steps []spec.Step) {
 }
 
 func explainScenario(b *strings.Builder, sc *spec.Scenario) {
-	fmt.Fprintf(b, "\nScenario: %s", sc.Name)
-	if len(sc.Tags) > 0 {
-		fmt.Fprintf(b, "  [tags: %s]", strings.Join(sc.Tags, ", "))
-	}
-	if sc.Only != nil && sc.Only.OS != "" {
-		fmt.Fprintf(b, "  [only os=%s]", sc.Only.OS)
-	}
-	if sc.Skip != nil && sc.Skip.OS != "" {
-		fmt.Fprintf(b, "  [skip os=%s]", sc.Skip.OS)
-	}
-	// A reviewer must see which scenarios are documentation of a known bug
-	// rather than guarantees, or a suite reads as promising more than it does.
-	if sc.ExpectFail != nil {
-		fmt.Fprintf(b, "  [expect_fail: %s]", sc.ExpectFail.Reason)
-		if sc.ExpectFail.Issue != "" {
-			fmt.Fprintf(b, " [%s]", sc.ExpectFail.Issue)
-		}
-	}
-	b.WriteByte('\n')
+	explainScenarioHeading(b, sc)
 
 	var fixtures, commands, expects, stores, services []string
 	vars := map[string]bool{}
@@ -123,95 +105,10 @@ func explainScenario(b *strings.Builder, sc *spec.Scenario) {
 	for i := range sc.Steps {
 		step := &sc.Steps[i]
 		// Variable references are collected by the shared spec walk so explain and
-		// manifest never disagree about which ${name}s a step uses; the switch
+		// manifest never disagree about which ${name}s a step uses; the bucketing
 		// below only formats the human-facing summary lines.
 		spec.CollectStepVars(vars, step)
-		switch step.Kind() {
-		case spec.StepFixture:
-			fixtures = append(fixtures, describeFixture(step.Fixture))
-		case spec.StepRun:
-			commands = append(commands, describeRun(step.Run))
-		case spec.StepAssert:
-			expects = append(expects, describeAsserts(step.Assert)...)
-		case spec.StepStore:
-			if step.Store != nil {
-				stores = append(stores, step.Store.Name)
-			}
-		case spec.StepHTTP:
-			if step.HTTP != nil {
-				commands = append(commands, fmt.Sprintf("HTTP %s %s", step.HTTP.Method, step.HTTP.Path))
-			}
-		case spec.StepQuery:
-			if step.Query != nil {
-				commands = append(commands, fmt.Sprintf("SQL query via %s: %s", step.Query.Runner, step.Query.SQL))
-			}
-		case spec.StepGRPC:
-			if step.GRPC != nil {
-				commands = append(commands, fmt.Sprintf("gRPC %s via %s", step.GRPC.Method, step.GRPC.Runner))
-			}
-		case spec.StepPTY:
-			if step.PTY != nil {
-				desc := fmt.Sprintf("interactive (pty): %s  [%d session actions]", step.PTY.Command, len(step.PTY.Session))
-				if step.PTY.ClearEnvEnabled() {
-					note := "  (cleared environment"
-					if len(step.PTY.PassEnv) > 0 {
-						note += ", passes: " + strings.Join(step.PTY.PassEnv, ", ")
-					}
-					desc += note + ")"
-				}
-				if step.PTY.SandboxHomeEnabled() {
-					desc += "  (isolated home)"
-				}
-				commands = append(commands, desc)
-				var keys []string
-				for _, a := range step.PTY.Session {
-					if a.Send == nil || a.Send.Key == "" {
-						continue
-					}
-					// A repeat says how many presses it stands for, so a
-					// reviewer sees "left x16" rather than a single "left"
-					// hiding sixteen of them (#377).
-					if a.Send.Times > 1 {
-						keys = append(keys, fmt.Sprintf("%s x%d", a.Send.Key, a.Send.Times))
-						continue
-					}
-					keys = append(keys, a.Send.Key)
-				}
-				if len(keys) > 0 {
-					commands[len(commands)-1] += "  [keys: " + strings.Join(keys, ", ") + "]"
-				}
-				// A resize changes what the program draws, so a reviewer reading
-				// the summary should see it (#379).
-				var resizes []string
-				for _, a := range step.PTY.Session {
-					if a.Resize != nil {
-						resizes = append(resizes, fmt.Sprintf("%dx%d", a.Resize.Rows, a.Resize.Cols))
-					}
-				}
-				if len(resizes) > 0 {
-					commands[len(commands)-1] += "  [resizes: " + strings.Join(resizes, ", ") + "]"
-				}
-				// A session that runs commands on the HOST is the one thing a
-				// reviewer must not have to read the YAML to discover (#380).
-				var execs []string
-				for _, a := range step.PTY.Session {
-					if a.Exec != nil {
-						execs = append(execs, a.Exec.Command)
-					}
-				}
-				if len(execs) > 0 {
-					commands[len(commands)-1] += "  [runs on the host: " + strings.Join(execs, "; ") + "]"
-				}
-			}
-		case spec.StepCDP:
-			if step.CDP != nil {
-				commands = append(commands, spec.CDPActionSummary(step.CDP))
-			}
-		case spec.StepSignal:
-			if step.Signal != nil {
-				commands = append(commands, describeSignal(step.Signal))
-			}
-		}
+		bucketScenarioStep(step, &fixtures, &commands, &expects, &stores)
 	}
 
 	// Teardown steps always run after the scenario — summarize them separately
@@ -220,26 +117,7 @@ func explainScenario(b *strings.Builder, sc *spec.Scenario) {
 	for i := range sc.Teardown {
 		step := &sc.Teardown[i]
 		spec.CollectStepVars(vars, step)
-		switch step.Kind() {
-		case spec.StepRun:
-			teardown = append(teardown, describeRun(step.Run))
-		case spec.StepHTTP:
-			teardown = append(teardown, fmt.Sprintf("HTTP %s %s", step.HTTP.Method, step.HTTP.Path))
-		case spec.StepQuery:
-			teardown = append(teardown, fmt.Sprintf("SQL query via %s: %s", step.Query.Runner, step.Query.SQL))
-		case spec.StepGRPC:
-			teardown = append(teardown, fmt.Sprintf("gRPC %s via %s", step.GRPC.Method, step.GRPC.Runner))
-		case spec.StepCDP:
-			teardown = append(teardown, spec.CDPActionSummary(step.CDP))
-		case spec.StepFixture:
-			teardown = append(teardown, describeFixture(step.Fixture))
-		case spec.StepAssert:
-			teardown = append(teardown, describeAsserts(step.Assert)...)
-		case spec.StepStore:
-			teardown = append(teardown, "store "+step.Store.Name)
-		case spec.StepSignal:
-			teardown = append(teardown, describeSignal(step.Signal))
-		}
+		teardown = append(teardown, describeTeardownStep(step)...)
 	}
 
 	// Generated artifacts and security notes come from the shared spec model, so
@@ -257,6 +135,154 @@ func explainScenario(b *strings.Builder, sc *spec.Scenario) {
 	if security := spec.SecurityNotes(sc); len(security) > 0 {
 		writeList(b, "⚠ Security notes", security)
 	}
+}
+
+// bucketScenarioStep files one scenario step's summary line under the section
+// it belongs to: fixtures, commands, expects, or stores.
+func bucketScenarioStep(step *spec.Step, fixtures, commands, expects, stores *[]string) {
+	switch step.Kind() {
+	case spec.StepFixture:
+		*fixtures = append(*fixtures, describeFixture(step.Fixture))
+	case spec.StepRun:
+		*commands = append(*commands, describeRun(step.Run))
+	case spec.StepAssert:
+		*expects = append(*expects, describeAsserts(step.Assert)...)
+	case spec.StepStore:
+		if step.Store != nil {
+			*stores = append(*stores, step.Store.Name)
+		}
+	case spec.StepHTTP:
+		if step.HTTP != nil {
+			*commands = append(*commands, fmt.Sprintf("HTTP %s %s", step.HTTP.Method, step.HTTP.Path))
+		}
+	case spec.StepQuery:
+		if step.Query != nil {
+			*commands = append(*commands, fmt.Sprintf("SQL query via %s: %s", step.Query.Runner, step.Query.SQL))
+		}
+	case spec.StepGRPC:
+		if step.GRPC != nil {
+			*commands = append(*commands, fmt.Sprintf("gRPC %s via %s", step.GRPC.Method, step.GRPC.Runner))
+		}
+	case spec.StepPTY:
+		if step.PTY != nil {
+			*commands = append(*commands, describePTY(step.PTY))
+		}
+	case spec.StepCDP:
+		if step.CDP != nil {
+			*commands = append(*commands, spec.CDPActionSummary(step.CDP))
+		}
+	case spec.StepSignal:
+		if step.Signal != nil {
+			*commands = append(*commands, describeSignal(step.Signal))
+		}
+	}
+}
+
+// explainScenarioHeading writes the scenario's title line: its name, tags, OS
+// gates, and the expect_fail marker. A reviewer must see which scenarios are
+// documentation of a known bug rather than guarantees, or a suite reads as
+// promising more than it does.
+func explainScenarioHeading(b *strings.Builder, sc *spec.Scenario) {
+	fmt.Fprintf(b, "\nScenario: %s", sc.Name)
+	if len(sc.Tags) > 0 {
+		fmt.Fprintf(b, "  [tags: %s]", strings.Join(sc.Tags, ", "))
+	}
+	if sc.Only != nil && sc.Only.OS != "" {
+		fmt.Fprintf(b, "  [only os=%s]", sc.Only.OS)
+	}
+	if sc.Skip != nil && sc.Skip.OS != "" {
+		fmt.Fprintf(b, "  [skip os=%s]", sc.Skip.OS)
+	}
+	if sc.ExpectFail != nil {
+		fmt.Fprintf(b, "  [expect_fail: %s]", sc.ExpectFail.Reason)
+		if sc.ExpectFail.Issue != "" {
+			fmt.Fprintf(b, " [%s]", sc.ExpectFail.Issue)
+		}
+	}
+	b.WriteByte('\n')
+}
+
+// describePTY renders a one-line summary of an interactive pty step: the
+// command, its isolation notes, and the session's keys, resizes, and host
+// execs.
+func describePTY(p *spec.PTY) string {
+	desc := fmt.Sprintf("interactive (pty): %s  [%d session actions]", p.Command, len(p.Session))
+	if p.ClearEnvEnabled() {
+		note := "  (cleared environment"
+		if len(p.PassEnv) > 0 {
+			note += ", passes: " + strings.Join(p.PassEnv, ", ")
+		}
+		desc += note + ")"
+	}
+	if p.SandboxHomeEnabled() {
+		desc += "  (isolated home)"
+	}
+	var keys []string
+	for _, a := range p.Session {
+		if a.Send == nil || a.Send.Key == "" {
+			continue
+		}
+		// A repeat says how many presses it stands for, so a reviewer sees
+		// "left x16" rather than a single "left" hiding sixteen of them (#377).
+		if a.Send.Times > 1 {
+			keys = append(keys, fmt.Sprintf("%s x%d", a.Send.Key, a.Send.Times))
+			continue
+		}
+		keys = append(keys, a.Send.Key)
+	}
+	if len(keys) > 0 {
+		desc += "  [keys: " + strings.Join(keys, ", ") + "]"
+	}
+	// A resize changes what the program draws, so a reviewer reading the
+	// summary should see it (#379).
+	var resizes []string
+	for _, a := range p.Session {
+		if a.Resize != nil {
+			resizes = append(resizes, fmt.Sprintf("%dx%d", a.Resize.Rows, a.Resize.Cols))
+		}
+	}
+	if len(resizes) > 0 {
+		desc += "  [resizes: " + strings.Join(resizes, ", ") + "]"
+	}
+	// A session that runs commands on the HOST is the one thing a reviewer
+	// must not have to read the YAML to discover (#380).
+	var execs []string
+	for _, a := range p.Session {
+		if a.Exec != nil {
+			execs = append(execs, a.Exec.Command)
+		}
+	}
+	if len(execs) > 0 {
+		desc += "  [runs on the host: " + strings.Join(execs, "; ") + "]"
+	}
+	return desc
+}
+
+// describeTeardownStep renders a teardown step's summary lines. Unlike the
+// scenario body, whose steps are bucketed into Commands/Expects/Fixtures,
+// teardown is one flat list — cleanup reads in execution order.
+func describeTeardownStep(step *spec.Step) []string {
+	switch step.Kind() {
+	case spec.StepRun:
+		return []string{describeRun(step.Run)}
+	case spec.StepHTTP:
+		return []string{fmt.Sprintf("HTTP %s %s", step.HTTP.Method, step.HTTP.Path)}
+	case spec.StepQuery:
+		return []string{fmt.Sprintf("SQL query via %s: %s", step.Query.Runner, step.Query.SQL)}
+	case spec.StepGRPC:
+		return []string{fmt.Sprintf("gRPC %s via %s", step.GRPC.Method, step.GRPC.Runner)}
+	case spec.StepCDP:
+		return []string{spec.CDPActionSummary(step.CDP)}
+	case spec.StepFixture:
+		return []string{describeFixture(step.Fixture)}
+	case spec.StepAssert:
+		return describeAsserts(step.Assert)
+	case spec.StepStore:
+		return []string{"store " + step.Store.Name}
+	case spec.StepSignal:
+		return []string{describeSignal(step.Signal)}
+	}
+	return nil
 }
 
 // describeService renders a one-line summary of a background service and how its

--- a/internal/report/console.go
+++ b/internal/report/console.go
@@ -60,31 +60,7 @@ func writeDetail(b *strings.Builder, color bool, suite, specPath string, sc *eng
 	where := specSuffix(specPath)
 	switch sc.Status {
 	case engine.StatusFailed:
-		var lastRun *runner.Result
-		for _, step := range sc.Steps {
-			// Track the most recent run result BEFORE rendering this step's
-			// checks: a run step's own retry `until` checks assert against that
-			// step's result, and every failure block names THAT command.
-			if step.Run != nil {
-				lastRun = step.Run
-			}
-			for _, ck := range step.Checks {
-				if ck == nil || ck.OK {
-					continue
-				}
-				fmt.Fprintf(b, "\n%s %s / %s%s\n", colorize(color, cRed+cBold, "FAILED:"), suite, sc.Name, where)
-				writeCheckFailure(b, color, ck, commandOf(lastRun))
-				writeFailureStreams(b, ck, lastRun)
-				// Keep console output compact: reference the durable payloads by path
-				// rather than dumping them inline (#48).
-				if len(ck.ArtifactFiles) > 0 {
-					fmt.Fprintf(b, "\nArtifacts:\n")
-					for _, a := range ck.ArtifactFiles {
-						fmt.Fprintf(b, "  %s: %s\n", a.Role, a.Path)
-					}
-				}
-			}
-		}
+		writeFailedChecks(b, color, suite, where, sc)
 	case engine.StatusXPass:
 		// The loud one. A known bug that is no longer there means the fix landed
 		// and the scenario has to move into the suite that guards against a
@@ -97,43 +73,12 @@ func writeDetail(b *strings.Builder, color bool, suite, specPath string, sc *eng
 		fmt.Fprintf(b, "\n%s %s / %s%s\n", colorize(color, cYellow+cBold, "XFAIL:"), suite, sc.Name, where)
 		fmt.Fprintf(b, "\n%s\n", indent(expectFailNarrative(sc.ExpectFail, false)))
 	case engine.StatusError:
-		for _, step := range sc.Steps {
-			if step.ErrMsg == "" {
-				continue
-			}
-			// A setup-phase error comes from before any numbered step ran; rendering
-			// it as "step 0 ()" is misleading. Use the phase label — distinguishing a
-			// suite.setup failure from service readiness so neither is mislabeled — so
-			// every report format agrees.
-			var phase string
-			if isSetupError(step) {
-				phase = setupPhaseLabelFor(step)
-			} else {
-				phase = fmt.Sprintf("step %d (%s)", step.Index, step.Kind)
-			}
-			fmt.Fprintf(b, "\n%s %s / %s%s\n  %s: %s\n",
-				colorize(color, cRed+cBold, "ERROR:"), suite, sc.Name, where, phase, step.ErrMsg)
-		}
+		writeErroredSteps(b, color, suite, where, sc)
 	}
 	// A failed teardown never flips the verdict — the steps decide that — but
 	// incomplete cleanup of external resources must stay loud.
 	if sc.TeardownFailed() {
-		for _, step := range sc.Teardown {
-			for _, ck := range step.Checks {
-				if ck == nil || ck.OK {
-					continue
-				}
-				fmt.Fprintf(b, "\n%s %s / %s%s\n", colorize(color, cYellow+cBold, "TEARDOWN FAILED:"), suite, sc.Name, where)
-				fmt.Fprintf(b, "\nStep:\n  %s\n", ck.Desc)
-				if ck.Hint != "" {
-					fmt.Fprintf(b, "\nHint:\n  %s\n", ck.Hint)
-				}
-			}
-			if step.ErrMsg != "" {
-				fmt.Fprintf(b, "\n%s %s / %s%s\n  teardown step %d (%s): %s\n",
-					colorize(color, cYellow+cBold, "TEARDOWN FAILED:"), suite, sc.Name, where, step.Index, step.Kind, step.ErrMsg)
-			}
-		}
+		writeTeardownFailures(b, color, suite, where, sc)
 	}
 	// Reference any preserved background-service logs by path (#51), keeping the
 	// console compact instead of dumping the captured output inline.
@@ -141,6 +86,79 @@ func writeDetail(b *strings.Builder, color bool, suite, specPath string, sc *eng
 		fmt.Fprintf(b, "\nService logs:\n")
 		for _, sl := range sc.ServiceLogs {
 			fmt.Fprintf(b, "  %s: %s\n", sl.Name, sl.Path)
+		}
+	}
+}
+
+// writeFailedChecks prints one FAILED block per failing check of a failed
+// scenario.
+func writeFailedChecks(b *strings.Builder, color bool, suite, where string, sc *engine.ScenarioResult) {
+	var lastRun *runner.Result
+	for _, step := range sc.Steps {
+		// Track the most recent run result BEFORE rendering this step's
+		// checks: a run step's own retry `until` checks assert against that
+		// step's result, and every failure block names THAT command.
+		if step.Run != nil {
+			lastRun = step.Run
+		}
+		for _, ck := range step.Checks {
+			if ck == nil || ck.OK {
+				continue
+			}
+			fmt.Fprintf(b, "\n%s %s / %s%s\n", colorize(color, cRed+cBold, "FAILED:"), suite, sc.Name, where)
+			writeCheckFailure(b, color, ck, commandOf(lastRun))
+			writeFailureStreams(b, ck, lastRun)
+			// Keep console output compact: reference the durable payloads by path
+			// rather than dumping them inline (#48).
+			if len(ck.ArtifactFiles) > 0 {
+				fmt.Fprintf(b, "\nArtifacts:\n")
+				for _, a := range ck.ArtifactFiles {
+					fmt.Fprintf(b, "  %s: %s\n", a.Role, a.Path)
+				}
+			}
+		}
+	}
+}
+
+// writeErroredSteps prints one ERROR block per step that carries an error
+// message.
+func writeErroredSteps(b *strings.Builder, color bool, suite, where string, sc *engine.ScenarioResult) {
+	for _, step := range sc.Steps {
+		if step.ErrMsg == "" {
+			continue
+		}
+		// A setup-phase error comes from before any numbered step ran; rendering
+		// it as "step 0 ()" is misleading. Use the phase label — distinguishing a
+		// suite.setup failure from service readiness so neither is mislabeled — so
+		// every report format agrees.
+		var phase string
+		if isSetupError(step) {
+			phase = setupPhaseLabelFor(step)
+		} else {
+			phase = fmt.Sprintf("step %d (%s)", step.Index, step.Kind)
+		}
+		fmt.Fprintf(b, "\n%s %s / %s%s\n  %s: %s\n",
+			colorize(color, cRed+cBold, "ERROR:"), suite, sc.Name, where, phase, step.ErrMsg)
+	}
+}
+
+// writeTeardownFailures prints one TEARDOWN FAILED block per failing teardown
+// check or errored teardown step.
+func writeTeardownFailures(b *strings.Builder, color bool, suite, where string, sc *engine.ScenarioResult) {
+	for _, step := range sc.Teardown {
+		for _, ck := range step.Checks {
+			if ck == nil || ck.OK {
+				continue
+			}
+			fmt.Fprintf(b, "\n%s %s / %s%s\n", colorize(color, cYellow+cBold, "TEARDOWN FAILED:"), suite, sc.Name, where)
+			fmt.Fprintf(b, "\nStep:\n  %s\n", ck.Desc)
+			if ck.Hint != "" {
+				fmt.Fprintf(b, "\nHint:\n  %s\n", ck.Hint)
+			}
+		}
+		if step.ErrMsg != "" {
+			fmt.Fprintf(b, "\n%s %s / %s%s\n  teardown step %d (%s): %s\n",
+				colorize(color, cYellow+cBold, "TEARDOWN FAILED:"), suite, sc.Name, where, step.Index, step.Kind, step.ErrMsg)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Second pass of the v1.0.0 refactoring series (after #445). Four functions with the highest cognitive complexity among the "linear" ones — long sequential blocks rather than state machines — are decomposed into named helpers with no behavior change: every extracted block keeps its exact output strings, ordering of side effects, and exit-code folding.

## Changes

- internal/explain/explain.go: explainScenario (cognitive complexity 100 → under threshold) now delegates to explainScenarioHeading, bucketScenarioStep (the step-kind switch), describePTY (the pty summary with keys/resizes/host execs), and describeTeardownStep.
- internal/assert/file.go: checkFile (55) keeps only path resolution, the artifact-attachment hook, size/count composition, and the matcher dispatch; each matcher body moved to checkFileExists, checkFileContains, checkFileNotContains, checkFileExecutable, checkFileEquals, checkFileEqualsFile.
- internal/report/console.go: writeDetail (53) now dispatches to writeFailedChecks, writeErroredSteps, and writeTeardownFailures; the short XPASS/XFAIL arms stay inline.
- internal/cli/run_finish.go: finishRun (50) now reads as its real phases — collectSuiteExits, settleRerunLedger, emptySelectionExit — and ctx moved from the last parameter to the idiomatic first position (call sites in run.go and run_split_test.go updated).

## Design Decisions

- Helpers take the narrowest inputs that preserve behavior (e.g. checkFileContains receives the already-read bytes so the deferred artifact hook in checkFile keeps observing exactly the reads it did before; checkFileEqualsFile reads the comparison file plainly, preserving which file becomes the failure artifact).
- settleRerunLedger returns an exit contribution instead of mutating exit in place, so finishRun folds every phase through the same worseExit path; the matched-nothing early return preserves the ledger-untouched invariant the old boolean guarded.
- gocognit/nestif on the touched packages now report nothing in production code; the full suite (33 packages) and repo golangci-lint config are green.

## Limitations

- valuesEqual and checkDirRecursive in internal/assert remain over the gocognit threshold; they are recursive comparators rather than linear blocks and are handled in a later PR of the series.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of interrupted runs and empty test selections, including clearer warnings and appropriate exit results.
  * Ensured rerun failures are reported consistently without corrupting result tracking.
  * Preserved detailed failure output, including commands, artifacts, captured streams, hints, and teardown diagnostics.

* **Refactor**
  * Improved internal organization of file assertions, scenario explanations, run completion, and console reporting without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->