### PR TITLE
chore(release): stamp v0.20.1 in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.20.1] - 2026-08-15
+
 ### Added
 
 - Windows installs through winget: `winget install nao1215.atago`. A stable tagged release pushes the generated manifests to a fork of the community repository and opens the pull request against microsoft/winget-pkgs, so the package tracks releases without a separate manual submission. A pre-release tag opens nothing, since the community repository takes stable versions only. The Windows archives are zips, which winget installs as a portable package — `atago.exe` lands on PATH with no installer to run.


### PR DESCRIPTION
## Summary

Stamp the winget entry sitting under Unreleased as v0.20.1. Nothing else changes.

The release matters more than a patch usually does here: the winget pipe only runs on a tag, so `winget install nao1215.atago` starts working when this version is tagged, not when the feature merged. The tagged run also opens the first pull request against microsoft/winget-pkgs, which is a new-package submission and gets more review than a version update.

Related issue:

## Checklist

- [ ] Tests added or updated
- [x] `make build`, `make test`, `make vet`, and `make lint` pass locally
- [x] Docs updated when behavior changed (`README.md`, `CONTRIBUTING.md`, and release docs if needed)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] Cross-platform impact considered for Linux, macOS, and Windows
