### PR TITLE
docs(comparison): place atago against Microsoft TUI Test

### DIFF
--- a/website/content/comparison.md
+++ b/website/content/comparison.md
@@ -1,7 +1,7 @@
 ---
 toc: true
 title: Comparison
-description: How atago compares with Bats-core v1.14.0, ShellSpec 0.28.1, commander v2.5.0, goss v0.4.10, runn v1.9.4, and venom v1.3.0 — feature by feature, versions stated, sourced from official documentation.
+description: How atago compares with Bats-core v1.14.0, ShellSpec 0.28.1, commander v2.5.0, goss v0.4.10, runn v1.9.4, venom v1.3.0, and Microsoft TUI Test 0.0.4 — feature by feature, versions stated, sourced from official documentation.
 ---
 
 Every tool here is good software, written by people who understood their
@@ -9,18 +9,20 @@ problem well; several of them shaped how atago thinks about testing. This page
 exists to answer one practical question — *which tool owns which layer* — not
 to rank projects.
 
-Compared releases, checked on 2026-08-14 against each project's official
-documentation and release pages (linked under [Sources](#sources)):
+Compared releases, checked against each project's official documentation and
+release pages (linked under [Sources](#sources)) on 2026-08-14, and TUI Test on
+2026-08-15:
 
 | Tool | Release compared | Released |
 |------|------------------|----------|
-| [atago](https://github.com/nao1215/atago) | v0.19.0 | 2026 |
+| [atago](https://github.com/nao1215/atago) | v0.20.1 | 2026-08-15 |
 | [Bats-core](https://github.com/bats-core/bats-core) | v1.14.0 | 2026-07-21 |
 | [ShellSpec](https://github.com/shellspec/shellspec) | 0.28.1 | 2021-01-11 |
 | [commander](https://github.com/commander-cli/commander) | v2.5.0 | 2023-03-28 |
 | [goss](https://github.com/goss-org/goss) | v0.4.10 | 2026-07-26 |
 | [runn](https://github.com/k1LoW/runn) | v1.9.4 | 2026-06-30 |
 | [venom](https://github.com/ovh/venom) | v1.3.0 | 2026-01-06 |
+| [TUI Test](https://github.com/microsoft/tui-test) | 0.0.4 | 2026-04-04 |
 
 In the tables below, — means the compared release does not provide the
 feature itself, as far as its official documentation shows. If we got
@@ -53,7 +55,7 @@ test, they are the better choice:
 
 Bats, ShellSpec, and commander overlap with atago directly: all four run a
 command and assert on what happened. The tables compare that shared job.
-Columns are atago v0.19.0, Bats-core v1.14.0, ShellSpec 0.28.1, and
+Columns are atago v0.20.1, Bats-core v1.14.0, ShellSpec 0.28.1, and
 commander v2.5.0.
 
 ### Writing and running tests
@@ -116,6 +118,71 @@ commander v2.5.0.
 | Coverage of shell scripts | — | — | kcov integration built in | — |
 | Report formats | console / JSON / JUnit / GHA / TAP | pretty / TAP / TAP13 / JUnit | documentation / TAP / JUnit / custom | — |
 
+## The terminal layer: TUI applications
+
+[TUI Test](https://github.com/microsoft/tui-test) from Microsoft is the closest
+tool to atago on the axis atago is usually picked for — driving a real terminal
+and asserting on what a full-screen program drew. It deserves a careful look
+rather than a footnote, and if the terminal is the whole of what you are
+testing, it may well be the better fit.
+
+The columns below are atago v0.20.1 and TUI Test 0.0.4, its current stable
+release. Note that TUI Test is mid-rewrite: 0.0.4 is the TypeScript framework
+described here, while [0.1.0-beta.1](https://github.com/microsoft/tui-test/releases/tag/0.1.0-beta.1)
+(2026-08-10) is a Rust rewrite with a different shape — a session-driving CLI
+plus Rust, Python, and Node libraries, with the test-file format and suite
+runner gone from the CLI surface and a stated focus on AI agents driving a live
+terminal. The beta adds exit-code and command-output assertions, always-on
+[asciinema](https://asciinema.org/) recording, SVG screenshots, a live monitor
+view, and per-cell inspection. If you are choosing today, read the beta's
+README as well: the table below will be out of date the moment that line ships
+stable.
+
+### Driving and asserting on a terminal
+
+| | atago v0.20.1 | TUI Test 0.0.4 |
+|---|---|---|
+| Tests are written in | YAML | TypeScript / JavaScript |
+| Ships as | single binary | npm package (Node 16.6+, or Bun on macOS/Linux) |
+| Terminal emulation | vt10x, in-process | [xterm.js](https://xtermjs.org/) |
+| Isolation | fresh workdir and PTY per scenario | fresh terminal context (terminal + PTY) per test |
+| Named keys, typing, submit | `send:` with a named-key vocabulary | `keyPress` and per-key helpers, `submit`, `write` |
+| Mouse | clicks, drags, wheel, as SGR 1006 reports | `mouseDown` / `mousePress` / `mouseTo` / `mouseUp` |
+| Resize mid-session | `resize:` | `resize()` |
+| Assert on visible text | `expect_screen:` / `screen:` | `getByText(...)` with `toBeVisible` |
+| Assert on colors and styling | `attrs:` — fg, bg, bold, italic, underline, reverse, blink | `toHaveFgColor` / `toHaveBgColor` |
+| Screen snapshots | `snapshot:` with normalization and `atago snapshot update` | `toMatchSnapshot` |
+| Retry / flake handling | `retry:`, `--repeat`, `--retry-failed`, flake reported | `retries`, auto-wait before assertions |
+| Parallel execution | `--parallel` | `workers` |
+| What a failure leaves behind | `--artifacts-dir` writes the actual and expected payloads | traces record everything the terminal received, replayed with `show-trace` |
+| Replaying the session itself | — | traces, via `show-trace` |
+| Authoring a first test from a real session | `atago record --pty` writes the spec | — |
+| Windows | native, ConPTY | supported (Bun on macOS/Linux only) |
+| Shells driven | any executable, shell or not | cmd, Windows PowerShell, PowerShell, bash, git-bash, fish, zsh, xonsh |
+
+### Where each one is the better choice
+
+TUI Test is terminal-first: its world is the rendered screen, and it is very
+good at that. Its traces are a genuinely better debugging story than anything
+atago has — a full replay of what the terminal received, which is exactly what
+you want when a test fails only on someone else's machine. If your project is
+already a Node codebase, its tests are TypeScript next to your other tests,
+with the editor support and refactoring that brings, and Microsoft is behind
+it.
+
+atago is CLI-first, and the terminal is one surface among several. In 0.0.4 a
+test asserts on what the screen shows; there is no exit-code matcher, and no
+assertions about files the program wrote, the exact set of paths a run touched,
+a mock HTTP server it called, or a background service it needed. atago covers
+those in the same YAML file as the `pty:` session, so one scenario can drive a
+TUI and then check what it left on disk. atago also needs no host language or
+package manager — a single binary and a YAML file — which matters when the
+program under test is not written in JavaScript.
+
+Put plainly: if the terminal screen is the product, look hard at TUI Test. If
+the terminal is one of several things your CLI does, atago covers the rest of
+them without a second tool.
+
 ## Other tools you might be weighing
 
 Adjacent tools that come up in the same search, each with an honest placement
@@ -170,6 +237,10 @@ An honest table needs the reverse direction spelled out:
   XML assertions and a first-class docker execution node, which atago lacks.
 - goss / runn / venom own their layers outright, as described
   [above](#tools-that-own-a-different-layer).
+- TUI Test is the stronger choice when the terminal screen is the
+  product and your project is already a Node codebase, and its trace replay
+  beats anything atago offers for diagnosing a failure that only reproduces
+  elsewhere. See [the terminal layer](#the-terminal-layer-tui-applications).
 
 atago is also the youngest project on this page and still pre-1.0. The spec
 format is versioned and every feature ships with a runnable, CI-tested
@@ -192,4 +263,5 @@ release stated above:
 - goss: [README](https://github.com/goss-org/goss), [releases](https://github.com/goss-org/goss/releases)
 - runn: [README](https://github.com/k1LoW/runn), [releases](https://github.com/k1LoW/runn/releases)
 - venom: [README](https://github.com/ovh/venom), [releases](https://github.com/ovh/venom/releases)
+- TUI Test: [README at 0.0.4](https://github.com/microsoft/tui-test/blob/0.0.4/README.md), [beta README](https://github.com/microsoft/tui-test/blob/main/README.md), [releases](https://github.com/microsoft/tui-test/releases)
 - atago: the [reference](/reference/) and the [runnable examples](/cookbook/#every-feature-has-a-runnable-spec) behind every claim

--- a/website/content/comparison.md
+++ b/website/content/comparison.md
@@ -120,25 +120,7 @@ commander v2.5.0.
 
 ## The terminal layer: TUI applications
 
-[TUI Test](https://github.com/microsoft/tui-test) from Microsoft is the closest
-tool to atago on the axis atago is usually picked for — driving a real terminal
-and asserting on what a full-screen program drew. It deserves a careful look
-rather than a footnote, and if the terminal is the whole of what you are
-testing, it may well be the better fit.
-
-The columns below are atago v0.20.1 and TUI Test 0.0.4, its current stable
-release. Note that TUI Test is mid-rewrite: 0.0.4 is the TypeScript framework
-described here, while [0.1.0-beta.1](https://github.com/microsoft/tui-test/releases/tag/0.1.0-beta.1)
-(2026-08-10) is a Rust rewrite with a different shape — a session-driving CLI
-plus Rust, Python, and Node libraries, with the test-file format and suite
-runner gone from the CLI surface and a stated focus on AI agents driving a live
-terminal. The beta adds exit-code and command-output assertions, always-on
-[asciinema](https://asciinema.org/) recording, SVG screenshots, a live monitor
-view, and per-cell inspection. If you are choosing today, read the beta's
-README as well: the table below will be out of date the moment that line ships
-stable.
-
-### Driving and asserting on a terminal
+[TUI Test](https://github.com/microsoft/tui-test) from Microsoft is the closest tool to atago at driving a real terminal. Columns are atago v0.20.1 and TUI Test 0.0.4; [0.1.0-beta.1](https://github.com/microsoft/tui-test/releases/tag/0.1.0-beta.1) is a Rust rewrite with a different shape, so read its README too.
 
 | | atago v0.20.1 | TUI Test 0.0.4 |
 |---|---|---|
@@ -160,28 +142,8 @@ stable.
 | Windows | native, ConPTY | supported (Bun on macOS/Linux only) |
 | Shells driven | any executable, shell or not | cmd, Windows PowerShell, PowerShell, bash, git-bash, fish, zsh, xonsh |
 
-### Where each one is the better choice
-
-TUI Test is terminal-first: its world is the rendered screen, and it is very
-good at that. Its traces are a genuinely better debugging story than anything
-atago has — a full replay of what the terminal received, which is exactly what
-you want when a test fails only on someone else's machine. If your project is
-already a Node codebase, its tests are TypeScript next to your other tests,
-with the editor support and refactoring that brings, and Microsoft is behind
-it.
-
-atago is CLI-first, and the terminal is one surface among several. In 0.0.4 a
-test asserts on what the screen shows; there is no exit-code matcher, and no
-assertions about files the program wrote, the exact set of paths a run touched,
-a mock HTTP server it called, or a background service it needed. atago covers
-those in the same YAML file as the `pty:` session, so one scenario can drive a
-TUI and then check what it left on disk. atago also needs no host language or
-package manager — a single binary and a YAML file — which matters when the
-program under test is not written in JavaScript.
-
-Put plainly: if the terminal screen is the product, look hard at TUI Test. If
-the terminal is one of several things your CLI does, atago covers the rest of
-them without a second tool.
+Where atago loses: TUI Test replays a failing session from a trace, which atago
+cannot do, and its tests are TypeScript beside the rest of a Node project.
 
 ## Other tools you might be weighing
 
@@ -237,10 +199,8 @@ An honest table needs the reverse direction spelled out:
   XML assertions and a first-class docker execution node, which atago lacks.
 - goss / runn / venom own their layers outright, as described
   [above](#tools-that-own-a-different-layer).
-- TUI Test is the stronger choice when the terminal screen is the
-  product and your project is already a Node codebase, and its trace replay
-  beats anything atago offers for diagnosing a failure that only reproduces
-  elsewhere. See [the terminal layer](#the-terminal-layer-tui-applications).
+- TUI Test replays a failing terminal session from a trace, which atago
+  cannot do. See [the terminal layer](#the-terminal-layer-tui-applications).
 
 atago is also the youngest project on this page and still pre-1.0. The spec
 format is versioned and every feature ships with a runnable, CI-tested


### PR DESCRIPTION
## Summary

The comparison page covered Bats, ShellSpec, commander, goss, runn, and venom, but not [Microsoft TUI Test](https://github.com/microsoft/tui-test) — the closest tool on the axis atago is usually picked for. Anyone searching for how to test a TUI finds it and wants to know the difference.

The section is a table plus two lines saying where atago loses: TUI Test replays a failing session from a trace, which atago cannot do, and its tests are TypeScript beside the rest of a Node project.

TUI Test is mid-rewrite, noted in one line. 0.0.4 is the TypeScript framework the table describes; 0.1.0-beta.1 is a Rust session-driving CLI with language bindings and no test-file format.

## How the claims were checked

TUI Test claims come from the repository at the `0.0.4` tag, not its README summary: the matcher set (`toBeVisible`, `toHaveFgColor`, `toHaveBgColor`, `toMatchSnapshot`), the terminal API, the config options, and the documented runtimes and shells. The beta's surface came from `crates/tui-test-cli/src/cli.rs` on `main`, which is how the absence of a suite runner there is stated as fact.

atago claims come from `website/data/spec_keys.json`. That corrected two rows: `attrs:` carries italic, underline, and blink besides fg, bg, bold, and reverse, and the row that paired `atago record` with trace replay was simply wrong — record authors a spec, it does not replay a failure — so trace replay is now a `—` for atago.

atago's own row moves from v0.19.0 to v0.20.1.

Related issue:

## Checklist

- [ ] Tests added or updated
- [x] `make build`, `make test`, `make vet`, and `make lint` pass locally
- [x] Docs updated when behavior changed (`README.md`, `CONTRIBUTING.md`, and release docs if needed)
- [ ] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] Cross-platform impact considered for Linux, macOS, and Windows
