### PR TITLE
refactor(engine,loader): decompose the run pipeline and validation hot spots

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -22,7 +22,7 @@ import (
 )
 
 // teardownInterruptTimeout bounds teardown execution after the run itself was
-// cancelled (Ctrl-C / SIGTERM): cleanup of external resources still runs, but a
+// canceled (Ctrl-C / SIGTERM): cleanup of external resources still runs, but a
 // hung teardown cannot keep an interrupted process alive indefinitely.
 const teardownInterruptTimeout = 30 * time.Second
 
@@ -281,7 +281,7 @@ func (p *scenarioPool) stopped() bool {
 }
 
 // produce feeds selected scenario indices until fail-fast stops scheduling or
-// the run is cancelled (Ctrl-C / SIGTERM). On cancellation it stops scheduling
+// the run is canceled (Ctrl-C / SIGTERM). On cancellation it stops scheduling
 // new scenarios; in-flight scenarios stop at their next step via ctx.Err().
 func (p *scenarioPool) produce(ctx context.Context, selected []int, jobs chan<- int) {
 	defer close(jobs)
@@ -313,7 +313,7 @@ func (p *scenarioPool) work(ctx context.Context, jobs <-chan int) {
 			// The global semaphore is shared across every suite in the run.
 			// On Ctrl-C, slots free up only as in-flight scenarios unwind, so
 			// waiting for one here would both stall shutdown and then run a
-			// scenario the user already cancelled. Bail instead; the scenario
+			// scenario the user already canceled. Bail instead; the scenario
 			// is reported as "skipped after interrupt".
 			select {
 			case e.Sem <- struct{}{}:

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -129,24 +129,7 @@ func builtinVars() map[string]string {
 func (e *Engine) Run(ctx context.Context, s *spec.Spec, specPath string) *SuiteResult {
 	start := time.Now()
 	res := &SuiteResult{Suite: s.Suite.Name, SpecPath: specPath, Status: StatusPassed}
-	rc := runConfig{
-		specDir:      filepath.Dir(specPath),
-		fixturesDir:  absPath(s.FixturesDir),
-		specPath:     specPath,
-		masker:       security.NewMaskerForSpec(s),
-		scrubber:     newScrubber(s),
-		runners:      s.Runners,
-		allow:        allowedHosts(s),
-		suiteTimeout: s.Suite.Timeout,
-	}
-	if s.Defaults != nil && s.Defaults.Run != nil {
-		rc.defaultsRunTimeout = s.Defaults.Run.Timeout
-	}
-
-	workers := e.Parallel
-	if workers < 1 {
-		workers = 1
-	}
+	rc := newRunConfig(s, specPath)
 
 	selected := e.selectScenarios(s, specPath)
 
@@ -156,10 +139,7 @@ func (e *Engine) Run(ctx context.Context, s *spec.Spec, specPath string) *SuiteR
 	suiteRT, rtErr := e.newSuiteRuntime(s, rc.specDir, rc.fixturesDir)
 	if rtErr != nil {
 		res.Status = StatusError
-		for _, i := range selected {
-			res.Scenarios = append(res.Scenarios, ScenarioResult{Name: s.Scenarios[i].Name, Suite: s.Suite.Name, Status: StatusError,
-				Steps: []StepResult{{Kind: spec.StepNone, Setup: true, ErrMsg: suiteSetupLabel + ": " + rtErr.Error()}}})
-		}
+		res.Scenarios = e.errorSelected(s, selected, suiteSetupLabel+": "+rtErr.Error(), false)
 		res.Duration = time.Since(start)
 		return res
 	}
@@ -172,15 +152,7 @@ func (e *Engine) Run(ctx context.Context, s *spec.Spec, specPath string) *SuiteR
 			// named; none of their steps run. Teardown still runs: a partially
 			// executed setup may have created external state worth cleaning.
 			res.Status = StatusError
-			failure := suiteSetupFailure(res.Setup)
-			for _, i := range selected {
-				sr := ScenarioResult{Name: s.Scenarios[i].Name, Suite: s.Suite.Name, Status: StatusError,
-					Steps: []StepResult{{Kind: spec.StepNone, Setup: true, ErrMsg: failure}}}
-				if e.OnScenario != nil {
-					e.OnScenario(sr)
-				}
-				res.Scenarios = append(res.Scenarios, sr)
-			}
+			res.Scenarios = e.errorSelected(s, selected, suiteSetupFailure(res.Setup), true)
 			res.Teardown = e.runSuiteTeardown(ctx, s, suiteRT, rc)
 			res.Duration = time.Since(start)
 			return res
@@ -196,80 +168,7 @@ func (e *Engine) Run(ctx context.Context, s *spec.Spec, specPath string) *SuiteR
 		}()
 	}
 
-	results := make([]ScenarioResult, len(s.Scenarios))
-	done := make([]bool, len(s.Scenarios))
-	jobs := make(chan int)
-	var mu sync.Mutex // guards OnScenario, failStop, results/done writes from the emit path
-	failStop := false
-
-	// Producer: feed selected scenario indices until fail-fast stops scheduling or
-	// the run is cancelled (Ctrl-C / SIGTERM). On cancellation it stops scheduling
-	// new scenarios; in-flight scenarios stop at their next step via ctx.Err().
-	go func() {
-		defer close(jobs)
-		for _, i := range selected {
-			if ctx.Err() != nil {
-				return
-			}
-			mu.Lock()
-			stop := failStop
-			mu.Unlock()
-			if stop {
-				return
-			}
-			select {
-			case jobs <- i:
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
-
-	var wg sync.WaitGroup
-	for w := 0; w < workers; w++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for idx := range jobs {
-				// A job may have been queued just before another worker tripped
-				// fail-fast; re-check so it is left as skipped rather than run.
-				mu.Lock()
-				stop := failStop
-				mu.Unlock()
-				if stop {
-					continue
-				}
-				if e.Sem != nil {
-					// The global semaphore is shared across every suite in the run.
-					// On Ctrl-C, slots free up only as in-flight scenarios unwind, so
-					// waiting for one here would both stall shutdown and then run a
-					// scenario the user already cancelled. Bail instead; the scenario
-					// is reported as "skipped after interrupt".
-					select {
-					case e.Sem <- struct{}{}:
-					case <-ctx.Done():
-						continue
-					}
-				}
-				sc := e.runScenarioWithPolicy(ctx, idx, &s.Scenarios[idx], rc)
-				sc.Suite = s.Suite.Name
-				if e.Sem != nil {
-					<-e.Sem
-				}
-				mu.Lock()
-				results[idx] = sc
-				done[idx] = true
-				if e.OnScenario != nil {
-					e.OnScenario(sc)
-				}
-				if e.FailFast && FailsRun(sc.Status, e.AllowFlaky, e.AllowXPass) {
-					failStop = true
-				}
-				mu.Unlock()
-			}
-		}()
-	}
-	wg.Wait()
+	results, done := e.runSelected(ctx, s, selected, rc)
 
 	// Build the report from the selected scenarios in definition order. Selected
 	// scenarios that never ran (stopped by fail-fast) are recorded as skipped.
@@ -292,6 +191,158 @@ func (e *Engine) Run(ctx context.Context, s *spec.Spec, specPath string) *SuiteR
 	}
 	res.Duration = time.Since(start)
 	return res
+}
+
+// newRunConfig derives the per-suite execution config from the spec.
+func newRunConfig(s *spec.Spec, specPath string) runConfig {
+	rc := runConfig{
+		specDir:      filepath.Dir(specPath),
+		fixturesDir:  absPath(s.FixturesDir),
+		specPath:     specPath,
+		masker:       security.NewMaskerForSpec(s),
+		scrubber:     newScrubber(s),
+		runners:      s.Runners,
+		allow:        allowedHosts(s),
+		suiteTimeout: s.Suite.Timeout,
+	}
+	if s.Defaults != nil && s.Defaults.Run != nil {
+		rc.defaultsRunTimeout = s.Defaults.Run.Timeout
+	}
+	return rc
+}
+
+// errorSelected marks every selected scenario as errored with the suite-setup
+// failure named, none of their steps having run. emit additionally streams each
+// result through OnScenario: a suite whose runtime never came up has no live
+// progress to reconcile, so that path stays silent.
+func (e *Engine) errorSelected(s *spec.Spec, selected []int, errMsg string, emit bool) []ScenarioResult {
+	out := make([]ScenarioResult, 0, len(selected))
+	for _, i := range selected {
+		sr := ScenarioResult{Name: s.Scenarios[i].Name, Suite: s.Suite.Name, Status: StatusError,
+			Steps: []StepResult{{Kind: spec.StepNone, Setup: true, ErrMsg: errMsg}}}
+		if emit && e.OnScenario != nil {
+			e.OnScenario(sr)
+		}
+		out = append(out, sr)
+	}
+	return out
+}
+
+// runSelected executes the selected scenarios on the worker pool and reports
+// which finished. results and done are indexed by scenario position in the
+// spec, so unrun entries are zero values with done[i] false.
+func (e *Engine) runSelected(ctx context.Context, s *spec.Spec, selected []int, rc runConfig) (results []ScenarioResult, done []bool) {
+	workers := e.Parallel
+	if workers < 1 {
+		workers = 1
+	}
+
+	pool := &scenarioPool{
+		e:       e,
+		s:       s,
+		rc:      rc,
+		results: make([]ScenarioResult, len(s.Scenarios)),
+		done:    make([]bool, len(s.Scenarios)),
+	}
+	jobs := make(chan int)
+	go pool.produce(ctx, selected, jobs)
+
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			pool.work(ctx, jobs)
+		}()
+	}
+	wg.Wait()
+	return pool.results, pool.done
+}
+
+// scenarioPool is the shared state of one suite's scenario workers: the
+// results/done slices they fill in, and the fail-fast flag that stops
+// scheduling.
+type scenarioPool struct {
+	e       *Engine
+	s       *spec.Spec
+	rc      runConfig
+	results []ScenarioResult
+	done    []bool
+
+	mu       sync.Mutex // guards OnScenario, failStop, results/done writes from the emit path
+	failStop bool
+}
+
+// stopped reports whether fail-fast has tripped.
+func (p *scenarioPool) stopped() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.failStop
+}
+
+// produce feeds selected scenario indices until fail-fast stops scheduling or
+// the run is cancelled (Ctrl-C / SIGTERM). On cancellation it stops scheduling
+// new scenarios; in-flight scenarios stop at their next step via ctx.Err().
+func (p *scenarioPool) produce(ctx context.Context, selected []int, jobs chan<- int) {
+	defer close(jobs)
+	for _, i := range selected {
+		if ctx.Err() != nil {
+			return
+		}
+		if p.stopped() {
+			return
+		}
+		select {
+		case jobs <- i:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// work runs scenarios from jobs until the channel closes.
+func (p *scenarioPool) work(ctx context.Context, jobs <-chan int) {
+	e := p.e
+	for idx := range jobs {
+		// A job may have been queued just before another worker tripped
+		// fail-fast; re-check so it is left as skipped rather than run.
+		if p.stopped() {
+			continue
+		}
+		if e.Sem != nil {
+			// The global semaphore is shared across every suite in the run.
+			// On Ctrl-C, slots free up only as in-flight scenarios unwind, so
+			// waiting for one here would both stall shutdown and then run a
+			// scenario the user already cancelled. Bail instead; the scenario
+			// is reported as "skipped after interrupt".
+			select {
+			case e.Sem <- struct{}{}:
+			case <-ctx.Done():
+				continue
+			}
+		}
+		sc := e.runScenarioWithPolicy(ctx, idx, &p.s.Scenarios[idx], p.rc)
+		sc.Suite = p.s.Suite.Name
+		if e.Sem != nil {
+			<-e.Sem
+		}
+		p.emit(idx, sc)
+	}
+}
+
+// emit records one finished scenario and trips fail-fast when its outcome
+// fails the run.
+func (p *scenarioPool) emit(idx int, sc ScenarioResult) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.results[idx] = sc
+	p.done[idx] = true
+	if p.e.OnScenario != nil {
+		p.e.OnScenario(sc)
+	}
+	if p.e.FailFast && FailsRun(sc.Status, p.e.AllowFlaky, p.e.AllowXPass) {
+		p.failStop = true
+	}
 }
 
 // selectScenarios returns the indices of scenarios that pass the filter/tag

--- a/internal/engine/pty.go
+++ b/internal/engine/pty.go
@@ -52,33 +52,7 @@ func (e *Engine) runPTY(ctx context.Context, p *spec.PTY, st *store.Store, scena
 	if len(p.Session) > 0 {
 		c.Session = make([]spec.PTYAction, len(p.Session))
 		for i, a := range p.Session {
-			na := spec.PTYAction{Expect: st.Expand(a.Expect)}
-			if a.Send != nil {
-				cs := *a.Send
-				// Only verbatim text gets ${name} expansion; named keys are
-				// fixed byte sequences (#26).
-				if cs.Text != nil {
-					txt := st.Expand(*cs.Text)
-					cs.Text = &txt
-				}
-				// A paste carries author-written text like any other send, so it
-				// gets the same expansion (#378).
-				if cs.Paste != nil {
-					pasted := st.Expand(*cs.Paste)
-					cs.Paste = &pasted
-				}
-				na.Send = &cs
-			}
-			// A resize carries only integers, so it needs no expansion — but it
-			// still has to be carried into the copy the runner drives (#379).
-			na.Resize = a.Resize
-			if a.Exec != nil {
-				ce := *a.Exec
-				ce.Command = st.Expand(a.Exec.Command)
-				na.Exec = &ce
-			}
-			na.ExpectScreen = spec.WalkPTYExpectScreenStrings(a.ExpectScreen, st.Expand)
-			c.Session[i] = na
+			c.Session[i] = expandPTYAction(a, st)
 		}
 	}
 	// sandbox_home (#71) redirects the pty child's home under ${workdir}/.atago-home.
@@ -91,6 +65,39 @@ func (e *Engine) runPTY(ctx context.Context, p *spec.PTY, st *store.Store, scena
 		sandbox = s
 	}
 	return ptyrun.Run(ctx, &c, workdir, runnercmd.BuildEnv(c.Env, c.ClearEnvEnabled(), c.PassEnv, sandbox))
+}
+
+// expandPTYAction returns a's copy with every author-written string run
+// through ${name} expansion, leaving the runner's copy independent of the
+// spec's.
+func expandPTYAction(a spec.PTYAction, st *store.Store) spec.PTYAction {
+	na := spec.PTYAction{Expect: st.Expand(a.Expect)}
+	if a.Send != nil {
+		cs := *a.Send
+		// Only verbatim text gets ${name} expansion; named keys are
+		// fixed byte sequences (#26).
+		if cs.Text != nil {
+			txt := st.Expand(*cs.Text)
+			cs.Text = &txt
+		}
+		// A paste carries author-written text like any other send, so it
+		// gets the same expansion (#378).
+		if cs.Paste != nil {
+			pasted := st.Expand(*cs.Paste)
+			cs.Paste = &pasted
+		}
+		na.Send = &cs
+	}
+	// A resize carries only integers, so it needs no expansion — but it
+	// still has to be carried into the copy the runner drives (#379).
+	na.Resize = a.Resize
+	if a.Exec != nil {
+		ce := *a.Exec
+		ce.Command = st.Expand(a.Exec.Command)
+		na.Exec = &ce
+	}
+	na.ExpectScreen = spec.WalkPTYExpectScreenStrings(a.ExpectScreen, st.Expand)
+	return na
 }
 
 // checkPTYSessionResolved reports the first session entry whose send text or

--- a/internal/engine/stepexec.go
+++ b/internal/engine/stepexec.go
@@ -234,25 +234,7 @@ func (x *scenarioRun) execStep(ctx context.Context, steps []spec.Step, i int, st
 			status = StatusError
 		}
 	case spec.StepRun:
-		if msg := runRefGuard(x.st, step.Run, x.rc.runners); msg != "" {
-			sr.ErrMsg = msg
-			return sr, StatusError, false
-		}
-		run := mergeScenarioEnv(x.scEnv, expandRun(x.st, step.Run), x.st)
-		r, untilChecks, err := x.e.runStep(ctx, run, x.st, x.workdir, x.specDir, x.rc, x.sshConns, beforeAttempt)
-		if err != nil {
-			sr.ErrMsg = err.Error()
-			return sr, StatusError, isPolicyViolation(err)
-		}
-		// Assertions run against the real result (current); the copy kept for
-		// reporting is masked so secrets never reach logs/reports.
-		x.adopt(&sr, r)
-		if x.recordUntil(&sr, i, untilChecks) == StatusFailed {
-			status = StatusFailed
-		}
-		if ck := timeoutKillCheck(r, steps, i); ck != nil {
-			status = x.fail(&sr, i, ck)
-		}
+		return x.execRunStep(ctx, steps, i, step, beforeAttempt)
 	case spec.StepAssert:
 		crs := assert.CheckAll(expandAssert(x.st, step.Assert), x.current, assert.Env{
 			Workdir:         x.workdir,
@@ -300,21 +282,7 @@ func (x *scenarioRun) execStep(ctx context.Context, steps []spec.Step, i int, st
 		}
 		x.adopt(&sr, r)
 	case spec.StepPTY:
-		r, ef, err := x.e.runPTY(ctx, step.PTY, x.st, x.scEnv, x.workdir)
-		if err != nil {
-			sr.ErrMsg = err.Error()
-			return sr, StatusError, false
-		}
-		x.adopt(&sr, r)
-		if ef != nil {
-			// A never-matching expect fails like an assertion: the pattern
-			// and the transcript excerpt land in the failure block.
-			status = x.fail(&sr, i, ptyExpectCheck(ef))
-		} else if ck := timeoutKillCheck(r, steps, i); ck != nil {
-			// No expect failed, so nothing else would notice that the program
-			// never exited before the session timeout killed it.
-			status = x.fail(&sr, i, ck)
-		}
+		return x.execPTYStep(ctx, steps, i, step)
 	case spec.StepCDP:
 		r, err := x.e.runCDP(ctx, expandCDP(x.st, step.CDP), x.workdir, x.st, x.rc, x.browserConns)
 		if err != nil {
@@ -336,6 +304,56 @@ func (x *scenarioRun) execStep(ctx context.Context, steps []spec.Step, i int, st
 		status = StatusError
 	}
 	return sr, status, secViolation
+}
+
+// execRunStep executes one run step: the ${name} guard, the command itself,
+// its retry `until` checks, and the silent-timeout-kill check.
+func (x *scenarioRun) execRunStep(ctx context.Context, steps []spec.Step, i int, step *spec.Step, beforeAttempt func()) (StepResult, Status, bool) {
+	sr := StepResult{Index: i, Kind: step.Kind()}
+	status := StatusPassed
+	if msg := runRefGuard(x.st, step.Run, x.rc.runners); msg != "" {
+		sr.ErrMsg = msg
+		return sr, StatusError, false
+	}
+	run := mergeScenarioEnv(x.scEnv, expandRun(x.st, step.Run), x.st)
+	r, untilChecks, err := x.e.runStep(ctx, run, x.st, x.workdir, x.specDir, x.rc, x.sshConns, beforeAttempt)
+	if err != nil {
+		sr.ErrMsg = err.Error()
+		return sr, StatusError, isPolicyViolation(err)
+	}
+	// Assertions run against the real result (current); the copy kept for
+	// reporting is masked so secrets never reach logs/reports.
+	x.adopt(&sr, r)
+	if x.recordUntil(&sr, i, untilChecks) == StatusFailed {
+		status = StatusFailed
+	}
+	if ck := timeoutKillCheck(r, steps, i); ck != nil {
+		status = x.fail(&sr, i, ck)
+	}
+	return sr, status, false
+}
+
+// execPTYStep executes one interactive pty step and folds an expect failure or
+// a silent session-timeout kill into the step's checks.
+func (x *scenarioRun) execPTYStep(ctx context.Context, steps []spec.Step, i int, step *spec.Step) (StepResult, Status, bool) {
+	sr := StepResult{Index: i, Kind: step.Kind()}
+	status := StatusPassed
+	r, ef, err := x.e.runPTY(ctx, step.PTY, x.st, x.scEnv, x.workdir)
+	if err != nil {
+		sr.ErrMsg = err.Error()
+		return sr, StatusError, false
+	}
+	x.adopt(&sr, r)
+	if ef != nil {
+		// A never-matching expect fails like an assertion: the pattern
+		// and the transcript excerpt land in the failure block.
+		status = x.fail(&sr, i, ptyExpectCheck(ef))
+	} else if ck := timeoutKillCheck(r, steps, i); ck != nil {
+		// No expect failed, so nothing else would notice that the program
+		// never exited before the session timeout killed it.
+		status = x.fail(&sr, i, ck)
+	}
+	return sr, status, false
 }
 
 // runSteps executes the scenario steps after the leading fixtures, scanning the
@@ -444,64 +462,13 @@ func isSSHRunner(name string, runners map[string]spec.Runner) bool {
 // until passes or the attempt budget is spent; the last attempt's result is what
 // later steps observe.
 func (e *Engine) runStep(ctx context.Context, run *spec.Run, st *store.Store, workdir, specDir string, rc runConfig, sshConns map[string]*sshrunner.Runner, beforeAttempt func()) (*runner.Result, []*assert.CheckResult, error) {
-	// A run step naming an ssh runner executes remotely; otherwise it
-	// runs locally via the cmd runner. The runner is resolved once (not per
-	// retry attempt) so the timeout precedence below sees the pristine authored
-	// step value.
-	remote := false
-	var runnerTimeout string
-	if run.Runner != "" {
-		rdef, ok := rc.runners[run.Runner]
-		if !ok {
-			return nil, nil, fmt.Errorf("run step references unknown runner %q", run.Runner)
-		}
-		switch rdef.Type {
-		case "ssh":
-			remote = true
-		case "cmd", "":
-			// Layer the runner's cwd beneath the step's own value; the step
-			// wins. run is the caller's expanded copy, so mutating it is safe;
-			// cwd gets the same use-time ${name} expansion as the other runner
-			// families' fields.
-			if run.Cwd == "" {
-				run.Cwd = st.Expand(rdef.Cwd)
-			}
-			runnerTimeout = rdef.Timeout
-		default:
-			return nil, nil, fmt.Errorf("runner %q (type %q) cannot run a command step; use a step matching its type", run.Runner, rdef.Type)
-		}
-	}
-	if !remote {
-		// Resolve the effective timeout across all five levels (#17) and
-		// remember which level supplied it so a timeout kill can name the knob
-		// in its hint. Remote (ssh) runs apply only the step's own explicit
-		// timeout below — the other levels shape local execution, and the ssh
-		// runner's dial-time timeout already bounds every remote command.
-		run.Timeout, run.TimeoutSource = resolveTimeout(run.Timeout, runnerTimeout, rc.defaultsRunTimeout, rc.suiteTimeout)
-	} else if run.Timeout != "" {
-		run.TimeoutSource = "run.timeout"
+	remote, err := resolveRunTarget(run, st, rc)
+	if err != nil {
+		return nil, nil, err
 	}
 	exec := func(ctx context.Context) (*runner.Result, error) {
 		if remote {
-			conn, err := sshConn(run.Runner, st, rc, sshConns)
-			if err != nil {
-				return nil, err
-			}
-			// The loader whitelists `timeout` on ssh run steps because it is
-			// honored remotely — so honor it: the step's own timeout arrives at
-			// the runner as a context deadline and takes precedence over the
-			// runner-level timeout applied inside conn.Run.
-			if run.Timeout != "" {
-				d, _ := time.ParseDuration(run.Timeout) // validated at load time
-				var cancel context.CancelFunc
-				ctx, cancel = context.WithTimeout(ctx, d)
-				defer cancel()
-			}
-			r, err := conn.Run(ctx, run.Command)
-			if r != nil && r.TimedOut && r.TimeoutSource == "" {
-				r.TimeoutSource = run.TimeoutSource
-			}
-			return r, err
+			return runRemote(ctx, run, st, rc, sshConns)
 		}
 		return e.cmd.Run(ctx, run, workdir)
 	}
@@ -530,6 +497,68 @@ func (e *Engine) runStep(ctx context.Context, run *spec.Run, st *store.Store, wo
 	}
 	env := assert.Env{Workdir: workdir, SpecDir: specDir, UpdateSnapshots: e.UpdateSnapshots, Secrets: rc.masker.MaskBytes, Scrub: rc.scrubber.Apply}
 	return pollUntil(ctx, run.Retry, st, env, exec, beforeAttempt)
+}
+
+// resolveRunTarget decides whether a run step executes remotely and settles
+// its effective cwd and timeout. The runner is resolved once (not per retry
+// attempt) so the timeout precedence sees the pristine authored step value.
+// run is the caller's expanded copy, so mutating it is safe.
+func resolveRunTarget(run *spec.Run, st *store.Store, rc runConfig) (remote bool, err error) {
+	var runnerTimeout string
+	if run.Runner != "" {
+		rdef, ok := rc.runners[run.Runner]
+		if !ok {
+			return false, fmt.Errorf("run step references unknown runner %q", run.Runner)
+		}
+		switch rdef.Type {
+		case "ssh":
+			remote = true
+		case "cmd", "":
+			// Layer the runner's cwd beneath the step's own value; the step
+			// wins. cwd gets the same use-time ${name} expansion as the other
+			// runner families' fields.
+			if run.Cwd == "" {
+				run.Cwd = st.Expand(rdef.Cwd)
+			}
+			runnerTimeout = rdef.Timeout
+		default:
+			return false, fmt.Errorf("runner %q (type %q) cannot run a command step; use a step matching its type", run.Runner, rdef.Type)
+		}
+	}
+	if !remote {
+		// Resolve the effective timeout across all five levels (#17) and
+		// remember which level supplied it so a timeout kill can name the knob
+		// in its hint. Remote (ssh) runs apply only the step's own explicit
+		// timeout — the other levels shape local execution, and the ssh
+		// runner's dial-time timeout already bounds every remote command.
+		run.Timeout, run.TimeoutSource = resolveTimeout(run.Timeout, runnerTimeout, rc.defaultsRunTimeout, rc.suiteTimeout)
+	} else if run.Timeout != "" {
+		run.TimeoutSource = "run.timeout"
+	}
+	return remote, nil
+}
+
+// runRemote executes one command over the step's ssh runner.
+func runRemote(ctx context.Context, run *spec.Run, st *store.Store, rc runConfig, sshConns map[string]*sshrunner.Runner) (*runner.Result, error) {
+	conn, err := sshConn(run.Runner, st, rc, sshConns)
+	if err != nil {
+		return nil, err
+	}
+	// The loader whitelists `timeout` on ssh run steps because it is
+	// honored remotely — so honor it: the step's own timeout arrives at
+	// the runner as a context deadline and takes precedence over the
+	// runner-level timeout applied inside conn.Run.
+	if run.Timeout != "" {
+		d, _ := time.ParseDuration(run.Timeout) // validated at load time
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, d)
+		defer cancel()
+	}
+	r, err := conn.Run(ctx, run.Command)
+	if r != nil && r.TimedOut && r.TimeoutSource == "" {
+		r.TimeoutSource = run.TimeoutSource
+	}
+	return r, err
 }
 
 // measurableForChanges reports whether a step kind produces a workdir delta a

--- a/internal/engine/suite.go
+++ b/internal/engine/suite.go
@@ -108,13 +108,12 @@ func (e *Engine) newSuiteRuntime(s *spec.Spec, specDir, fixturesDir string) (*su
 // The returned bool reports whether every step succeeded.
 func (e *Engine) runSuiteSteps(ctx context.Context, steps []spec.Step, rt *suiteRuntime, rc runConfig, stopOnFailure bool, label string) ([]StepResult, bool) {
 	var out []StepResult
-	var current *runner.Result
+	x := &suiteStepper{e: e, rt: rt, rc: rc, label: label}
 	ok := true
 
 	for i := range steps {
 		step := &steps[i]
 		sr := StepResult{Index: i, Kind: step.Kind()}
-		failed := false
 
 		if ctx.Err() != nil {
 			sr.ErrMsg = fmt.Sprintf("run canceled: %v", ctx.Err())
@@ -122,96 +121,7 @@ func (e *Engine) runSuiteSteps(ctx context.Context, steps []spec.Step, rt *suite
 			return out, false
 		}
 
-		switch step.Kind() {
-		case spec.StepFixture:
-			if err := fixture.Write(expandFixture(rt.st, step.Fixture), rt.dir, rc.specDir); err != nil {
-				sr.ErrMsg = err.Error()
-				failed = true
-			}
-		case spec.StepRun:
-			// Same unresolved/leaked-${name} guard the scenario path enforces, so a
-			// typo in suite.setup errors with the explained diagnostic instead of
-			// leaking the literal reference into argv (#243).
-			if msg := runRefGuard(rt.st, step.Run, rc.runners); msg != "" {
-				sr.ErrMsg = msg
-				failed = true
-				break
-			}
-			run := mergeScenarioEnv(resolvableEnv(rt.st, rt.env), expandRun(rt.st, step.Run), rt.st)
-			r, untilChecks, err := e.runStep(ctx, run, rt.st, rt.dir, rc.specDir, rc, rt.sshConns, nil) // suite setup/teardown steps carry no changes assert
-			if err != nil {
-				sr.ErrMsg = err.Error()
-				failed = true
-				break
-			}
-			current = r
-			sr.Run = maskResult(rc.masker, r)
-			if len(untilChecks) > 0 {
-				// recordChecks masks secrets in the check payloads and writes any
-				// --artifacts-dir sidecars, exactly as the scenario path does — the
-				// suite path used to set sr.Checks raw and leak both (#243).
-				e.recordChecks(rc.masker, untilChecks, suiteArtifactScope(rc, label), i)
-				sr.Checks = untilChecks
-				if !assert.AllOK(untilChecks) {
-					failed = true
-				}
-			}
-		case spec.StepStore:
-			val, err := extractValue(expandStore(rt.st, step.Store), current, rt.dir)
-			if err != nil {
-				sr.ErrMsg = err.Error()
-				failed = true
-			} else {
-				rt.set(step.Store.Name, val)
-			}
-		case spec.StepAssert:
-			crs := assert.CheckAll(expandAssert(rt.st, step.Assert), current, assert.Env{
-				Workdir:         rt.dir,
-				SpecDir:         rc.specDir,
-				UpdateSnapshots: e.UpdateSnapshots,
-				Secrets:         rc.masker.MaskBytes,
-				Scrub:           rc.scrubber.Apply,
-				MockRecords: func(name string) ([]mockrunner.Record, bool) {
-					for _, m := range rt.mocks {
-						if m.Name() == name {
-							return m.Records(), true
-						}
-					}
-					return nil, false
-				},
-			})
-			e.recordChecks(rc.masker, crs, suiteArtifactScope(rc, label), i)
-			sr.Checks = crs
-			if !assert.AllOK(crs) {
-				failed = true
-			}
-		case spec.StepService:
-			proc, captured, err := servicerunner.Start(ctx, expandService(rt.st, resolvableEnv(rt.st, rt.env), step.Service), rt.dir)
-			if proc != nil {
-				rt.services = append(rt.services, proc)
-			}
-			if err != nil {
-				sr.ErrMsg = err.Error()
-				failed = true
-				break
-			}
-			if step.Service.Ready != nil && step.Service.Ready.Store != "" {
-				rt.set(step.Service.Ready.Store, captured)
-			}
-		case spec.StepMockServer:
-			ms, err := mockrunner.Start(ctx, step.MockServer, rc.specDir)
-			if err != nil {
-				sr.ErrMsg = err.Error()
-				failed = true
-				break
-			}
-			rt.mocks = append(rt.mocks, ms)
-			rt.set(ms.Name()+".url", ms.URL())
-			rt.set(ms.Name()+".port", ms.Port())
-		default:
-			sr.ErrMsg = fmt.Sprintf("%s steps are not allowed at suite level", step.Kind())
-			failed = true
-		}
+		failed := x.exec(ctx, step, i, &sr)
 
 		sr.ErrMsg = rc.masker.Mask(sr.ErrMsg)
 		out = append(out, sr)
@@ -223,6 +133,130 @@ func (e *Engine) runSuiteSteps(ctx context.Context, steps []spec.Step, rt *suite
 		}
 	}
 	return out, ok
+}
+
+// suiteStepper executes one suite-level block's steps, threading the latest
+// run result between them the way scenario steps do (store/assert read the
+// most recent run).
+type suiteStepper struct {
+	e       *Engine
+	rt      *suiteRuntime
+	rc      runConfig
+	label   string
+	current *runner.Result
+}
+
+// exec dispatches one suite step to its kind's executor and reports failure.
+func (x *suiteStepper) exec(ctx context.Context, step *spec.Step, i int, sr *StepResult) (failed bool) {
+	switch step.Kind() {
+	case spec.StepFixture:
+		if err := fixture.Write(expandFixture(x.rt.st, step.Fixture), x.rt.dir, x.rc.specDir); err != nil {
+			sr.ErrMsg = err.Error()
+			return true
+		}
+		return false
+	case spec.StepRun:
+		return x.execRun(ctx, step, i, sr)
+	case spec.StepStore:
+		val, err := extractValue(expandStore(x.rt.st, step.Store), x.current, x.rt.dir)
+		if err != nil {
+			sr.ErrMsg = err.Error()
+			return true
+		}
+		x.rt.set(step.Store.Name, val)
+		return false
+	case spec.StepAssert:
+		return x.execAssert(step, i, sr)
+	case spec.StepService:
+		return x.execService(ctx, step, sr)
+	case spec.StepMockServer:
+		return x.execMockServer(ctx, step, sr)
+	default:
+		sr.ErrMsg = fmt.Sprintf("%s steps are not allowed at suite level", step.Kind())
+		return true
+	}
+}
+
+// execRun runs one suite-level command and folds its retry `until` checks.
+func (x *suiteStepper) execRun(ctx context.Context, step *spec.Step, i int, sr *StepResult) bool {
+	// Same unresolved/leaked-${name} guard the scenario path enforces, so a
+	// typo in suite.setup errors with the explained diagnostic instead of
+	// leaking the literal reference into argv (#243).
+	if msg := runRefGuard(x.rt.st, step.Run, x.rc.runners); msg != "" {
+		sr.ErrMsg = msg
+		return true
+	}
+	run := mergeScenarioEnv(resolvableEnv(x.rt.st, x.rt.env), expandRun(x.rt.st, step.Run), x.rt.st)
+	r, untilChecks, err := x.e.runStep(ctx, run, x.rt.st, x.rt.dir, x.rc.specDir, x.rc, x.rt.sshConns, nil) // suite setup/teardown steps carry no changes assert
+	if err != nil {
+		sr.ErrMsg = err.Error()
+		return true
+	}
+	x.current = r
+	sr.Run = maskResult(x.rc.masker, r)
+	if len(untilChecks) > 0 {
+		// recordChecks masks secrets in the check payloads and writes any
+		// --artifacts-dir sidecars, exactly as the scenario path does — the
+		// suite path used to set sr.Checks raw and leak both (#243).
+		x.e.recordChecks(x.rc.masker, untilChecks, suiteArtifactScope(x.rc, x.label), i)
+		sr.Checks = untilChecks
+		if !assert.AllOK(untilChecks) {
+			return true
+		}
+	}
+	return false
+}
+
+// execAssert checks one suite-level assert against the latest run result.
+func (x *suiteStepper) execAssert(step *spec.Step, i int, sr *StepResult) bool {
+	crs := assert.CheckAll(expandAssert(x.rt.st, step.Assert), x.current, assert.Env{
+		Workdir:         x.rt.dir,
+		SpecDir:         x.rc.specDir,
+		UpdateSnapshots: x.e.UpdateSnapshots,
+		Secrets:         x.rc.masker.MaskBytes,
+		Scrub:           x.rc.scrubber.Apply,
+		MockRecords: func(name string) ([]mockrunner.Record, bool) {
+			for _, m := range x.rt.mocks {
+				if m.Name() == name {
+					return m.Records(), true
+				}
+			}
+			return nil, false
+		},
+	})
+	x.e.recordChecks(x.rc.masker, crs, suiteArtifactScope(x.rc, x.label), i)
+	sr.Checks = crs
+	return !assert.AllOK(crs)
+}
+
+// execService starts one suite-level background service and records it for
+// LIFO shutdown even when startup fails partway.
+func (x *suiteStepper) execService(ctx context.Context, step *spec.Step, sr *StepResult) bool {
+	proc, captured, err := servicerunner.Start(ctx, expandService(x.rt.st, resolvableEnv(x.rt.st, x.rt.env), step.Service), x.rt.dir)
+	if proc != nil {
+		x.rt.services = append(x.rt.services, proc)
+	}
+	if err != nil {
+		sr.ErrMsg = err.Error()
+		return true
+	}
+	if step.Service.Ready != nil && step.Service.Ready.Store != "" {
+		x.rt.set(step.Service.Ready.Store, captured)
+	}
+	return false
+}
+
+// execMockServer starts one suite-level mock server and exposes its address.
+func (x *suiteStepper) execMockServer(ctx context.Context, step *spec.Step, sr *StepResult) bool {
+	ms, err := mockrunner.Start(ctx, step.MockServer, x.rc.specDir)
+	if err != nil {
+		sr.ErrMsg = err.Error()
+		return true
+	}
+	x.rt.mocks = append(x.rt.mocks, ms)
+	x.rt.set(ms.Name()+".url", ms.URL())
+	x.rt.set(ms.Name()+".port", ms.Port())
+	return false
 }
 
 // suiteSetupFailure summarizes a failed setup block for the per-scenario error.

--- a/internal/loader/defaults.go
+++ b/internal/loader/defaults.go
@@ -32,28 +32,26 @@ func applyDefaults(s *spec.Spec) {
 			}
 		}
 		if d.Run != nil {
-			for j := range sc.Steps {
-				if sc.Steps[j].Run != nil {
-					mergeRunDefaults(d.Run, sc.Steps[j].Run, s.Runners)
-				}
-				// A pty step carries the same environment surface as a run step
-				// (env/clear_env/pass_env/sandbox_home), so defaults.run layers
-				// that shared subset onto it too (#77) — without it, a shared
-				// sandbox_home would leave pty children on the host home.
-				if sc.Steps[j].PTY != nil {
-					mergePTYDefaults(d.Run, sc.Steps[j].PTY)
-				}
-			}
+			mergeStepRunDefaults(d.Run, sc.Steps, s.Runners)
 			// Teardown steps are steps too: shared run defaults (shell, env, ...)
 			// apply so cleanup does not need to re-declare them.
-			for j := range sc.Teardown {
-				if sc.Teardown[j].Run != nil {
-					mergeRunDefaults(d.Run, sc.Teardown[j].Run, s.Runners)
-				}
-				if sc.Teardown[j].PTY != nil {
-					mergePTYDefaults(d.Run, sc.Teardown[j].PTY)
-				}
-			}
+			mergeStepRunDefaults(d.Run, sc.Teardown, s.Runners)
+		}
+	}
+}
+
+// mergeStepRunDefaults layers defaults.run beneath every run and pty step in
+// one step list. A pty step carries the same environment surface as a run step
+// (env/clear_env/pass_env/sandbox_home), so defaults.run layers that shared
+// subset onto it too (#77) — without it, a shared sandbox_home would leave pty
+// children on the host home.
+func mergeStepRunDefaults(def *spec.Run, steps []spec.Step, runners map[string]spec.Runner) {
+	for j := range steps {
+		if steps[j].Run != nil {
+			mergeRunDefaults(def, steps[j].Run, runners)
+		}
+		if steps[j].PTY != nil {
+			mergePTYDefaults(def, steps[j].PTY)
 		}
 	}
 }

--- a/internal/loader/validate.go
+++ b/internal/loader/validate.go
@@ -64,91 +64,118 @@ func validate(s *spec.Spec) []string {
 
 	// Suite services are legal signal targets from any scenario (#23), and
 	// suite mock servers are legal mock-assert targets (#24).
-	suiteServiceNames := map[string]bool{}
-	suiteMockNames := map[string]bool{}
-	for i := range s.Suite.Setup {
-		if svc := s.Suite.Setup[i].Service; svc != nil && svc.Name != "" {
-			suiteServiceNames[svc.Name] = true
-		}
-		if ms := s.Suite.Setup[i].MockServer; ms != nil && ms.Name != "" {
-			suiteMockNames[ms.Name] = true
-		}
-	}
+	suiteServiceNames, suiteMockNames := suiteResourceNames(s)
 
 	seen := make(map[string]bool, len(s.Scenarios))
 	for i := range s.Scenarios {
-		sc := &s.Scenarios[i]
-		where := fmt.Sprintf("scenarios[%d]", i)
-		if sc.Name == "" {
-			add("%s.name is required", where)
-		} else {
-			if c := firstControlChar(sc.Name); c != "" {
-				add("%s.name must not contain the control character %s (it breaks list output and generated docs)", where, c)
-			}
-			if seen[sc.Name] {
-				add("duplicate scenario name %q", sc.Name)
-			}
-			seen[sc.Name] = true
-			where = fmt.Sprintf("scenario %q", sc.Name)
-		}
-		validateCondition(add, where, "skip", sc.Skip)
-		validateCondition(add, where, "only", sc.Only)
-		validateExpectFail(add, where, sc.ExpectFail)
-		validateServices(add, where, sc.Services)
-		serviceNames := maps.Clone(suiteServiceNames)
-		for j := range sc.Services {
-			if sc.Services[j].Name != "" {
-				serviceNames[sc.Services[j].Name] = true
-			}
-		}
-		mockNames := maps.Clone(suiteMockNames)
-		validateMockServers(add, where, sc.MockServers, mockNames)
-		if len(sc.Steps) == 0 {
-			add("%s: steps must contain at least one step", where)
-			continue
-		}
-		// A screen assert renders a pty step's terminal (#27) and a duration
-		// assert bounds the immediately preceding measurable step (#31):
-		// reject placements no step could feed.
-		ptySeen := false
-		prevMeasurable := false
-		prevRunOrPTY := false
-		for j := range sc.Steps {
-			sw := fmt.Sprintf("%s.steps[%d]", where, j)
-			st := &sc.Steps[j]
-			if st.Kind() == spec.StepPTY {
-				ptySeen = true
-			}
-			if st.Assert != nil && st.Assert.Screen != nil && !ptySeen {
-				add("%s.assert.screen requires a preceding pty step (the screen is the pty step's rendered terminal)", sw)
-			}
-			if st.Assert != nil && st.Assert.Duration != nil && !prevMeasurable {
-				add("%s.assert.duration requires an immediately preceding run/http/query/grpc/pty step (the step whose wall-clock time it bounds)", sw)
-			}
-			// changes bounds the workdir delta of the immediately preceding
-			// run/pty step (#70): reject a placement no such step feeds.
-			if st.Assert != nil && st.Assert.Changes != nil && !prevRunOrPTY {
-				add("%s.assert.changes requires an immediately preceding run/pty step (the step whose workdir delta it pins); combine it with the assert block directly after the step (one assert may set exit_code, stdout, and changes together)", sw)
-			}
-			validateStep(add, sw, st, s.Runners, serviceNames, mockNames)
-			prevMeasurable = measurableStep(st.Kind())
-			prevRunOrPTY = st.Kind() == spec.StepRun || st.Kind() == spec.StepPTY
-		}
-		for j := range sc.Teardown {
-			tw := fmt.Sprintf("%s.teardown[%d]", where, j)
-			st := &sc.Teardown[j]
-			if st.Assert != nil && st.Assert.Screen != nil && !ptySeen {
-				add("%s.assert.screen requires a pty step in the scenario", tw)
-			}
-			// The workdir delta is only tracked around Steps, so a changes assert
-			// in teardown could never be fed (#70).
-			if st.Assert != nil && st.Assert.Changes != nil {
-				add("%s.assert.changes is not supported in teardown (the workdir delta is tracked only around the scenario's steps)", tw)
-			}
-			validateStep(add, tw, st, s.Runners, serviceNames, mockNames)
-		}
+		validateScenario(add, s, i, seen, suiteServiceNames, suiteMockNames)
 	}
 	return errs
+}
+
+// suiteResourceNames collects the names of services and mock servers declared
+// in suite.setup, which every scenario may target.
+func suiteResourceNames(s *spec.Spec) (services, mocks map[string]bool) {
+	services = map[string]bool{}
+	mocks = map[string]bool{}
+	for i := range s.Suite.Setup {
+		if svc := s.Suite.Setup[i].Service; svc != nil && svc.Name != "" {
+			services[svc.Name] = true
+		}
+		if ms := s.Suite.Setup[i].MockServer; ms != nil && ms.Name != "" {
+			mocks[ms.Name] = true
+		}
+	}
+	return services, mocks
+}
+
+// validateScenario checks one scenario: its identity, gates, services, and
+// every step and teardown step. seen tracks scenario names across the suite
+// for the duplicate check.
+func validateScenario(add func(string, ...any), s *spec.Spec, i int, seen, suiteServiceNames, suiteMockNames map[string]bool) {
+	sc := &s.Scenarios[i]
+	where := fmt.Sprintf("scenarios[%d]", i)
+	if sc.Name == "" {
+		add("%s.name is required", where)
+	} else {
+		if c := firstControlChar(sc.Name); c != "" {
+			add("%s.name must not contain the control character %s (it breaks list output and generated docs)", where, c)
+		}
+		if seen[sc.Name] {
+			add("duplicate scenario name %q", sc.Name)
+		}
+		seen[sc.Name] = true
+		where = fmt.Sprintf("scenario %q", sc.Name)
+	}
+	validateCondition(add, where, "skip", sc.Skip)
+	validateCondition(add, where, "only", sc.Only)
+	validateExpectFail(add, where, sc.ExpectFail)
+	validateServices(add, where, sc.Services)
+	serviceNames := maps.Clone(suiteServiceNames)
+	for j := range sc.Services {
+		if sc.Services[j].Name != "" {
+			serviceNames[sc.Services[j].Name] = true
+		}
+	}
+	mockNames := maps.Clone(suiteMockNames)
+	validateMockServers(add, where, sc.MockServers, mockNames)
+	if len(sc.Steps) == 0 {
+		add("%s: steps must contain at least one step", where)
+		return
+	}
+	ptySeen := validateScenarioSteps(add, where, sc, s.Runners, serviceNames, mockNames)
+	validateScenarioTeardown(add, where, sc, s.Runners, serviceNames, mockNames, ptySeen)
+}
+
+// validateScenarioSteps checks the scenario's steps in order, enforcing the
+// placement rules that tie an assert to the step that feeds it. It reports
+// whether the scenario contains a pty step, which teardown asserts may render.
+func validateScenarioSteps(add func(string, ...any), where string, sc *spec.Scenario, runners map[string]spec.Runner, serviceNames, mockNames map[string]bool) (ptySeen bool) {
+	// A screen assert renders a pty step's terminal (#27) and a duration
+	// assert bounds the immediately preceding measurable step (#31):
+	// reject placements no step could feed.
+	prevMeasurable := false
+	prevRunOrPTY := false
+	for j := range sc.Steps {
+		sw := fmt.Sprintf("%s.steps[%d]", where, j)
+		st := &sc.Steps[j]
+		if st.Kind() == spec.StepPTY {
+			ptySeen = true
+		}
+		if st.Assert != nil && st.Assert.Screen != nil && !ptySeen {
+			add("%s.assert.screen requires a preceding pty step (the screen is the pty step's rendered terminal)", sw)
+		}
+		if st.Assert != nil && st.Assert.Duration != nil && !prevMeasurable {
+			add("%s.assert.duration requires an immediately preceding run/http/query/grpc/pty step (the step whose wall-clock time it bounds)", sw)
+		}
+		// changes bounds the workdir delta of the immediately preceding
+		// run/pty step (#70): reject a placement no such step feeds.
+		if st.Assert != nil && st.Assert.Changes != nil && !prevRunOrPTY {
+			add("%s.assert.changes requires an immediately preceding run/pty step (the step whose workdir delta it pins); combine it with the assert block directly after the step (one assert may set exit_code, stdout, and changes together)", sw)
+		}
+		validateStep(add, sw, st, runners, serviceNames, mockNames)
+		prevMeasurable = measurableStep(st.Kind())
+		prevRunOrPTY = st.Kind() == spec.StepRun || st.Kind() == spec.StepPTY
+	}
+	return ptySeen
+}
+
+// validateScenarioTeardown checks the scenario's teardown steps, whose asserts
+// may render a pty screen but can never be fed a workdir delta.
+func validateScenarioTeardown(add func(string, ...any), where string, sc *spec.Scenario, runners map[string]spec.Runner, serviceNames, mockNames map[string]bool, ptySeen bool) {
+	for j := range sc.Teardown {
+		tw := fmt.Sprintf("%s.teardown[%d]", where, j)
+		st := &sc.Teardown[j]
+		if st.Assert != nil && st.Assert.Screen != nil && !ptySeen {
+			add("%s.assert.screen requires a pty step in the scenario", tw)
+		}
+		// The workdir delta is only tracked around Steps, so a changes assert
+		// in teardown could never be fed (#70).
+		if st.Assert != nil && st.Assert.Changes != nil {
+			add("%s.assert.changes is not supported in teardown (the workdir delta is tracked only around the scenario's steps)", tw)
+		}
+		validateStep(add, tw, st, runners, serviceNames, mockNames)
+	}
 }
 
 // validateSuiteTimeout checks the suite-level default step timeout (#17).

--- a/internal/loader/validate_artifact.go
+++ b/internal/loader/validate_artifact.go
@@ -117,6 +117,25 @@ func validateDir(add func(string, ...any), where string, d *spec.DirAssert) {
 	if d.Path == "" {
 		add("%s.path is required", where)
 	}
+	n := countDirMatchers(add, where, d)
+	if d.MinCount != nil && d.MaxCount != nil && *d.MinCount > *d.MaxCount {
+		add("%s: min_count %d exceeds max_count %d", where, *d.MinCount, *d.MaxCount)
+	}
+	validateDirComposition(add, where, d, n)
+	for _, pat := range d.Ignore {
+		trimmed := strings.TrimSuffix(pat, "/**")
+		if _, err := path.Match(trimmed, "probe"); err != nil {
+			add("%s.ignore %q is not a valid glob: %v", where, pat, err)
+		}
+	}
+	if n == 0 && d.Snapshot == "" {
+		add("%s: must set at least one of exists/contains/not_contains/count/min_count/max_count/glob/snapshot", where)
+	}
+}
+
+// countDirMatchers counts the matcher-family constraints set on a dir
+// assertion, validating each countable one as it goes.
+func countDirMatchers(add func(string, ...any), where string, d *spec.DirAssert) int {
 	n := 0
 	if d.Exists != nil {
 		n++
@@ -145,12 +164,13 @@ func validateDir(add func(string, ...any), where string, d *spec.DirAssert) {
 			add("%s.glob %q is not a valid glob: %v", where, d.Glob, err)
 		}
 	}
-	if d.MinCount != nil && d.MaxCount != nil && *d.MinCount > *d.MaxCount {
-		add("%s: min_count %d exceeds max_count %d", where, *d.MinCount, *d.MaxCount)
-	}
-	// Tree snapshot rules (#25): the golden manifest IS the whole assertion,
-	// so it composes only with ignore; the matcher family needs recursive or
-	// the historical single-level semantics.
+	return n
+}
+
+// validateDirComposition enforces the tree snapshot rules (#25): the golden
+// manifest IS the whole assertion, so it composes only with ignore; the
+// matcher family needs recursive or the historical single-level semantics.
+func validateDirComposition(add func(string, ...any), where string, d *spec.DirAssert, n int) {
 	if d.Snapshot != "" {
 		if n > 0 || d.Exists != nil {
 			add("%s: snapshot cannot be combined with the matcher family (exists/contains/not_contains/count/glob) — the manifest already pins the whole tree", where)
@@ -158,22 +178,13 @@ func validateDir(add func(string, ...any), where string, d *spec.DirAssert) {
 		if d.Recursive {
 			add("%s: recursive is implied by snapshot; drop it", where)
 		}
-	} else {
-		if d.Recursive && n == 0 {
-			add("%s: recursive needs at least one of contains/not_contains/count/min_count/max_count/glob", where)
-		}
-		if len(d.Ignore) > 0 && !d.Recursive {
-			add("%s: ignore only applies to recursive or snapshot assertions", where)
-		}
+		return
 	}
-	for _, pat := range d.Ignore {
-		trimmed := strings.TrimSuffix(pat, "/**")
-		if _, err := path.Match(trimmed, "probe"); err != nil {
-			add("%s.ignore %q is not a valid glob: %v", where, pat, err)
-		}
+	if d.Recursive && n == 0 {
+		add("%s: recursive needs at least one of contains/not_contains/count/min_count/max_count/glob", where)
 	}
-	if n == 0 && d.Snapshot == "" {
-		add("%s: must set at least one of exists/contains/not_contains/count/min_count/max_count/glob/snapshot", where)
+	if len(d.Ignore) > 0 && !d.Recursive {
+		add("%s: ignore only applies to recursive or snapshot assertions", where)
 	}
 }
 

--- a/internal/loader/validate_assert.go
+++ b/internal/loader/validate_assert.go
@@ -141,35 +141,8 @@ func validateStream(add func(string, ...any), where string, s *spec.StreamAssert
 	validateStringList(add, where, "contains", s.Contains)
 	validateStringList(add, where, "not_contains", s.NotContains)
 
-	// A count bound needs exactly one countable matcher to count (#396).
-	// contains and matches both compose freely without it, so the ambiguity only
-	// appears once a bound is written, and it has to be refused there rather
-	// than resolved by a precedence rule nobody would remember.
 	if s.HasCount() {
-		validateCountBounds(add, where, s.Count, s.MinCount, s.MaxCount)
-		countable := 0
-		if s.Contains != nil {
-			countable++
-			if len(s.Contains) > 1 {
-				add("%s: count applies to one substring; contains lists %d (write one assert per substring)", where, len(s.Contains))
-			}
-		}
-		if s.Matches != nil {
-			countable++
-		}
-		switch {
-		case countable == 0:
-			add("%s: count/min_count/max_count need a contains or matches matcher to count", where)
-		case countable > 1:
-			add("%s: count/min_count/max_count need exactly one countable matcher, but both contains and matches are set", where)
-		}
-		// The other text matchers stay meaningful next to a count, but the
-		// whole-stream ones do not: `equals` already pins every byte.
-		for _, m := range matchers {
-			if streamExclusiveMatchers[m] {
-				add("%s: count/min_count/max_count cannot be combined with %s", where, m)
-			}
-		}
+		validateStreamCount(add, where, s, matchers)
 	}
 
 	if s.Line != nil {
@@ -180,6 +153,38 @@ func validateStream(add func(string, ...any), where string, s *spec.StreamAssert
 		// text matchers — json/snapshot operate on the whole document.
 		if len(s.JSON) > 0 || len(s.YAML) > 0 || s.Snapshot != "" {
 			add("%s.line cannot be combined with json/yaml/snapshot (use contains/matches/equals/empty)", where)
+		}
+	}
+}
+
+// validateStreamCount checks a stream assert's occurrence bounds (#396). A
+// count bound needs exactly one countable matcher to count; contains and
+// matches both compose freely without it, so the ambiguity only appears once a
+// bound is written, and it has to be refused there rather than resolved by a
+// precedence rule nobody would remember.
+func validateStreamCount(add func(string, ...any), where string, s *spec.StreamAssert, matchers []string) {
+	validateCountBounds(add, where, s.Count, s.MinCount, s.MaxCount)
+	countable := 0
+	if s.Contains != nil {
+		countable++
+		if len(s.Contains) > 1 {
+			add("%s: count applies to one substring; contains lists %d (write one assert per substring)", where, len(s.Contains))
+		}
+	}
+	if s.Matches != nil {
+		countable++
+	}
+	switch {
+	case countable == 0:
+		add("%s: count/min_count/max_count need a contains or matches matcher to count", where)
+	case countable > 1:
+		add("%s: count/min_count/max_count need exactly one countable matcher, but both contains and matches are set", where)
+	}
+	// The other text matchers stay meaningful next to a count, but the
+	// whole-stream ones do not: `equals` already pins every byte.
+	for _, m := range matchers {
+		if streamExclusiveMatchers[m] {
+			add("%s: count/min_count/max_count cannot be combined with %s", where, m)
 		}
 	}
 }

--- a/internal/loader/validate_run.go
+++ b/internal/loader/validate_run.go
@@ -162,34 +162,45 @@ func shellMetachar(cmd string) string {
 			}
 			continue
 		}
-		switch c {
-		case '\'', '"':
+		if c == '\'' || c == '"' {
 			quote = c
-		case '`':
-			return "`"
-		case '|':
-			if i+1 < len(runes) && runes[i+1] == '|' {
-				return "||"
-			}
-			return "|"
-		case '&':
-			if i+1 < len(runes) && runes[i+1] == '&' {
-				return "&&"
-			}
-			// A lone `&` (background) is not in the guarded set; ignore it.
-		case ';':
-			return ";"
-		case '<':
-			return "<"
-		case '>':
-			if i+1 < len(runes) && runes[i+1] == '>' {
-				return ">>"
-			}
-			return ">"
-		case '$':
-			if i+1 < len(runes) && runes[i+1] == '(' {
-				return "$("
-			}
+			continue
+		}
+		if op := metacharAt(runes, i); op != "" {
+			return op
+		}
+	}
+	return ""
+}
+
+// metacharAt reports the guarded shell operator starting at runes[i], or ""
+// when the rune is ordinary. A lone `&` (background) is not in the guarded set.
+func metacharAt(runes []rune, i int) string {
+	next := func(r rune) bool { return i+1 < len(runes) && runes[i+1] == r }
+	switch runes[i] {
+	case '`':
+		return "`"
+	case '|':
+		if next('|') {
+			return "||"
+		}
+		return "|"
+	case '&':
+		if next('&') {
+			return "&&"
+		}
+	case ';':
+		return ";"
+	case '<':
+		return "<"
+	case '>':
+		if next('>') {
+			return ">>"
+		}
+		return ">"
+	case '$':
+		if next('(') {
+			return "$("
 		}
 	}
 	return ""


### PR DESCRIPTION
## Summary

Third pass of the v1.0.0 refactoring series (after #445 and #446), covering internal/engine and internal/loader. Every function in both packages now sits under the gocognit/nestif thresholds, with no behavior change: extracted helpers keep the exact side-effect order, messages, and locking of the originals, and the engine package passes with -race.

## Changes

- internal/engine/engine.go: Engine.Run (cognitive complexity 63) now reads as its phases — newRunConfig, errorSelected (the suite-setup error fanout, with its emit/no-emit distinction kept), runSelected, and the report fold. The producer/worker machinery moved into a scenarioPool whose mutex-guarded state (results/done/failStop) lives next to the emit method that mutates it.
- internal/engine/suite.go: runSuiteSteps (55) keeps only the loop skeleton (cancellation, masking, stop-on-failure); each step kind's body moved to a suiteStepper method, which also carries the `current` run result that store/assert steps read.
- internal/engine/stepexec.go: the run and pty arms of execStep moved to execRunStep/execPTYStep; runStep's runner resolution and ssh execution moved to resolveRunTarget/runRemote.
- internal/engine/pty.go: the per-action ${name} expansion moved to expandPTYAction.
- internal/loader: validate (54) split into suiteResourceNames, validateScenario, validateScenarioSteps, and validateScenarioTeardown; applyDefaults' twin step loops merged into mergeStepRunDefaults; validateDir split into countDirMatchers and validateDirComposition; shellMetachar's operator switch moved to metacharAt; the stream count-bound block moved to validateStreamCount.

## Design Decisions

- scenarioPool exists because the worker closure closed over five shared variables; making the mutex and the state it guards fields of one struct with a single emit path is the same synchronization, stated once. The engine tests pass under -race.
- suiteStepper mirrors the scenario path's existing scenarioRun shape, so the suite and scenario step executors are now structurally parallel and a reader can diff them.
- errorSelected keeps the historical asymmetry (runtime-creation failure does not stream OnScenario, setup failure does) explicit in a parameter instead of two near-identical loops.

## Limitations

- valuesEqual and checkDirRecursive (internal/assert) and the browser/spec/record 30-range functions are handled in the next PRs of the series.