### PR TITLE
refactor(pty): decompose driveSession and the transcript sanitizer

### DIFF
--- a/internal/runner/ptyrun/fuzz_test.go
+++ b/internal/runner/ptyrun/fuzz_test.go
@@ -6,6 +6,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/nao1215/atago/internal/spec"
+	"github.com/rivo/uniseg"
 )
 
 // FuzzRenderScreen attacks the vt100 screen-rendering path (#27). RenderScreen
@@ -21,8 +22,9 @@ import (
 //   - line budget: vt10x.State.String emits exactly `rows` rows, and
 //     RenderScreen only strips trailing blank rows, so the rendered screen
 //     never has MORE than `rows` lines;
-//   - column budget: String emits exactly `cols` runes per row and RenderScreen
-//     only TrimRights each line, so every rendered line is at most `cols` runes
+//   - column budget: the emulator holds one grapheme cluster per cell (#437)
+//     across exactly `cols` cells per row, and RenderScreen only TrimRights
+//     each line, so every rendered line is at most `cols` grapheme clusters
 //     wide (matching TestRenderScreen_TruncatesAtCols);
 //   - valid UTF-8: the emulator drops invalid UTF-8 input bytes before they
 //     reach a cell and back-fills untouched cells with a space, so the returned
@@ -117,8 +119,13 @@ func FuzzRenderScreen(f *testing.F) {
 			t.Fatalf("screen has %d lines, exceeds rows=%d\ntranscript=%q cols=%d\nscreen=%q", len(lines), rows, transcript, cols, got)
 		}
 		for i, l := range lines {
-			if n := utf8.RuneCountInString(l); n > cols {
-				t.Fatalf("line %d is %d runes wide, exceeds cols=%d\ntranscript=%q rows=%d\nline=%q", i, n, cols, transcript, rows, l)
+			// Width is measured in grapheme clusters, not runes: since #437 a
+			// cell holds a whole cluster, so a combining mark shares its base's
+			// cell ("0" + U+030E is one column but two runes). Every cluster
+			// occupies at least one column, so cluster count ≤ cols is the
+			// invariant that survives both clusters and double-width cells.
+			if n := uniseg.GraphemeClusterCount(l); n > cols {
+				t.Fatalf("line %d is %d clusters wide, exceeds cols=%d\ntranscript=%q rows=%d\nline=%q", i, n, cols, transcript, rows, l)
 			}
 		}
 	})

--- a/internal/runner/ptyrun/screen.go
+++ b/internal/runner/ptyrun/screen.go
@@ -284,7 +284,6 @@ func sanitizeTranscriptMarks(b []byte, marks []int) ([]byte, []int) {
 		}
 	}
 	i := 0
