### PR TITLE
feat(release): publish Windows builds to winget

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,10 @@ jobs:
           # Tap-scoped token so the Homebrew cask can be pushed to
           # nao1215/homebrew-tap (#79). Only used by the publish step on a real tag.
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+          # Fork-scoped token so the winget manifests can be pushed to
+          # nao1215/winget-pkgs and the pull request opened against
+          # microsoft/winget-pkgs. Also only used on a real tag.
+          WINGET_GITHUB_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -84,6 +84,54 @@ scoops:
     license: MIT
     commit_msg_template: "chore(scoop): update the bucket manifest for {{ .Tag }}"
 
+# winget distribution for Windows. The Windows archives are already zips, which
+# winget installs as a portable package, so `winget install nao1215.atago` puts
+# atago.exe on PATH without an installer. GoReleaser writes the three manifests
+# (version, installer, locale) to a branch on nao1215/winget-pkgs — a fork of
+# the community repository — and opens the pull request against
+# microsoft/winget-pkgs, so a tag is still the only manual step. Skipped by
+# `--skip=publish` (release-smoke) and, via `skip_upload: auto`, on pre-release
+# tags, which the community repository does not accept.
+winget:
+  - name: atago
+    package_identifier: nao1215.atago
+    publisher: nao1215
+    publisher_url: "https://github.com/nao1215"
+    publisher_support_url: "https://github.com/nao1215/atago/issues"
+    homepage: "https://github.com/nao1215/atago"
+    short_description: "Tests CLI behavior from plain YAML: exit codes, output, files, snapshots, and interactive terminals (PTY/TUI)"
+    description: |
+      atago runs a command-line program the way a user does and checks what
+      actually happened: the exit code, stdout and stderr, the files and
+      directories the run created or changed, golden snapshots, and interactive
+      terminal sessions driven through a real PTY. Scenarios are plain YAML, so
+      a test suite needs no test framework and no shell scripting.
+    license: MIT
+    license_url: "https://github.com/nao1215/atago/blob/main/LICENSE"
+    copyright: "Copyright (c) 2026 Naohiro CHIKAMATSU"
+    release_notes_url: "https://github.com/nao1215/atago/releases/tag/{{ .Tag }}"
+    tags:
+      - cli
+      - testing
+      - e2e
+      - end-to-end
+      - yaml
+      - tui
+      - golang
+    skip_upload: auto
+    repository:
+      owner: nao1215
+      name: winget-pkgs
+      branch: "atago-{{ .Version }}"
+      token: "{{ .Env.WINGET_GITHUB_TOKEN }}"
+      pull_request:
+        enabled: true
+        draft: false
+        base:
+          owner: microsoft
+          name: winget-pkgs
+          branch: master
+
 dockers_v2:
   - images:
       - "ghcr.io/nao1215/atago"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Windows installs through winget: `winget install nao1215.atago`. A stable tagged release pushes the generated manifests to a fork of the community repository and opens the pull request against microsoft/winget-pkgs, so the package tracks releases without a separate manual submission. A pre-release tag opens nothing, since the community repository takes stable versions only. The Windows archives are zips, which winget installs as a portable package — `atago.exe` lands on PATH with no installer to run.
+
 ## [0.20.0] - 2026-08-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -79,7 +79,13 @@ On macOS, Homebrew works too:
 brew install --cask nao1215/tap/atago
 ```
 
-On Windows, [Scoop](https://scoop.sh/) installs it from this repository's own bucket:
+On Windows, winget installs it from the community repository:
+
+```shell
+winget install nao1215.atago
+```
+
+[Scoop](https://scoop.sh/) installs it from this repository's own bucket:
 
 ```shell
 scoop bucket add nao1215 https://github.com/nao1215/atago

