### PR TITLE
refactor: clear the last complexity hot spots and enforce the bounds in lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,10 +13,12 @@ linters:
     - errorlint
     - gocheckcompilerdirectives
     - gochecknoinits
+    - gocognit
     - gosec
     - govet
     - ineffassign
     - misspell
+    - nestif
     - nilerr
     - noctx
     - nolintlint
@@ -29,6 +31,12 @@ linters:
     - wastedassign
     - whitespace
   settings:
+    # The 2026-08 refactoring series brought every production function under
+    # these bounds; the linters keep the next hot spot from growing back.
+    gocognit:
+      min-complexity: 30
+    nestif:
+      min-complexity: 5
     errcheck:
       disable-default-exclusions: false
       check-type-assertions: true
@@ -58,6 +66,12 @@ linters:
       # spec text; gosec's G304/G101 are noise there.
       - linters:
           - gosec
+        path: _test\.go
+      # Table-driven tests and fuzz harnesses are long by nature; the
+      # complexity bounds are a production-code contract.
+      - linters:
+          - gocognit
+          - nestif
         path: _test\.go
     paths:
       - third_party$

--- a/internal/assert/jsonmatch.go
+++ b/internal/assert/jsonmatch.go
@@ -366,45 +366,15 @@ func valuesEqual(node, want any) bool {
 	// operand keeps number/numeric-string equality while making string-vs-string
 	// byte-exact.
 	if isNumericKind(node) || isNumericKind(want) {
-		// Prefer exact integer comparison. Two distinct integers beyond 2^53 (a
-		// JSON id, or a value beyond int64 that decodes as json.Number) round to
-		// the same float64, so a float compare would report them equal. big.Int
-		// keeps every digit.
-		if ni, ok := toBigInt(node); ok {
-			if wi, ok := toBigInt(want); ok {
-				return ni.Cmp(wi) == 0
-			}
-		}
-		if nf, ok := toFloat(node); ok {
-			if wf, ok := toFloat(want); ok {
-				return nf == wf
-			}
+		if eq, ok := numericEqual(node, want); ok {
+			return eq
 		}
 	}
 	switch n := node.(type) {
 	case map[string]any:
-		w, ok := want.(map[string]any)
-		if !ok || len(n) != len(w) {
-			return false
-		}
-		for k, nv := range n {
-			wv, present := w[k]
-			if !present || !valuesEqual(nv, wv) {
-				return false
-			}
-		}
-		return true
+		return mapValuesEqual(n, want)
 	case []any:
-		w, ok := want.([]any)
-		if !ok || len(n) != len(w) {
-			return false
-		}
-		for i := range n {
-			if !valuesEqual(n[i], w[i]) {
-				return false
-			}
-		}
-		return true
+		return sliceValuesEqual(n, want)
 	case string:
 		// A non-numeric node vs a string is a string match (the string-vs-number
 		// case was already handled by the numeric branch above). Comparing by
@@ -420,6 +390,59 @@ func valuesEqual(node, want any) bool {
 		return want == nil
 	}
 	return fmt.Sprintf("%v", node) == fmt.Sprintf("%v", want)
+}
+
+// numericEqual compares two values numerically. ok is false when neither the
+// exact-integer nor the float comparison applied (one side is not a number in
+// any usable shape), telling valuesEqual to fall through to the structural
+// rules. Exact integer comparison is preferred: two distinct integers beyond
+// 2^53 (a JSON id, or a value beyond int64 that decodes as json.Number) round
+// to the same float64, so a float compare would report them equal. big.Int
+// keeps every digit.
+func numericEqual(node, want any) (eq, ok bool) {
+	if ni, o := toBigInt(node); o {
+		if wi, o := toBigInt(want); o {
+			return ni.Cmp(wi) == 0, true
+		}
+	}
+	if nf, o := toFloat(node); o {
+		if wf, o := toFloat(want); o {
+			return nf == wf, true
+		}
+	}
+	return false, false
+}
+
+// mapValuesEqual compares a JSON object with the expected value, key-order
+// independent (#40): want must be an object with the same keys, every value
+// equal.
+func mapValuesEqual(n map[string]any, want any) bool {
+	w, ok := want.(map[string]any)
+	if !ok || len(n) != len(w) {
+		return false
+	}
+	for k, nv := range n {
+		wv, present := w[k]
+		if !present || !valuesEqual(nv, wv) {
+			return false
+		}
+	}
+	return true
+}
+
+// sliceValuesEqual compares a JSON array with the expected value elementwise,
+// in order.
+func sliceValuesEqual(n []any, want any) bool {
+	w, ok := want.([]any)
+	if !ok || len(n) != len(w) {
+		return false
+	}
+	for i := range n {
+		if !valuesEqual(n[i], w[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 // isNumericKind reports whether v is a genuine number (not an arbitrary numeric

--- a/internal/assert/mock.go
+++ b/internal/assert/mock.go
@@ -54,28 +54,38 @@ func checkMock(m *spec.MockAssert, env Env) *CheckResult {
 		}
 	}
 
-	if m.Header != nil || m.Body != nil {
-		if len(matched) == 0 {
-			// Count: 0 with matchers is contradictory; the validator rejects it,
-			// but stay safe for direct API users.
-			return &CheckResult{Desc: desc, Hint: "header/body matchers need at least one matching request"}
-		}
-		last := matched[len(matched)-1]
-		if m.Header != nil {
-			if cr := checkHeaderValue(m.Header, last.Header.Get(m.Header.Name), "recorded request"); !cr.OK {
-				return cr
-			}
-		}
-		if m.Body != nil {
-			if cr := checkStream("mock request body", m.Body, last.Body, true, env); !cr.OK {
-				return cr
-			}
-		}
+	if cr := checkMockRequestMatchers(m, desc, matched, env); cr != nil {
+		return cr
 	}
 	if m.Count != nil {
 		return pass(fmt.Sprintf("assert mock %q received %s", m.Name, plural.Count(*m.Count, "request", "requests")))
 	}
 	return pass(desc + " received a matching request")
+}
+
+// checkMockRequestMatchers applies the header/body matchers to the LAST
+// matching recorded request. It returns nil when they hold (or none are set).
+func checkMockRequestMatchers(m *spec.MockAssert, desc string, matched []mock.Record, env Env) *CheckResult {
+	if m.Header == nil && m.Body == nil {
+		return nil
+	}
+	if len(matched) == 0 {
+		// Count: 0 with matchers is contradictory; the validator rejects it,
+		// but stay safe for direct API users.
+		return &CheckResult{Desc: desc, Hint: "header/body matchers need at least one matching request"}
+	}
+	last := matched[len(matched)-1]
+	if m.Header != nil {
+		if cr := checkHeaderValue(m.Header, last.Header.Get(m.Header.Name), "recorded request"); !cr.OK {
+			return cr
+		}
+	}
+	if m.Body != nil {
+		if cr := checkStream("mock request body", m.Body, last.Body, true, env); !cr.OK {
+			return cr
+		}
+	}
+	return nil
 }
 
 // mockFilterLabel names the path/method filter for Expected lines.

--- a/internal/assert/tree.go
+++ b/internal/assert/tree.go
@@ -193,6 +193,34 @@ func checkDirRecursive(d *spec.DirAssert, dirPath string) *CheckResult {
 	// "what does the tree actually hold?".
 	listing := treeListing(entries)
 
+	if cr := checkTreeContains(d, present, listing); cr != nil {
+		return cr
+	}
+
+	if d.Count != nil && files != *d.Count {
+		return dirCountFailure(d, files, fmt.Sprintf("exactly %d files in the tree", *d.Count), listing)
+	}
+	if d.MinCount != nil && files < *d.MinCount {
+		return dirCountFailure(d, files, fmt.Sprintf("at least %d files in the tree", *d.MinCount), listing)
+	}
+	if d.MaxCount != nil && files > *d.MaxCount {
+		return dirCountFailure(d, files, fmt.Sprintf("at most %d files in the tree", *d.MaxCount), listing)
+	}
+
+	if d.Glob != "" && !treeGlobMatches(d.Glob, entries) {
+		return &CheckResult{
+			Desc:     fmt.Sprintf("assert dir %q glob %q", d.Path, d.Glob),
+			Expected: fmt.Sprintf("at least one tree entry matching %q", d.Glob),
+			Actual:   listing,
+			Hint:     fmt.Sprintf("no entry under %q matched glob %q (recursive)", d.Path, d.Glob),
+		}
+	}
+	return nil
+}
+
+// checkTreeContains enforces contains/not_contains over the walked tree's
+// path set. nil means both lists hold.
+func checkTreeContains(d *spec.DirAssert, present map[string]bool, listing string) *CheckResult {
 	for _, child := range d.Contains {
 		if !present[path.Clean(filepath.ToSlash(child))] {
 			return &CheckResult{
@@ -213,41 +241,24 @@ func checkDirRecursive(d *spec.DirAssert, dirPath string) *CheckResult {
 			}
 		}
 	}
-
-	if d.Count != nil && files != *d.Count {
-		return dirCountFailure(d, files, fmt.Sprintf("exactly %d files in the tree", *d.Count), listing)
-	}
-	if d.MinCount != nil && files < *d.MinCount {
-		return dirCountFailure(d, files, fmt.Sprintf("at least %d files in the tree", *d.MinCount), listing)
-	}
-	if d.MaxCount != nil && files > *d.MaxCount {
-		return dirCountFailure(d, files, fmt.Sprintf("at most %d files in the tree", *d.MaxCount), listing)
-	}
-
-	if d.Glob != "" {
-		matched := false
-		for _, e := range entries {
-			if ok, _ := path.Match(d.Glob, e.rel); ok {
-				matched = true
-				break
-			}
-			if !strings.Contains(d.Glob, "/") {
-				if ok, _ := path.Match(d.Glob, path.Base(e.rel)); ok {
-					matched = true
-					break
-				}
-			}
-		}
-		if !matched {
-			return &CheckResult{
-				Desc:     fmt.Sprintf("assert dir %q glob %q", d.Path, d.Glob),
-				Expected: fmt.Sprintf("at least one tree entry matching %q", d.Glob),
-				Actual:   listing,
-				Hint:     fmt.Sprintf("no entry under %q matched glob %q (recursive)", d.Path, d.Glob),
-			}
-		}
-	}
 	return nil
+}
+
+// treeGlobMatches reports whether any walked entry matches the glob — against
+// its tree-relative path, or (for a glob with no separator) its base name, so
+// "*.log" finds a log anywhere in the tree.
+func treeGlobMatches(glob string, entries []treeEntry) bool {
+	for _, e := range entries {
+		if ok, _ := path.Match(glob, e.rel); ok {
+			return true
+		}
+		if !strings.Contains(glob, "/") {
+			if ok, _ := path.Match(glob, path.Base(e.rel)); ok {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // checkDirSnapshot compares (or updates) the tree's golden manifest (#25).

--- a/internal/docgen/docgen.go
+++ b/internal/docgen/docgen.go
@@ -333,49 +333,63 @@ func clearedEnvBullet(passEnv []string) string {
 func commands(steps []spec.Step, expand func(string) string) []string {
 	var out []string
 	for i := range steps {
-		step := &steps[i]
-		switch step.Kind() {
-		case spec.StepRun:
-			out = append(out, expand(step.Run.Command))
-		case spec.StepHTTP:
-			if step.HTTP != nil {
-				out = append(out, fmt.Sprintf("# HTTP %s %s", step.HTTP.Method, expand(step.HTTP.Path)))
-			}
-		case spec.StepQuery:
-			if step.Query != nil {
-				out = append(out, fmt.Sprintf("# SQL via %s: %s", step.Query.Runner, expand(step.Query.SQL)))
-			}
-		case spec.StepGRPC:
-			if step.GRPC != nil {
-				out = append(out, fmt.Sprintf("# gRPC %s via %s", step.GRPC.Method, step.GRPC.Runner))
-			}
-		case spec.StepPTY:
-			if step.PTY != nil {
-				out = append(out, fmt.Sprintf("# interactive (pty): %s", expand(step.PTY.Command)))
-			}
-		case spec.StepCDP:
-			if step.CDP != nil {
-				out = append(out, "# CDP via "+step.CDP.Runner+": "+cdpActions(step.CDP))
-			}
-		case spec.StepStore:
-			if step.Store != nil {
-				out = append(out, fmt.Sprintf("# capture ${%s} from %s", step.Store.Name, storeSourceLabel(step.Store)))
-			}
-		case spec.StepSignal:
-			if step.Signal != nil {
-				line := fmt.Sprintf("# send SIG%s to service %s", spec.NormalizeSignalName(step.Signal.Signal), expand(step.Signal.Service))
-				if step.Signal.Wait != nil {
-					timeout := step.Signal.Wait.Timeout
-					if timeout == "" {
-						timeout = "5s"
-					}
-					line += fmt.Sprintf(" and wait up to %s for exit", timeout)
-				}
-				out = append(out, line)
-			}
+		if line, ok := commandLine(&steps[i], expand); ok {
+			out = append(out, line)
 		}
 	}
 	return out
+}
+
+// commandLine renders one step's "When" line; ok is false for a step kind that
+// contributes nothing (fixtures, asserts).
+func commandLine(step *spec.Step, expand func(string) string) (string, bool) {
+	switch step.Kind() {
+	case spec.StepRun:
+		return expand(step.Run.Command), true
+	case spec.StepHTTP:
+		if step.HTTP != nil {
+			return fmt.Sprintf("# HTTP %s %s", step.HTTP.Method, expand(step.HTTP.Path)), true
+		}
+	case spec.StepQuery:
+		if step.Query != nil {
+			return fmt.Sprintf("# SQL via %s: %s", step.Query.Runner, expand(step.Query.SQL)), true
+		}
+	case spec.StepGRPC:
+		if step.GRPC != nil {
+			return fmt.Sprintf("# gRPC %s via %s", step.GRPC.Method, step.GRPC.Runner), true
+		}
+	case spec.StepPTY:
+		if step.PTY != nil {
+			return fmt.Sprintf("# interactive (pty): %s", expand(step.PTY.Command)), true
+		}
+	case spec.StepCDP:
+		if step.CDP != nil {
+			return "# CDP via " + step.CDP.Runner + ": " + cdpActions(step.CDP), true
+		}
+	case spec.StepStore:
+		if step.Store != nil {
+			return fmt.Sprintf("# capture ${%s} from %s", step.Store.Name, storeSourceLabel(step.Store)), true
+		}
+	case spec.StepSignal:
+		if step.Signal != nil {
+			return signalLine(step.Signal, expand), true
+		}
+	}
+	return "", false
+}
+
+// signalLine renders a signal step's "When" line, naming the wait budget when
+// the step also waits for the service to exit.
+func signalLine(sg *spec.Signal, expand func(string) string) string {
+	line := fmt.Sprintf("# send SIG%s to service %s", spec.NormalizeSignalName(sg.Signal), expand(sg.Service))
+	if sg.Wait != nil {
+		timeout := sg.Wait.Timeout
+		if timeout == "" {
+			timeout = "5s"
+		}
+		line += fmt.Sprintf(" and wait up to %s for exit", timeout)
+	}
+	return line
 }
 
 // storeSourceLabel names where a store step reads its value from.

--- a/internal/runner/browser/download.go
+++ b/internal/runner/browser/download.go
@@ -25,24 +25,7 @@ func downloadAction(clickSelector, destDir string, name *string) chromedp.Action
 			return fmt.Errorf("cdp download: %w", err)
 		}
 
-		willBegin := make(chan string, 1)
-		done := make(chan string, 1)
-		chromedp.ListenTarget(ctx, func(ev any) {
-			switch e := ev.(type) {
-			case *browser.EventDownloadWillBegin:
-				select {
-				case willBegin <- e.SuggestedFilename:
-				default:
-				}
-			case *browser.EventDownloadProgress:
-				if e.State == browser.DownloadProgressStateCompleted {
-					select {
-					case done <- e.GUID:
-					default:
-					}
-				}
-			}
-		})
+		willBegin, done := listenDownloadEvents(ctx)
 
 		// AllowAndName saves each download under its GUID in destDir and emits the
 		// progress events we listen for.
@@ -64,22 +47,7 @@ func downloadAction(clickSelector, destDir string, name *string) chromedp.Action
 			return fmt.Errorf("cdp download: timed out waiting for the download to finish: %w", ctx.Err())
 		}
 
-		// The suggested filename is captured from the will-begin event; fall back to
-		// the GUID when the browser did not provide one. filepath.Base defends
-		// against a server-suggested name containing path separators.
-		suggested := guid
-		select {
-		case s := <-willBegin:
-			if s != "" {
-				suggested = s
-			}
-		default:
-		}
-		final := filepath.Base(suggested)
-		if final == "." || final == "/" || final == "" {
-			final = guid
-		}
-
+		final := downloadFinalName(guid, willBegin)
 		src := filepath.Join(destDir, guid)
 		dst := filepath.Join(destDir, final)
 		if src != dst {
@@ -90,4 +58,50 @@ func downloadAction(clickSelector, destDir string, name *string) chromedp.Action
 		*name = final
 		return nil
 	})
+}
+
+// listenDownloadEvents subscribes to the target's download events: willBegin
+// receives the server-suggested filename, done the GUID of a completed
+// download. Both channels are buffered so the listener never blocks the event
+// loop.
+func listenDownloadEvents(ctx context.Context) (willBegin, done chan string) {
+	willBegin = make(chan string, 1)
+	done = make(chan string, 1)
+	chromedp.ListenTarget(ctx, func(ev any) {
+		switch e := ev.(type) {
+		case *browser.EventDownloadWillBegin:
+			select {
+			case willBegin <- e.SuggestedFilename:
+			default:
+			}
+		case *browser.EventDownloadProgress:
+			if e.State == browser.DownloadProgressStateCompleted {
+				select {
+				case done <- e.GUID:
+				default:
+				}
+			}
+		}
+	})
+	return willBegin, done
+}
+
+// downloadFinalName picks the deterministic base name for a completed
+// download: the suggested filename captured from the will-begin event, falling
+// back to the GUID when the browser did not provide one. filepath.Base defends
+// against a server-suggested name containing path separators.
+func downloadFinalName(guid string, willBegin <-chan string) string {
+	suggested := guid
+	select {
+	case s := <-willBegin:
+		if s != "" {
+			suggested = s
+		}
+	default:
+	}
+	final := filepath.Base(suggested)
+	if final == "." || final == "/" || final == "" {
+		final = guid
+	}
+	return final
 }

--- a/internal/spec/pty_send.go
+++ b/internal/spec/pty_send.go
@@ -70,49 +70,63 @@ func (p *PTYSend) UnmarshalYAML(node ast.Node) error {
 		return fail("send must be a string or {key: <name>} (e.g. {key: enter})")
 	}
 	for k, v := range raw {
-		switch k {
-		case "key":
-			str, ok := v.(string)
-			if !ok {
-				return fail("send.key must be a string")
-			}
-			p.Key = strings.ToLower(strings.TrimSpace(str))
-		case "times":
-			// The range check lives here rather than in the loader because this
-			// is the only layer that can still tell an authored `times: 0` from
-			// an omitted one — the decoded field is a plain int, so by the time
-			// validation runs the two are the same value.
-			n, ok := asInt(v)
-			if !ok {
-				return fail("send.times must be an integer (e.g. {key: left, times: 16})")
-			}
-			if n < 1 {
-				return fail("send.times must be at least 1 (got %d); omit it for a single press", n)
-			}
-			if n > MaxPTYSendTimes {
-				return fail("send.times must not exceed %d (got %d)", MaxPTYSendTimes, n)
-			}
-			p.Times = n
-		case "paste":
-			str, ok := v.(string)
-			if !ok {
-				return fail("send.paste must be a string")
-			}
-			p.Paste = &str
-		case "mouse":
-			var mouse PTYMouse
-			raw, ok := v.(map[string]any)
-			if !ok {
-				return fail("send.mouse must be a mapping (e.g. {mouse: {row: 5, col: 12}})")
-			}
-			if err := decodeMouse(raw, &mouse, fail); err != nil {
-				return err
-			}
-			p.Mouse = &mouse
-		default:
-			return fail("send: unknown key %q (accepted: key, times, paste, mouse)", k)
+		if err := p.decodeSendField(k, v, fail); err != nil {
+			return err
 		}
 	}
+	return p.checkSendShape(fail)
+}
+
+// decodeSendField decodes one key of the send mapping, rejecting unknown keys.
+func (p *PTYSend) decodeSendField(k string, v any, fail func(string, ...any) error) error {
+	switch k {
+	case "key":
+		str, ok := v.(string)
+		if !ok {
+			return fail("send.key must be a string")
+		}
+		p.Key = strings.ToLower(strings.TrimSpace(str))
+	case "times":
+		// The range check lives here rather than in the loader because this
+		// is the only layer that can still tell an authored `times: 0` from
+		// an omitted one — the decoded field is a plain int, so by the time
+		// validation runs the two are the same value.
+		n, ok := asInt(v)
+		if !ok {
+			return fail("send.times must be an integer (e.g. {key: left, times: 16})")
+		}
+		if n < 1 {
+			return fail("send.times must be at least 1 (got %d); omit it for a single press", n)
+		}
+		if n > MaxPTYSendTimes {
+			return fail("send.times must not exceed %d (got %d)", MaxPTYSendTimes, n)
+		}
+		p.Times = n
+	case "paste":
+		str, ok := v.(string)
+		if !ok {
+			return fail("send.paste must be a string")
+		}
+		p.Paste = &str
+	case "mouse":
+		var mouse PTYMouse
+		raw, ok := v.(map[string]any)
+		if !ok {
+			return fail("send.mouse must be a mapping (e.g. {mouse: {row: 5, col: 12}})")
+		}
+		if err := decodeMouse(raw, &mouse, fail); err != nil {
+			return err
+		}
+		p.Mouse = &mouse
+	default:
+		return fail("send: unknown key %q (accepted: key, times, paste, mouse)", k)
+	}
+	return nil
+}
+
+// checkSendShape enforces the mapping form's one-of rule (key/paste/mouse) and
+// that times only ever qualifies a named key.
+func (p *PTYSend) checkSendShape(fail func(string, ...any) error) error {
 	if countSet(p.Key != "", p.Paste != nil, p.Mouse != nil) > 1 {
 		return fail("send: set exactly one of {key: <name>}, {paste: <text>}, or {mouse: {...}}")
 	}


### PR DESCRIPTION
## Summary

Final pass of the v1.0.0 refactoring series (#445, #446, #447, #448). The five remaining functions above the cognitive-complexity threshold and the three remaining deep-nesting sites are decomposed, bringing the production codebase to zero gocognit/nestif findings — and the closing commit adds both linters to .golangci.yml so the next hot spot cannot grow back unnoticed.

## Changes

- internal/runner/browser/download.go: downloadAction (cognitive complexity 37) split into listenDownloadEvents and downloadFinalName around the chromedp action's own flow.
- internal/assert/jsonmatch.go: valuesEqual (34) now dispatches to numericEqual (the exact-big.Int-then-float ladder), mapValuesEqual, and sliceValuesEqual.
- internal/assert/mock.go: the header/body matcher block moved to checkMockRequestMatchers.
- internal/assert/tree.go: checkDirRecursive (31) delegates to checkTreeContains and treeGlobMatches.
- internal/docgen/docgen.go: commands (33) renders each step through commandLine, with the signal wait narration in signalLine.
- internal/spec/pty_send.go: PTYSend.UnmarshalYAML (34) split into decodeSendField (per-key decode) and checkSendShape (the one-of and times rules).
- .golangci.yml: enable gocognit (min-complexity 30) and nestif (min-complexity 5), excluded for _test.go the same way gosec already is — table-driven tests and fuzz harnesses are long by nature, and the bound is a production-code contract.

## Design Decisions

- Every extraction keeps the original failure messages and evaluation order byte-for-byte; the full suite (33 packages), the repo lint config with the new linters active, and the 542-scenario self-hosted E2E run are green.
- The lint thresholds are the linters' conventional defaults, stated explicitly so a future default change upstream cannot silently move the bar.

## Limitations

- gocyclo still reports functions above 15 (flat switches over step kinds and assert targets); cyclomatic complexity punishes exactly the flat dispatch shapes this series steered toward, so it is deliberately not enforced.