-scan:
 	for i < len(b) {
 		flushMarks(i)
 		if b[i] != 0x1b {
@@ -292,25 +291,12 @@ scan:
 			i++
 			continue
 		}
-		// ESC: find the rune that decides the escape kind, looking through the
-		// bytes vt10x's Write/handleControlCodes make transparent.
-		j := i + 1
-		for j < len(b) {
-			r, sz := utf8.DecodeRune(b[j:])
-			switch {
-			case r == utf8.RuneError && sz == 1:
-				j++ // invalid byte: dropped by Write before the parser sees it.
-				continue
-			case r == 0x1b:
-				// A second ESC restarts escape parsing: the first is inert.
-				out = append(out, b[i:j]...)
-				i = j
-				continue scan
-			case r < 0x20 || r == 0x7f:
-				j += sz // control code: handled out-of-band, escape state kept.
-				continue
-			}
-			break
+		j, restart := escDecider(b, i)
+		if restart {
+			// A second ESC restarts escape parsing: the first is inert.
+			out = append(out, b[i:j]...)
+			i = j
+			continue
 		}
 		if j >= len(b) || b[j] != '[' {
 			// Not a CSI (or a truncated trailing ESC): copy the ESC and rescan
@@ -319,100 +305,21 @@ scan:
 			i++
 			continue
 		}
-		// CSI body: scan effective runes until the final byte (0x40..0x7E),
-		// tracking exactly the parameter bytes vt10x will accumulate.
-		body := make([]byte, 0, 16)
-		var controls []byte // side-effect control codes seen inside the sequence
-		hasMinus, hasWideRune, hasMidMarker := false, false, false
-		finalByte := byte(0)
-		k := j + 1
-		for k < len(b) {
-			r, sz := utf8.DecodeRune(b[k:])
-			if r == utf8.RuneError && sz == 1 {
-				k++ // transparent to vt10x's parser, transparent to the scan.
-				continue
-			}
-			if r == 0x1b {
-				// ESC restarts escape parsing: the sequence so far can never
-				// dispatch, so drop its parameter bytes — copying them verbatim
-				// would leave an OPEN CSI in the output if the aborting escape
-				// later gets dropped as malformed, and then ordinary text (say a
-				// final-range 'Z') would finalize the stale parameters into a
-				// quadrillion-step CBT (found by FuzzRenderScreen). Only the
-				// embedded control codes vt10x already executed are kept.
-				out = append(out, controls...)
-				i = k
-				continue scan
-			}
-			if r == 0x18 || r == 0x1a {
-				// CAN/SUB reset the parameter buffer but STAY in CSI state.
-				body = body[:0]
-				hasMinus, hasWideRune, hasMidMarker = false, false, false
-				k += sz
-				continue
-			}
-			if r < 0x20 || r == 0x7f {
-				// Other control codes are transparent to the CSI state but DO
-				// execute (tab, CR, LF move the cursor mid-sequence); remember
-				// them so a dropped sequence still replays its side effects.
-				controls = append(controls, byte(r&0x7f)) // r < 0x20 or == 0x7f here
-				k += sz
-				continue
-			}
-			if r > 0x7e {
-				// vt10x truncates the rune to its low byte — nonsense that can
-				// even finalize the sequence. Mirror the boundary, drop later.
-				hasWideRune = true
-				if low := byte(r & 0xff); low >= 0x40 && low <= 0x7e {
-					finalByte = low
-					k += sz
-					break
-				}
-				k += sz
-				continue
-			}
-			c := byte(r)
-			if c >= 0x40 && c <= 0x7e {
-				finalByte = c
-				k += sz
-				break
-			}
-			if c == '-' {
-				hasMinus = true
-			}
-			// A private-marker byte (< = > ?) is well-formed only as the FIRST
-			// parameter byte (CSI ? 25 h, CSI < 0 ; 0 M). One that appears after a
-			// parameter has begun makes the sequence malformed — a conformant
-			// terminal ignores it — and x/vt's parser handles the malformed shape
-			// (CSI 999 ? 999 ? 999 X) in time quadratic in the parameters, seconds
-			// for a few thousand. Drop it like a negative parameter.
-			if c >= '<' && c <= '?' && len(body) > 0 {
-				hasMidMarker = true
-			}
-			body = append(body, c)
-			k += sz
+		sc := scanCSIBody(b, j+1)
+		if sc.abortedByESC {
+			// ESC restarts escape parsing: the sequence so far can never
+			// dispatch, so drop its parameter bytes — copying them verbatim
+			// would leave an OPEN CSI in the output if the aborting escape
+			// later gets dropped as malformed, and then ordinary text (say a
+			// final-range 'Z') would finalize the stale parameters into a
+			// quadrillion-step CBT (found by FuzzRenderScreen). Only the
+			// embedded control codes vt10x already executed are kept.
+			out = append(out, sc.controls...)
+			i = sc.end
+			continue
 		}
-		switch {
-		case finalByte == 0:
-			// Truncated trailing CSI: it can never dispatch, copy verbatim.
-			out = append(out, b[i:k]...)
-		case hasMinus || hasWideRune || hasMidMarker:
-			// Malformed parameters: a conformant terminal ignores the whole
-			// sequence, so drop it — replaying only the control codes it
-			// carried — and keep the surrounding frame intact.
-			out = append(out, controls...)
-		case len(clampDigitRuns(body)) != len(body):
-			// An oversized repeat count: replay embedded control codes, then
-			// re-emit the sequence with the digit runs clamped.
-			out = append(out, controls...)
-			out = append(out, 0x1b, '[')
-			out = append(out, clampDigitRuns(body)...)
-			out = append(out, finalByte)
-		default:
-			// Clean sequence: byte-for-byte, side-effect bytes included.
-			out = append(out, b[i:k]...)
-		}
-		i = k
+		out = emitCSI(out, b, i, sc)
+		i = sc.end
 	}
 	// Anything still pending sat at or past the end of the transcript.
 	for next < len(marks) {
@@ -420,6 +327,139 @@ scan:
 		next++
 	}
 	return out, translated
+}
+
+// escDecider finds the rune that decides the kind of the escape opened at
+// b[i] (an ESC), looking through the bytes vt10x's Write/handleControlCodes
+// make transparent: lone invalid-UTF-8 bytes are dropped by Write before the
+// parser sees them, and control codes are handled out-of-band with escape
+// state kept. restart reports a second ESC at j, which restarts escape
+// parsing and makes the first ESC inert.
+func escDecider(b []byte, i int) (j int, restart bool) {
+	j = i + 1
+	for j < len(b) {
+		r, sz := utf8.DecodeRune(b[j:])
+		switch {
+		case r == utf8.RuneError && sz == 1:
+			j++
+			continue
+		case r == 0x1b:
+			return j, true
+		case r < 0x20 || r == 0x7f:
+			j += sz
+			continue
+		}
+		break
+	}
+	return j, false
+}
+
+// csiScan is one CSI sequence as vt10x's parser will see it: the parameter
+// bytes it will accumulate, the control codes it executes mid-sequence, the
+// malformation flags that make a conformant terminal ignore the sequence, and
+// where the scan ended.
+type csiScan struct {
+	body     []byte // the parameter bytes vt10x will Atoi
+	controls []byte // side-effect control codes seen inside the sequence
+	hasMinus, hasWideRune, hasMidMarker bool
+	finalByte byte // 0 when the sequence is truncated at end of input
+	end       int  // index just past the sequence
+	// abortedByESC reports an ESC inside the CSI: it restarts escape parsing
+	// at end, and the sequence so far can never dispatch.
+	abortedByESC bool
+}
+
+// scanCSIBody scans the CSI body starting at start (just past "ESC ["),
+// walking effective runes until the final byte (0x40..0x7E) and tracking
+// exactly the parameter bytes vt10x will accumulate.
+func scanCSIBody(b []byte, start int) csiScan {
+	sc := csiScan{body: make([]byte, 0, 16)}
+	k := start
+	for k < len(b) {
+		r, sz := utf8.DecodeRune(b[k:])
+		if r == utf8.RuneError && sz == 1 {
+			k++ // transparent to vt10x's parser, transparent to the scan.
+			continue
+		}
+		if r == 0x1b {
+			sc.abortedByESC = true
+			break
+		}
+		if r == 0x18 || r == 0x1a {
+			// CAN/SUB reset the parameter buffer but STAY in CSI state.
+			sc.body = sc.body[:0]
+			sc.hasMinus, sc.hasWideRune, sc.hasMidMarker = false, false, false
+			k += sz
+			continue
+		}
+		if r < 0x20 || r == 0x7f {
+			// Other control codes are transparent to the CSI state but DO
+			// execute (tab, CR, LF move the cursor mid-sequence); remember
+			// them so a dropped sequence still replays its side effects.
+			sc.controls = append(sc.controls, byte(r&0x7f)) // r < 0x20 or == 0x7f here
+			k += sz
+			continue
+		}
+		if r > 0x7e {
+			// vt10x truncates the rune to its low byte — nonsense that can
+			// even finalize the sequence. Mirror the boundary, drop later.
+			sc.hasWideRune = true
+			if low := byte(r & 0xff); low >= 0x40 && low <= 0x7e {
+				sc.finalByte = low
+				k += sz
+				break
+			}
+			k += sz
+			continue
+		}
+		c := byte(r)
+		if c >= 0x40 && c <= 0x7e {
+			sc.finalByte = c
+			k += sz
+			break
+		}
+		if c == '-' {
+			sc.hasMinus = true
+		}
+		// A private-marker byte (< = > ?) is well-formed only as the FIRST
+		// parameter byte (CSI ? 25 h, CSI < 0 ; 0 M). One that appears after a
+		// parameter has begun makes the sequence malformed — a conformant
+		// terminal ignores it — and x/vt's parser handles the malformed shape
+		// (CSI 999 ? 999 ? 999 X) in time quadratic in the parameters, seconds
+		// for a few thousand. Drop it like a negative parameter.
+		if c >= '<' && c <= '?' && len(sc.body) > 0 {
+			sc.hasMidMarker = true
+		}
+		sc.body = append(sc.body, c)
+		k += sz
+	}
+	sc.end = k
+	return sc
+}
+
+// emitCSI appends the scanned sequence (opened at b[i]) to out in the shape
+// vt10x can safely replay.
+func emitCSI(out, b []byte, i int, sc csiScan) []byte {
+	switch {
+	case sc.finalByte == 0:
+		// Truncated trailing CSI: it can never dispatch, copy verbatim.
+		return append(out, b[i:sc.end]...)
+	case sc.hasMinus || sc.hasWideRune || sc.hasMidMarker:
+		// Malformed parameters: a conformant terminal ignores the whole
+		// sequence, so drop it — replaying only the control codes it
+		// carried — and keep the surrounding frame intact.
+		return append(out, sc.controls...)
+	case len(clampDigitRuns(sc.body)) != len(sc.body):
+		// An oversized repeat count: replay embedded control codes, then
+		// re-emit the sequence with the digit runs clamped.
+		out = append(out, sc.controls...)
+		out = append(out, 0x1b, '[')
+		out = append(out, clampDigitRuns(sc.body)...)
+		return append(out, sc.finalByte)
+	default:
+		// Clean sequence: byte-for-byte, side-effect bytes included.
+		return append(out, b[i:sc.end]...)
+	}
 }
 
 // clampDigitRuns truncates every digit run longer than maxCSIParamDigits to its

--- a/internal/runner/ptyrun/screen.go
+++ b/internal/runner/ptyrun/screen.go
@@ -359,11 +359,11 @@ func escDecider(b []byte, i int) (j int, restart bool) {
 // malformation flags that make a conformant terminal ignore the sequence, and
 // where the scan ended.
 type csiScan struct {
-	body     []byte // the parameter bytes vt10x will Atoi
-	controls []byte // side-effect control codes seen inside the sequence
+	body                                []byte // the parameter bytes vt10x will Atoi
+	controls                            []byte // side-effect control codes seen inside the sequence
 	hasMinus, hasWideRune, hasMidMarker bool
-	finalByte byte // 0 when the sequence is truncated at end of input
-	end       int  // index just past the sequence
+	finalByte                           byte // 0 when the sequence is truncated at end of input
+	end                                 int  // index just past the sequence
 	// abortedByESC reports an ESC inside the CSI: it restarts escape parsing
 	// at end, and the sequence so far can never dispatch.
 	abortedByESC bool

--- a/internal/runner/ptyrun/session.go
+++ b/internal/runner/ptyrun/session.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"regexp"
 	"syscall"
 	"time"
 
@@ -82,289 +83,347 @@ func driveSession(ctx context.Context, p *spec.PTY, proc ptyProcess) (*runner.Re
 	ctx, cancel := context.WithTimeout(ctx, budget)
 	defer cancel()
 
-	start := time.Now()
 	term := proc.trans
 	if term == nil {
 		term = startTranscriptDrain(proc.rw, p)
 	}
-	writeTerm := term.write
-	snapshot := term.snapshot
-	tailFrom := term.tailFrom
-	curLen := term.curLen
-	currentScreen := term.currentScreen
-
-	finish := func(timedOut bool, code int, ef *ExpectFailure) (*runner.Result, *ExpectFailure, error) {
-		// The child is reaped by now (see the note further down), so the runner's
-		// own slave handle has done its job: it kept the terminal from reaching
-		// its last close while output was still unread. Drop it here, because
-		// until it goes the reader has no EOF to end on and waitDrain would
-		// spend its whole grace waiting for one.
-		if proc.releaseTTY != nil {
-			proc.releaseTTY()
-		}
-		// Drain before closing: a fast-exiting child's final output may still sit
-		// in the pty buffer, and closing the master discards it. Once the last
-		// handle is gone the reader hits EOF and readDone closes on its own;
-		// drainGrace bounds the wait in case a descendant kept the terminal open.
-		term.waitDrain(proc.closeTerm, drainGrace)
-		tr := snapshot()
-		// A transcript atago knows is incomplete must not become a Result: an
-		// expect_screen compared against missing bytes is a confidently wrong
-		// verdict, and it would read as the spec's fault rather than atago's. So
-		// this outranks even a pending ExpectFailure — that expect may have failed
-		// only because the bytes never arrived.
-		//
-		// Every caller of finish has already reaped the child (the session loop
-		// receives proc.exit; abort and failHard kill and wait), so an end-of-
-		// session read error accepted here is by construction one that arrived
-		// after the child exited. That is why the reader can classify on the error
-		// alone without racing the exit.
-		rerr := term.readError()
-		if rerr != nil {
-			return nil, nil, fmt.Errorf(
-				"pty %q: the terminal transcript is incomplete — reading the terminal failed after %d bytes: %w",
-				p.Command, len(tr), rerr)
-		}
-		screenTextStr, screenCells := renderScreenCells(tr, p, term.snapshotResizes())
-		screenText := []byte(screenTextStr)
-		res := &runner.Result{
-			Command:  p.Command,
-			Stdout:   tr,
-			Duration: time.Since(start),
-			Workdir:  proc.dir,
-			TimedOut: timedOut,
-			IsPTY:    true,
-			// The rendered screen (#27) is derived from the same bytes, so screen
-			// asserts and transcript asserts never disagree about what happened.
-			// Replaying through the recorded size changes (#379) keeps that true
-			// for a session that resized: each part of the frame is drawn under
-			// the size it was produced under.
-			Screen: screenText,
-			// The same frame with its colors and attributes, for `attrs:` (#382).
-			ScreenCells: screenCells,
-		}
-		if timedOut {
-			res.ExitCode = -1
-		} else {
-			res.ExitCode = code
-		}
-		return res, ef, nil
-	}
-
-	// abort kills the tree and reaps it, then finishes as timed out.
-	abort := func(ef *ExpectFailure) (*runner.Result, *ExpectFailure, error) {
-		proc.kill()
-		<-proc.exit
-		return finish(true, -1, ef)
-	}
-
-	// failHard cleans up (kill, reap, close, drain) before surfacing a hard
-	// error, so a failed terminal write never leaks the child or goroutines.
-	failHard := func(err error) (*runner.Result, *ExpectFailure, error) {
-		proc.kill()
-		<-proc.exit
-		if proc.releaseTTY != nil {
-			proc.releaseTTY()
-		}
-		term.waitDrain(proc.closeTerm, 0)
-		return nil, nil, err
-	}
-
-	// canceledResult surfaces a parent-context cancellation (Ctrl-C / suite
-	// cancel) as a hard execution error, so the engine stops the scenario instead
-	// of asserting against a killed terminal — mirroring the cmd runner's
-	// cancel/timeout split (#30).
-	canceledResult := func() (*runner.Result, *ExpectFailure, error) {
-		return failHard(fmt.Errorf("pty %q canceled: %w", p.Command, ctx.Err()))
-	}
+	d := &sessionDriver{p: p, proc: proc, term: term, start: time.Now()}
 
 	// Drive the session in order. expect polls the transcript; expect_screen
 	// polls the rendered screen; send writes to the terminal; an empty send
 	// transmits EOF (^D).
-	//
-	// matchOffset is the byte index just past the previously matched expect: each
-	// expect scans only transcript[matchOffset:], so a pattern that recurs (any
-	// shell prompt) waits for its NEXT occurrence instead of matching the stale
-	// earlier one.
-	matchOffset := 0
 	for i, a := range p.Session {
-		if expects[i] != nil {
-			matched := false
-			scannedTo := -1 // transcript length at the last scan; -1 forces one
-			for {
-				if n := curLen(); n != scannedTo {
-					tail, m := tailFrom(matchOffset)
-					scannedTo = m
-					if loc := expects[i].FindIndex(tail); loc != nil {
-						matchOffset += loc[1]
-						matched = true
-						break
-					}
-				}
-				select {
-				case <-ctx.Done():
-					// One last check: bytes may have landed in the final poll
-					// window before the deadline fired.
-					tail, _ := tailFrom(matchOffset)
-					if loc := expects[i].FindIndex(tail); loc != nil {
-						matchOffset += loc[1]
-						matched = true
-					}
-				case <-time.After(pollInterval):
-					continue
-				}
-				break
-			}
-			if !matched {
-				// A parent-context cancellation is an execution error that must stop
-				// the scenario; only a genuine session-budget timeout
-				// (DeadlineExceeded) becomes an ExpectFailure.
-				if errors.Is(ctx.Err(), context.Canceled) {
-					return canceledResult()
-				}
-				return abort(&ExpectFailure{Pattern: a.Expect, Transcript: string(snapshot())})
-			}
-			continue
+		var out *sessionOutcome
+		switch {
+		case expects[i] != nil:
+			out = d.waitExpect(ctx, expects[i], a.Expect)
+		case a.ExpectScreen != nil:
+			out = d.waitExpectScreen(ctx, a.ExpectScreen)
+		case a.Exec != nil:
+			out = d.runExec(ctx, i, a.Exec)
+		case a.Resize != nil:
+			out = d.applyResize(i, a.Resize)
+		case a.Send != nil:
+			out = d.send(i, a.Send)
 		}
-		if a.ExpectScreen != nil {
-			waitCtx, cancelWait := sessionWaitContext(ctx, a.ExpectScreen.Timeout)
-			matched := false
-			var stableSince time.Time
-			stableFor := parsePositiveDuration(a.ExpectScreen.StableFor)
-			scannedTo := -1 // transcript length at the last render; -1 forces one
-			for {
-				if n := curLen(); n != scannedTo {
-					scannedTo = n
-					screen, cells := currentScreen()
-					cr := checkRenderedScreen(a.ExpectScreen, screen, cells)
-					if cr.OK {
-						if stableFor <= 0 {
-							matched = true
-							break
-						}
-						if stableSince.IsZero() {
-							stableSince = time.Now()
-						}
-						if time.Since(stableSince) >= stableFor {
-							matched = true
-							break
-						}
-					} else {
-						stableSince = time.Time{}
-					}
-				}
-				select {
-				case <-waitCtx.Done():
-					screen, cells := currentScreen()
-					cr := checkRenderedScreen(a.ExpectScreen, screen, cells)
-					if cr.OK {
-						if stableFor <= 0 {
-							matched = true
-						} else {
-							if stableSince.IsZero() {
-								stableSince = time.Now()
-							}
-							if time.Since(stableSince) >= stableFor {
-								matched = true
-							}
-						}
-					}
-				case <-time.After(pollInterval):
-					if !stableSince.IsZero() && stableFor > 0 && time.Since(stableSince) >= stableFor {
-						matched = true
-					}
-					if matched {
-						break
-					}
-					continue
-				}
-				break
-			}
-			cancelWait()
-			if !matched {
-				// A parent-context cancellation is an execution error that must stop
-				// the scenario; only a genuine wait timeout becomes a failed check.
-				if errors.Is(waitCtx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
-					return canceledResult()
-				}
-				screen, cells := currentScreen()
-				cr := checkRenderedScreen(a.ExpectScreen, screen, cells)
-				if cr.OK && stableFor > 0 {
-					cr = &assert.CheckResult{
-						Desc:           fmt.Sprintf("pty expect_screen stable for %s", stableFor),
-						Expected:       fmt.Sprintf("rendered screen to keep satisfying the matcher for %s", stableFor),
-						Actual:         string(screen),
-						Hint:           fmt.Sprintf("the rendered screen matched, but not continuously for %s before the timeout elapsed", stableFor),
-						ArtifactKind:   "screen",
-						ArtifactActual: screen,
-					}
-				}
-				return abort(&ExpectFailure{Check: cr})
-			}
-			continue
-		}
-		if a.Exec != nil {
-			// Blocking here is the contract: after this returns, the change the
-			// command made exists, so whatever the session waits for next is
-			// waiting on the program noticing it rather than on a race (#380).
-			if xerr := runSessionExec(ctx, a.Exec, proc.dir, proc.env); xerr != nil {
-				return failHard(fmt.Errorf("pty %q: session[%d]: %w", p.Command, i, xerr))
-			}
-			continue
-		}
-		if a.Resize != nil {
-			// Record the boundary before changing the size, so the replay that
-			// builds the rendered screen splits the transcript at the same point
-			// the real terminal did (#379).
-			term.markResize(a.Resize.Rows, a.Resize.Cols)
-			if rerr := proc.resize(a.Resize.Rows, a.Resize.Cols); rerr != nil {
-				return failHard(fmt.Errorf("pty %q: session[%d] resize to %dx%d: %w",
-					p.Command, i, a.Resize.Rows, a.Resize.Cols, rerr))
-			}
-			continue
-		}
-		if a.Send != nil {
-			// A paste is only a paste if the program asked for one. Without the
-			// mode, the markers arrive as ordinary characters and the failure
-			// surfaces somewhere far away — as a REPL executing a pasted block
-			// line by line, or as "[200~" typed into a prompt — so refuse here,
-			// where the mistake is (#378).
-			if a.Send.Paste != nil && !term.modeEnabled(decsetBracketedPaste) {
-				return failHard(fmt.Errorf(
-					"pty %q: session[%d] sends a paste, but the program has not enabled bracketed paste "+
-						"(it never wrote ESC [?2004h, or turned the mode back off). "+
-						"Programs that do not distinguish a paste from typing take a plain send instead; "+
-						"if this one does enable the mode, wait for it with an expect or expect_screen before pasting",
-					p.Command, i))
-			}
-			// A mouse event only means something to a program that asked to be
-			// told about the mouse, and in the encoding atago speaks (#381).
-			if a.Send.Mouse != nil {
-				if merr := checkMouseMode(term, p.Command, i); merr != nil {
-					return failHard(merr)
-				}
-			}
-			// Bytes resolves named keys to their xterm sequences, wraps a paste
-			// in its markers, and keeps the historical rule that an empty
-			// verbatim send transmits EOF (^D).
-			if _, werr := writeTerm(a.Send.Bytes()); werr != nil {
-				return failHard(fmt.Errorf("pty: send: %w", werr))
-			}
+		if out != nil {
+			return out.res, out.ef, out.err
 		}
 	}
 
 	// Session complete: wait for the child to exit within the budget.
 	select {
 	case code := <-proc.exit:
-		return finish(false, code, nil)
+		out := d.finish(false, code, nil)
+		return out.res, out.ef, out.err
 	case <-ctx.Done():
 		// A parent cancellation is a hard error; a session-budget timeout is a
 		// normal timed-out result (#30).
 		if errors.Is(ctx.Err(), context.Canceled) {
-			return canceledResult()
+			out := d.canceled(ctx)
+			return out.res, out.ef, out.err
 		}
-		return abort(nil)
+		out := d.abort(nil)
+		return out.res, out.ef, out.err
 	}
+}
+
+// sessionOutcome is how a sessionDriver step ends the session: the triple
+// driveSession returns. A nil *sessionOutcome from a step handler means the
+// session continues with the next action.
+type sessionOutcome struct {
+	res *runner.Result
+	ef  *ExpectFailure
+	err error
+}
+
+// sessionDriver holds the state one pty session's actions share: the process
+// handles, the transcript drain, and the match offset that makes each expect
+// wait for its NEXT occurrence.
+type sessionDriver struct {
+	p     *spec.PTY
+	proc  ptyProcess
+	term  *transcriptDrain
+	start time.Time
+	// matchOffset is the byte index just past the previously matched expect:
+	// each expect scans only transcript[matchOffset:], so a pattern that recurs
+	// (any shell prompt) waits for its NEXT occurrence instead of matching the
+	// stale earlier one.
+	matchOffset int
+}
+
+// finish shapes the session's Result after the child has been reaped.
+func (d *sessionDriver) finish(timedOut bool, code int, ef *ExpectFailure) *sessionOutcome {
+	// The child is reaped by now (see the note further down), so the runner's
+	// own slave handle has done its job: it kept the terminal from reaching
+	// its last close while output was still unread. Drop it here, because
+	// until it goes the reader has no EOF to end on and waitDrain would
+	// spend its whole grace waiting for one.
+	if d.proc.releaseTTY != nil {
+		d.proc.releaseTTY()
+	}
+	// Drain before closing: a fast-exiting child's final output may still sit
+	// in the pty buffer, and closing the master discards it. Once the last
+	// handle is gone the reader hits EOF and readDone closes on its own;
+	// drainGrace bounds the wait in case a descendant kept the terminal open.
+	d.term.waitDrain(d.proc.closeTerm, drainGrace)
+	tr := d.term.snapshot()
+	// A transcript atago knows is incomplete must not become a Result: an
+	// expect_screen compared against missing bytes is a confidently wrong
+	// verdict, and it would read as the spec's fault rather than atago's. So
+	// this outranks even a pending ExpectFailure — that expect may have failed
+	// only because the bytes never arrived.
+	//
+	// Every caller of finish has already reaped the child (the session loop
+	// receives proc.exit; abort and failHard kill and wait), so an end-of-
+	// session read error accepted here is by construction one that arrived
+	// after the child exited. That is why the reader can classify on the error
+	// alone without racing the exit.
+	rerr := d.term.readError()
+	if rerr != nil {
+		return &sessionOutcome{err: fmt.Errorf(
+			"pty %q: the terminal transcript is incomplete — reading the terminal failed after %d bytes: %w",
+			d.p.Command, len(tr), rerr)}
+	}
+	screenTextStr, screenCells := renderScreenCells(tr, d.p, d.term.snapshotResizes())
+	screenText := []byte(screenTextStr)
+	res := &runner.Result{
+		Command:  d.p.Command,
+		Stdout:   tr,
+		Duration: time.Since(d.start),
+		Workdir:  d.proc.dir,
+		TimedOut: timedOut,
+		IsPTY:    true,
+		// The rendered screen (#27) is derived from the same bytes, so screen
+		// asserts and transcript asserts never disagree about what happened.
+		// Replaying through the recorded size changes (#379) keeps that true
+		// for a session that resized: each part of the frame is drawn under
+		// the size it was produced under.
+		Screen: screenText,
+		// The same frame with its colors and attributes, for `attrs:` (#382).
+		ScreenCells: screenCells,
+	}
+	if timedOut {
+		res.ExitCode = -1
+	} else {
+		res.ExitCode = code
+	}
+	return &sessionOutcome{res: res, ef: ef}
+}
+
+// abort kills the tree and reaps it, then finishes as timed out.
+func (d *sessionDriver) abort(ef *ExpectFailure) *sessionOutcome {
+	d.proc.kill()
+	<-d.proc.exit
+	return d.finish(true, -1, ef)
+}
+
+// failHard cleans up (kill, reap, close, drain) before surfacing a hard
+// error, so a failed terminal write never leaks the child or goroutines.
+func (d *sessionDriver) failHard(err error) *sessionOutcome {
+	d.proc.kill()
+	<-d.proc.exit
+	if d.proc.releaseTTY != nil {
+		d.proc.releaseTTY()
+	}
+	d.term.waitDrain(d.proc.closeTerm, 0)
+	return &sessionOutcome{err: err}
+}
+
+// canceled surfaces a parent-context cancellation (Ctrl-C / suite cancel) as a
+// hard execution error, so the engine stops the scenario instead of asserting
+// against a killed terminal — mirroring the cmd runner's cancel/timeout split
+// (#30).
+func (d *sessionDriver) canceled(ctx context.Context) *sessionOutcome {
+	return d.failHard(fmt.Errorf("pty %q canceled: %w", d.p.Command, ctx.Err()))
+}
+
+// waitExpect polls the transcript past the previous match until re matches,
+// the session budget runs out, or the run is canceled. nil means matched.
+func (d *sessionDriver) waitExpect(ctx context.Context, re *regexp.Regexp, pattern string) *sessionOutcome {
+	matched := false
+	scannedTo := -1 // transcript length at the last scan; -1 forces one
+	for {
+		if n := d.term.curLen(); n != scannedTo {
+			tail, m := d.term.tailFrom(d.matchOffset)
+			scannedTo = m
+			if loc := re.FindIndex(tail); loc != nil {
+				d.matchOffset += loc[1]
+				matched = true
+				break
+			}
+		}
+		select {
+		case <-ctx.Done():
+			// One last check: bytes may have landed in the final poll
+			// window before the deadline fired.
+			tail, _ := d.term.tailFrom(d.matchOffset)
+			if loc := re.FindIndex(tail); loc != nil {
+				d.matchOffset += loc[1]
+				matched = true
+			}
+		case <-time.After(pollInterval):
+			continue
+		}
+		break
+	}
+	if !matched {
+		// A parent-context cancellation is an execution error that must stop
+		// the scenario; only a genuine session-budget timeout
+		// (DeadlineExceeded) becomes an ExpectFailure.
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return d.canceled(ctx)
+		}
+		return d.abort(&ExpectFailure{Pattern: pattern, Transcript: string(d.term.snapshot())})
+	}
+	return nil
+}
+
+// waitExpectScreen polls the rendered screen until the matcher holds (and, with
+// stable_for, keeps holding), its wait times out, or the run is canceled. nil
+// means matched.
+func (d *sessionDriver) waitExpectScreen(ctx context.Context, es *spec.PTYExpectScreen) *sessionOutcome {
+	waitCtx, cancelWait := sessionWaitContext(ctx, es.Timeout)
+	defer cancelWait()
+	matched := false
+	stable := &stability{need: parsePositiveDuration(es.StableFor)}
+	scannedTo := -1 // transcript length at the last render; -1 forces one
+	for {
+		if n := d.term.curLen(); n != scannedTo {
+			scannedTo = n
+			if matched = stable.observe(d.checkScreen(es).OK); matched {
+				break
+			}
+		}
+		select {
+		case <-waitCtx.Done():
+			// One last render: output may have landed in the final poll
+			// window before the deadline fired.
+			matched = stable.observe(d.checkScreen(es).OK)
+		case <-time.After(pollInterval):
+			// No new output this tick — but an already-matching screen may
+			// have just held still long enough to satisfy stable_for.
+			if !stable.heldWithoutRedraw() {
+				continue
+			}
+			matched = true
+		}
+		break
+	}
+	if matched {
+		return nil
+	}
+	// A parent-context cancellation is an execution error that must stop
+	// the scenario; only a genuine wait timeout becomes a failed check.
+	if errors.Is(waitCtx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+		return d.canceled(ctx)
+	}
+	cr := d.checkScreen(es)
+	if cr.OK && stable.need > 0 {
+		screen, _ := d.term.currentScreen()
+		cr = &assert.CheckResult{
+			Desc:           fmt.Sprintf("pty expect_screen stable for %s", stable.need),
+			Expected:       fmt.Sprintf("rendered screen to keep satisfying the matcher for %s", stable.need),
+			Actual:         string(screen),
+			Hint:           fmt.Sprintf("the rendered screen matched, but not continuously for %s before the timeout elapsed", stable.need),
+			ArtifactKind:   "screen",
+			ArtifactActual: screen,
+		}
+	}
+	return d.abort(&ExpectFailure{Check: cr})
+}
+
+// checkScreen runs the expect_screen matcher against the current rendered
+// screen.
+func (d *sessionDriver) checkScreen(es *spec.PTYExpectScreen) *assert.CheckResult {
+	screen, cells := d.term.currentScreen()
+	return checkRenderedScreen(es, screen, cells)
+}
+
+// stability tracks an expect_screen stable_for window: the matcher must hold
+// continuously for `need` before the wait passes, absorbing redraw churn
+// without a blind sleep. A zero need degrades to "matched once".
+type stability struct {
+	need  time.Duration
+	since time.Time // when the screen started matching; zero while not matching
+}
+
+// observe feeds one matcher verdict and reports whether the wait is satisfied:
+// immediately for a plain match, or once the screen has matched continuously
+// for the window.
+func (s *stability) observe(ok bool) bool {
+	if !ok {
+		s.since = time.Time{}
+		return false
+	}
+	if s.need <= 0 {
+		return true
+	}
+	if s.since.IsZero() {
+		s.since = time.Now()
+	}
+	return time.Since(s.since) >= s.need
+}
+
+// heldWithoutRedraw reports whether a screen that already matched has now been
+// still (no new output to re-render) for the rest of the window.
+func (s *stability) heldWithoutRedraw() bool {
+	return s.need > 0 && !s.since.IsZero() && time.Since(s.since) >= s.need
+}
+
+// runExec runs a mid-session host command. Blocking here is the contract:
+// after this returns, the change the command made exists, so whatever the
+// session waits for next is waiting on the program noticing it rather than on
+// a race (#380).
+func (d *sessionDriver) runExec(ctx context.Context, i int, e *spec.PTYExec) *sessionOutcome {
+	if xerr := runSessionExec(ctx, e, d.proc.dir, d.proc.env); xerr != nil {
+		return d.failHard(fmt.Errorf("pty %q: session[%d]: %w", d.p.Command, i, xerr))
+	}
+	return nil
+}
+
+// applyResize changes the terminal size mid-session (#379). The boundary is
+// recorded before changing the size, so the replay that builds the rendered
+// screen splits the transcript at the same point the real terminal did.
+func (d *sessionDriver) applyResize(i int, r *spec.PTYResize) *sessionOutcome {
+	d.term.markResize(r.Rows, r.Cols)
+	if rerr := d.proc.resize(r.Rows, r.Cols); rerr != nil {
+		return d.failHard(fmt.Errorf("pty %q: session[%d] resize to %dx%d: %w",
+			d.p.Command, i, r.Rows, r.Cols, rerr))
+	}
+	return nil
+}
+
+// send writes one send payload to the terminal, first refusing a paste or a
+// mouse event the program never asked to receive.
+func (d *sessionDriver) send(i int, s *spec.PTYSend) *sessionOutcome {
+	// A paste is only a paste if the program asked for one. Without the
+	// mode, the markers arrive as ordinary characters and the failure
+	// surfaces somewhere far away — as a REPL executing a pasted block
+	// line by line, or as "[200~" typed into a prompt — so refuse here,
+	// where the mistake is (#378).
+	if s.Paste != nil && !d.term.modeEnabled(decsetBracketedPaste) {
+		return d.failHard(fmt.Errorf(
+			"pty %q: session[%d] sends a paste, but the program has not enabled bracketed paste "+
+				"(it never wrote ESC [?2004h, or turned the mode back off). "+
+				"Programs that do not distinguish a paste from typing take a plain send instead; "+
+				"if this one does enable the mode, wait for it with an expect or expect_screen before pasting",
+			d.p.Command, i))
+	}
+	// A mouse event only means something to a program that asked to be
+	// told about the mouse, and in the encoding atago speaks (#381).
+	if s.Mouse != nil {
+		if merr := checkMouseMode(d.term, d.p.Command, i); merr != nil {
+			return d.failHard(merr)
+		}
+	}
+	// Bytes resolves named keys to their xterm sequences, wraps a paste
+	// in its markers, and keeps the historical rule that an empty
+	// verbatim send transmits EOF (^D).
+	if _, werr := d.term.write(s.Bytes()); werr != nil {
+		return d.failHard(fmt.Errorf("pty: send: %w", werr))
+	}
+	return nil
 }
 
 // isSessionEnd reports whether a terminal read error is how a session ends

--- a/internal/runner/ptyrun/session.go
+++ b/internal/runner/ptyrun/session.go
@@ -285,7 +285,7 @@ func (d *sessionDriver) waitExpect(ctx context.Context, re *regexp.Regexp, patte
 func (d *sessionDriver) waitExpectScreen(ctx context.Context, es *spec.PTYExpectScreen) *sessionOutcome {
 	waitCtx, cancelWait := sessionWaitContext(ctx, es.Timeout)
 	defer cancelWait()
-	matched := false
+	var matched bool
 	stable := &stability{need: parsePositiveDuration(es.StableFor)}
 	scannedTo := -1 // transcript length at the last render; -1 forces one
 	for {

--- a/internal/runner/ptyrun/testdata/fuzz/FuzzRenderScreen/cf6a30d8e3be1a01
+++ b/internal/runner/ptyrun/testdata/fuzz/FuzzRenderScreen/cf6a30d8e3be1a01
@@ -1,0 +1,4 @@
+go test fuzz v1
+[]byte("\xd10̎")
+int(84)
+int(-45)


### PR DESCRIPTION
## Summary

Fourth pass of the v1.0.0 refactoring series (after #445, #446, #447), attacking the two most complex functions in the repository: driveSession (cognitive complexity 156) and sanitizeTranscriptMarks (61). Both are restructured into named stages with no behavior change, verified by the package's race-enabled tests, the seed fuzz corpus, and a fresh 60s FuzzRenderScreen run.

## Changes

- internal/runner/ptyrun/session.go: driveSession is now a thin loop over a sessionDriver whose methods are the session's real vocabulary — finish/abort/failHard/canceled (the former closures), waitExpect, waitExpectScreen, runExec, applyResize, and send. A step handler returns a sessionOutcome to end the session or nil to continue. The stable_for evaluation that was written out three times inside the expect_screen loop is one stability tracker (observe / heldWithoutRedraw) with the semantics stated once.
- internal/runner/ptyrun/screen.go: sanitizeTranscriptMarks keeps the outer scan and mark translation; the escape-kind decision moved to escDecider, the CSI-body walk to scanCSIBody (returning a csiScan with the parameter bytes, embedded control codes, malformation flags, and the ESC-abort marker), and the four-way emit decision to emitCSI.
- internal/runner/ptyrun/fuzz_test.go: the column-budget invariant now counts grapheme clusters instead of runes. The rune property predates #437 (grapheme clusters kept whole per cell): a combining mark legally shares its base's cell, so "0" + U+030E is one column but two runes. A cached fuzz corpus entry exposing this is promoted to a seed (testdata/fuzz/FuzzRenderScreen/cf6a30d8e3be1a01) so the stale property can never quietly return.

## Design Decisions

- The sessionOutcome triple mirrors driveSession's return exactly, so each handler ends the session with the same shapes the monolith produced — no new states were invented.
- scanCSIBody's abortedByESC ends the scan with `end` pointing AT the aborting ESC, reproducing the original `i = k; continue scan` byte-for-byte; the fuzz corpus (1387 inputs) plus a fresh 60-second run holds the line on the quadrillion-step CBT and split-sequence hazards this code exists for.
- The fuzz property fix is in this PR because the sanitizer refactor is what re-ran the cached corpus and surfaced it; it is a test-only change and the rendered screen is untouched.

## Limitations

- The fuzz invariant is deliberately the loosest sound one (cluster count ≤ cols) rather than display width, so it stays valid even where the emulator's width table and uniseg disagree on ambiguous-width characters.