--- a/doc/RELEASE.md
+++ b/doc/RELEASE.md
@@ -34,6 +34,7 @@ The release workflow then:
 - signs the checksums with cosign (keyless) and attaches SBOMs
 - attests build provenance via GitHub OIDC
 - publishes a Homebrew cask to [nao1215/homebrew-tap](https://github.com/nao1215/homebrew-tap)
+- pushes the winget manifests to `nao1215/winget-pkgs` and opens the pull request against [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs), on a stable tag only
 
 ## Required secrets
 - `GITHUB_TOKEN`: provided automatically; used to create the GitHub Release.
@@ -41,6 +42,14 @@ The release workflow then:
   GoReleaser to push the Homebrew cask on a tagged release. The push-time
   release smoke skips publishing (`--skip=publish`), so only real tag releases
   need it.
+- `WINGET_GITHUB_TOKEN`: a **classic** personal access token with the `public_repo` scope. GoReleaser v2.16.0 uses this one token for both writes: committing the manifests to a branch on `nao1215/winget-pkgs` and opening the pull request against microsoft/winget-pkgs. A fine-grained token cannot do the second — it can only be scoped to repositories you own, and microsoft/winget-pkgs is not one of them, so the push succeeds and the pull request fails with 403. Same publish-time-only rule as the tap token.
+
+## The winget pull request
+A **stable** tagged release opens a pull request on microsoft/winget-pkgs; a moderator merges it, usually within a day, once their validation pipeline passes. A pre-release tag opens nothing: `skip_upload: auto` skips the winget pipe whenever the tag carries a pre-release suffix, because the community repository takes stable versions only.
+
+Nothing in the release depends on that pull request, so a rejected or delayed one never blocks a version — GoReleaser logs the failure and finishes the release. Watch the [pull requests authored by nao1215](https://github.com/microsoft/winget-pkgs/pulls/nao1215) after the first submission of a new package, which gets more review than an update to an existing one.
+
+If a release finishes but no pull request appears, the manifests were still generated and the recovery is manual: `dist/winget/manifests/n/nao1215/atago/<version>/` holds the three files, and they can be committed to a `atago-<version>` branch on the fork and submitted by hand. A failure at the push step points at the token's scope; a failure only at the pull-request step points at a fine-grained token.
 
 ## After releasing
 - Check the [Releases page](https://github.com/nao1215/atago/releases) for the

--- a/website/content/install.md
+++ b/website/content/install.md
@@ -1,6 +1,6 @@
 ---
 title: Install
-description: Install atago with go install, Homebrew, Scoop, the AUR, prebuilt binaries for Linux/macOS/Windows, or the setup-atago GitHub Action — and verify what you download.
+description: Install atago with go install, Homebrew, winget, Scoop, the AUR, prebuilt binaries for Linux/macOS/Windows, or the setup-atago GitHub Action — and verify what you download.
 ---
 
 ```shell
@@ -13,7 +13,13 @@ On macOS, Homebrew works too:
 brew install --cask nao1215/tap/atago
 ```
 
-On Windows, [Scoop](https://scoop.sh/) installs it from atago's own bucket:
+On Windows, winget installs it from the community repository:
+
+```shell
+winget install nao1215.atago
+```
+
+[Scoop](https://scoop.sh/) installs it from atago's own bucket:
 
 ```shell
 scoop bucket add nao1215 https://github.com/nao1215/atago


### PR DESCRIPTION
## Summary

Windows users can install atago with Scoop today, but only after adding a bucket by hand. winget is the package manager that ships with Windows, and the release already builds everything it needs: the Windows archives are zips, which winget installs as a portable package, so `winget install nao1215.atago` puts atago.exe on PATH with no installer to build or sign.

GoReleaser writes the three manifests to a branch on nao1215/winget-pkgs, a fork of the community repository, and opens the pull request against microsoft/winget-pkgs. A tag stays the only manual step. Pre-release tags are skipped via `skip_upload: auto` because the community repository does not accept them, and a failure there is logged without failing the release, so a rejected or delayed pull request cannot block a version.

The release workflow gains `WINGET_GITHUB_TOKEN`, a token scoped to the fork with contents and pull-request write. doc/RELEASE.md documents it next to `TAP_GITHUB_TOKEN` and describes what to expect from the upstream review.

Verified locally with the pinned GoReleaser (v2.16.0) and with v2.17.1: both generate the version, installer, and locale manifests, with x64 and arm64 installers pointing at the release zips, `NestedInstallerType: portable`, and `PortableCommandAlias: atago`. ReleaseSmoke covers the same generation on every PR, since only the upload is skipped there.

Related issue: <!-- e.g. Closes #123, or Refs #123 if the reporter should confirm first -->

## Checklist

- [ ] Tests added or updated
- [x] `make build`, `make test`, `make vet`, and `make lint` pass locally
- [x] Docs updated when behavior changed (`README.md`, `CONTRIBUTING.md`, and release docs if needed)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] Cross-platform impact considered for Linux, macOS, and Windows


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows installation through WinGet.
  * Stable tagged releases now publish WinGet manifests and open upstream pull requests automatically.
  * Added portable ZIP installation guidance for placing `atago.exe` on PATH.

* **Documentation**
  * Updated the README, website installation page, changelog, and release guide with WinGet setup and release-process details.
  * Documented pre-release handling, validation, monitoring, recovery procedures, and non-blocking pull-request behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
