### PR TITLE
chore(release): v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-08-15
+
 ### Added
 
 - Third-party E2E suite for [OpenFGA](https://openfga.dev/), in
@@ -56,6 +58,15 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- A `file:` assertion's `exists:` and `executable:` matchers now stat their
+  target without following a symlink, bound to the scenario workdir — the same
+  rule the read path (`contains:`/`equals:`) and `size:` already apply. A
+  program under test could plant a symlink at the assertion target and have
+  `exists: true` or `executable: true` answered with the existence or execute
+  bit of a HOST file outside the workdir; the same assert family refused to
+  READ through that link, so one planted link made the assertion disagree with
+  itself. A symlink at the target is now refused outright for all of them, and
+  a plainly missing file still answers `exists: false`.
 - The live terminal that answers a program's device queries during a `pty`
   session (DA1, cursor-position and status reports) now runs the incoming bytes
   through the same CSI sanitizer the screen render uses, carried across read


### PR DESCRIPTION
## Summary

Stamps the Unreleased section as 0.20.0 (2026-08-15) and records one behavior change that had not yet reached the changelog: the file assertion's exists/executable matchers now stat through security.StatNoFollow (from #446), aligning them with the read and size paths so a planted symlink can no longer have them answered with host-file metadata.

## Changes

- CHANGELOG.md: move Unreleased under `## [0.20.0] - 2026-08-15` and add the exists/executable StatNoFollow entry under Fixed.

## Release contents

- Added: the OpenFGA third-party E2E suite; the website comparison and migration-guide pages backed by CI-run parity suites.
- Changed: `record --pty` flags unanchored back-to-back sends; `record` anchors an observed stderr on its first informative line; pty expects anchor on informative output rather than decoration.
- Fixed: pty device-query sanitizing across read boundaries; grapheme clusters and wide characters in screen assertions; os.Root-bound confined I/O; ancestor-symlink containment; dir-assert symlinked roots; raw-mode TUI keystrokes no longer masked as secrets; the macOS fast-exit transcript race; and the exists/executable symlink refusal above.
- Internal (not in release notes): the #445–#449 refactoring series brought every production function under the gocognit/nestif bounds now enforced in lint; no new spec keys, so website/data/spec_keys.json needs no stamp.

Verified locally: full test suite (33 packages, drift guards included), repo lint, `make release-smoke` (archives, packages, cask, scoop manifest, Docker snapshot images all built and verified).