### PR TITLE
feat(diag): give every spec error a stable diagnostic code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Diagnostic codes on spec errors. Every error atago raises while loading a spec now carries a stable, searchable code such as `ATG2201`, added to the message rather than replacing it, so the wording stays free to improve while `ATG2201` keeps meaning the same thing. The first digit is the exit code the run produces, making `ATG2xxx` a refinement of the exit contract rather than a second contract beside it. Assertion failures deliberately carry no code: exit 1 is a spec doing its job.
+- An [error code reference](https://nao1215.github.io/atago/errors/), generated from the registry that defines the codes, listing what each one means, what causes it, and what to change. A code cannot exist without that documentation: registering it is the only way to create one, and registration refuses an entry that omits the explanation or the fix. A committed `doc/errors.md` is drift-guarded against the registry, and a coverage gate fails CI when a published code is not provoked by a scenario in atago's own E2E suite.
+
 ## [0.20.1] - 2026-08-15
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -95,8 +95,9 @@ dogfood-mimixbox: ## Full mimixbox applet e2e (builds + --full-installs applets;
 dogfood-mobilepkg: ## Full mobilepkg e2e (builds latest mobilepkg; set MOBILEPKG_REPO)
 	bash ./test/e2e/tools/mobilepkg/run.sh --parallel $(PARALLEL)
 
-docs: ## Regenerate the committed behavior docs under doc/e2e/ from the specs
+docs: ## Regenerate the committed behavior docs under doc/e2e/ and the error reference in doc/errors.md
 	env CGO_ENABLED=0 $(GO_BUILD) $(GO_LDFLAGS) -o ./dist/$(APP) .
+	env UPDATE_ERRORS=1 $(GO) test -run TestDocs_ErrorReferenceInSync .
 	./dist/$(APP) doc --out doc/e2e/atago.md      ./test/e2e/atago
 	./dist/$(APP) doc --out doc/e2e/actionlint.md  ./test/e2e/thirdparty/actionlint
 	./dist/$(APP) doc --out doc/e2e/aqua.md        ./test/e2e/thirdparty/aqua

--- a/README.md
+++ b/README.md
@@ -348,6 +348,8 @@ atago manifest ./specs
 atago list ./specs
 ```
 
+Every error atago reports carries a code — `spec.yaml: ATG2201: suite.name is required` — whose first digit is the exit code, so `ATG2xxx` always exits 2. Codes are searchable and stable across rewordings of the message, and the [error reference](https://nao1215.github.io/atago/errors/) says what each one means and what to change. Assertion failures carry no code: exit 1 is a spec doing its job, not atago failing to do its own.
+
 Scenario names say what happens; an optional `description:` on the suite and on
 a scenario says why it matters. Both are prose for the reader of the generated
 Markdown — rendered under the matching heading, never expanded, and with no

--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ atago manifest ./specs
 atago list ./specs
 ```
 
-Every error atago reports carries a code — `spec.yaml: ATG2201: suite.name is required` — whose first digit is the exit code, so `ATG2xxx` always exits 2. Codes are searchable and stable across rewordings of the message, and the [error reference](https://nao1215.github.io/atago/errors/) says what each one means and what to change. Assertion failures carry no code: exit 1 is a spec doing its job, not atago failing to do its own.
+A spec error carries a code — `spec.yaml: ATG2201: suite.name is required` — whose first digit is the exit code, so `ATG2xxx` always exits 2. Codes are searchable and stable across rewordings of the message, and the [error reference](https://nao1215.github.io/atago/errors/) says what each one means and what to change. Codes are being assigned one family at a time, and the reference says which families carry them today. Assertion failures carry none by design: exit 1 is a spec doing its job, not atago failing to do its own.
 
 Scenario names say what happens; an optional `description:` on the suite and on
 a scenario says why it matters. Both are prose for the reader of the generated

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-80 suites · 522 scenarios
+81 suites · 563 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -144,6 +144,48 @@
   - [file not_contains passes when the substring is absent](#scenario-file-not_contains-passes-when-the-substring-is-absent)
   - [not_contains fails when the substring is present](#scenario-not_contains-fails-when-the-substring-is-present)
   - [a shell metacharacter without shell is a load-time error](#scenario-a-shell-metacharacter-without-shell-is-a-load-time-error)
+- [atago self-hosting / every spec-error diagnostic code](#atago-self-hosting--every-spec-error-diagnostic-code) — 41 scenarios
+  - [ATG2001 is a spec file that cannot be read](#scenario-atg2001-is-a-spec-file-that-cannot-be-read)
+  - [ATG2002 is a spec file with no YAML document in it](#scenario-atg2002-is-a-spec-file-with-no-yaml-document-in-it)
+  - [ATG2003 is a document that is not valid YAML](#scenario-atg2003-is-a-document-that-is-not-valid-yaml)
+  - [ATG2004 is an explicit YAML tag](#scenario-atg2004-is-an-explicit-yaml-tag)
+  - [ATG2005 is a key the schema does not define](#scenario-atg2005-is-a-key-the-schema-does-not-define)
+  - [ATG2006 is a value written in a shape its key cannot take](#scenario-atg2006-is-a-value-written-in-a-shape-its-key-cannot-take)
+  - [ATG2010 is an unsupported spec format version](#scenario-atg2010-is-an-unsupported-spec-format-version)
+  - [ATG2101 is a step that sets no action](#scenario-atg2101-is-a-step-that-sets-no-action)
+  - [ATG2102 is a step that sets more than one action](#scenario-atg2102-is-a-step-that-sets-more-than-one-action)
+  - [ATG2103 is a pair of keys that contradict each other](#scenario-atg2103-is-a-pair-of-keys-that-contradict-each-other)
+  - [ATG2104 is a group that takes exactly one member and got two](#scenario-atg2104-is-a-group-that-takes-exactly-one-member-and-got-two)
+  - [ATG2105 is a real key in a position where it means nothing](#scenario-atg2105-is-a-real-key-in-a-position-where-it-means-nothing)
+  - [ATG2106 is a block at the wrong level of the spec](#scenario-atg2106-is-a-block-at-the-wrong-level-of-the-spec)
+  - [ATG2107 is an assertion with no step to describe](#scenario-atg2107-is-an-assertion-with-no-step-to-describe)
+  - [ATG2108 is a key whose companion key is not set](#scenario-atg2108-is-a-key-whose-companion-key-is-not-set)
+  - [ATG2201 is a required key that is absent](#scenario-atg2201-is-a-required-key-that-is-absent)
+  - [ATG2202 is a list that must hold an entry and holds none](#scenario-atg2202-is-a-list-that-must-hold-an-entry-and-holds-none)
+  - [ATG2203 is a group that needs at least one member and got none](#scenario-atg2203-is-a-group-that-needs-at-least-one-member-and-got-none)
+  - [ATG2204 is a key present with an empty value](#scenario-atg2204-is-a-key-present-with-an-empty-value)
+  - [ATG2301 is a duration atago cannot read](#scenario-atg2301-is-a-duration-atago-cannot-read)
+  - [ATG2302 is a negative value where a negative means nothing](#scenario-atg2302-is-a-negative-value-where-a-negative-means-nothing)
+  - [ATG2303 is a value that must be positive and is not](#scenario-atg2303-is-a-value-that-must-be-positive-and-is-not)
+  - [ATG2304 is a number outside the range its key accepts](#scenario-atg2304-is-a-number-outside-the-range-its-key-accepts)
+  - [ATG2305 is a regular expression that does not compile](#scenario-atg2305-is-a-regular-expression-that-does-not-compile)
+  - [ATG2306 is a glob pattern that does not parse](#scenario-atg2306-is-a-glob-pattern-that-does-not-parse)
+  - [ATG2307 is a value outside a closed vocabulary](#scenario-atg2307-is-a-value-outside-a-closed-vocabulary)
+  - [ATG2308 is a range nothing could satisfy](#scenario-atg2308-is-a-range-nothing-could-satisfy)
+  - [ATG2309 is an absolute path where a relative one is required](#scenario-atg2309-is-an-absolute-path-where-a-relative-one-is-required)
+  - [ATG2310 is a path that climbs out of the workdir](#scenario-atg2310-is-a-path-that-climbs-out-of-the-workdir)
+  - [ATG2311 is a control character in a name](#scenario-atg2311-is-a-control-character-in-a-name)
+  - [ATG2312 is a matcher that could never fail](#scenario-atg2312-is-a-matcher-that-could-never-fail)
+  - [ATG2313 is a value in the wrong notation](#scenario-atg2313-is-a-value-in-the-wrong-notation)
+  - [ATG2401 is a runner the spec never declared](#scenario-atg2401-is-a-runner-the-spec-never-declared)
+  - [ATG2402 is a declared runner of the wrong type](#scenario-atg2402-is-a-declared-runner-of-the-wrong-type)
+  - [ATG2403 is a reference to something the spec never declared](#scenario-atg2403-is-a-reference-to-something-the-spec-never-declared)
+  - [ATG2404 is a stored value shadowing a built-in](#scenario-atg2404-is-a-stored-value-shadowing-a-built-in)
+  - [ATG2405 is a manifest path that resolves to nothing](#scenario-atg2405-is-a-manifest-path-that-resolves-to-nothing)
+  - [ATG2501 is two scenarios sharing a name](#scenario-atg2501-is-two-scenarios-sharing-a-name)
+  - [ATG2502 is a set listing the same entry twice](#scenario-atg2502-is-a-set-listing-the-same-entry-twice)
+  - [a code is added to the message rather than replacing it](#scenario-a-code-is-added-to-the-message-rather-than-replacing-it)
+  - [several problems each report their own code in one pass](#scenario-several-problems-each-report-their-own-code-in-one-pass)
 - [atago self-hosting / exit_code in-set matcher](#atago-self-hosting--exit_code-in-set-matcher) — 4 scenarios
   - [a listed exit code passes](#scenario-a-listed-exit-code-passes)
   - [an unlisted exit code fails and the output lists the set](#scenario-an-unlisted-exit-code-fails-and-the-output-lists-the-set)
@@ -3258,6 +3300,791 @@ ${atago} run bad.atago.yaml
 #### Then
 - exit code is `2`
 - stderr contains `shell is not enabled`, `shell: true`, `stdout_to`
+## atago self-hosting / every spec-error diagnostic code
+Source: `test/e2e/atago/error_codes.atago.yaml`
+### Scenario: ATG2001 is a spec file that cannot be read
+_skipped on Windows_
+#### Given
+- Fixture file `broken.atago.yaml` is created.
+#### When
+```shell
+${atago} run .
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2001`
+### Scenario: ATG2002 is a spec file with no YAML document in it
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+# only a comment
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2002`
+### Scenario: ATG2003 is a document that is not valid YAML
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+  suite: {name: x}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2003`
+### Scenario: ATG2004 is an explicit YAML tag
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: !!str x}
+scenarios: [{name: a, steps: [{run: {command: echo}}]}]
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2004`
+### Scenario: ATG2005 is a key the schema does not define
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenariosss: []
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2005`, `unknown field "scenariosss"`
+### Scenario: ATG2006 is a value written in a shape its key cannot take
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios: [{name: a, steps: [{assert: {stdout: hi}}]}]
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2006`
+### Scenario: ATG2010 is an unsupported spec format version
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "9"
+suite: {name: x}
+scenarios: [{name: a, steps: [{run: {command: echo}}]}]
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2010`
+### Scenario: ATG2101 is a step that sets no action
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios: [{name: a, steps: [{}]}]
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2101`
+### Scenario: ATG2102 is a step that sets more than one action
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps:
+      - run: {command: echo}
+        fixture: {file: f, content: c}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2102`
+### Scenario: ATG2103 is a pair of keys that contradict each other
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps:
+      - run: {command: echo}
+      - assert: {file: {path: f, size: 1, snapshot: s}}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2103`
+### Scenario: ATG2104 is a group that takes exactly one member and got two
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps:
+      - pty: {command: echo, session: [{expect: a, send: b}]}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2104`
+### Scenario: ATG2105 is a real key in a position where it means nothing
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+defaults: {run: {command: echo}}
+scenarios: [{name: a, steps: [{run: {command: echo}}]}]
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2105`
+### Scenario: ATG2106 is a block at the wrong level of the spec
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps:
+      - service: {name: s, command: "sleep 1"}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2106`
+### Scenario: ATG2107 is an assertion with no step to describe
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps:
+      - run: {command: echo}
+      - assert: {screen: {contains: hi}}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2107`
+### Scenario: ATG2108 is a key whose companion key is not set
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps:
+      - run: {command: echo}
+      - assert: {image: {path: f, max_diff: 0.5}}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2108`
+### Scenario: ATG2201 is a required key that is absent
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {}
+scenarios: [{name: a, steps: [{run: {command: echo}}]}]
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2201`
+### Scenario: ATG2202 is a list that must hold an entry and holds none
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios: []
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2202`
+### Scenario: ATG2203 is a group that needs at least one member and got none
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps:
+      - run: {command: echo}
+      - assert: {changes: {}}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2203`
+### Scenario: ATG2204 is a key present with an empty value
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps:
+      - run: {command: echo}
+      - assert: {file: {path: f, equals_file: ""}}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2204`
+### Scenario: ATG2301 is a duration atago cannot read
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x, timeout: "soon"}
+scenarios: [{name: a, steps: [{run: {command: echo}}]}]
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2301`
+### Scenario: ATG2302 is a negative value where a negative means nothing
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x, timeout: "-1s"}
+scenarios: [{name: a, steps: [{run: {command: echo}}]}]
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2302`
+### Scenario: ATG2303 is a value that must be positive and is not
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    services: [{name: s, command: "sleep 1", max_log_bytes: -1}]
+    steps:
+      - run: {command: echo}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2303`
+### Scenario: ATG2304 is a number outside the range its key accepts
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps:
+      - pty: {command: echo, session: [{expect: a}]}
+      - assert: {screen: {attrs: [{text: hi, bold: true, row: -1}]}}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2304`
+### Scenario: ATG2305 is a regular expression that does not compile
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps:
+      - run: {command: echo}
+      - assert: {stdout: {matches: "["}}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2305`
+### Scenario: ATG2306 is a glob pattern that does not parse
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps:
+      - run: {command: echo}
+      - assert: {dir: {path: ".", glob: "["}}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2306`
+### Scenario: ATG2307 is a value outside a closed vocabulary
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios: [{name: a, skip: {os: macos}, steps: [{run: {command: echo}}]}]
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2307`
+### Scenario: ATG2308 is a range nothing could satisfy
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps:
+      - run: {command: echo}
+      - assert: {file: {path: f, min_size: 10, max_size: 5}}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2308`
+### Scenario: ATG2309 is an absolute path where a relative one is required
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps:
+      - run: {command: echo}
+      - assert: {changes: {created: ["/tmp/x"]}}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2309`
+### Scenario: ATG2310 is a path that climbs out of the workdir
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps:
+      - run: {command: echo}
+      - assert: {changes: {created: ["../x"]}}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2310`
+### Scenario: ATG2311 is a control character in a name
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: "x\ty"}
+scenarios: [{name: a, steps: [{run: {command: echo}}]}]
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2311`
+### Scenario: ATG2312 is a matcher that could never fail
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps:
+      - run: {command: echo}
+      - assert: {stdout: {contains: ""}}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2312`
+### Scenario: ATG2313 is a value in the wrong notation
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps:
+      - fixture: {file: f, content: c, mode: "99"}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2313`
+### Scenario: ATG2401 is a runner the spec never declared
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps:
+      - http: {runner: api, method: GET, path: /}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2401`
+### Scenario: ATG2402 is a declared runner of the wrong type
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+runners: {api: {type: db, dsn: "sqlite://:memory:"}}
+scenarios:
+  - name: a
+    steps:
+      - http: {runner: api, method: GET, path: /}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2402`
+### Scenario: ATG2403 is a reference to something the spec never declared
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps:
+      - signal: {service: ghost, signal: TERM}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2403`
+### Scenario: ATG2404 is a stored value shadowing a built-in
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps:
+      - run: {command: echo}
+      - store: {name: workdir, from: {stdout: {matches: "x"}}}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2404`
+### Scenario: ATG2405 is a manifest path that resolves to nothing
+#### Given
+- Fixture file `atago.project.yaml` is created.
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `atago.project.yaml`:_
+```text
+fixtures_dir: nowhere
+```
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios: [{name: a, steps: [{run: {command: echo}}]}]
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2405`
+### Scenario: ATG2501 is two scenarios sharing a name
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios:
+  - {name: a, steps: [{run: {command: echo}}]}
+  - {name: a, steps: [{run: {command: echo}}]}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2501`
+### Scenario: ATG2502 is a set listing the same entry twice
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps:
+      - run: {command: echo}
+      - assert: {exit_code: {in: [0, 0]}}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2502`
+### Scenario: a code is added to the message rather than replacing it
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {}
+scenarios: [{name: a, steps: [{run: {command: echo}}]}]
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr matches `/ATG2201: suite\.name is required/`
+### Scenario: several problems each report their own code in one pass
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "9"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps:
+      - run: {command: echo}
+      - assert: {stdout: {matches: "["}}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `2`
+- stderr contains `ATG2010`, `ATG2305`
 ## atago self-hosting / exit_code in-set matcher
 Source: `test/e2e/atago/exit_code_in.atago.yaml`
 ### Scenario: a listed exit code passes

--- a/doc/errors.md
+++ b/doc/errors.md
@@ -1,0 +1,378 @@
+# Error codes
+
+Every error atago reports carries a code, so a failure can be searched for, linked to, and branched on without matching on prose that is free to improve. Assertion failures are not errors in this sense and carry no code: a spec that fails is a spec doing its job, and its message already says what was expected and what happened.
+
+A code is `ATG` followed by four digits, and the first of those digits is the exit status the run produced. Reading `ATG2103` tells you the process exited 2 before it tells you anything else.
+
+| Codes | Exit | Meaning |
+|---|---|---|
+| `ATG2xxx` | 2 | spec error — the file could not be parsed, or does not describe a runnable suite |
+| `ATG3xxx` | 3 | configuration error — the command line, its flags, or the spec files it selected |
+| `ATG4xxx` | 4 | execution error — a step could not be carried out |
+| `ATG5xxx` | 5 | internal error — a bug in atago |
+| `ATG6xxx` | 6 | security policy violation — atago refused an operation on policy grounds |
+
+`ATG1xxx` is never assigned. Exit 1 means one or more scenarios failed, which is a result rather than an error.
+
+Codes are grouped by what you have to fix rather than by where in atago the error was raised, so one code can be reported from several places when the answer is the same in all of them.
+
+Look a code up from the terminal with `atago explain ATG2201`, which prints this same text without a browser.
+
+## Every code
+
+| Code | Meaning | Exit | Since |
+|---|---|---|---|
+| [`ATG2001`](#atg2001--the-spec-file-could-not-be-read) | the spec file could not be read | 2 | v0.21.0 |
+| [`ATG2002`](#atg2002--the-spec-file-contains-no-yaml-document) | the spec file contains no YAML document | 2 | v0.21.0 |
+| [`ATG2003`](#atg2003--the-file-is-not-valid-yaml) | the file is not valid YAML | 2 | v0.21.0 |
+| [`ATG2004`](#atg2004--an-explicit-yaml-tag-is-not-supported-in-a-spec) | an explicit YAML tag is not supported in a spec | 2 | v0.21.0 |
+| [`ATG2005`](#atg2005--the-spec-sets-a-key-the-schema-does-not-define) | the spec sets a key the schema does not define | 2 | v0.21.0 |
+| [`ATG2006`](#atg2006--a-value-is-written-in-a-shape-the-key-does-not-accept) | a value is written in a shape the key does not accept | 2 | v0.21.0 |
+| [`ATG2010`](#atg2010--the-spec-declares-a-format-version-atago-does-not-support) | the spec declares a format version atago does not support | 2 | v0.21.0 |
+| [`ATG2101`](#atg2101--a-step-sets-no-action) | a step sets no action | 2 | v0.21.0 |
+| [`ATG2102`](#atg2102--a-step-sets-more-than-one-action) | a step sets more than one action | 2 | v0.21.0 |
+| [`ATG2103`](#atg2103--keys-that-contradict-each-other-are-set-together) | keys that contradict each other are set together | 2 | v0.21.0 |
+| [`ATG2104`](#atg2104--a-group-of-keys-that-takes-exactly-one-member-has-none-or-several) | a group of keys that takes exactly one member has none or several | 2 | v0.21.0 |
+| [`ATG2105`](#atg2105--a-key-is-real-but-has-no-meaning-in-this-position) | a key is real but has no meaning in this position | 2 | v0.21.0 |
+| [`ATG2106`](#atg2106--a-block-is-not-allowed-at-this-level-of-the-spec) | a block is not allowed at this level of the spec | 2 | v0.21.0 |
+| [`ATG2107`](#atg2107--an-assertion-needs-a-preceding-step-it-does-not-have) | an assertion needs a preceding step it does not have | 2 | v0.21.0 |
+| [`ATG2108`](#atg2108--a-key-needs-another-key-that-is-not-set) | a key needs another key that is not set | 2 | v0.21.0 |
+| [`ATG2201`](#atg2201--a-required-key-is-missing) | a required key is missing | 2 | v0.21.0 |
+| [`ATG2202`](#atg2202--a-list-that-must-hold-at-least-one-entry-is-empty) | a list that must hold at least one entry is empty | 2 | v0.21.0 |
+| [`ATG2203`](#atg2203--a-group-of-keys-that-needs-at-least-one-member-has-none) | a group of keys that needs at least one member has none | 2 | v0.21.0 |
+| [`ATG2204`](#atg2204--a-value-that-must-not-be-empty-is-empty) | a value that must not be empty is empty | 2 | v0.21.0 |
+| [`ATG2301`](#atg2301--a-duration-is-not-written-in-a-form-atago-can-read) | a duration is not written in a form atago can read | 2 | v0.21.0 |
+| [`ATG2302`](#atg2302--a-value-is-negative-where-a-negative-has-no-meaning) | a value is negative where a negative has no meaning | 2 | v0.21.0 |
+| [`ATG2303`](#atg2303--a-value-must-be-positive-and-is-zero-or-below) | a value must be positive and is zero or below | 2 | v0.21.0 |
+| [`ATG2304`](#atg2304--a-number-is-outside-the-range-the-key-accepts) | a number is outside the range the key accepts | 2 | v0.21.0 |
+| [`ATG2305`](#atg2305--a-regular-expression-does-not-compile) | a regular expression does not compile | 2 | v0.21.0 |
+| [`ATG2306`](#atg2306--a-glob-pattern-is-not-valid) | a glob pattern is not valid | 2 | v0.21.0 |
+| [`ATG2307`](#atg2307--a-value-is-not-one-of-the-choices-the-key-allows) | a value is not one of the choices the key allows | 2 | v0.21.0 |
+| [`ATG2308`](#atg2308--the-bounds-of-a-range-describe-an-interval-nothing-can-fall-in) | the bounds of a range describe an interval nothing can fall in | 2 | v0.21.0 |
+| [`ATG2309`](#atg2309--a-path-is-absolute-where-it-must-be-workdir-relative) | a path is absolute where it must be workdir-relative | 2 | v0.21.0 |
+| [`ATG2310`](#atg2310--a-path-leads-outside-the-scenario-workdir) | a path leads outside the scenario workdir | 2 | v0.21.0 |
+| [`ATG2311`](#atg2311--a-name-contains-a-control-character) | a name contains a control character | 2 | v0.21.0 |
+| [`ATG2312`](#atg2312--a-matcher-can-never-fail-or-can-never-pass) | a matcher can never fail, or can never pass | 2 | v0.21.0 |
+| [`ATG2313`](#atg2313--a-value-is-not-written-in-the-notation-the-key-requires) | a value is not written in the notation the key requires | 2 | v0.21.0 |
+| [`ATG2401`](#atg2401--a-step-names-a-runner-the-spec-does-not-declare) | a step names a runner the spec does not declare | 2 | v0.21.0 |
+| [`ATG2402`](#atg2402--a-step-names-a-runner-of-the-wrong-type) | a step names a runner of the wrong type | 2 | v0.21.0 |
+| [`ATG2403`](#atg2403--a-reference-names-something-the-spec-does-not-declare) | a reference names something the spec does not declare | 2 | v0.21.0 |
+| [`ATG2404`](#atg2404--a-name-collides-with-one-atago-reserves) | a name collides with one atago reserves | 2 | v0.21.0 |
+| [`ATG2405`](#atg2405--a-path-does-not-exist-or-is-not-the-kind-of-thing-the-key-needs) | a path does not exist, or is not the kind of thing the key needs | 2 | v0.21.0 |
+| [`ATG2501`](#atg2501--two-entries-in-the-same-spec-share-a-name) | two entries in the same spec share a name | 2 | v0.21.0 |
+| [`ATG2502`](#atg2502--a-list-repeats-an-entry-that-must-appear-once) | a list repeats an entry that must appear once | 2 | v0.21.0 |
+
+## ATG2xxx — exit 2
+
+### ATG2001 — the spec file could not be read
+
+atago was given a path and the operating system refused to open it. The file may not exist, may be a directory, or may not be readable by the user running atago. Nothing was parsed, so no other diagnostic can be reported about this file.
+
+Fix: Check the path as spelled on the command line, and check the file's permissions. `atago list <dir>` shows which spec files atago can actually see in a directory.
+
+Exits 2. Since v0.21.0.
+
+### ATG2002 — the spec file contains no YAML document
+
+The file was read but holds nothing a spec can be built from — it is empty, or contains only whitespace and comments. This is most often a file that was created but never filled in, or one whose contents were lost by an editor or a bad merge.
+
+Fix: A spec needs at least `version`, `suite`, and `scenarios`. Run `atago init` to write a runnable starter spec and edit that.
+
+Exits 2. Since v0.21.0.
+
+### ATG2003 — the file is not valid YAML
+
+Parsing stopped before atago could look at what the document means. The reported line and column are where the parser gave up, which is usually at or just after the real mistake. Inconsistent indentation, a missing colon after a key, and an unclosed quote or bracket account for most of these.
+
+Fix: Fix the syntax at the reported position. Indentation in YAML must use spaces, never tabs, and every level must be indented consistently.
+
+Exits 2. Since v0.21.0.
+
+### ATG2004 — an explicit YAML tag is not supported in a spec
+
+The document carries an explicit tag such as `!!str` or `!!map`. atago's schema is closed and fully typed: every field's type already fixes how its value is read, so a tag can only restate what the schema says or contradict it. The one exception is `!!binary`, which `atago record` writes when a captured stream is not valid UTF-8.
+
+Fix: Remove the tag. If a value needs to be forced to text, quote it instead.
+
+Exits 2. Since v0.21.0.
+
+### ATG2005 — the spec sets a key the schema does not define
+
+Specs are decoded strictly, so a key atago does not know is an error rather than something quietly ignored — a silently dropped `assert:` block is a test that passes without testing anything. The usual causes are a typo, a key written at the wrong nesting level, and a key from a newer atago than the one running.
+
+Fix: Check the spelling and the indentation against the message's suggestion. The JSON Schema under `schema/atago.schema.json` gives an editor live completion for every key.
+
+Exits 2. Since v0.21.0.
+
+### ATG2006 — a value is written in a shape the key does not accept
+
+The key exists but its value is the wrong kind of thing — a bare string where a mapping is wanted, a mapping where a list is wanted, or text where a number is wanted. The most common instance by far is a stream assertion written as a bare scalar: `stdout: hello` rather than `stdout: {contains: hello}`.
+
+Fix: Write the value in the shape the key takes. Stream assertions (`stdout`, `stderr`, `body`, `rows`, `message`, `value`) always take a matcher mapping such as `{contains: "..."}` or `{equals: "..."}`.
+
+Exits 2. Since v0.21.0.
+
+### ATG2010 — the spec declares a format version atago does not support
+
+The `version` key names the spec format, not the atago release, and `"1"` is the only format that exists. A version of `1` without quotes is read as a number and is also refused, because the field is a format name rather than a quantity.
+
+Fix: Write `version: "1"`, with the quotes.
+
+Exits 2. Since v0.21.0.
+
+### ATG2101 — a step sets no action
+
+Every step does exactly one thing: run a command, make a request, drive a terminal, write a fixture, assert, or one of the other actions. A step with none of them is usually a block whose action key was lost to a bad indent, or a placeholder that was never filled in.
+
+Fix: Give the step exactly one of `fixture`, `run`, `http`, `query`, `grpc`, `cdp`, `assert`, `store`, `pty`, or `signal` — or delete the step.
+
+Exits 2. Since v0.21.0.
+
+### ATG2102 — a step sets more than one action
+
+A step is one action so that ordering, timing, and failure are unambiguous: a step that both ran a command and made a request has no single answer for which one a `duration` bounds or which one an assertion followed. The usual cause is a second action indented into the previous step instead of starting a new one.
+
+Fix: Split the actions into separate list items under `steps:`, one `- ` per action.
+
+Exits 2. Since v0.21.0.
+
+### ATG2103 — keys that contradict each other are set together
+
+Two keys were set whose meanings cannot both hold. A snapshot already pins every byte of what it captures, so pairing it with a size bound or with the `contains`/`count`/`glob` family asks the same question twice and invites the two answers to disagree. An exact `size` next to `min_size`/`max_size`, two lower bounds, and `exists: false` next to a size are the same mistake in other places.
+
+Fix: Keep the key that expresses what you actually want to pin and drop the other. The message names both.
+
+Exits 2. Since v0.21.0.
+
+### ATG2104 — a group of keys that takes exactly one member has none or several
+
+Some blocks offer alternatives that are mutually exclusive by nature: a `pty` step is one of expect, send, expect_screen, resize, or exec; an `exit_code` is a bare number, a `not`, or an `in`. Setting several leaves the meaning undefined, and setting none leaves the block with nothing to do.
+
+Fix: Set exactly one member of the group the message lists. To do two things, write two entries.
+
+Exits 2. Since v0.21.0.
+
+### ATG2105 — a key is real but has no meaning in this position
+
+The key exists elsewhere in the schema but not here, and accepting it silently would make it look effective when it is not. `defaults.run.command` is the clearest case: defaults describe how every step runs, while the command is what an individual step is, so a default command would be inherited by steps that already have one and quietly ignored. `trim` and `text` outside a store source, and `recursive` next to `snapshot`, are the same shape of mistake.
+
+Fix: Move the key to where it applies, or drop it. The message says which of the two the key needs.
+
+Exits 2. Since v0.21.0.
+
+### ATG2106 — a block is not allowed at this level of the spec
+
+Some blocks are tied to a level by what they own. A `service` or `mock_server` step belongs in `suite.setup` because it outlives any one scenario; a scenario-scoped peer goes in that scenario's own `services:` or `mock_servers:` list instead. Others go the other way: steps needing a scenario workdir and runners cannot sit at suite level, and `assert.changes` is not available in teardown because the workdir delta is tracked only around a scenario's steps.
+
+Fix: Move the block to the level the message names.
+
+Exits 2. Since v0.21.0.
+
+### ATG2107 — an assertion needs a preceding step it does not have
+
+Some assertions describe the step before them rather than the scenario as a whole. `assert.screen` reads the terminal a `pty` step rendered, `assert.duration` bounds the wall-clock time of the step it follows, and `assert.changes` pins the workdir delta of the run or pty step it follows. Without that step there is nothing for the assertion to be about, so it would pass or fail for reasons unrelated to what it says.
+
+Fix: Put the assertion directly after the step it describes. One assert block may set several keys at once, so an `exit_code`, a `stdout`, and a `changes` about the same step belong together.
+
+Exits 2. Since v0.21.0.
+
+### ATG2108 — a key needs another key that is not set
+
+The key is only meaningful in the presence of a second one: `max_diff` bounds the difference `similar_to` measures, `pass_env` selects which host variables survive a `clear_env`, and `count` counts the matches of a `contains`. Alone, the key has nothing to act on, so accepting it would leave a spec that looks like it constrains something and does not.
+
+Fix: Add the key the message names, or drop the one that depends on it.
+
+Exits 2. Since v0.21.0.
+
+### ATG2201 — a required key is missing
+
+The block cannot be acted on without this key: a service with no command has nothing to start, an HTTP step with no method has no request to make, a scenario with no name cannot be selected, reported on, or documented. atago refuses these at load time rather than discovering them mid-run, so a broken spec fails before it starts changing anything.
+
+Fix: Add the key the message names to the block it names.
+
+Exits 2. Since v0.21.0.
+
+### ATG2202 — a list that must hold at least one entry is empty
+
+A suite with no scenarios, a scenario with no steps, or a `cdp` block with no actions is accepted by YAML and means nothing to run. Left alone it would report success without having tested anything, which is worse than failing.
+
+Fix: Add an entry to the list, or remove the block that holds it.
+
+Exits 2. Since v0.21.0.
+
+### ATG2203 — a group of keys that needs at least one member has none
+
+Unlike an exactly-one group, these accept any combination — but not the empty one, which would assert nothing. `assert.changes` needs at least one of `created`, `modified`, or `deleted`; a bounds block needs at least one of `lt`, `lte`, `gt`, or `gte`; a recursive directory assert needs at least one matcher.
+
+Fix: Set one or more members of the group the message lists. To assert that a category changed nothing, write it explicitly as an empty list, e.g. `created: []`.
+
+Exits 2. Since v0.21.0.
+
+### ATG2204 — a value that must not be empty is empty
+
+The key is present but carries nothing. This is worse than leaving the key out, because an empty value usually does not mean what it looks like: an empty ignore pattern excludes nothing, an empty name identifies nothing, an empty path names the workdir itself.
+
+Fix: Give the key a value, or remove the key. Where removing it is the right answer the message says so.
+
+Exits 2. Since v0.21.0.
+
+### ATG2301 — a duration is not written in a form atago can read
+
+Durations are written as a number with a unit — `500ms`, `2s`, `2m`, `1h30m` — and a bare number is refused because it does not say which unit was meant. A timeout that silently meant nanoseconds instead of seconds would look like a hang.
+
+Fix: Write the value with a unit, e.g. `timeout: 2m`. Where a duration can be disabled, `"0"` does that.
+
+Exits 2. Since v0.21.0.
+
+### ATG2302 — a value is negative where a negative has no meaning
+
+Wall-clock bounds, sizes, counts, and page numbers are never below zero. A negative here is nearly always a sign slip or an arithmetic mistake in a generated spec, and treating it as zero would hide that.
+
+Fix: Use zero or a positive value. Where the intent was to disable a bound rather than set it to nothing, the message names the way to do that.
+
+Exits 2. Since v0.21.0.
+
+### ATG2303 — a value must be positive and is zero or below
+
+Some values have no sensible zero: an interval that never elapses, a worker count of nobody, a retry that waits no time between attempts. Where atago has a working default, zero would be indistinguishable from not setting the key at all.
+
+Fix: Set a positive value, or omit the key to take atago's default.
+
+Exits 2. Since v0.21.0.
+
+### ATG2304 — a number is outside the range the key accepts
+
+The value parsed but falls outside what the field can mean. Screen coordinates are 1-based cells, so row or column zero is not the first cell but a mistake, and it is the instance of this seen most often — a spec written against a 0-based mental model reads the wrong cell everywhere or nowhere.
+
+Fix: Bring the value into the range the message states.
+
+Exits 2. Since v0.21.0.
+
+### ATG2305 — a regular expression does not compile
+
+atago compiles every pattern in a spec at load time — `matches`, scrub patterns, readiness patterns — so a broken one is reported before the run rather than at the moment it would first have been used, halfway through a suite. The syntax is Go's RE2: no backreferences and no lookaround.
+
+Fix: Correct the pattern at the position the message reports. Regex metacharacters that are meant literally need escaping, and a pattern inside a YAML double-quoted string needs its backslashes doubled — single quotes avoid that.
+
+Exits 2. Since v0.21.0.
+
+### ATG2306 — a glob pattern is not valid
+
+Globs match paths by shape — `*` within a path segment, `**` across segments, `?` for one character, `[...]` for a class, `{a,b}` for alternatives. An unclosed bracket or brace is the usual cause.
+
+Fix: Close the unbalanced bracket or brace, or escape it if it was meant literally.
+
+Exits 2. Since v0.21.0.
+
+### ATG2307 — a value is not one of the choices the key allows
+
+The key takes a fixed vocabulary and the value is not in it. Platform names are the common case: `os` accepts `linux`, `darwin`, or `windows`, so `macos` or `osx` — reasonable words that Go's platform names do not use — are refused rather than quietly never matching.
+
+Fix: Use one of the values the message lists.
+
+Exits 2. Since v0.21.0.
+
+### ATG2308 — the bounds of a range describe an interval nothing can fall in
+
+A lower bound at or above the upper bound leaves no value that could satisfy both, so the assertion can only ever fail. This is almost always two bounds swapped, or a copied block whose second bound was not updated.
+
+Fix: Order the bounds so the lower one is genuinely below the upper one, or use a single bound if only one side matters.
+
+Exits 2. Since v0.21.0.
+
+### ATG2309 — a path is absolute where it must be workdir-relative
+
+Paths in a spec are relative to the scenario's own workdir, which is created fresh for each scenario. That is what lets the same spec run on another machine, in CI, and in parallel with itself. An absolute path names one machine's filesystem and breaks all three.
+
+Fix: Write the path relative to the scenario workdir, e.g. `out/report.json` rather than `/home/you/project/out/report.json`.
+
+Exits 2. Since v0.21.0.
+
+### ATG2310 — a path leads outside the scenario workdir
+
+The path is relative but climbs out of the workdir with `../`. Scenario isolation is what makes a failing scenario reproducible and a parallel run safe, and a path that reaches outside it can read or overwrite another scenario's files, or the repository being tested. This is refused while loading; the equivalent refusal during a run is reported as a security violation and exits 6.
+
+Fix: Keep the path inside the workdir. To work with a file that genuinely lives elsewhere, copy it in with a `fixture` step, which is the supported way to bring outside data into a scenario.
+
+Exits 2. Since v0.21.0.
+
+### ATG2311 — a name contains a control character
+
+Suite and scenario names are printed in aligned tables, written into generated Markdown as headings, and turned into anchors and report fields. A newline, tab, or other control byte corrupts every one of those, and a name that renders differently in each place cannot be selected reliably with `--scenario`.
+
+Fix: Remove the control character. A name spanning lines usually comes from a YAML block scalar (`|` or `>`) where a plain string was meant.
+
+Exits 2. Since v0.21.0.
+
+### ATG2312 — a matcher can never fail, or can never pass
+
+The matcher is well-formed and asserts nothing. An empty substring is contained in every string, so `contains: ""` always passes and `not_contains: ""` never can; a regexp matching the empty string behaves the same way. A test that cannot fail is worse than no test, because it reports success and is counted as coverage.
+
+Fix: Give the matcher a real substring or pattern, or remove it. Where a pattern is meant to match an empty field, anchor it (`^$`) rather than leaving it empty.
+
+Exits 2. Since v0.21.0.
+
+### ATG2313 — a value is not written in the notation the key requires
+
+The key takes a value in a specific notation rather than from a fixed list of choices — an octal file mode, an RFC 3339 timestamp, base64 data, a JSON path, a color, a URL path beginning with a slash. The value given does not parse in that notation.
+
+Fix: Rewrite the value in the notation the message names. Its example shows the accepted form.
+
+Exits 2. Since v0.21.0.
+
+### ATG2401 — a step names a runner the spec does not declare
+
+Steps that reach outside the local machine — `http`, `query`, `grpc`, `cdp`, `ssh` — address a runner by name, and runners are declared once under the spec's `runners:` block. A name with no declaration behind it is a typo or a block that was never added.
+
+Fix: Declare the runner under `runners:`, or correct the name to one that is declared. The message lists the names the spec does declare.
+
+Exits 2. Since v0.21.0.
+
+### ATG2402 — a step names a runner of the wrong type
+
+The runner is declared, but it is not the kind this step needs: a `query` step needs a database runner, an `http` step needs an HTTP runner. The usual cause is one name copied where another was meant, in a spec that declares several runners.
+
+Fix: Name a runner of the type the message asks for.
+
+Exits 2. Since v0.21.0.
+
+### ATG2403 — a reference names something the spec does not declare
+
+Services, mock servers, and stored values are addressed by name from elsewhere in the spec — a signal targets a service, an assertion targets a mock, an expansion reads a stored value. A name nothing declares would be resolved at run time against nothing at all.
+
+Fix: Declare the target, or correct the name. Suite-level services and mocks are visible to every scenario; a scenario's own are visible only within it.
+
+Exits 2. Since v0.21.0.
+
+### ATG2404 — a name collides with one atago reserves
+
+atago provides a few variables of its own — `atago`, `workdir`, `suitedir` — and a stored value taking one of those names would shadow it. Every later expansion would then read the spec's value where it meant atago's, silently and only in the specs that happen to declare the name.
+
+Fix: Choose another name for the stored value.
+
+Exits 2. Since v0.21.0.
+
+### ATG2405 — a path does not exist, or is not the kind of thing the key needs
+
+Some paths are resolved while loading rather than during a run, because a typo caught here is one message about the spec instead of an identical failure in every scenario that uses it. A directory manifest's `fixtures_dir` is the usual case: a path that is missing, or that names a file where a directory is wanted.
+
+Fix: Correct the path, or create what it points at. Relative paths are resolved against the file that declares them.
+
+Exits 2. Since v0.21.0.
+
+### ATG2501 — two entries in the same spec share a name
+
+Names identify: `--scenario` selects by them, reports and generated docs are keyed by them, and services and mocks are addressed by them. With a duplicate, selecting one of the pair is impossible and a report cannot say which of the two it describes. Copy-and-edit that stopped before editing the name is the usual cause.
+
+Fix: Rename one of the two. Where the duplicates were meant to be one thing parameterized, `matrix:` generates distinct names for each combination.
+
+Exits 2. Since v0.21.0.
+
+### ATG2502 — a list repeats an entry that must appear once
+
+Some lists are sets: the exit codes `in` accepts, the observables `deterministic.compare` watches, the modifiers a key press carries. A repeat has no second meaning, so it is either a merge artefact or a value that was meant to be different.
+
+Fix: Remove the repeat, or change it to the value that was meant.
+
+Exits 2. Since v0.21.0.
+

--- a/doc/errors.md
+++ b/doc/errors.md
@@ -1,16 +1,18 @@
 # Error codes
 
-Every error atago reports carries a code, so a failure can be searched for, linked to, and branched on without matching on prose that is free to improve. Assertion failures are not errors in this sense and carry no code: a spec that fails is a spec doing its job, and its message already says what was expected and what happened.
+A coded error carries a name that can be searched for, linked to, and branched on, so the message beside it stays free to improve without breaking anyone. Assertion failures are not errors in this sense and carry no code: a spec that fails is a spec doing its job, and its message already says what was expected and what happened.
 
 A code is `ATG` followed by four digits, and the first of those digits is the exit status the run produced. Reading `ATG2103` tells you the process exited 2 before it tells you anything else.
 
-| Codes | Exit | Meaning |
-|---|---|---|
-| `ATG2xxx` | 2 | spec error — the file could not be parsed, or does not describe a runnable suite |
-| `ATG3xxx` | 3 | configuration error — the command line, its flags, or the spec files it selected |
-| `ATG4xxx` | 4 | execution error — a step could not be carried out |
-| `ATG5xxx` | 5 | internal error — a bug in atago |
-| `ATG6xxx` | 6 | security policy violation — atago refused an operation on policy grounds |
+Codes are being assigned one family at a time. The table says which families carry them today; an error from a family not yet covered still exits the same way and still says what went wrong, it just has no code to look up here yet.
+
+| Codes | Exit | Meaning | Assigned |
+|---|---|---|---|
+| `ATG2xxx` | 2 | spec error — the file could not be parsed, or does not describe a runnable suite | 39 codes |
+| `ATG3xxx` | 3 | configuration error — the command line, its flags, or the spec files it selected | not yet |
+| `ATG4xxx` | 4 | execution error — a step could not be carried out | not yet |
+| `ATG5xxx` | 5 | internal error — a bug in atago | not yet |
+| `ATG6xxx` | 6 | security policy violation — atago refused an operation on policy grounds | not yet |
 
 `ATG1xxx` is never assigned. Exit 1 means one or more scenarios failed, which is a result rather than an error.
 
@@ -132,7 +134,7 @@ Exits 2. Since v0.21.0.
 
 A step is one action so that ordering, timing, and failure are unambiguous: a step that both ran a command and made a request has no single answer for which one a `duration` bounds or which one an assertion followed. The usual cause is a second action indented into the previous step instead of starting a new one.
 
-Fix: Split the actions into separate list items under `steps:`, one `- ` per action.
+Fix: Split the actions into separate list items under `steps:`, one list item per action.
 
 Exits 2. Since v0.21.0.
 
@@ -370,7 +372,7 @@ Exits 2. Since v0.21.0.
 
 ### ATG2502 — a list repeats an entry that must appear once
 
-Some lists are sets: the exit codes `in` accepts, the observables `deterministic.compare` watches, the modifiers a key press carries. A repeat has no second meaning, so it is either a merge artefact or a value that was meant to be different.
+Some lists are sets: the exit codes `in` accepts, the observables `deterministic.compare` watches, the modifiers a key press carries. A repeat has no second meaning, so it is either a merge artifact or a value that was meant to be different.
 
 Fix: Remove the repeat, or change it to the value that was meant.
 

--- a/drift_test.go
+++ b/drift_test.go
@@ -12,10 +12,12 @@ import (
 	"testing"
 
 	"github.com/nao1215/atago/internal/cli"
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/docgen"
 	"github.com/nao1215/atago/internal/engine"
 	"github.com/nao1215/atago/internal/loader"
 	"github.com/nao1215/atago/internal/sitegen"
+	"github.com/nao1215/atago/internal/spec"
 )
 
 // This file holds the drift guards over committed generated artifacts: the
@@ -465,6 +467,117 @@ func TestSite_InSync(t *testing.T) {
 			t.Errorf("%s is out of date with the generator; regenerate with `make site`", name)
 		}
 	}
+}
+
+// TestDocs_ErrorReferenceInSync keeps the published error reference in lockstep
+// with the diagnostic registry that produces the codes. The registry is the
+// only place a code can be created, and this is what makes its documentation
+// arrive with it: a code added, reworded, or retired without regenerating the
+// page fails here. Regenerate with `make docs` (or `UPDATE_ERRORS=1 go test
+// -run TestDocs_ErrorReferenceInSync .`).
+func TestDocs_ErrorReferenceInSync(t *testing.T) {
+	const path = "doc/errors.md"
+	want := diag.Markdown()
+
+	if os.Getenv("UPDATE_ERRORS") == "1" {
+		if err := os.WriteFile(path, want, 0o600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+		return
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v (run `make docs`)", path, err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("%s is out of date with the diagnostic registry; regenerate with `make docs`", path)
+	}
+}
+
+// TestDocs_EveryCodeIsDocumented is the reader's side of the same guarantee:
+// whatever the generator does, the committed page has to name every code and
+// say what to do about it.
+func TestDocs_EveryCodeIsDocumented(t *testing.T) {
+	page := readDoc(t, "doc/errors.md")
+	for _, e := range diag.All() {
+		if !strings.Contains(page, e.Code.String()) {
+			t.Errorf("doc/errors.md does not mention %s (%s)", e.Code, e.Name)
+		}
+		if !strings.Contains(page, e.Fix) {
+			t.Errorf("doc/errors.md does not tell the reader how to fix %s (%s)", e.Code, e.Name)
+		}
+	}
+}
+
+// TestE2E_EveryCodeIsProvoked is the coverage gate over the diagnostic
+// registry: a published code must be produced by the real binary in a real
+// run, not merely written down. Registering a code therefore obliges you to
+// add the scenario that provokes it, in the same change.
+//
+// Documentation alone would let a code rot in place after the check that
+// raised it was deleted or reworded past the point of reaching it. The
+// scenarios live in test/e2e/atago/error_codes.atago.yaml; any spec in the
+// directory counts, so a code that already has a home elsewhere needs no
+// second one.
+func TestE2E_EveryCodeIsProvoked(t *testing.T) {
+	const dir = "test/e2e/atago"
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	provoked := map[diag.Code]bool{}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") && !strings.HasSuffix(e.Name(), ".yml") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		s, lerr := loader.Load(path)
+		if lerr != nil {
+			t.Fatalf("load %s: %v", path, lerr)
+		}
+		// Only what a scenario ASSERTS counts. Scanning the file as text would
+		// let a scenario title or a comment mentioning a code satisfy the gate,
+		// which is the opposite of what it is for.
+		for _, text := range assertedText(s) {
+			for _, c := range diag.Codes(text) {
+				provoked[c] = true
+			}
+		}
+	}
+	for _, e := range diag.All() {
+		if !provoked[e.Code] {
+			t.Errorf("%s (%s) is a published code that no scenario in %s provokes; add one to error_codes.atago.yaml", e.Code, e.Name, dir)
+		}
+	}
+}
+
+// assertedText collects the strings a spec's stream assertions compare
+// against — the only place a diagnostic code can be claimed rather than merely
+// mentioned.
+func assertedText(s *spec.Spec) []string {
+	var out []string
+	collect := func(sa *spec.StreamAssert) {
+		if sa == nil {
+			return
+		}
+		out = append(out, []string(sa.Contains)...)
+		for _, p := range []*string{sa.Matches, sa.Equals} {
+			if p != nil {
+				out = append(out, *p)
+			}
+		}
+	}
+	for i := range s.Scenarios {
+		steps := append(append([]spec.Step{}, s.Scenarios[i].Steps...), s.Scenarios[i].Teardown...)
+		for j := range steps {
+			if a := steps[j].Assert; a != nil {
+				collect(a.Stdout)
+				collect(a.Stderr)
+			}
+		}
+	}
+	return out
 }
 
 var siteLinkRe = regexp.MustCompile(`\]\(([^)]+)\)`)

--- a/internal/diag/codes_spec.go
+++ b/internal/diag/codes_spec.go
@@ -13,7 +13,7 @@ package diag
 //	ATG24xx  a name that does not resolve to anything the spec declares
 //	ATG25xx  identity — names that collide
 //
-// Numbers are left with gaps so a later code joins its neighbours. A retired
+// Numbers are left with gaps so a later code joins its neighbors. A retired
 // code is never reused: the registry records the version each shipped in, and
 // a number that once meant something else would make an old CI log lie.
 const specSince = "v0.21.0"
@@ -91,7 +91,7 @@ var (
 	StepManyActions = register(2102, "StepManyActions", Entry{
 		Summary: "a step sets more than one action",
 		Detail:  "A step is one action so that ordering, timing, and failure are unambiguous: a step that both ran a command and made a request has no single answer for which one a `duration` bounds or which one an assertion followed. The usual cause is a second action indented into the previous step instead of starting a new one.",
-		Fix:     "Split the actions into separate list items under `steps:`, one `- ` per action.",
+		Fix:     "Split the actions into separate list items under `steps:`, one list item per action.",
 		Since:   specSince,
 	})
 
@@ -344,7 +344,7 @@ var (
 	// DuplicateEntry is a list repeating something it must list once.
 	DuplicateEntry = register(2502, "DuplicateEntry", Entry{
 		Summary: "a list repeats an entry that must appear once",
-		Detail:  "Some lists are sets: the exit codes `in` accepts, the observables `deterministic.compare` watches, the modifiers a key press carries. A repeat has no second meaning, so it is either a merge artefact or a value that was meant to be different.",
+		Detail:  "Some lists are sets: the exit codes `in` accepts, the observables `deterministic.compare` watches, the modifiers a key press carries. A repeat has no second meaning, so it is either a merge artifact or a value that was meant to be different.",
 		Fix:     "Remove the repeat, or change it to the value that was meant.",
 		Since:   specSince,
 	})

--- a/internal/diag/codes_spec.go
+++ b/internal/diag/codes_spec.go
@@ -1,0 +1,351 @@
+package diag
+
+// ATG2xxx — spec errors, which exit 2. These are raised while reading a spec
+// file: the document could not be parsed, or it parsed but does not describe a
+// runnable suite. Nothing has been executed when one of these is reported.
+//
+// The sub-ranges group by what the reader has to do about it:
+//
+//	ATG20xx  the document itself — syntax, encoding, the schema's outer shape
+//	ATG21xx  a key that should not be there, or a combination that contradicts
+//	ATG22xx  a key that should be there and is not
+//	ATG23xx  a value that is present but wrong
+//	ATG24xx  a name that does not resolve to anything the spec declares
+//	ATG25xx  identity — names that collide
+//
+// Numbers are left with gaps so a later code joins its neighbours. A retired
+// code is never reused: the registry records the version each shipped in, and
+// a number that once meant something else would make an old CI log lie.
+const specSince = "v0.21.0"
+
+// ATG20xx — the document itself.
+var (
+	// SpecUnreadable is the file never being opened.
+	SpecUnreadable = register(2001, "SpecUnreadable", Entry{
+		Summary: "the spec file could not be read",
+		Detail:  "atago was given a path and the operating system refused to open it. The file may not exist, may be a directory, or may not be readable by the user running atago. Nothing was parsed, so no other diagnostic can be reported about this file.",
+		Fix:     "Check the path as spelled on the command line, and check the file's permissions. `atago list <dir>` shows which spec files atago can actually see in a directory.",
+		Since:   specSince,
+	})
+
+	// SpecEmpty is a file with nothing in it to run.
+	SpecEmpty = register(2002, "SpecEmpty", Entry{
+		Summary: "the spec file contains no YAML document",
+		Detail:  "The file was read but holds nothing a spec can be built from — it is empty, or contains only whitespace and comments. This is most often a file that was created but never filled in, or one whose contents were lost by an editor or a bad merge.",
+		Fix:     "A spec needs at least `version`, `suite`, and `scenarios`. Run `atago init` to write a runnable starter spec and edit that.",
+		Since:   specSince,
+	})
+
+	// YAMLSyntax is the document not being YAML at all.
+	YAMLSyntax = register(2003, "YAMLSyntax", Entry{
+		Summary: "the file is not valid YAML",
+		Detail:  "Parsing stopped before atago could look at what the document means. The reported line and column are where the parser gave up, which is usually at or just after the real mistake. Inconsistent indentation, a missing colon after a key, and an unclosed quote or bracket account for most of these.",
+		Fix:     "Fix the syntax at the reported position. Indentation in YAML must use spaces, never tabs, and every level must be indented consistently.",
+		Since:   specSince,
+	})
+
+	// YAMLTag is an explicit tag written into a spec.
+	YAMLTag = register(2004, "YAMLTag", Entry{
+		Summary: "an explicit YAML tag is not supported in a spec",
+		Detail:  "The document carries an explicit tag such as `!!str` or `!!map`. atago's schema is closed and fully typed: every field's type already fixes how its value is read, so a tag can only restate what the schema says or contradict it. The one exception is `!!binary`, which `atago record` writes when a captured stream is not valid UTF-8.",
+		Fix:     "Remove the tag. If a value needs to be forced to text, quote it instead.",
+		Since:   specSince,
+	})
+
+	// UnknownKey is a key the schema does not define.
+	UnknownKey = register(2005, "UnknownKey", Entry{
+		Summary: "the spec sets a key the schema does not define",
+		Detail:  "Specs are decoded strictly, so a key atago does not know is an error rather than something quietly ignored — a silently dropped `assert:` block is a test that passes without testing anything. The usual causes are a typo, a key written at the wrong nesting level, and a key from a newer atago than the one running.",
+		Fix:     "Check the spelling and the indentation against the message's suggestion. The JSON Schema under `schema/atago.schema.json` gives an editor live completion for every key.",
+		Since:   specSince,
+	})
+
+	// WrongValueShape is a value written in a shape its key cannot take.
+	WrongValueShape = register(2006, "WrongValueShape", Entry{
+		Summary: "a value is written in a shape the key does not accept",
+		Detail:  "The key exists but its value is the wrong kind of thing — a bare string where a mapping is wanted, a mapping where a list is wanted, or text where a number is wanted. The most common instance by far is a stream assertion written as a bare scalar: `stdout: hello` rather than `stdout: {contains: hello}`.",
+		Fix:     "Write the value in the shape the key takes. Stream assertions (`stdout`, `stderr`, `body`, `rows`, `message`, `value`) always take a matcher mapping such as `{contains: \"...\"}` or `{equals: \"...\"}`.",
+		Since:   specSince,
+	})
+
+	// SpecVersion is an unsupported spec format version.
+	SpecVersion = register(2010, "SpecVersion", Entry{
+		Summary: "the spec declares a format version atago does not support",
+		Detail:  "The `version` key names the spec format, not the atago release, and `\"1\"` is the only format that exists. A version of `1` without quotes is read as a number and is also refused, because the field is a format name rather than a quantity.",
+		Fix:     "Write `version: \"1\"`, with the quotes.",
+		Since:   specSince,
+	})
+)
+
+// ATG21xx — a key that should not be there, or a contradictory combination.
+var (
+	// StepNoAction is a step that does nothing.
+	StepNoAction = register(2101, "StepNoAction", Entry{
+		Summary: "a step sets no action",
+		Detail:  "Every step does exactly one thing: run a command, make a request, drive a terminal, write a fixture, assert, or one of the other actions. A step with none of them is usually a block whose action key was lost to a bad indent, or a placeholder that was never filled in.",
+		Fix:     "Give the step exactly one of `fixture`, `run`, `http`, `query`, `grpc`, `cdp`, `assert`, `store`, `pty`, or `signal` — or delete the step.",
+		Since:   specSince,
+	})
+
+	// StepManyActions is a step that tries to do several things at once.
+	StepManyActions = register(2102, "StepManyActions", Entry{
+		Summary: "a step sets more than one action",
+		Detail:  "A step is one action so that ordering, timing, and failure are unambiguous: a step that both ran a command and made a request has no single answer for which one a `duration` bounds or which one an assertion followed. The usual cause is a second action indented into the previous step instead of starting a new one.",
+		Fix:     "Split the actions into separate list items under `steps:`, one `- ` per action.",
+		Since:   specSince,
+	})
+
+	// ExclusiveKeys is a combination that contradicts itself.
+	ExclusiveKeys = register(2103, "ExclusiveKeys", Entry{
+		Summary: "keys that contradict each other are set together",
+		Detail:  "Two keys were set whose meanings cannot both hold. A snapshot already pins every byte of what it captures, so pairing it with a size bound or with the `contains`/`count`/`glob` family asks the same question twice and invites the two answers to disagree. An exact `size` next to `min_size`/`max_size`, two lower bounds, and `exists: false` next to a size are the same mistake in other places.",
+		Fix:     "Keep the key that expresses what you actually want to pin and drop the other. The message names both.",
+		Since:   specSince,
+	})
+
+	// ChooseExactlyOne is a group where exactly one member is required.
+	ChooseExactlyOne = register(2104, "ChooseExactlyOne", Entry{
+		Summary: "a group of keys that takes exactly one member has none or several",
+		Detail:  "Some blocks offer alternatives that are mutually exclusive by nature: a `pty` step is one of expect, send, expect_screen, resize, or exec; an `exit_code` is a bare number, a `not`, or an `in`. Setting several leaves the meaning undefined, and setting none leaves the block with nothing to do.",
+		Fix:     "Set exactly one member of the group the message lists. To do two things, write two entries.",
+		Since:   specSince,
+	})
+
+	// KeyNotHere is a real key used where it has no meaning.
+	KeyNotHere = register(2105, "KeyNotHere", Entry{
+		Summary: "a key is real but has no meaning in this position",
+		Detail:  "The key exists elsewhere in the schema but not here, and accepting it silently would make it look effective when it is not. `defaults.run.command` is the clearest case: defaults describe how every step runs, while the command is what an individual step is, so a default command would be inherited by steps that already have one and quietly ignored. `trim` and `text` outside a store source, and `recursive` next to `snapshot`, are the same shape of mistake.",
+		Fix:     "Move the key to where it applies, or drop it. The message says which of the two the key needs.",
+		Since:   specSince,
+	})
+
+	// BlockNotHere is a whole block used at the wrong level.
+	BlockNotHere = register(2106, "BlockNotHere", Entry{
+		Summary: "a block is not allowed at this level of the spec",
+		Detail:  "Some blocks are tied to a level by what they own. A `service` or `mock_server` step belongs in `suite.setup` because it outlives any one scenario; a scenario-scoped peer goes in that scenario's own `services:` or `mock_servers:` list instead. Others go the other way: steps needing a scenario workdir and runners cannot sit at suite level, and `assert.changes` is not available in teardown because the workdir delta is tracked only around a scenario's steps.",
+		Fix:     "Move the block to the level the message names.",
+		Since:   specSince,
+	})
+
+	// AssertNeedsStep is an assertion with nothing to assert about.
+	AssertNeedsStep = register(2107, "AssertNeedsStep", Entry{
+		Summary: "an assertion needs a preceding step it does not have",
+		Detail:  "Some assertions describe the step before them rather than the scenario as a whole. `assert.screen` reads the terminal a `pty` step rendered, `assert.duration` bounds the wall-clock time of the step it follows, and `assert.changes` pins the workdir delta of the run or pty step it follows. Without that step there is nothing for the assertion to be about, so it would pass or fail for reasons unrelated to what it says.",
+		Fix:     "Put the assertion directly after the step it describes. One assert block may set several keys at once, so an `exit_code`, a `stdout`, and a `changes` about the same step belong together.",
+		Since:   specSince,
+	})
+
+	// KeyNeedsAnother is a key that only means something alongside another.
+	KeyNeedsAnother = register(2108, "KeyNeedsAnother", Entry{
+		Summary: "a key needs another key that is not set",
+		Detail:  "The key is only meaningful in the presence of a second one: `max_diff` bounds the difference `similar_to` measures, `pass_env` selects which host variables survive a `clear_env`, and `count` counts the matches of a `contains`. Alone, the key has nothing to act on, so accepting it would leave a spec that looks like it constrains something and does not.",
+		Fix:     "Add the key the message names, or drop the one that depends on it.",
+		Since:   specSince,
+	})
+)
+
+// ATG22xx — something required is missing.
+var (
+	// RequiredKey is a key the spec cannot do without.
+	RequiredKey = register(2201, "RequiredKey", Entry{
+		Summary: "a required key is missing",
+		Detail:  "The block cannot be acted on without this key: a service with no command has nothing to start, an HTTP step with no method has no request to make, a scenario with no name cannot be selected, reported on, or documented. atago refuses these at load time rather than discovering them mid-run, so a broken spec fails before it starts changing anything.",
+		Fix:     "Add the key the message names to the block it names.",
+		Since:   specSince,
+	})
+
+	// EmptyList is a list that has to hold something and does not.
+	EmptyList = register(2202, "EmptyList", Entry{
+		Summary: "a list that must hold at least one entry is empty",
+		Detail:  "A suite with no scenarios, a scenario with no steps, or a `cdp` block with no actions is accepted by YAML and means nothing to run. Left alone it would report success without having tested anything, which is worse than failing.",
+		Fix:     "Add an entry to the list, or remove the block that holds it.",
+		Since:   specSince,
+	})
+
+	// ChooseAtLeastOne is a group where at least one member is required.
+	ChooseAtLeastOne = register(2203, "ChooseAtLeastOne", Entry{
+		Summary: "a group of keys that needs at least one member has none",
+		Detail:  "Unlike an exactly-one group, these accept any combination — but not the empty one, which would assert nothing. `assert.changes` needs at least one of `created`, `modified`, or `deleted`; a bounds block needs at least one of `lt`, `lte`, `gt`, or `gte`; a recursive directory assert needs at least one matcher.",
+		Fix:     "Set one or more members of the group the message lists. To assert that a category changed nothing, write it explicitly as an empty list, e.g. `created: []`.",
+		Since:   specSince,
+	})
+
+	// EmptyValue is a key written with nothing in it.
+	EmptyValue = register(2204, "EmptyValue", Entry{
+		Summary: "a value that must not be empty is empty",
+		Detail:  "The key is present but carries nothing. This is worse than leaving the key out, because an empty value usually does not mean what it looks like: an empty ignore pattern excludes nothing, an empty name identifies nothing, an empty path names the workdir itself.",
+		Fix:     "Give the key a value, or remove the key. Where removing it is the right answer the message says so.",
+		Since:   specSince,
+	})
+)
+
+// ATG23xx — a value that is present but wrong.
+var (
+	// BadDuration is text that does not parse as a duration.
+	BadDuration = register(2301, "BadDuration", Entry{
+		Summary: "a duration is not written in a form atago can read",
+		Detail:  "Durations are written as a number with a unit — `500ms`, `2s`, `2m`, `1h30m` — and a bare number is refused because it does not say which unit was meant. A timeout that silently meant nanoseconds instead of seconds would look like a hang.",
+		Fix:     "Write the value with a unit, e.g. `timeout: 2m`. Where a duration can be disabled, `\"0\"` does that.",
+		Since:   specSince,
+	})
+
+	// NegativeValue is a quantity below zero that cannot be.
+	NegativeValue = register(2302, "NegativeValue", Entry{
+		Summary: "a value is negative where a negative has no meaning",
+		Detail:  "Wall-clock bounds, sizes, counts, and page numbers are never below zero. A negative here is nearly always a sign slip or an arithmetic mistake in a generated spec, and treating it as zero would hide that.",
+		Fix:     "Use zero or a positive value. Where the intent was to disable a bound rather than set it to nothing, the message names the way to do that.",
+		Since:   specSince,
+	})
+
+	// NonPositiveValue is zero where zero has no meaning.
+	NonPositiveValue = register(2303, "NonPositiveValue", Entry{
+		Summary: "a value must be positive and is zero or below",
+		Detail:  "Some values have no sensible zero: an interval that never elapses, a worker count of nobody, a retry that waits no time between attempts. Where atago has a working default, zero would be indistinguishable from not setting the key at all.",
+		Fix:     "Set a positive value, or omit the key to take atago's default.",
+		Since:   specSince,
+	})
+
+	// OutOfRange is a number outside what the field accepts.
+	OutOfRange = register(2304, "OutOfRange", Entry{
+		Summary: "a number is outside the range the key accepts",
+		Detail:  "The value parsed but falls outside what the field can mean. Screen coordinates are 1-based cells, so row or column zero is not the first cell but a mistake, and it is the instance of this seen most often — a spec written against a 0-based mental model reads the wrong cell everywhere or nowhere.",
+		Fix:     "Bring the value into the range the message states.",
+		Since:   specSince,
+	})
+
+	// BadRegexp is a pattern that does not compile.
+	BadRegexp = register(2305, "BadRegexp", Entry{
+		Summary: "a regular expression does not compile",
+		Detail:  "atago compiles every pattern in a spec at load time — `matches`, scrub patterns, readiness patterns — so a broken one is reported before the run rather than at the moment it would first have been used, halfway through a suite. The syntax is Go's RE2: no backreferences and no lookaround.",
+		Fix:     "Correct the pattern at the position the message reports. Regex metacharacters that are meant literally need escaping, and a pattern inside a YAML double-quoted string needs its backslashes doubled — single quotes avoid that.",
+		Since:   specSince,
+	})
+
+	// BadGlob is a path pattern that does not parse.
+	BadGlob = register(2306, "BadGlob", Entry{
+		Summary: "a glob pattern is not valid",
+		Detail:  "Globs match paths by shape — `*` within a path segment, `**` across segments, `?` for one character, `[...]` for a class, `{a,b}` for alternatives. An unclosed bracket or brace is the usual cause.",
+		Fix:     "Close the unbalanced bracket or brace, or escape it if it was meant literally.",
+		Since:   specSince,
+	})
+
+	// NotAllowedValue is a value outside a closed set of choices.
+	NotAllowedValue = register(2307, "NotAllowedValue", Entry{
+		Summary: "a value is not one of the choices the key allows",
+		Detail:  "The key takes a fixed vocabulary and the value is not in it. Platform names are the common case: `os` accepts `linux`, `darwin`, or `windows`, so `macos` or `osx` — reasonable words that Go's platform names do not use — are refused rather than quietly never matching.",
+		Fix:     "Use one of the values the message lists.",
+		Since:   specSince,
+	})
+
+	// EmptyInterval is a range that can never be satisfied.
+	EmptyInterval = register(2308, "EmptyInterval", Entry{
+		Summary: "the bounds of a range describe an interval nothing can fall in",
+		Detail:  "A lower bound at or above the upper bound leaves no value that could satisfy both, so the assertion can only ever fail. This is almost always two bounds swapped, or a copied block whose second bound was not updated.",
+		Fix:     "Order the bounds so the lower one is genuinely below the upper one, or use a single bound if only one side matters.",
+		Since:   specSince,
+	})
+
+	// AbsolutePath is an absolute path where a relative one is required.
+	AbsolutePath = register(2309, "AbsolutePath", Entry{
+		Summary: "a path is absolute where it must be workdir-relative",
+		Detail:  "Paths in a spec are relative to the scenario's own workdir, which is created fresh for each scenario. That is what lets the same spec run on another machine, in CI, and in parallel with itself. An absolute path names one machine's filesystem and breaks all three.",
+		Fix:     "Write the path relative to the scenario workdir, e.g. `out/report.json` rather than `/home/you/project/out/report.json`.",
+		Since:   specSince,
+	})
+
+	// PathEscapesWorkdir is a relative path pointing outside the workdir.
+	PathEscapesWorkdir = register(2310, "PathEscapesWorkdir", Entry{
+		Summary: "a path leads outside the scenario workdir",
+		Detail:  "The path is relative but climbs out of the workdir with `../`. Scenario isolation is what makes a failing scenario reproducible and a parallel run safe, and a path that reaches outside it can read or overwrite another scenario's files, or the repository being tested. This is refused while loading; the equivalent refusal during a run is reported as a security violation and exits 6.",
+		Fix:     "Keep the path inside the workdir. To work with a file that genuinely lives elsewhere, copy it in with a `fixture` step, which is the supported way to bring outside data into a scenario.",
+		Since:   specSince,
+	})
+
+	// ControlCharacter is an unprintable byte in a name.
+	ControlCharacter = register(2311, "ControlCharacter", Entry{
+		Summary: "a name contains a control character",
+		Detail:  "Suite and scenario names are printed in aligned tables, written into generated Markdown as headings, and turned into anchors and report fields. A newline, tab, or other control byte corrupts every one of those, and a name that renders differently in each place cannot be selected reliably with `--scenario`.",
+		Fix:     "Remove the control character. A name spanning lines usually comes from a YAML block scalar (`|` or `>`) where a plain string was meant.",
+		Since:   specSince,
+	})
+
+	// VacuousMatcher is a matcher that cannot do its job.
+	VacuousMatcher = register(2312, "VacuousMatcher", Entry{
+		Summary: "a matcher can never fail, or can never pass",
+		Detail:  "The matcher is well-formed and asserts nothing. An empty substring is contained in every string, so `contains: \"\"` always passes and `not_contains: \"\"` never can; a regexp matching the empty string behaves the same way. A test that cannot fail is worse than no test, because it reports success and is counted as coverage.",
+		Fix:     "Give the matcher a real substring or pattern, or remove it. Where a pattern is meant to match an empty field, anchor it (`^$`) rather than leaving it empty.",
+		Since:   specSince,
+	})
+
+	// BadFormat is a value that does not follow the notation its key requires.
+	BadFormat = register(2313, "BadFormat", Entry{
+		Summary: "a value is not written in the notation the key requires",
+		Detail:  "The key takes a value in a specific notation rather than from a fixed list of choices — an octal file mode, an RFC 3339 timestamp, base64 data, a JSON path, a color, a URL path beginning with a slash. The value given does not parse in that notation.",
+		Fix:     "Rewrite the value in the notation the message names. Its example shows the accepted form.",
+		Since:   specSince,
+	})
+)
+
+// ATG24xx — a name that does not resolve.
+var (
+	// RunnerNotDeclared is a step naming a runner the spec never declared.
+	RunnerNotDeclared = register(2401, "RunnerNotDeclared", Entry{
+		Summary: "a step names a runner the spec does not declare",
+		Detail:  "Steps that reach outside the local machine — `http`, `query`, `grpc`, `cdp`, `ssh` — address a runner by name, and runners are declared once under the spec's `runners:` block. A name with no declaration behind it is a typo or a block that was never added.",
+		Fix:     "Declare the runner under `runners:`, or correct the name to one that is declared. The message lists the names the spec does declare.",
+		Since:   specSince,
+	})
+
+	// RunnerTypeMismatch is a declared runner of the wrong kind.
+	RunnerTypeMismatch = register(2402, "RunnerTypeMismatch", Entry{
+		Summary: "a step names a runner of the wrong type",
+		Detail:  "The runner is declared, but it is not the kind this step needs: a `query` step needs a database runner, an `http` step needs an HTTP runner. The usual cause is one name copied where another was meant, in a spec that declares several runners.",
+		Fix:     "Name a runner of the type the message asks for.",
+		Since:   specSince,
+	})
+
+	// NameNotDeclared is a reference to a service, mock, or stored value that
+	// the spec never defines.
+	NameNotDeclared = register(2403, "NameNotDeclared", Entry{
+		Summary: "a reference names something the spec does not declare",
+		Detail:  "Services, mock servers, and stored values are addressed by name from elsewhere in the spec — a signal targets a service, an assertion targets a mock, an expansion reads a stored value. A name nothing declares would be resolved at run time against nothing at all.",
+		Fix:     "Declare the target, or correct the name. Suite-level services and mocks are visible to every scenario; a scenario's own are visible only within it.",
+		Since:   specSince,
+	})
+
+	// ReservedName is a name atago has already given a meaning.
+	ReservedName = register(2404, "ReservedName", Entry{
+		Summary: "a name collides with one atago reserves",
+		Detail:  "atago provides a few variables of its own — `atago`, `workdir`, `suitedir` — and a stored value taking one of those names would shadow it. Every later expansion would then read the spec's value where it meant atago's, silently and only in the specs that happen to declare the name.",
+		Fix:     "Choose another name for the stored value.",
+		Since:   specSince,
+	})
+
+	// PathNotUsable is a path that resolves to nothing, or to the wrong kind
+	// of thing.
+	PathNotUsable = register(2405, "PathNotUsable", Entry{
+		Summary: "a path does not exist, or is not the kind of thing the key needs",
+		Detail:  "Some paths are resolved while loading rather than during a run, because a typo caught here is one message about the spec instead of an identical failure in every scenario that uses it. A directory manifest's `fixtures_dir` is the usual case: a path that is missing, or that names a file where a directory is wanted.",
+		Fix:     "Correct the path, or create what it points at. Relative paths are resolved against the file that declares them.",
+		Since:   specSince,
+	})
+)
+
+// ATG25xx — identity.
+var (
+	// DuplicateName is two things in one spec answering to the same name.
+	DuplicateName = register(2501, "DuplicateName", Entry{
+		Summary: "two entries in the same spec share a name",
+		Detail:  "Names identify: `--scenario` selects by them, reports and generated docs are keyed by them, and services and mocks are addressed by them. With a duplicate, selecting one of the pair is impossible and a report cannot say which of the two it describes. Copy-and-edit that stopped before editing the name is the usual cause.",
+		Fix:     "Rename one of the two. Where the duplicates were meant to be one thing parameterized, `matrix:` generates distinct names for each combination.",
+		Since:   specSince,
+	})
+
+	// DuplicateEntry is a list repeating something it must list once.
+	DuplicateEntry = register(2502, "DuplicateEntry", Entry{
+		Summary: "a list repeats an entry that must appear once",
+		Detail:  "Some lists are sets: the exit codes `in` accepts, the observables `deterministic.compare` watches, the modifiers a key press carries. A repeat has no second meaning, so it is either a merge artefact or a value that was meant to be different.",
+		Fix:     "Remove the repeat, or change it to the value that was meant.",
+		Since:   specSince,
+	})
+)

--- a/internal/diag/diag.go
+++ b/internal/diag/diag.go
@@ -1,0 +1,187 @@
+// Package diag defines atago's diagnostic codes: the stable, searchable names
+// for the errors atago itself reports.
+//
+// A message alone is a dead end. "unknown assert key" cannot be searched for,
+// linked to, or branched on, and rewording it next release breaks every
+// bookmark and every script that matched on the prose. A code survives
+// rewording, so the message stays free to improve.
+//
+// A code is `ATG` followed by four digits whose thousands digit is the process
+// exit code the diagnostic produces, making the code a refinement of the exit
+// contract rather than a second contract beside it:
+//
+//	ATG2xxx  exit 2  spec error — YAML syntax, schema, semantic validation
+//	ATG3xxx  exit 3  configuration error — CLI invocation, flags, target selection
+//	ATG4xxx  exit 4  execution error — a step could not be carried out
+//	ATG5xxx  exit 5  internal error — an atago bug
+//	ATG6xxx  exit 6  security policy violation
+//
+// ATG1xxx is never assigned: exit 1 is an assertion failing, which is a spec
+// doing its job rather than atago failing to do its own.
+//
+// Codes are grouped by what the reader has to fix, never one per call site.
+// Two errors share a code when the fix is the same and differ when it differs,
+// so the published reference reads as a list of problems a person can act on.
+//
+// # Why a code cannot go missing
+//
+// Codes are not constants that a registry then describes; they are what
+// registering returns. [register] is the only way to obtain a [Code], and it
+// refuses an entry that omits any of the text the published reference needs. A
+// code with no documentation is therefore not something to test for — it is
+// unconstructable.
+package diag
+
+import (
+	"fmt"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// Code is one diagnostic's stable identity. The zero value is not a valid
+// code; every Code comes from [register], which is unexported, so the set of
+// codes is closed and each member is documented by construction.
+type Code int
+
+// String renders the code in its published form, e.g. "ATG2201".
+func (c Code) String() string {
+	return fmt.Sprintf("ATG%04d", int(c))
+}
+
+// ExitCode is the process exit status a diagnostic with this code produces,
+// which is the code's own thousands digit.
+func (c Code) ExitCode() int {
+	return int(c) / 1000
+}
+
+// Annotate prefixes a message with the code, which is how every coded
+// diagnostic reaches the user: the code is added to the sentence, never
+// substituted for it.
+func (c Code) Annotate(msg string) string {
+	return c.String() + ": " + msg
+}
+
+// Entry is a code's published documentation.
+type Entry struct {
+	// Code is the diagnostic's identity.
+	Code Code
+	// Name is the Go identifier this package binds the code to. It lets a test
+	// prove that every registered code is reachable from real code, and that
+	// the identifier and the entry have not drifted apart.
+	Name string
+	// Summary is the one-line meaning, written as the problem rather than as
+	// the message any single call site happens to print.
+	Summary string
+	// Detail explains what atago was doing and why this is refused.
+	Detail string
+	// Fix tells the reader what to change. A diagnostic that does not say how
+	// to proceed gets worked around instead of fixed.
+	Fix string
+	// Since is the atago version the code first shipped in.
+	Since string
+}
+
+// codeText matches a code in its published form, anywhere in a string. It is
+// the same syntax [Parse] accepts and the form the E2E coverage gate looks for
+// in the specs.
+var codeText = regexp.MustCompile(`\bATG([0-9]{4})\b`)
+
+// registry holds every code in registration order; [All] sorts it.
+var registry []Entry
+
+// byCode indexes the registry for lookup, and is what makes a duplicate
+// number impossible to register.
+var byCode = map[Code]Entry{}
+
+// register records one diagnostic and returns its code. It is the only source
+// of a [Code], so a code cannot exist without the documentation the published
+// reference is generated from.
+//
+// It panics on a malformed registration rather than returning an error: every
+// call is a package-level variable in this file, so a mistake is a programming
+// error caught the first time anything imports diag, including the first test.
+func register(number int, name string, e Entry) Code {
+	c := Code(number)
+	switch {
+	case number < 2000 || number > 6999:
+		panic(fmt.Sprintf("diag: code %d is outside the ATG2000-ATG6999 range", number))
+	case number/1000 == 1:
+		panic(fmt.Sprintf("diag: code %d is in the ATG1xxx range, which is reserved: exit 1 is an assertion failing, not an atago error", number))
+	case name == "":
+		panic(fmt.Sprintf("diag: %s has no identifier name", c))
+	case e.Summary == "":
+		panic(fmt.Sprintf("diag: %s has no summary", c))
+	case e.Detail == "":
+		panic(fmt.Sprintf("diag: %s has no detail", c))
+	case e.Fix == "":
+		panic(fmt.Sprintf("diag: %s has no fix", c))
+	case e.Since == "":
+		panic(fmt.Sprintf("diag: %s does not say which version it shipped in", c))
+	}
+	if prev, dup := byCode[c]; dup {
+		panic(fmt.Sprintf("diag: %s is already registered as %s", c, prev.Name))
+	}
+	e.Code = c
+	e.Name = name
+	registry = append(registry, e)
+	byCode[c] = e
+	return c
+}
+
+// All returns every registered diagnostic, ordered by code. The published
+// reference and `atago explain` both render this, so neither can drift from
+// the other.
+func All() []Entry {
+	out := slices.Clone(registry)
+	slices.SortFunc(out, func(a, b Entry) int { return int(a.Code) - int(b.Code) })
+	return out
+}
+
+// Lookup returns the entry for a code.
+func Lookup(c Code) (Entry, bool) {
+	e, ok := byCode[c]
+	return e, ok
+}
+
+// Parse reads a code written in its published form, e.g. "ATG2201". It accepts
+// only registered codes: a well-formed number nobody assigned is not a code,
+// and reporting it as one would send the reader to a page that does not exist.
+// Case is ignored so a code copied out of prose still resolves.
+func Parse(s string) (Code, bool) {
+	s = strings.TrimSpace(s)
+	if !strings.EqualFold(s[:min(len(s), 3)], "ATG") {
+		return 0, false
+	}
+	n, err := strconv.Atoi(s[3:])
+	if err != nil {
+		return 0, false
+	}
+	c := Code(n)
+	if _, ok := byCode[c]; !ok {
+		return 0, false
+	}
+	return c, true
+}
+
+// Codes returns every registered code mentioned in text, in order of
+// appearance and without repeats. The E2E coverage gate uses it to prove that
+// each published code is provoked by a real scenario.
+func Codes(text string) []Code {
+	var out []Code
+	for _, m := range codeText.FindAllStringSubmatch(text, -1) {
+		n, err := strconv.Atoi(m[1])
+		if err != nil {
+			continue
+		}
+		c := Code(n)
+		if _, ok := byCode[c]; !ok {
+			continue
+		}
+		if !slices.Contains(out, c) {
+			out = append(out, c)
+		}
+	}
+	return out
+}

--- a/internal/diag/diag_test.go
+++ b/internal/diag/diag_test.go
@@ -1,0 +1,314 @@
+package diag
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestCode_String(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		code Code
+		want string
+	}{
+		"four digits":       {code: Code(2201), want: "ATG2201"},
+		"trailing zeros":    {code: Code(2010), want: "ATG2010"},
+		"highest family":    {code: Code(6999), want: "ATG6999"},
+		"padded to four":    {code: Code(2001), want: "ATG2001"},
+		"exit-4 family":     {code: Code(4100), want: "ATG4100"},
+		"unregistered code": {code: Code(2999), want: "ATG2999"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.code.String(); got != tt.want {
+				t.Errorf("String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCode_ExitCode(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		code Code
+		want int
+	}{
+		"spec error":    {code: SpecEmpty, want: 2},
+		"config error":  {code: Code(3001), want: 3},
+		"exec error":    {code: Code(4999), want: 4},
+		"internal":      {code: Code(5000), want: 5},
+		"security":      {code: Code(6500), want: 6},
+		"top of family": {code: Code(2999), want: 2},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.code.ExitCode(); got != tt.want {
+				t.Errorf("ExitCode() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCode_Annotate(t *testing.T) {
+	t.Parallel()
+	got := RequiredKey.Annotate(`scenarios[0].name is required`)
+	want := `ATG2201: scenarios[0].name is required`
+	if got != want {
+		t.Errorf("Annotate() = %q, want %q", got, want)
+	}
+}
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		in     string
+		want   Code
+		wantOK bool
+	}{
+		"registered code":     {in: "ATG2201", want: RequiredKey, wantOK: true},
+		"surrounding spaces":  {in: "  ATG2201 ", want: RequiredKey, wantOK: true},
+		"lowercase prefix":    {in: "atg2201", want: RequiredKey, wantOK: true},
+		"mixed case prefix":   {in: "Atg2201", want: RequiredKey, wantOK: true},
+		"well-formed unknown": {in: "ATG2999", wantOK: false},
+		"unassigned family":   {in: "ATG1000", wantOK: false},
+		"no prefix":           {in: "2201", wantOK: false},
+		"not a number":        {in: "ATGabcd", wantOK: false},
+		"empty":               {in: "", wantOK: false},
+		"prefix only":         {in: "ATG", wantOK: false},
+		"shorter than prefix": {in: "AT", wantOK: false},
+		"trailing text":       {in: "ATG2201x", wantOK: false},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := Parse(tt.in)
+			if ok != tt.wantOK {
+				t.Fatalf("Parse(%q) ok = %v, want %v", tt.in, ok, tt.wantOK)
+			}
+			if ok && got != tt.want {
+				t.Errorf("Parse(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCodes(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		in   string
+		want []Code
+	}{
+		"one code in a sentence": {
+			in:   "spec.yaml: ATG2201: suite.name is required",
+			want: []Code{RequiredKey},
+		},
+		"several, in order of appearance": {
+			in:   "ATG2501 and then ATG2201",
+			want: []Code{DuplicateName, RequiredKey},
+		},
+		"repeats collapse": {
+			in:   "ATG2201 ATG2201 ATG2201",
+			want: []Code{RequiredKey},
+		},
+		"unregistered numbers are not codes": {
+			in:   "ATG2999 ATG2201",
+			want: []Code{RequiredKey},
+		},
+		"a longer number is not a code": {
+			in:   "ATG22015",
+			want: nil,
+		},
+		"no codes": {
+			in:   "everything passed",
+			want: nil,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := Codes(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("Codes() = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("Codes() = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestLookup(t *testing.T) {
+	t.Parallel()
+	e, ok := Lookup(RequiredKey)
+	if !ok {
+		t.Fatal("Lookup(RequiredKey) reported the code as unregistered")
+	}
+	if e.Code != RequiredKey || e.Name != "RequiredKey" {
+		t.Errorf("Lookup() = %+v, want the RequiredKey entry", e)
+	}
+	if _, ok := Lookup(Code(2999)); ok {
+		t.Error("Lookup(ATG2999) found an entry for an unassigned code")
+	}
+}
+
+// TestAll_Ordered checks the reference is rendered in code order regardless of
+// the order the entries happen to be declared in.
+func TestAll_Ordered(t *testing.T) {
+	t.Parallel()
+	all := All()
+	if len(all) == 0 {
+		t.Fatal("no diagnostics are registered")
+	}
+	for i := 1; i < len(all); i++ {
+		if all[i-1].Code >= all[i].Code {
+			t.Fatalf("All() is not ascending at %d: %s then %s", i, all[i-1].Code, all[i].Code)
+		}
+	}
+}
+
+// TestAll_EntriesAreComplete restates at the registry level what register
+// enforces per call, so a future entry added by some other path cannot land
+// half-documented.
+func TestAll_EntriesAreComplete(t *testing.T) {
+	t.Parallel()
+	for _, e := range All() {
+		if e.Name == "" || e.Summary == "" || e.Detail == "" || e.Fix == "" || e.Since == "" {
+			t.Errorf("%s (%s) is missing published text: %+v", e.Code, e.Name, e)
+		}
+		if fam := e.Code.ExitCode(); fam < 2 || fam > 6 {
+			t.Errorf("%s is in family %d, outside the documented ATG2xxx-ATG6xxx range", e.Code, fam)
+		}
+	}
+}
+
+// TestRegister_RejectsBadRegistrations pins the guarantees register makes. They
+// are what lets the rest of the codebase treat "a code exists" and "a code is
+// documented" as the same statement.
+func TestRegister_RejectsBadRegistrations(t *testing.T) {
+	t.Parallel()
+	full := Entry{Summary: "s", Detail: "d", Fix: "f", Since: "v0.21.0"}
+	tests := map[string]struct {
+		number int
+		name   string
+		entry  Entry
+	}{
+		"below the range":    {number: 1999, name: "X", entry: full},
+		"above the range":    {number: 7000, name: "X", entry: full},
+		"reserved family":    {number: 1200, name: "X", entry: full},
+		"no name":            {number: 2900, name: "", entry: full},
+		"no summary":         {number: 2900, name: "X", entry: Entry{Detail: "d", Fix: "f", Since: "v"}},
+		"no detail":          {number: 2900, name: "X", entry: Entry{Summary: "s", Fix: "f", Since: "v"}},
+		"no fix":             {number: 2900, name: "X", entry: Entry{Summary: "s", Detail: "d", Since: "v"}},
+		"no since":           {number: 2900, name: "X", entry: Entry{Summary: "s", Detail: "d", Fix: "f"}},
+		"already registered": {number: int(RequiredKey), name: "X", entry: full},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			defer func() {
+				if recover() == nil {
+					t.Errorf("register(%d, %q, ...) was accepted, want a panic", tt.number, tt.name)
+				}
+			}()
+			register(tt.number, tt.name, tt.entry)
+		})
+	}
+}
+
+// TestRegistry_NamesMatchIdentifiers is the guard against the one duplication
+// in this package: register takes the identifier's name as a string so the
+// registry can report it, and nothing but this test stops the two from
+// drifting. It also proves every code in the package is registered rather than
+// constructed some other way, by requiring each Code-typed package variable to
+// come from a register call.
+func TestRegistry_NamesMatchIdentifiers(t *testing.T) {
+	t.Parallel()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read the diag package directory: %v", err)
+	}
+	fset := token.NewFileSet()
+	declared := map[string]int{}
+	for _, de := range entries {
+		path := de.Name()
+		if de.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		for _, decl := range file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.VAR {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for i, name := range vs.Names {
+					if i >= len(vs.Values) {
+						continue
+					}
+					call, ok := vs.Values[i].(*ast.CallExpr)
+					if !ok {
+						continue
+					}
+					fn, ok := call.Fun.(*ast.Ident)
+					if !ok || fn.Name != "register" {
+						continue
+					}
+					if len(call.Args) < 2 {
+						t.Fatalf("%s: register(%s) takes a number and a name", filepath.Base(path), name.Name)
+					}
+					lit, ok := call.Args[1].(*ast.BasicLit)
+					if !ok || lit.Kind != token.STRING {
+						t.Fatalf("%s: register's name argument for %s is not a string literal", filepath.Base(path), name.Name)
+					}
+					got, err := strconv.Unquote(lit.Value)
+					if err != nil {
+						t.Fatalf("%s: unquote the name argument for %s: %v", filepath.Base(path), name.Name, err)
+					}
+					if got != name.Name {
+						t.Errorf("%s: %s is registered under the name %q; the identifier and the registered name must match, or the reference names something that does not exist", filepath.Base(path), name.Name, got)
+					}
+					num, ok := call.Args[0].(*ast.BasicLit)
+					if !ok || num.Kind != token.INT {
+						t.Fatalf("%s: register's code argument for %s is not a literal number", filepath.Base(path), name.Name)
+					}
+					n, err := strconv.Atoi(num.Value)
+					if err != nil {
+						t.Fatalf("%s: parse the code argument for %s: %v", filepath.Base(path), name.Name, err)
+					}
+					declared[name.Name] = n
+				}
+			}
+		}
+	}
+
+	if len(declared) != len(All()) {
+		t.Errorf("the package declares %d register calls but %d diagnostics are registered", len(declared), len(All()))
+	}
+	for _, e := range All() {
+		n, ok := declared[e.Name]
+		if !ok {
+			t.Errorf("%s is registered as %q, which is not a package variable in diag", e.Code, e.Name)
+			continue
+		}
+		if Code(n) != e.Code {
+			t.Errorf("%s is bound to the identifier %s, which registers %d", e.Code, e.Name, n)
+		}
+	}
+}

--- a/internal/diag/markdown.go
+++ b/internal/diag/markdown.go
@@ -1,0 +1,93 @@
+package diag
+
+import (
+	"fmt"
+	"strings"
+)
+
+// families describes each code range on the generated reference page, in the
+// order the page presents them.
+var families = []struct {
+	exit    int
+	label   string
+	meaning string
+}{
+	{2, "ATG2xxx", "spec error — the file could not be parsed, or does not describe a runnable suite"},
+	{3, "ATG3xxx", "configuration error — the command line, its flags, or the spec files it selected"},
+	{4, "ATG4xxx", "execution error — a step could not be carried out"},
+	{5, "ATG5xxx", "internal error — a bug in atago"},
+	{6, "ATG6xxx", "security policy violation — atago refused an operation on policy grounds"},
+}
+
+// Markdown renders the published error reference from the registry. The
+// committed `doc/errors.md` is this output, and a drift test fails when the two
+// disagree, so a code cannot be added, reworded, or removed without its
+// documentation following.
+func Markdown() []byte {
+	var b strings.Builder
+
+	b.WriteString("# Error codes\n\n")
+	b.WriteString("Every error atago reports carries a code, so a failure can be searched for, linked to, and branched on without matching on prose that is free to improve. Assertion failures are not errors in this sense and carry no code: a spec that fails is a spec doing its job, and its message already says what was expected and what happened.\n\n")
+	b.WriteString("A code is `ATG` followed by four digits, and the first of those digits is the exit status the run produced. Reading `ATG2103` tells you the process exited 2 before it tells you anything else.\n\n")
+
+	b.WriteString("| Codes | Exit | Meaning |\n|---|---|---|\n")
+	for _, f := range families {
+		fmt.Fprintf(&b, "| `%s` | %d | %s |\n", f.label, f.exit, f.meaning)
+	}
+	b.WriteString("\n")
+	b.WriteString("`ATG1xxx` is never assigned. Exit 1 means one or more scenarios failed, which is a result rather than an error.\n\n")
+	b.WriteString("Codes are grouped by what you have to fix rather than by where in atago the error was raised, so one code can be reported from several places when the answer is the same in all of them.\n\n")
+	b.WriteString("Look a code up from the terminal with `atago explain ATG2201`, which prints this same text without a browser.\n\n")
+
+	all := All()
+	b.WriteString("## Every code\n\n")
+	b.WriteString("| Code | Meaning | Exit | Since |\n|---|---|---|---|\n")
+	for _, e := range all {
+		fmt.Fprintf(&b, "| [`%s`](#%s) | %s | %d | %s |\n", e.Code, anchor(e), e.Summary, e.Code.ExitCode(), e.Since)
+	}
+	b.WriteString("\n")
+
+	for _, f := range families {
+		section := entriesOf(all, f.exit)
+		if len(section) == 0 {
+			continue
+		}
+		fmt.Fprintf(&b, "## %s — exit %d\n\n", f.label, f.exit)
+		for _, e := range section {
+			fmt.Fprintf(&b, "### %s — %s\n\n", e.Code, e.Summary)
+			b.WriteString(e.Detail)
+			b.WriteString("\n\n")
+			fmt.Fprintf(&b, "Fix: %s\n\n", e.Fix)
+			fmt.Fprintf(&b, "Exits %d. Since %s.\n\n", e.Code.ExitCode(), e.Since)
+		}
+	}
+
+	return []byte(b.String())
+}
+
+// entriesOf returns the entries belonging to one exit-code family, in order.
+func entriesOf(all []Entry, exit int) []Entry {
+	var out []Entry
+	for _, e := range all {
+		if e.Code.ExitCode() == exit {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// anchor is the heading anchor GitHub and Hugo both derive from an entry's
+// heading: lowercased, non-alphanumerics dropped, spaces hyphenated.
+func anchor(e Entry) string {
+	heading := fmt.Sprintf("%s — %s", e.Code, e.Summary)
+	var b strings.Builder
+	for _, r := range strings.ToLower(heading) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-':
+			b.WriteRune(r)
+		case r == ' ':
+			b.WriteByte('-')
+		}
+	}
+	return b.String()
+}

--- a/internal/diag/markdown.go
+++ b/internal/diag/markdown.go
@@ -26,20 +26,26 @@ var families = []struct {
 func Markdown() []byte {
 	var b strings.Builder
 
-	b.WriteString("# Error codes\n\n")
-	b.WriteString("Every error atago reports carries a code, so a failure can be searched for, linked to, and branched on without matching on prose that is free to improve. Assertion failures are not errors in this sense and carry no code: a spec that fails is a spec doing its job, and its message already says what was expected and what happened.\n\n")
-	b.WriteString("A code is `ATG` followed by four digits, and the first of those digits is the exit status the run produced. Reading `ATG2103` tells you the process exited 2 before it tells you anything else.\n\n")
+	all := All()
 
-	b.WriteString("| Codes | Exit | Meaning |\n|---|---|---|\n")
+	b.WriteString("# Error codes\n\n")
+	b.WriteString("A coded error carries a name that can be searched for, linked to, and branched on, so the message beside it stays free to improve without breaking anyone. Assertion failures are not errors in this sense and carry no code: a spec that fails is a spec doing its job, and its message already says what was expected and what happened.\n\n")
+	b.WriteString("A code is `ATG` followed by four digits, and the first of those digits is the exit status the run produced. Reading `ATG2103` tells you the process exited 2 before it tells you anything else.\n\n")
+	b.WriteString("Codes are being assigned one family at a time. The table says which families carry them today; an error from a family not yet covered still exits the same way and still says what went wrong, it just has no code to look up here yet.\n\n")
+
+	b.WriteString("| Codes | Exit | Meaning | Assigned |\n|---|---|---|---|\n")
 	for _, f := range families {
-		fmt.Fprintf(&b, "| `%s` | %d | %s |\n", f.label, f.exit, f.meaning)
+		assigned := "not yet"
+		if n := len(entriesOf(all, f.exit)); n > 0 {
+			assigned = fmt.Sprintf("%d codes", n)
+		}
+		fmt.Fprintf(&b, "| `%s` | %d | %s | %s |\n", f.label, f.exit, f.meaning, assigned)
 	}
 	b.WriteString("\n")
 	b.WriteString("`ATG1xxx` is never assigned. Exit 1 means one or more scenarios failed, which is a result rather than an error.\n\n")
 	b.WriteString("Codes are grouped by what you have to fix rather than by where in atago the error was raised, so one code can be reported from several places when the answer is the same in all of them.\n\n")
 	b.WriteString("Look a code up from the terminal with `atago explain ATG2201`, which prints this same text without a browser.\n\n")
 
-	all := All()
 	b.WriteString("## Every code\n\n")
 	b.WriteString("| Code | Meaning | Exit | Since |\n|---|---|---|---|\n")
 	for _, e := range all {

--- a/internal/diag/usage_test.go
+++ b/internal/diag/usage_test.go
@@ -1,0 +1,162 @@
+package diag
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// familyOf maps a package to the exit code the diagnostics it raises must
+// belong to. A package that raises coded errors has to appear here, so adding
+// one is a deliberate statement about which family it reports in rather than
+// something that happens by accident.
+//
+// The point is the thousands digit: ATG2103 promises the process exits 2, and
+// that promise is only true if the package raising it exits 2. A loader
+// reporting an ATG4xxx would make the code lie about what the reader is
+// looking at.
+var familyOf = map[string]int{
+	"internal/loader": 2,
+}
+
+// TestCodes_AreReferenced is the guard against a code that exists only in the
+// reference. Every registered diagnostic must be raised from somewhere in
+// non-test code: publishing a code atago cannot produce sends the reader
+// looking for a cause that is not there, and leaves dead entries behind when a
+// check is deleted.
+func TestCodes_AreReferenced(t *testing.T) {
+	t.Parallel()
+	used := usedCodes(t)
+	for _, e := range All() {
+		if _, ok := used[e.Name]; !ok {
+			t.Errorf("%s (diag.%s) is registered and documented but never raised; either use it or remove its entry", e.Code, e.Name)
+		}
+	}
+}
+
+// TestCodes_MatchTheirPackageFamily checks the thousands digit against the
+// exit code the raising package produces, so a code cannot promise one exit
+// status while its caller returns another.
+func TestCodes_MatchTheirPackageFamily(t *testing.T) {
+	t.Parallel()
+	byName := map[string]Entry{}
+	for _, e := range All() {
+		byName[e.Name] = e
+	}
+	for name, pkgs := range usedCodes(t) {
+		e := byName[name]
+		for _, pkg := range pkgs {
+			want, ok := familyOf[pkg]
+			if !ok {
+				t.Errorf("%s raises diagnostics but is not listed in familyOf; add it with the exit code it reports", pkg)
+				continue
+			}
+			if got := e.Code.ExitCode(); got != want {
+				t.Errorf("%s raises %s (diag.%s), which is family %d, but %s reports exit %d", pkg, e.Code, e.Name, got, pkg, want)
+			}
+		}
+	}
+}
+
+// usedCodes reports every registered diagnostic referenced from non-test Go
+// files outside this package, mapped to the slash-separated package
+// directories that reference it. References to the package's other exported
+// names — the Code type, Lookup, All — are not codes and are skipped.
+func usedCodes(t *testing.T) map[string][]string {
+	t.Helper()
+	root := repoRoot(t)
+	registered := map[string]bool{}
+	for _, e := range All() {
+		registered[e.Name] = true
+	}
+	used := map[string][]string{}
+	fset := token.NewFileSet()
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "dist", "node_modules", "public", "testdata", "diag":
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		file, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			return perr
+		}
+		if !importsDiag(file) {
+			return nil
+		}
+		rel, rerr := filepath.Rel(root, filepath.Dir(path))
+		if rerr != nil {
+			return rerr
+		}
+		pkg := filepath.ToSlash(rel)
+		ast.Inspect(file, func(n ast.Node) bool {
+			sel, ok := n.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			ident, ok := sel.X.(*ast.Ident)
+			if !ok || ident.Name != "diag" {
+				return true
+			}
+			name := sel.Sel.Name
+			if !registered[name] {
+				return true
+			}
+			if !slices.Contains(used[name], pkg) {
+				used[name] = append(used[name], pkg)
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk the repository: %v", err)
+	}
+	return used
+}
+
+// importsDiag reports whether the file imports this package, so a local
+// variable that happens to be called diag in an unrelated file cannot be read
+// as a reference to it.
+func importsDiag(file *ast.File) bool {
+	for _, imp := range file.Imports {
+		if imp.Path != nil && strings.HasSuffix(strings.Trim(imp.Path.Value, `"`), "/internal/diag") {
+			return true
+		}
+	}
+	return false
+}
+
+// repoRoot walks up from this package to the directory holding go.mod.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("working directory: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found above the diag package")
+		}
+		dir = parent
+	}
+}

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -16,6 +16,7 @@ import (
 	"github.com/goccy/go-yaml"
 	"github.com/goccy/go-yaml/ast"
 	"github.com/goccy/go-yaml/parser"
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/spec"
 )
 
@@ -31,24 +32,34 @@ const (
 )
 
 // Error is a loader failure annotated with the source path and kind.
+//
+// Code names the diagnostic. A validation failure reports several problems at
+// once, each carrying its own code inside Msg, so Code is set only when the
+// whole failure is one diagnostic — which is every parse error, since parsing
+// stops at the first one.
 type Error struct {
 	Path string
 	Kind Kind
+	Code diag.Code
 	Msg  string
 }
 
 func (e *Error) Error() string {
-	if e.Path == "" {
-		return e.Msg
+	msg := e.Msg
+	if e.Code != 0 {
+		msg = e.Code.Annotate(msg)
 	}
-	return fmt.Sprintf("%s: %s", e.Path, e.Msg)
+	if e.Path == "" {
+		return msg
+	}
+	return fmt.Sprintf("%s: %s", e.Path, msg)
 }
 
 // Load reads and validates the spec file at path.
 func Load(path string) (*spec.Spec, error) {
 	data, err := os.ReadFile(path) //nolint:gosec // path comes from user-specified spec args
 	if err != nil {
-		return nil, &Error{Path: path, Kind: KindValidation, Msg: err.Error()}
+		return nil, &Error{Path: path, Kind: KindValidation, Code: diag.SpecUnreadable, Msg: err.Error()}
 	}
 	// A directory-level manifest (#392) is configuration for a TREE of specs, so
 	// it is discovered from the spec's own location rather than passed in: every
@@ -173,7 +184,7 @@ func loadBytesWithProject(path string, data []byte, proj *Project) (*spec.Spec, 
 	// a single leading BOM transparently.
 	data = bytes.TrimPrefix(data, []byte("\ufeff"))
 	if msg := explicitTagError(data); msg != "" {
-		return nil, &Error{Path: path, Kind: KindParse, Msg: msg}
+		return nil, &Error{Path: path, Kind: KindParse, Code: diag.YAMLTag, Msg: msg}
 	}
 	var s spec.Spec
 	dec := yaml.NewDecoder(bytes.NewReader(data), yaml.Strict())
@@ -182,9 +193,10 @@ func loadBytesWithProject(path string, data []byte, proj *Project) (*spec.Spec, 
 		// io.EOF, whose bare "EOF" tells the user nothing. Name the problem and
 		// what a spec needs instead.
 		if errors.Is(err, io.EOF) {
-			return nil, &Error{Path: path, Kind: KindParse, Msg: "spec is empty: expected a YAML document with version, suite, and scenarios"}
+			return nil, &Error{Path: path, Kind: KindParse, Code: diag.SpecEmpty, Msg: "spec is empty: expected a YAML document with version, suite, and scenarios"}
 		}
-		return nil, &Error{Path: path, Kind: KindParse, Msg: formatYAMLError(err)}
+		msg := formatYAMLError(err)
+		return nil, &Error{Path: path, Kind: KindParse, Code: classifyYAMLError(data, msg), Msg: msg}
 	}
 	// Record each scenario's authored index before matrix expansion, so every
 	// expanded instance can be traced back to its authored source location (#80).
@@ -218,6 +230,26 @@ func formatYAMLError(err error) string {
 		return suggestScalarMatcher(suggestUnknownField(yaml.FormatError(err, false, true)))
 	}
 	return suggestScalarMatcher(suggestUnknownField(err.Error()))
+}
+
+// classifyYAMLError picks the diagnostic for a decode failure. goccy reports
+// all of them through one error type, but they are three different mistakes
+// with three different fixes: a document that is not YAML at all, a key the
+// schema does not define, and a value written in a shape its key cannot take.
+//
+// The first is separated structurally rather than by matching the message: if
+// the parser cannot build a document from the bytes, the problem is syntax; if
+// it can, the YAML was fine and the spec model is what rejected it. That keeps
+// the classification correct for the schema errors raised by the spec package's
+// own unmarshalers, whose wording this file has no business knowing.
+func classifyYAMLError(data []byte, msg string) diag.Code {
+	if _, err := parser.ParseBytes(data, 0); err != nil {
+		return diag.YAMLSyntax
+	}
+	if unknownFieldRe.MatchString(msg) {
+		return diag.UnknownKey
+	}
+	return diag.WrongValueShape
 }
 
 func joinErrors(errs []string) string {

--- a/internal/loader/project.go
+++ b/internal/loader/project.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/goccy/go-yaml"
 
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/spec"
 )
 
@@ -95,16 +96,19 @@ func LoadProject(path string) (*Project, error) {
 	}
 	data, err := os.ReadFile(path) //nolint:gosec // path is the manifest atago itself located
 	if err != nil {
-		return nil, &Error{Path: path, Kind: KindValidation, Msg: err.Error()}
+		return nil, &Error{Path: path, Kind: KindValidation, Code: diag.SpecUnreadable, Msg: err.Error()}
 	}
 	var p Project
 	if derr := yaml.UnmarshalWithOptions(data, &p, yaml.Strict()); derr != nil {
-		return nil, &Error{Path: path, Kind: KindParse, Msg: yaml.FormatError(derr, false, true)}
+		msg := yaml.FormatError(derr, false, true)
+		return nil, &Error{Path: path, Kind: KindParse, Code: classifyYAMLError(data, msg), Msg: msg}
 	}
 	p.Path = path
 
 	var msgs []string
-	add := func(format string, args ...any) { msgs = append(msgs, fmt.Sprintf(format, args...)) }
+	add := func(code diag.Code, format string, args ...any) {
+		msgs = append(msgs, code.Annotate(fmt.Sprintf(format, args...)))
+	}
 	if p.Defaults != nil {
 		validateDefaults(add, p.Defaults)
 	}
@@ -120,9 +124,9 @@ func LoadProject(path string) (*Project, error) {
 		st, serr := os.Stat(resolved)
 		switch {
 		case serr != nil:
-			add("fixtures_dir %q does not exist (resolved to %s)", p.FixturesDir, resolved)
+			add(diag.PathNotUsable, "fixtures_dir %q does not exist (resolved to %s)", p.FixturesDir, resolved)
 		case !st.IsDir():
-			add("fixtures_dir %q is not a directory (resolved to %s)", p.FixturesDir, resolved)
+			add(diag.PathNotUsable, "fixtures_dir %q is not a directory (resolved to %s)", p.FixturesDir, resolved)
 		default:
 			p.ResolvedFixturesDir = resolved
 		}
@@ -213,46 +217,46 @@ type Profile struct {
 }
 
 // validateSubject checks the subject/profiles block (#393).
-func validateSubject(add func(string, ...any), sub *Subject, profiles map[string]Profile) {
+func validateSubject(add addFunc, sub *Subject, profiles map[string]Profile) {
 	for name, prof := range profiles {
 		if name == "" {
-			add("profiles has an empty name")
+			add(diag.EmptyValue, "profiles has an empty name")
 		}
 		if prof.Build == nil && len(prof.Env) == 0 {
-			add("profiles.%s sets neither build nor env, so selecting it would change nothing", name)
+			add(diag.ChooseAtLeastOne, "profiles.%s sets neither build nor env, so selecting it would change nothing", name)
 		}
 		if prof.Build != nil {
 			validateBuild(add, "profiles."+name+".build", prof.Build)
 		}
 		if prof.Build != nil && sub == nil {
-			add("profiles.%s declares a build, but there is no subject: to build", name)
+			add(diag.KeyNeedsAnother, "profiles.%s declares a build, but there is no subject: to build", name)
 		}
 	}
 	if sub == nil {
 		return
 	}
 	if sub.Name == "" {
-		add("subject.name is required: it is what specs call the binary")
+		add(diag.RequiredKey, "subject.name is required: it is what specs call the binary")
 	}
 	if sub.Artifact == "" {
-		add("subject.artifact is required: it is where the build writes, and what ${artifact} expands to")
+		add(diag.RequiredKey, "subject.artifact is required: it is where the build writes, and what ${artifact} expands to")
 	} else if filepath.IsAbs(sub.Artifact) {
-		add("subject.artifact %q must be relative: it is written into a run-scoped scratch directory, not into the repository", sub.Artifact)
+		add(diag.AbsolutePath, "subject.artifact %q must be relative: it is written into a run-scoped scratch directory, not into the repository", sub.Artifact)
 	}
 	if sub.Build == nil {
-		add("subject.build is required: atago has to know how to produce the binary")
+		add(diag.RequiredKey, "subject.build is required: atago has to know how to produce the binary")
 		return
 	}
 	validateBuild(add, "subject.build", sub.Build)
 }
 
-func validateBuild(add func(string, ...any), where string, b *Build) {
+func validateBuild(add addFunc, where string, b *Build) {
 	if b.Command == "" {
-		add("%s.command is required", where)
+		add(diag.RequiredKey, "%s.command is required", where)
 	}
 	if b.Timeout != "" {
 		if d, err := time.ParseDuration(b.Timeout); err != nil || d <= 0 {
-			add("%s.timeout must be a positive Go duration (got %q)", where, b.Timeout)
+			add(diag.BadDuration, "%s.timeout must be a positive Go duration (got %q)", where, b.Timeout)
 		}
 	}
 }

--- a/internal/loader/project.go
+++ b/internal/loader/project.go
@@ -255,8 +255,13 @@ func validateBuild(add addFunc, where string, b *Build) {
 		add(diag.RequiredKey, "%s.command is required", where)
 	}
 	if b.Timeout != "" {
-		if d, err := time.ParseDuration(b.Timeout); err != nil || d <= 0 {
+		// Two different mistakes, and the reader fixes them differently: text
+		// that is not a duration at all, and a duration that parsed but leaves
+		// the build no time to run.
+		if d, err := time.ParseDuration(b.Timeout); err != nil {
 			add(diag.BadDuration, "%s.timeout must be a positive Go duration (got %q)", where, b.Timeout)
+		} else if d <= 0 {
+			add(diag.NonPositiveValue, "%s.timeout must be a positive Go duration (got %q)", where, b.Timeout)
 		}
 	}
 }

--- a/internal/loader/validate.go
+++ b/internal/loader/validate.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/scrub"
 	"github.com/nao1215/atago/internal/spec"
 )
@@ -36,26 +37,32 @@ func firstControlChar(name string) string {
 	return ""
 }
 
+// addFunc records one validation problem under the diagnostic code that names
+// it. Taking the code as the first argument is what keeps the published error
+// reference honest: a check added later cannot report a problem without
+// deciding which diagnostic it is, because omitting the code does not compile.
+type addFunc func(code diag.Code, format string, args ...any)
+
 // validate runs schema and semantic checks and
 // returns all problems found so the user can fix them in one pass.
 func validate(s *spec.Spec) []string {
 	var errs []string
-	add := func(format string, args ...any) {
-		errs = append(errs, fmt.Sprintf(format, args...))
+	add := func(code diag.Code, format string, args ...any) {
+		errs = append(errs, code.Annotate(fmt.Sprintf(format, args...)))
 	}
 
 	if s.Version != "1" {
-		add("version must be \"1\" (got %q)", s.Version)
+		add(diag.SpecVersion, "version must be \"1\" (got %q)", s.Version)
 	}
 	if s.Suite.Name == "" {
-		add("suite.name is required")
+		add(diag.RequiredKey, "suite.name is required")
 	} else if c := firstControlChar(s.Suite.Name); c != "" {
-		add("suite.name must not contain the control character %s (it breaks list output and generated docs)", c)
+		add(diag.ControlCharacter, "suite.name must not contain the control character %s (it breaks list output and generated docs)", c)
 	}
 	validateSuiteTimeout(add, &s.Suite)
 	validateScrub(add, s.Scrub)
 	if len(s.Scenarios) == 0 {
-		add("scenarios must contain at least one scenario")
+		add(diag.EmptyList, "scenarios must contain at least one scenario")
 	}
 	validateRunners(add, s.Runners)
 	validateDefaults(add, s.Defaults)
@@ -92,17 +99,17 @@ func suiteResourceNames(s *spec.Spec) (services, mocks map[string]bool) {
 // validateScenario checks one scenario: its identity, gates, services, and
 // every step and teardown step. seen tracks scenario names across the suite
 // for the duplicate check.
-func validateScenario(add func(string, ...any), s *spec.Spec, i int, seen, suiteServiceNames, suiteMockNames map[string]bool) {
+func validateScenario(add addFunc, s *spec.Spec, i int, seen, suiteServiceNames, suiteMockNames map[string]bool) {
 	sc := &s.Scenarios[i]
 	where := fmt.Sprintf("scenarios[%d]", i)
 	if sc.Name == "" {
-		add("%s.name is required", where)
+		add(diag.RequiredKey, "%s.name is required", where)
 	} else {
 		if c := firstControlChar(sc.Name); c != "" {
-			add("%s.name must not contain the control character %s (it breaks list output and generated docs)", where, c)
+			add(diag.ControlCharacter, "%s.name must not contain the control character %s (it breaks list output and generated docs)", where, c)
 		}
 		if seen[sc.Name] {
-			add("duplicate scenario name %q", sc.Name)
+			add(diag.DuplicateName, "duplicate scenario name %q", sc.Name)
 		}
 		seen[sc.Name] = true
 		where = fmt.Sprintf("scenario %q", sc.Name)
@@ -120,7 +127,7 @@ func validateScenario(add func(string, ...any), s *spec.Spec, i int, seen, suite
 	mockNames := maps.Clone(suiteMockNames)
 	validateMockServers(add, where, sc.MockServers, mockNames)
 	if len(sc.Steps) == 0 {
-		add("%s: steps must contain at least one step", where)
+		add(diag.EmptyList, "%s: steps must contain at least one step", where)
 		return
 	}
 	ptySeen := validateScenarioSteps(add, where, sc, s.Runners, serviceNames, mockNames)
@@ -130,7 +137,7 @@ func validateScenario(add func(string, ...any), s *spec.Spec, i int, seen, suite
 // validateScenarioSteps checks the scenario's steps in order, enforcing the
 // placement rules that tie an assert to the step that feeds it. It reports
 // whether the scenario contains a pty step, which teardown asserts may render.
-func validateScenarioSteps(add func(string, ...any), where string, sc *spec.Scenario, runners map[string]spec.Runner, serviceNames, mockNames map[string]bool) (ptySeen bool) {
+func validateScenarioSteps(add addFunc, where string, sc *spec.Scenario, runners map[string]spec.Runner, serviceNames, mockNames map[string]bool) (ptySeen bool) {
 	// A screen assert renders a pty step's terminal (#27) and a duration
 	// assert bounds the immediately preceding measurable step (#31):
 	// reject placements no step could feed.
@@ -143,15 +150,15 @@ func validateScenarioSteps(add func(string, ...any), where string, sc *spec.Scen
 			ptySeen = true
 		}
 		if st.Assert != nil && st.Assert.Screen != nil && !ptySeen {
-			add("%s.assert.screen requires a preceding pty step (the screen is the pty step's rendered terminal)", sw)
+			add(diag.AssertNeedsStep, "%s.assert.screen requires a preceding pty step (the screen is the pty step's rendered terminal)", sw)
 		}
 		if st.Assert != nil && st.Assert.Duration != nil && !prevMeasurable {
-			add("%s.assert.duration requires an immediately preceding run/http/query/grpc/pty step (the step whose wall-clock time it bounds)", sw)
+			add(diag.AssertNeedsStep, "%s.assert.duration requires an immediately preceding run/http/query/grpc/pty step (the step whose wall-clock time it bounds)", sw)
 		}
 		// changes bounds the workdir delta of the immediately preceding
 		// run/pty step (#70): reject a placement no such step feeds.
 		if st.Assert != nil && st.Assert.Changes != nil && !prevRunOrPTY {
-			add("%s.assert.changes requires an immediately preceding run/pty step (the step whose workdir delta it pins); combine it with the assert block directly after the step (one assert may set exit_code, stdout, and changes together)", sw)
+			add(diag.AssertNeedsStep, "%s.assert.changes requires an immediately preceding run/pty step (the step whose workdir delta it pins); combine it with the assert block directly after the step (one assert may set exit_code, stdout, and changes together)", sw)
 		}
 		validateStep(add, sw, st, runners, serviceNames, mockNames)
 		prevMeasurable = measurableStep(st.Kind())
@@ -162,31 +169,31 @@ func validateScenarioSteps(add func(string, ...any), where string, sc *spec.Scen
 
 // validateScenarioTeardown checks the scenario's teardown steps, whose asserts
 // may render a pty screen but can never be fed a workdir delta.
-func validateScenarioTeardown(add func(string, ...any), where string, sc *spec.Scenario, runners map[string]spec.Runner, serviceNames, mockNames map[string]bool, ptySeen bool) {
+func validateScenarioTeardown(add addFunc, where string, sc *spec.Scenario, runners map[string]spec.Runner, serviceNames, mockNames map[string]bool, ptySeen bool) {
 	for j := range sc.Teardown {
 		tw := fmt.Sprintf("%s.teardown[%d]", where, j)
 		st := &sc.Teardown[j]
 		if st.Assert != nil && st.Assert.Screen != nil && !ptySeen {
-			add("%s.assert.screen requires a pty step in the scenario", tw)
+			add(diag.AssertNeedsStep, "%s.assert.screen requires a pty step in the scenario", tw)
 		}
 		// The workdir delta is only tracked around Steps, so a changes assert
 		// in teardown could never be fed (#70).
 		if st.Assert != nil && st.Assert.Changes != nil {
-			add("%s.assert.changes is not supported in teardown (the workdir delta is tracked only around the scenario's steps)", tw)
+			add(diag.BlockNotHere, "%s.assert.changes is not supported in teardown (the workdir delta is tracked only around the scenario's steps)", tw)
 		}
 		validateStep(add, tw, st, runners, serviceNames, mockNames)
 	}
 }
 
 // validateSuiteTimeout checks the suite-level default step timeout (#17).
-func validateSuiteTimeout(add func(string, ...any), s *spec.Suite) {
+func validateSuiteTimeout(add addFunc, s *spec.Suite) {
 	if s.Timeout == "" {
 		return
 	}
 	if d, err := time.ParseDuration(s.Timeout); err != nil {
-		add("suite.timeout %q is not a valid duration (e.g. \"2m\"); use \"0\" to disable the built-in default", s.Timeout)
+		add(diag.BadDuration, "suite.timeout %q is not a valid duration (e.g. \"2m\"); use \"0\" to disable the built-in default", s.Timeout)
 	} else if d < 0 {
-		add("suite.timeout must not be negative (got %q); a wall-clock bound is never below zero", s.Timeout)
+		add(diag.NegativeValue, "suite.timeout must not be negative (got %q); a wall-clock bound is never below zero", s.Timeout)
 	}
 }
 
@@ -195,14 +202,14 @@ func validateSuiteTimeout(add func(string, ...any), s *spec.Suite) {
 // than silently normalizing nothing (or, for an empty pattern, matching between
 // every byte). The compile check reuses scrub.New so validation and runtime
 // agree on what a valid rule is.
-func validateScrub(add func(string, ...any), rules []spec.ScrubRule) {
+func validateScrub(add addFunc, rules []spec.ScrubRule) {
 	for i, r := range rules {
 		if r.Pattern == "" {
-			add("scrub[%d].pattern is required (a regex to normalize; e.g. \"req-\\d+\")", i)
+			add(diag.RequiredKey, "scrub[%d].pattern is required (a regex to normalize; e.g. \"req-\\d+\")", i)
 		}
 	}
 	if _, err := scrub.New(rules); err != nil {
-		add("%v", err)
+		add(diag.BadRegexp, "%v", err)
 	}
 }
 
@@ -211,41 +218,41 @@ func validateScrub(add func(string, ...any), rules []spec.ScrubRule) {
 // ignore is reported here instead. Fields the loader does merge are validated on
 // the concrete elements after applyDefaults (and, for a shared readiness probe,
 // here too, so a wrong probe fails even when no scenario declares a service).
-func validateDefaults(add func(string, ...any), d *spec.Defaults) {
+func validateDefaults(add addFunc, d *spec.Defaults) {
 	if d == nil {
 		return
 	}
 	if r := d.Run; r != nil {
 		if r.Command != "" {
-			add("defaults.run.command is not supported (command is per-step)")
+			add(diag.KeyNotHere, "defaults.run.command is not supported (command is per-step)")
 		}
 		if r.Retry != nil {
-			add("defaults.run.retry is not supported (retry is per-step)")
+			add(diag.KeyNotHere, "defaults.run.retry is not supported (retry is per-step)")
 		}
 		if !r.Stdin.IsZero() {
-			add("defaults.run.stdin is not supported (stdin is per-step input data, like command)")
+			add(diag.KeyNotHere, "defaults.run.stdin is not supported (stdin is per-step input data, like command)")
 		}
 		nonNegativeDuration(add, "defaults.run.timeout", r.Timeout, "30s")
 		validateHermeticEnv(add, "defaults.run", r.ClearEnv, r.PassEnv)
 	}
 	if sv := d.Service; sv != nil {
 		if sv.Name != "" {
-			add("defaults.service.name is not supported (each service names itself)")
+			add(diag.KeyNotHere, "defaults.service.name is not supported (each service names itself)")
 		}
 		if sv.Command != "" {
-			add("defaults.service.command is not supported (each service sets its own command)")
+			add(diag.KeyNotHere, "defaults.service.command is not supported (each service sets its own command)")
 		}
 		validateHermeticEnv(add, "defaults.service", sv.ClearEnv, sv.PassEnv)
 		validateReady(add, "defaults.service", sv.Ready)
 	}
 }
 
-func validateCondition(add func(string, ...any), where, key string, c *spec.Condition) {
+func validateCondition(add addFunc, where, key string, c *spec.Condition) {
 	if c == nil {
 		return
 	}
 	if c.OS != "" && !validOS[c.OS] {
-		add("%s.%s.os %q is invalid (want linux, darwin, or windows)", where, key, c.OS)
+		add(diag.NotAllowedValue, "%s.%s.os %q is invalid (want linux, darwin, or windows)", where, key, c.OS)
 	}
 }
 
@@ -263,7 +270,7 @@ var stepRunnerTypes = map[string][]string{
 // validateRunnerRef checks that a step's named runner exists and has a type the
 // step can drive. An empty name is fine here: steps that require a runner
 // enforce that separately.
-func validateRunnerRef(add func(string, ...any), where, stepKind, name string, runners map[string]spec.Runner) {
+func validateRunnerRef(add addFunc, where, stepKind, name string, runners map[string]spec.Runner) {
 	if name == "" {
 		return
 	}
@@ -271,16 +278,16 @@ func validateRunnerRef(add func(string, ...any), where, stepKind, name string, r
 	if !ok {
 		declared := slices.Sorted(maps.Keys(runners))
 		if len(declared) == 0 {
-			add("%s.%s.runner %q is not declared (the spec has no runners: block)", where, stepKind, name)
+			add(diag.RunnerNotDeclared, "%s.%s.runner %q is not declared (the spec has no runners: block)", where, stepKind, name)
 			return
 		}
-		add("%s.%s.runner %q is not declared under runners: (declared: %s)", where, stepKind, name, strings.Join(declared, ", "))
+		add(diag.RunnerNotDeclared, "%s.%s.runner %q is not declared under runners: (declared: %s)", where, stepKind, name, strings.Join(declared, ", "))
 		return
 	}
 	want := stepRunnerTypes[stepKind]
 	// An unknown/empty type is reported by validateRunners already.
 	if r.Type != "" && validRunnerType[r.Type] && !slices.Contains(want, r.Type) {
-		add("%s: runner %q is a %s runner; a %s step needs a %s runner", where, name, r.Type, stepKind, strings.Join(want, " or "))
+		add(diag.RunnerTypeMismatch, "%s: runner %q is a %s runner; a %s step needs a %s runner", where, name, r.Type, stepKind, strings.Join(want, " or "))
 	}
 }
 
@@ -289,7 +296,7 @@ func validateRunnerRef(add func(string, ...any), where, stepKind, name string, r
 // allowed — fixture, run, store, assert, and (setup only) `service:`. The
 // runner-backed kinds (http/query/grpc/cdp) are per-scenario machinery and are
 // rejected with a pointer to where they belong.
-func validateSuiteBlock(add func(string, ...any), where string, steps []spec.Step, runners map[string]spec.Runner, allowService bool) {
+func validateSuiteBlock(add addFunc, where string, steps []spec.Step, runners map[string]spec.Runner, allowService bool) {
 	seenService := map[string]bool{}
 	seenMock := map[string]bool{}
 	for i := range steps {
@@ -297,7 +304,7 @@ func validateSuiteBlock(add func(string, ...any), where string, steps []spec.Ste
 		sw := fmt.Sprintf("%s[%d]", where, i)
 		keys := st.SetKeys()
 		if len(keys) != 1 {
-			add("%s: step must set exactly one action (got %v)", sw, keys)
+			add(diag.StepManyActions, "%s: step must set exactly one action (got %v)", sw, keys)
 			continue
 		}
 		switch st.Kind() {
@@ -311,19 +318,19 @@ func validateSuiteBlock(add func(string, ...any), where string, steps []spec.Ste
 			validateAssert(add, sw, st.Assert, nil)
 		case spec.StepService:
 			if !allowService {
-				add("%s: service steps are only allowed in suite.setup", sw)
+				add(diag.BlockNotHere, "%s: service steps are only allowed in suite.setup", sw)
 				continue
 			}
 			svc := st.Service
 			if svc.Name == "" {
-				add("%s.service.name is required", sw)
+				add(diag.RequiredKey, "%s.service.name is required", sw)
 			} else if seenService[svc.Name] {
-				add("%s: duplicate suite service name %q", where, svc.Name)
+				add(diag.DuplicateName, "%s: duplicate suite service name %q", where, svc.Name)
 			} else {
 				seenService[svc.Name] = true
 			}
 			if svc.Command == "" {
-				add("%s.service.command is required", sw)
+				add(diag.RequiredKey, "%s.service.command is required", sw)
 			}
 			validateHermeticEnv(add, sw+".service", svc.ClearEnv, svc.PassEnv)
 			validateReady(add, sw+".service", svc.Ready)
@@ -331,33 +338,33 @@ func validateSuiteBlock(add func(string, ...any), where string, steps []spec.Ste
 			// Mock servers follow the service rule (#24): setup-only, so the
 			// position in the sequence controls ordering.
 			if !allowService {
-				add("%s: mock_server steps are only allowed in suite.setup", sw)
+				add(diag.BlockNotHere, "%s: mock_server steps are only allowed in suite.setup", sw)
 				continue
 			}
 			ms := st.MockServer
 			if ms.Name == "" {
-				add("%s.mock_server.name is required", sw)
+				add(diag.RequiredKey, "%s.mock_server.name is required", sw)
 			} else if seenMock[ms.Name] {
-				add("%s: duplicate suite mock server name %q", where, ms.Name)
+				add(diag.DuplicateName, "%s: duplicate suite mock server name %q", where, ms.Name)
 			} else {
 				seenMock[ms.Name] = true
 			}
 			validateMockRoutes(add, sw+".mock_server", ms.Routes)
 		default:
-			add("%s: %s steps are per-scenario (they need a scenario workdir and runners); move it into a scenario", sw, st.Kind())
+			add(diag.BlockNotHere, "%s: %s steps are per-scenario (they need a scenario workdir and runners); move it into a scenario", sw, st.Kind())
 		}
 	}
 }
 
-func validateStep(add func(string, ...any), where string, st *spec.Step, runners map[string]spec.Runner, serviceNames, mockNames map[string]bool) {
+func validateStep(add addFunc, where string, st *spec.Step, runners map[string]spec.Runner, serviceNames, mockNames map[string]bool) {
 	keys := st.SetKeys()
 	switch len(keys) {
 	case 0:
-		add("%s: step must set exactly one of fixture/run/http/query/grpc/cdp/assert/store/pty/signal (got none)", where)
+		add(diag.StepNoAction, "%s: step must set exactly one of fixture/run/http/query/grpc/cdp/assert/store/pty/signal (got none)", where)
 		return
 	case 1:
 	default:
-		add("%s: step must set exactly one action, but set %v", where, keys)
+		add(diag.StepManyActions, "%s: step must set exactly one action, but set %v", where, keys)
 		return
 	}
 
@@ -371,49 +378,49 @@ func validateStep(add func(string, ...any), where string, st *spec.Step, runners
 	case spec.StepHTTP:
 		validateRunnerRef(add, where, "http", st.HTTP.Runner, runners)
 		if st.HTTP.Method == "" {
-			add("%s.http.method is required", where)
+			add(diag.RequiredKey, "%s.http.method is required", where)
 		}
 		validateHTTPPayload(add, where, st.HTTP)
 		for i, f := range st.HTTP.Files {
 			if f.Field == "" {
-				add("%s.http.files[%d].field is required (the multipart form field name)", where, i)
+				add(diag.RequiredKey, "%s.http.files[%d].field is required (the multipart form field name)", where, i)
 			}
 			if f.Path == "" {
-				add("%s.http.files[%d].path is required (the workdir-relative file to attach)", where, i)
+				add(diag.RequiredKey, "%s.http.files[%d].path is required (the workdir-relative file to attach)", where, i)
 			}
 		}
 		validateRetry(add, where+".http", st.HTTP.Retry)
 	case spec.StepQuery:
 		if st.Query.Runner == "" {
-			add("%s.query.runner is required", where)
+			add(diag.RequiredKey, "%s.query.runner is required", where)
 		}
 		validateRunnerRef(add, where, "query", st.Query.Runner, runners)
 		if st.Query.SQL == "" {
-			add("%s.query.sql is required", where)
+			add(diag.RequiredKey, "%s.query.sql is required", where)
 		}
 	case spec.StepGRPC:
 		if st.GRPC.Runner == "" {
-			add("%s.grpc.runner is required", where)
+			add(diag.RequiredKey, "%s.grpc.runner is required", where)
 		}
 		validateRunnerRef(add, where, "grpc", st.GRPC.Runner, runners)
 		if st.GRPC.Method == "" {
-			add("%s.grpc.method is required", where)
+			add(diag.RequiredKey, "%s.grpc.method is required", where)
 		}
 	case spec.StepCDP:
 		if st.CDP.Runner == "" {
-			add("%s.cdp.runner is required", where)
+			add(diag.RequiredKey, "%s.cdp.runner is required", where)
 		}
 		validateRunnerRef(add, where, "cdp", st.CDP.Runner, runners)
 		if len(st.CDP.Actions) == 0 {
-			add("%s.cdp.actions must contain at least one action", where)
+			add(diag.EmptyList, "%s.cdp.actions must contain at least one action", where)
 		}
 		validateCDPActions(add, where, st.CDP.Actions)
 	case spec.StepStore:
 		validateStore(add, where, st.Store)
 	case spec.StepService:
-		add("%s: service steps are only allowed in suite.setup (scenario-scoped peers go under the scenario's services: list)", where)
+		add(diag.BlockNotHere, "%s: service steps are only allowed in suite.setup (scenario-scoped peers go under the scenario's services: list)", where)
 	case spec.StepMockServer:
-		add("%s: mock_server steps are only allowed in suite.setup (a scenario-scoped stub goes under the scenario's mock_servers: list)", where)
+		add(diag.BlockNotHere, "%s: mock_server steps are only allowed in suite.setup (a scenario-scoped stub goes under the scenario's mock_servers: list)", where)
 	case spec.StepPTY:
 		validatePTY(add, where, st.PTY)
 	case spec.StepSignal:
@@ -438,34 +445,34 @@ func measurableStep(k spec.StepKind) bool {
 // they already had: retry.interval accepted negatives that every timeout field
 // rejected. key is the fully-qualified field ("scenario X.steps[0].run.timeout"),
 // example the hint value shown for an unparsable string.
-func nonNegativeDuration(add func(string, ...any), key, val, example string) {
+func nonNegativeDuration(add addFunc, key, val, example string) {
 	if val == "" {
 		return
 	}
 	d, err := time.ParseDuration(val)
 	if err != nil {
-		add("%s %q is not a valid duration (e.g. %q)", key, val, example)
+		add(diag.BadDuration, "%s %q is not a valid duration (e.g. %q)", key, val, example)
 		return
 	}
 	if d < 0 {
-		add("%s must not be negative (got %q); a wall-clock bound is never below zero", key, val)
+		add(diag.NegativeValue, "%s must not be negative (got %q); a wall-clock bound is never below zero", key, val)
 	}
 }
 
 // positiveDuration validates a duration knob whose zero value is meaningless
 // because omitting the key already selects a documented default; def names
 // that default in the failure message.
-func positiveDuration(add func(string, ...any), key, val, example, def string) {
+func positiveDuration(add addFunc, key, val, example, def string) {
 	if val == "" {
 		return
 	}
 	d, err := time.ParseDuration(val)
 	if err != nil {
-		add("%s %q is not a valid duration (e.g. %q)", key, val, example)
+		add(diag.BadDuration, "%s %q is not a valid duration (e.g. %q)", key, val, example)
 		return
 	}
 	if d <= 0 {
-		add("%s must be positive (got %q); omit it for the %s default", key, val, def)
+		add(diag.NonPositiveValue, "%s must be positive (got %q); omit it for the %s default", key, val, def)
 	}
 }
 
@@ -476,11 +483,11 @@ func positiveDuration(add func(string, ...any), key, val, example, def string) {
 // next reader has no way to tell whether the scenario documents a real defect
 // or is dead weight. An `issue` URL is optional but is what makes an XPASS
 // actionable, so its absence is worth nothing more than the missing link.
-func validateExpectFail(add func(string, ...any), where string, ef *spec.ExpectFail) {
+func validateExpectFail(add addFunc, where string, ef *spec.ExpectFail) {
 	if ef == nil {
 		return
 	}
 	if strings.TrimSpace(ef.Reason) == "" {
-		add("%s.expect_fail.reason is required: say what is broken, or a reader cannot tell a documented known bug from a test that was given up on", where)
+		add(diag.RequiredKey, "%s.expect_fail.reason is required: say what is broken, or a reader cannot tell a documented known bug from a test that was given up on", where)
 	}
 }

--- a/internal/loader/validate_artifact.go
+++ b/internal/loader/validate_artifact.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/spec"
 )
 
@@ -14,30 +15,30 @@ var validImageFormat = map[string]bool{
 	"bmp": true, "tiff": true, "avif": true, "svg": true,
 }
 
-func validateImage(add func(string, ...any), where string, im *spec.ImageAssert) {
+func validateImage(add addFunc, where string, im *spec.ImageAssert) {
 	if im.Path == "" {
-		add("%s.path is required", where)
+		add(diag.RequiredKey, "%s.path is required", where)
 	}
 	n := 0
 	if im.Format != "" {
 		n++
 		if !validImageFormat[im.Format] {
-			add("%s.format %q is invalid (want png/jpeg/gif/webp/bmp/tiff/avif/svg)", where, im.Format)
+			add(diag.NotAllowedValue, "%s.format %q is invalid (want png/jpeg/gif/webp/bmp/tiff/avif/svg)", where, im.Format)
 		}
 	}
 	for _, d := range []*int{im.Width, im.Height, im.MinWidth, im.MaxWidth, im.MinHeight, im.MaxHeight} {
 		if d != nil {
 			n++
 			if *d < 0 {
-				add("%s: dimensions must be >= 0 (got %d)", where, *d)
+				add(diag.NegativeValue, "%s: dimensions must be >= 0 (got %d)", where, *d)
 			}
 		}
 	}
 	if im.MinWidth != nil && im.MaxWidth != nil && *im.MinWidth > *im.MaxWidth {
-		add("%s: min_width %d exceeds max_width %d", where, *im.MinWidth, *im.MaxWidth)
+		add(diag.EmptyInterval, "%s: min_width %d exceeds max_width %d", where, *im.MinWidth, *im.MaxWidth)
 	}
 	if im.MinHeight != nil && im.MaxHeight != nil && *im.MinHeight > *im.MaxHeight {
-		add("%s: min_height %d exceeds max_height %d", where, *im.MinHeight, *im.MaxHeight)
+		add(diag.EmptyInterval, "%s: min_height %d exceeds max_height %d", where, *im.MinHeight, *im.MaxHeight)
 	}
 	if im.Alpha != nil {
 		n++
@@ -47,14 +48,14 @@ func validateImage(add func(string, ...any), where string, im *spec.ImageAssert)
 	}
 	if im.MaxDiff != nil {
 		if im.SimilarTo == "" {
-			add("%s.max_diff requires similar_to", where)
+			add(diag.KeyNeedsAnother, "%s.max_diff requires similar_to", where)
 		}
 		if *im.MaxDiff < 0 || *im.MaxDiff > 1 {
-			add("%s.max_diff must be between 0 and 1 (got %g)", where, *im.MaxDiff)
+			add(diag.OutOfRange, "%s.max_diff must be between 0 and 1 (got %g)", where, *im.MaxDiff)
 		}
 	}
 	if n == 0 {
-		add("%s: must set at least one of format/width/height/min_width/max_width/min_height/max_height/alpha/similar_to", where)
+		add(diag.ChooseAtLeastOne, "%s: must set at least one of format/width/height/min_width/max_width/min_height/max_height/alpha/similar_to", where)
 	}
 	// AVIF and SVG cannot be decoded in pure Go, so only their format can be
 	// asserted; reject measurement constraints up front for a clear error.
@@ -64,34 +65,34 @@ func validateImage(add func(string, ...any), where string, im *spec.ImageAssert)
 			im.MinHeight != nil || im.MaxHeight != nil ||
 			im.Alpha != nil || im.SimilarTo != ""
 		if measures {
-			add("%s: format %q cannot be measured (only format may be asserted for avif/svg)", where, im.Format)
+			add(diag.KeyNotHere, "%s: format %q cannot be measured (only format may be asserted for avif/svg)", where, im.Format)
 		}
 	}
 }
 
 // validatePDF checks a PDF assertion (#73): a path plus at least one constraint,
 // sane page bounds, known metadata fields, and a well-formed text matcher.
-func validatePDF(add func(string, ...any), where string, p *spec.PDFAssert) {
+func validatePDF(add addFunc, where string, p *spec.PDFAssert) {
 	if p.Path == "" {
-		add("%s.path is required", where)
+		add(diag.RequiredKey, "%s.path is required", where)
 	}
 	n := 0
 	for _, c := range []*int{p.Pages, p.MinPages, p.MaxPages} {
 		if c != nil {
 			n++
 			if *c < 0 {
-				add("%s: page counts must be >= 0 (got %d)", where, *c)
+				add(diag.NegativeValue, "%s: page counts must be >= 0 (got %d)", where, *c)
 			}
 		}
 	}
 	if p.MinPages != nil && p.MaxPages != nil && *p.MinPages > *p.MaxPages {
-		add("%s: min_pages %d exceeds max_pages %d", where, *p.MinPages, *p.MaxPages)
+		add(diag.EmptyInterval, "%s: min_pages %d exceeds max_pages %d", where, *p.MinPages, *p.MaxPages)
 	}
 	if len(p.Metadata) > 0 {
 		n++
 		for k := range p.Metadata {
 			if !validPDFMetaField[strings.ToLower(k)] {
-				add("%s.metadata: unknown field %q (want title/author/subject/keywords/creator/producer)", where, k)
+				add(diag.UnknownKey, "%s.metadata: unknown field %q (want title/author/subject/keywords/creator/producer)", where, k)
 			}
 		}
 	}
@@ -100,7 +101,7 @@ func validatePDF(add func(string, ...any), where string, p *spec.PDFAssert) {
 		validateStream(add, where+".text", p.Text)
 	}
 	if n == 0 {
-		add("%s: must set at least one of pages/min_pages/max_pages/metadata/text", where)
+		add(diag.ChooseAtLeastOne, "%s: must set at least one of pages/min_pages/max_pages/metadata/text", where)
 	}
 }
 
@@ -113,29 +114,29 @@ var validPDFMetaField = map[string]bool{
 // constraint, with sane count bounds. Every set field is an independent
 // constraint (like image), so no one-of rule applies beyond requiring at least
 // one.
-func validateDir(add func(string, ...any), where string, d *spec.DirAssert) {
+func validateDir(add addFunc, where string, d *spec.DirAssert) {
 	if d.Path == "" {
-		add("%s.path is required", where)
+		add(diag.RequiredKey, "%s.path is required", where)
 	}
 	n := countDirMatchers(add, where, d)
 	if d.MinCount != nil && d.MaxCount != nil && *d.MinCount > *d.MaxCount {
-		add("%s: min_count %d exceeds max_count %d", where, *d.MinCount, *d.MaxCount)
+		add(diag.EmptyInterval, "%s: min_count %d exceeds max_count %d", where, *d.MinCount, *d.MaxCount)
 	}
 	validateDirComposition(add, where, d, n)
 	for _, pat := range d.Ignore {
 		trimmed := strings.TrimSuffix(pat, "/**")
 		if _, err := path.Match(trimmed, "probe"); err != nil {
-			add("%s.ignore %q is not a valid glob: %v", where, pat, err)
+			add(diag.BadGlob, "%s.ignore %q is not a valid glob: %v", where, pat, err)
 		}
 	}
 	if n == 0 && d.Snapshot == "" {
-		add("%s: must set at least one of exists/contains/not_contains/count/min_count/max_count/glob/snapshot", where)
+		add(diag.ChooseAtLeastOne, "%s: must set at least one of exists/contains/not_contains/count/min_count/max_count/glob/snapshot", where)
 	}
 }
 
 // countDirMatchers counts the matcher-family constraints set on a dir
 // assertion, validating each countable one as it goes.
-func countDirMatchers(add func(string, ...any), where string, d *spec.DirAssert) int {
+func countDirMatchers(add addFunc, where string, d *spec.DirAssert) int {
 	n := 0
 	if d.Exists != nil {
 		n++
@@ -150,7 +151,7 @@ func countDirMatchers(add func(string, ...any), where string, d *spec.DirAssert)
 		if c != nil {
 			n++
 			if *c < 0 {
-				add("%s: counts must be >= 0 (got %d)", where, *c)
+				add(diag.NegativeValue, "%s: counts must be >= 0 (got %d)", where, *c)
 			}
 		}
 	}
@@ -161,7 +162,7 @@ func countDirMatchers(add func(string, ...any), where string, d *spec.DirAssert)
 		// instead of only misbehaving when the assertion runs. dir.glob is matched
 		// with path.Match at check time, so validate with the same grammar.
 		if _, err := path.Match(d.Glob, "probe"); err != nil {
-			add("%s.glob %q is not a valid glob: %v", where, d.Glob, err)
+			add(diag.BadGlob, "%s.glob %q is not a valid glob: %v", where, d.Glob, err)
 		}
 	}
 	return n
@@ -170,21 +171,21 @@ func countDirMatchers(add func(string, ...any), where string, d *spec.DirAssert)
 // validateDirComposition enforces the tree snapshot rules (#25): the golden
 // manifest IS the whole assertion, so it composes only with ignore; the
 // matcher family needs recursive or the historical single-level semantics.
-func validateDirComposition(add func(string, ...any), where string, d *spec.DirAssert, n int) {
+func validateDirComposition(add addFunc, where string, d *spec.DirAssert, n int) {
 	if d.Snapshot != "" {
 		if n > 0 || d.Exists != nil {
-			add("%s: snapshot cannot be combined with the matcher family (exists/contains/not_contains/count/glob) — the manifest already pins the whole tree", where)
+			add(diag.ExclusiveKeys, "%s: snapshot cannot be combined with the matcher family (exists/contains/not_contains/count/glob) — the manifest already pins the whole tree", where)
 		}
 		if d.Recursive {
-			add("%s: recursive is implied by snapshot; drop it", where)
+			add(diag.KeyNotHere, "%s: recursive is implied by snapshot; drop it", where)
 		}
 		return
 	}
 	if d.Recursive && n == 0 {
-		add("%s: recursive needs at least one of contains/not_contains/count/min_count/max_count/glob", where)
+		add(diag.ChooseAtLeastOne, "%s: recursive needs at least one of contains/not_contains/count/min_count/max_count/glob", where)
 	}
 	if len(d.Ignore) > 0 && !d.Recursive {
-		add("%s: ignore only applies to recursive or snapshot assertions", where)
+		add(diag.KeyNotHere, "%s: ignore only applies to recursive or snapshot assertions", where)
 	}
 }
 
@@ -192,10 +193,10 @@ func validateDirComposition(add func(string, ...any), where string, d *spec.DirA
 // created/modified/deleted set, and every entry a workdir-relative, confined
 // path or a valid /-glob. Entries are compared with forward slashes at check
 // time, so confinement is validated in the same /-separated space.
-func validateChanges(add func(string, ...any), where string, c *spec.ChangesAssert) {
+func validateChanges(add addFunc, where string, c *spec.ChangesAssert) {
 	if c.Created == nil && c.Modified == nil && c.Deleted == nil {
 		// ignore alone asserts nothing: it only narrows what the categories see.
-		add("%s: set at least one of created/modified/deleted (use [] to assert a category changed nothing)", where)
+		add(diag.ChooseAtLeastOne, "%s: set at least one of created/modified/deleted (use [] to assert a category changed nothing)", where)
 		return
 	}
 	for _, cat := range []struct {
@@ -213,17 +214,17 @@ func validateChanges(add func(string, ...any), where string, c *spec.ChangesAsse
 			field := fmt.Sprintf("%s.%s %q", where, cat.name, entry)
 			switch {
 			case entry == "":
-				add("%s must be a non-empty workdir-relative path or glob", field)
+				add(diag.EmptyValue, "%s must be a non-empty workdir-relative path or glob", field)
 			case strings.HasPrefix(entry, "/"):
-				add("%s must be workdir-relative, not absolute", field)
+				add(diag.AbsolutePath, "%s must be workdir-relative, not absolute", field)
 			case pathEscapesWorkdir(entry):
-				add("%s escapes the scenario workdir (no ../ traversal)", field)
+				add(diag.PathEscapesWorkdir, "%s escapes the scenario workdir (no ../ traversal)", field)
 			default:
 				// The entry doubles as a doublestar glob at check time (single
 				// `*` stays single-level; `**` crosses `/`); reject a malformed
 				// pattern here rather than silently matching nothing.
 				if !doublestar.ValidatePattern(entry) {
-					add("%s is not a valid glob: bad pattern syntax", field)
+					add(diag.BadGlob, "%s is not a valid glob: bad pattern syntax", field)
 				}
 			}
 		}
@@ -232,17 +233,17 @@ func validateChanges(add func(string, ...any), where string, c *spec.ChangesAsse
 		field := fmt.Sprintf("%s.ignore %q", where, pat)
 		switch {
 		case pat == "":
-			add("%s must be a non-empty workdir-relative glob", field)
+			add(diag.EmptyValue, "%s must be a non-empty workdir-relative glob", field)
 		case strings.HasPrefix(pat, "/"):
-			add("%s must be workdir-relative, not absolute", field)
+			add(diag.AbsolutePath, "%s must be workdir-relative, not absolute", field)
 		case pathEscapesWorkdir(pat):
-			add("%s escapes the scenario workdir (no ../ traversal)", field)
+			add(diag.PathEscapesWorkdir, "%s escapes the scenario workdir (no ../ traversal)", field)
 		case !doublestar.ValidatePattern(pat):
-			add("%s is not a valid glob: bad pattern syntax", field)
+			add(diag.BadGlob, "%s is not a valid glob: bad pattern syntax", field)
 		}
 	}
 	if c.Ignore != nil && len(c.Ignore) == 0 {
-		add("%s.ignore must not be empty; drop the key instead", where)
+		add(diag.EmptyValue, "%s.ignore must not be empty; drop the key instead", where)
 	}
 }
 

--- a/internal/loader/validate_assert.go
+++ b/internal/loader/validate_assert.go
@@ -8,13 +8,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/spec"
 )
 
-func validateAssert(add func(string, ...any), where string, a *spec.Assert, mockNames map[string]bool) {
+func validateAssert(add addFunc, where string, a *spec.Assert, mockNames map[string]bool) {
 	targets := a.SetTargets()
 	if len(targets) == 0 {
-		add("%s.assert: must set at least one assertion target (got none)", where)
+		add(diag.ChooseAtLeastOne, "%s.assert: must set at least one assertion target (got none)", where)
 		return
 	}
 	// Each set target is an independent check and all must hold, so validate every
@@ -25,7 +26,7 @@ func validateAssert(add func(string, ...any), where string, a *spec.Assert, mock
 }
 
 // validateAssertTarget checks the shape of a single assertion target family.
-func validateAssertTarget(add func(string, ...any), where string, a *spec.Assert, target spec.AssertTarget, mockNames map[string]bool) {
+func validateAssertTarget(add addFunc, where string, a *spec.Assert, target spec.AssertTarget, mockNames map[string]bool) {
 	switch target {
 	case spec.AssertExitCode:
 		// Scalar/mapping shape enforced by ExitCode.UnmarshalYAML; the one-of
@@ -69,7 +70,7 @@ func validateAssertTarget(add func(string, ...any), where string, a *spec.Assert
 // validateExitCode checks the exit_code assertion (#19): exactly one of the
 // bare-int / {not} / {in} forms, and an `in` set that is non-empty with unique
 // values — a duplicated code is authoring confusion, not a wider contract.
-func validateExitCode(add func(string, ...any), where string, e *spec.ExitCode) {
+func validateExitCode(add addFunc, where string, e *spec.ExitCode) {
 	set := 0
 	if e.Equals != nil {
 		set++
@@ -81,21 +82,21 @@ func validateExitCode(add func(string, ...any), where string, e *spec.ExitCode) 
 		set++
 	}
 	if set == 0 {
-		add("%s must be an int, {not: int}, or {in: [int, ...]}", where)
+		add(diag.ChooseExactlyOne, "%s must be an int, {not: int}, or {in: [int, ...]}", where)
 		return
 	}
 	if set > 1 {
-		add("%s: set exactly one of a bare int, not, or in", where)
+		add(diag.ChooseExactlyOne, "%s: set exactly one of a bare int, not, or in", where)
 		return
 	}
 	if e.In != nil {
 		if len(e.In) == 0 {
-			add("%s.in must list at least one accepted exit code", where)
+			add(diag.EmptyList, "%s.in must list at least one accepted exit code", where)
 		}
 		seen := make(map[int]bool, len(e.In))
 		for _, n := range e.In {
 			if seen[n] {
-				add("%s.in lists %d more than once", where, n)
+				add(diag.DuplicateEntry, "%s.in lists %d more than once", where, n)
 			}
 			seen[n] = true
 		}
@@ -110,14 +111,14 @@ var streamExclusiveMatchers = map[string]bool{
 	"json": true, "yaml": true, "snapshot": true,
 }
 
-func validateStream(add func(string, ...any), where string, s *spec.StreamAssert) {
+func validateStream(add addFunc, where string, s *spec.StreamAssert) {
 	// trim is a store-only selector (#158), not an assertion matcher.
 	if s.Trim != nil {
-		add("%s: trim is only valid in a store source, not an assertion", where)
+		add(diag.KeyNotHere, "%s: trim is only valid in a store source, not an assertion", where)
 	}
 	matchers := s.SetMatchers()
 	if len(matchers) == 0 {
-		add("%s: must set at least one matcher (empty/contains/not_contains/matches/not_matches/equals/not_equals/json/yaml/snapshot)", where)
+		add(diag.ChooseAtLeastOne, "%s: must set at least one matcher (empty/contains/not_contains/matches/not_matches/equals/not_equals/json/yaml/snapshot)", where)
 	}
 	// A whole-stream matcher cannot be combined with anything else; only the
 	// text matchers compose.
@@ -128,7 +129,7 @@ func validateStream(add func(string, ...any), where string, s *spec.StreamAssert
 		}
 	}
 	if len(exclusive) > 0 && len(matchers) > 1 {
-		add("%s: %v cannot be combined with another matcher (only contains/not_contains/matches/not_matches may be combined)", where, exclusive)
+		add(diag.ExclusiveKeys, "%s: %v cannot be combined with another matcher (only contains/not_contains/matches/not_matches may be combined)", where, exclusive)
 	}
 	validateJSONChecks(add, where+".json", s.JSON)
 	validateJSONChecks(add, where+".yaml", s.YAML)
@@ -147,12 +148,12 @@ func validateStream(add func(string, ...any), where string, s *spec.StreamAssert
 
 	if s.Line != nil {
 		if *s.Line < 1 {
-			add("%s.line must be >= 1 (got %d)", where, *s.Line)
+			add(diag.OutOfRange, "%s.line must be >= 1 (got %d)", where, *s.Line)
 		}
 		// line narrows the stream to one line, so it only composes with the
 		// text matchers — json/snapshot operate on the whole document.
 		if len(s.JSON) > 0 || len(s.YAML) > 0 || s.Snapshot != "" {
-			add("%s.line cannot be combined with json/yaml/snapshot (use contains/matches/equals/empty)", where)
+			add(diag.ExclusiveKeys, "%s.line cannot be combined with json/yaml/snapshot (use contains/matches/equals/empty)", where)
 		}
 	}
 }
@@ -162,13 +163,13 @@ func validateStream(add func(string, ...any), where string, s *spec.StreamAssert
 // matches both compose freely without it, so the ambiguity only appears once a
 // bound is written, and it has to be refused there rather than resolved by a
 // precedence rule nobody would remember.
-func validateStreamCount(add func(string, ...any), where string, s *spec.StreamAssert, matchers []string) {
+func validateStreamCount(add addFunc, where string, s *spec.StreamAssert, matchers []string) {
 	validateCountBounds(add, where, s.Count, s.MinCount, s.MaxCount)
 	countable := 0
 	if s.Contains != nil {
 		countable++
 		if len(s.Contains) > 1 {
-			add("%s: count applies to one substring; contains lists %d (write one assert per substring)", where, len(s.Contains))
+			add(diag.ExclusiveKeys, "%s: count applies to one substring; contains lists %d (write one assert per substring)", where, len(s.Contains))
 		}
 	}
 	if s.Matches != nil {
@@ -176,15 +177,15 @@ func validateStreamCount(add func(string, ...any), where string, s *spec.StreamA
 	}
 	switch {
 	case countable == 0:
-		add("%s: count/min_count/max_count need a contains or matches matcher to count", where)
+		add(diag.KeyNeedsAnother, "%s: count/min_count/max_count need a contains or matches matcher to count", where)
 	case countable > 1:
-		add("%s: count/min_count/max_count need exactly one countable matcher, but both contains and matches are set", where)
+		add(diag.ChooseExactlyOne, "%s: count/min_count/max_count need exactly one countable matcher, but both contains and matches are set", where)
 	}
 	// The other text matchers stay meaningful next to a count, but the
 	// whole-stream ones do not: `equals` already pins every byte.
 	for _, m := range matchers {
 		if streamExclusiveMatchers[m] {
-			add("%s: count/min_count/max_count cannot be combined with %s", where, m)
+			add(diag.ExclusiveKeys, "%s: count/min_count/max_count cannot be combined with %s", where, m)
 		}
 	}
 }
@@ -194,32 +195,32 @@ func validateStreamCount(add func(string, ...any), where string, s *spec.StreamA
 // has to be satisfiable. An unsatisfiable range (min above max) is an authoring
 // mistake that would otherwise fail at runtime with a message about the output
 // rather than about the spec.
-func validateCountBounds(add func(string, ...any), where string, exact, minCount, maxCount *int) {
+func validateCountBounds(add addFunc, where string, exact, minCount, maxCount *int) {
 	for name, v := range map[string]*int{"count": exact, "min_count": minCount, "max_count": maxCount} {
 		if v != nil && *v < 0 {
-			add("%s.%s must be >= 0 (got %d)", where, name, *v)
+			add(diag.NegativeValue, "%s.%s must be >= 0 (got %d)", where, name, *v)
 		}
 	}
 	if exact != nil && (minCount != nil || maxCount != nil) {
-		add("%s: count is the exact form; use min_count/max_count for a range, not both", where)
+		add(diag.ExclusiveKeys, "%s: count is the exact form; use min_count/max_count for a range, not both", where)
 	}
 	if minCount != nil && maxCount != nil && *minCount > *maxCount {
-		add("%s: min_count %d is greater than max_count %d, so nothing can satisfy it", where, *minCount, *maxCount)
+		add(diag.EmptyInterval, "%s: min_count %d is greater than max_count %d, so nothing can satisfy it", where, *minCount, *maxCount)
 	}
 }
 
 // validateSizeBounds is validateCountBounds for the byte-size family (#397).
-func validateSizeBounds(add func(string, ...any), where string, exact, minSize, maxSize *int64) {
+func validateSizeBounds(add addFunc, where string, exact, minSize, maxSize *int64) {
 	for name, v := range map[string]*int64{"size": exact, "min_size": minSize, "max_size": maxSize} {
 		if v != nil && *v < 0 {
-			add("%s.%s must be >= 0 (got %d)", where, name, *v)
+			add(diag.NegativeValue, "%s.%s must be >= 0 (got %d)", where, name, *v)
 		}
 	}
 	if exact != nil && (minSize != nil || maxSize != nil) {
-		add("%s: size is the exact form; use min_size/max_size for a range, not both", where)
+		add(diag.ExclusiveKeys, "%s: size is the exact form; use min_size/max_size for a range, not both", where)
 	}
 	if minSize != nil && maxSize != nil && *minSize > *maxSize {
-		add("%s: min_size %d is greater than max_size %d, so nothing can satisfy it", where, *minSize, *maxSize)
+		add(diag.EmptyInterval, "%s: min_size %d is greater than max_size %d, so nothing can satisfy it", where, *minSize, *maxSize)
 	}
 }
 
@@ -227,22 +228,22 @@ func validateSizeBounds(add func(string, ...any), where string, exact, minSize, 
 // alternatives. The list of alternatives is written once here per call site:
 // spelling it twice — for "none" and for "several" — is how the two messages
 // drift apart when a matcher is added.
-func requireExactlyOne(add func(string, ...any), where, alternatives string, n int) {
+func requireExactlyOne(add addFunc, where, alternatives string, n int) {
 	switch {
 	case n == 0:
-		add("%s: must set one of %s", where, alternatives)
+		add(diag.ChooseExactlyOne, "%s: must set one of %s", where, alternatives)
 	case n > 1:
-		add("%s: must set exactly one of %s", where, alternatives)
+		add(diag.ChooseExactlyOne, "%s: must set exactly one of %s", where, alternatives)
 	}
 }
 
-func validateFile(add func(string, ...any), where string, f *spec.FileAssert) {
+func validateFile(add addFunc, where string, f *spec.FileAssert) {
 	if f.Path == "" {
-		add("%s.path is required", where)
+		add(diag.RequiredKey, "%s.path is required", where)
 	}
 	// text is a store-only selector (#158), not an assertion matcher.
 	if f.Text != nil {
-		add("%s: text is only valid in a store source, not an assertion", where)
+		add(diag.KeyNotHere, "%s: text is only valid in a store source, not an assertion", where)
 	}
 	n := 0
 	if f.Exists != nil {
@@ -265,7 +266,7 @@ func validateFile(add func(string, ...any), where string, f *spec.FileAssert) {
 	if f.EqualsFile != nil {
 		n++
 		if *f.EqualsFile == "" {
-			add("%s.equals_file must not be empty", where)
+			add(diag.EmptyValue, "%s.equals_file must not be empty", where)
 		}
 	}
 	if len(f.JSON) > 0 {
@@ -285,13 +286,13 @@ func validateFile(add func(string, ...any), where string, f *spec.FileAssert) {
 		// be nothing to stat. Nothing can satisfy both, so it is an authoring
 		// mistake rather than a contract.
 		if f.Exists != nil && !*f.Exists {
-			add("%s: size/min_size/max_size cannot be combined with exists: false — an absent file has no size", where)
+			add(diag.ExclusiveKeys, "%s: size/min_size/max_size cannot be combined with exists: false — an absent file has no size", where)
 		}
 		if f.Snapshot != "" {
-			add("%s: size/min_size/max_size cannot be combined with snapshot — a snapshot already pins every byte", where)
+			add(diag.ExclusiveKeys, "%s: size/min_size/max_size cannot be combined with snapshot — a snapshot already pins every byte", where)
 		}
 		if n > 1 {
-			add("%s: must set exactly one of exists/contains/not_contains/executable/equals/equals_file/json/snapshot", where)
+			add(diag.ChooseExactlyOne, "%s: must set exactly one of exists/contains/not_contains/executable/equals/equals_file/json/snapshot", where)
 		}
 	} else {
 		requireExactlyOne(add, where, "exists/contains/not_contains/executable/equals/equals_file/json/snapshot", n)
@@ -303,16 +304,16 @@ func validateFile(add func(string, ...any), where string, f *spec.FileAssert) {
 		validateCountBounds(add, where, f.Count, f.MinCount, f.MaxCount)
 		switch {
 		case f.Contains == nil:
-			add("%s: count/min_count/max_count need a contains matcher to count", where)
+			add(diag.KeyNeedsAnother, "%s: count/min_count/max_count need a contains matcher to count", where)
 		case len(f.Contains) > 1:
-			add("%s: count applies to one substring; contains lists %d (write one assert per substring)", where, len(f.Contains))
+			add(diag.ExclusiveKeys, "%s: count applies to one substring; contains lists %d (write one assert per substring)", where, len(f.Contains))
 		}
 	}
 }
 
-func validateHeaderMatch(add func(string, ...any), where string, h *spec.HeaderMatch) {
+func validateHeaderMatch(add addFunc, where string, h *spec.HeaderMatch) {
 	if h.Name == "" {
-		add("%s.name is required", where)
+		add(diag.RequiredKey, "%s.name is required", where)
 	}
 	n := 0
 	if h.Contains != nil {
@@ -332,7 +333,7 @@ func validateHeaderMatch(add func(string, ...any), where string, h *spec.HeaderM
 // The empty-list case is already rejected by JSONChecks.UnmarshalYAML; a nil
 // list (the matcher is absent) is a no-op. Each entry names its index in the
 // error location so a spec author can find the failing check.
-func validateJSONChecks(add func(string, ...any), where string, list spec.JSONChecks) {
+func validateJSONChecks(add addFunc, where string, list spec.JSONChecks) {
 	if len(list) == 1 {
 		validateJSON(add, where, &list[0])
 		return
@@ -342,9 +343,9 @@ func validateJSONChecks(add func(string, ...any), where string, list spec.JSONCh
 	}
 }
 
-func validateJSON(add func(string, ...any), where string, j *spec.JSONAssert) {
+func validateJSON(add addFunc, where string, j *spec.JSONAssert) {
 	if j.Path == "" {
-		add("%s.path is required", where)
+		add(diag.RequiredKey, "%s.path is required", where)
 	}
 	n := 0
 	if j.HasEquals() {
@@ -357,7 +358,7 @@ func validateJSON(add func(string, ...any), where string, j *spec.JSONAssert) {
 	if j.Length != nil {
 		n++
 		if *j.Length < 0 {
-			add("%s.length must be >= 0 (got %d); no array, object, or string has a negative length", where, *j.Length)
+			add(diag.NegativeValue, "%s.length must be >= 0 (got %d); no array, object, or string has a negative length", where, *j.Length)
 		}
 	}
 	if j.Gt != nil {
@@ -381,13 +382,13 @@ func validateJSON(add func(string, ...any), where string, j *spec.JSONAssert) {
 // is an always-true no-op and `not_contains: ""` can never pass (every string
 // contains the empty substring), so either is an authoring mistake — caught at
 // load time like the empty-list case and like validateChanges' empty entries.
-func validateStringList(add func(string, ...any), where, key string, l spec.StringList) {
+func validateStringList(add addFunc, where, key string, l spec.StringList) {
 	if l != nil && len(l) == 0 {
-		add("%s.%s must not be empty", where, key)
+		add(diag.EmptyValue, "%s.%s must not be empty", where, key)
 	}
 	for i, s := range l {
 		if s == "" {
-			add("%s.%s[%d] is an empty string, which matches everything (contains) or nothing (not_contains); remove it or give a real substring", where, key, i)
+			add(diag.VacuousMatcher, "%s.%s[%d] is an empty string, which matches everything (contains) or nothing (not_contains); remove it or give a real substring", where, key, i)
 		}
 	}
 }
@@ -397,14 +398,14 @@ func validateStringList(add func(string, ...any), where, key string, l spec.Stri
 // ""` is an always-true no-op and `not_matches: ""` can never pass — either is
 // an authoring mistake, caught at load time like the empty-string contains/
 // not_contains case in validateStringList.
-func validateRegexp(add func(string, ...any), where, key, pattern string) {
+func validateRegexp(add addFunc, where, key, pattern string) {
 	if pattern == "" {
-		add("%s.%s must not be an empty regexp, which matches everything (matches) or nothing (not_matches); remove it or give a real pattern", where, key)
+		add(diag.VacuousMatcher, "%s.%s must not be an empty regexp, which matches everything (matches) or nothing (not_matches); remove it or give a real pattern", where, key)
 		return
 	}
 	re, err := regexp.Compile(pattern)
 	if err != nil {
-		add("%s.%s %q is not a valid regexp: %v", where, key, pattern, err)
+		add(diag.BadRegexp, "%s.%s %q is not a valid regexp: %v", where, key, pattern, err)
 		return
 	}
 	// A not_matches pattern that matches the empty string (e.g. "z*", "a?",
@@ -414,28 +415,28 @@ func validateRegexp(add func(string, ...any), where, key, pattern string) {
 	// hint. An empty-matching pattern under matches is legitimate (it matches
 	// everything, which the author may intend), so this applies to not_matches only.
 	if key == "not_matches" && re.MatchString("") {
-		add("%s.%s %q matches the empty string, so not_matches can never pass; anchor it or require at least one character (e.g. \"z+\")", where, key, pattern)
+		add(diag.VacuousMatcher, "%s.%s %q matches the empty string, so not_matches can never pass; anchor it or require at least one character (e.g. \"z+\")", where, key, pattern)
 	}
 }
 
 // validateDuration checks a duration assert (#31): at least one bound, lt/lte
 // and gt/gte mutually exclusive, every bound a valid Go duration, and any
 // interval non-empty (lower < upper).
-func validateDuration(add func(string, ...any), where string, d *spec.DurationAssert) {
+func validateDuration(add addFunc, where string, d *spec.DurationAssert) {
 	parse := func(field, val string) (time.Duration, bool) {
 		if val == "" {
 			return 0, false
 		}
 		dur, err := time.ParseDuration(val)
 		if err != nil {
-			add("%s.%s %q is not a valid duration (e.g. \"2s\", \"100ms\")", where, field, val)
+			add(diag.BadDuration, "%s.%s %q is not a valid duration (e.g. \"2s\", \"100ms\")", where, field, val)
 			return 0, false
 		}
 		// A measured wall-clock duration is never negative, so a negative bound
 		// is always an authoring mistake: gt/gte trivially hold and lt/lte can
 		// never pass. Caught at load time like the empty-interval case below.
 		if dur < 0 {
-			add("%s.%s must not be negative (got %q); a measured duration is never below zero", where, field, val)
+			add(diag.NegativeValue, "%s.%s must not be negative (got %q); a measured duration is never below zero", where, field, val)
 			return 0, false
 		}
 		return dur, true
@@ -446,14 +447,14 @@ func validateDuration(add func(string, ...any), where string, d *spec.DurationAs
 	gte, gteOK := parse("gte", d.GTE)
 
 	if d.LT == "" && d.LTE == "" && d.GT == "" && d.GTE == "" {
-		add("%s: set at least one bound (lt/lte/gt/gte)", where)
+		add(diag.ChooseAtLeastOne, "%s: set at least one bound (lt/lte/gt/gte)", where)
 		return
 	}
 	if d.LT != "" && d.LTE != "" {
-		add("%s: set only one upper bound (lt or lte, not both)", where)
+		add(diag.ExclusiveKeys, "%s: set only one upper bound (lt or lte, not both)", where)
 	}
 	if d.GT != "" && d.GTE != "" {
-		add("%s: set only one lower bound (gt or gte, not both)", where)
+		add(diag.ExclusiveKeys, "%s: set only one lower bound (gt or gte, not both)", where)
 	}
 
 	// The interval, when both ends are present, must be non-empty. lte/gte
@@ -471,9 +472,9 @@ func validateDuration(add func(string, ...any), where string, d *spec.DurationAs
 	}
 	if upOK && lowOK {
 		if (upStrict || lowStrict) && lower >= upper {
-			add("%s: the bounds form an empty interval (lower %s is not below upper %s)", where, lower, upper)
+			add(diag.EmptyInterval, "%s: the bounds form an empty interval (lower %s is not below upper %s)", where, lower, upper)
 		} else if !upStrict && !lowStrict && lower > upper {
-			add("%s: the bounds form an empty interval (lower %s exceeds upper %s)", where, lower, upper)
+			add(diag.EmptyInterval, "%s: the bounds form an empty interval (lower %s exceeds upper %s)", where, lower, upper)
 		}
 	}
 }
@@ -482,23 +483,23 @@ func validateDuration(add func(string, ...any), where string, d *spec.DurationAs
 // name (listed on a miss, mirroring the unknown-runner message), a sane
 // count, and well-formed header/body matchers. A nil mockNames (retry.until)
 // skips the declared-name check.
-func validateMockAssert(add func(string, ...any), where string, m *spec.MockAssert, mockNames map[string]bool) {
+func validateMockAssert(add addFunc, where string, m *spec.MockAssert, mockNames map[string]bool) {
 	switch {
 	case m.Name == "":
-		add("%s.name is required (the mock server whose recorded requests to check)", where)
+		add(diag.RequiredKey, "%s.name is required (the mock server whose recorded requests to check)", where)
 	case mockNames != nil && !mockNames[m.Name]:
 		declared := "none"
 		if len(mockNames) > 0 {
 			declared = strings.Join(slices.Sorted(maps.Keys(mockNames)), ", ")
 		}
-		add("%s.name %q is not a declared mock server (declared: %s)", where, m.Name, declared)
+		add(diag.NameNotDeclared, "%s.name %q is not a declared mock server (declared: %s)", where, m.Name, declared)
 	}
 	if m.Count != nil {
 		if *m.Count < 0 {
-			add("%s.count must be >= 0 (got %d)", where, *m.Count)
+			add(diag.NegativeValue, "%s.count must be >= 0 (got %d)", where, *m.Count)
 		}
 		if *m.Count == 0 && (m.Header != nil || m.Body != nil) {
-			add("%s: count: 0 cannot be combined with header/body matchers (there is no request to match)", where)
+			add(diag.ExclusiveKeys, "%s: count: 0 cannot be combined with header/body matchers (there is no request to match)", where)
 		}
 	}
 	if m.Header != nil {

--- a/internal/loader/validate_cdp.go
+++ b/internal/loader/validate_cdp.go
@@ -3,49 +3,50 @@ package loader
 import (
 	"fmt"
 
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/spec"
 )
 
 // validateCDPActions checks that each browser action sets exactly one action key
 // and supplies its required sub-fields, so a malformed cdp step fails at load
 // time with a clear message rather than mid-run (#50).
-func validateCDPActions(add func(string, ...any), where string, actions []spec.CDPAction) {
+func validateCDPActions(add addFunc, where string, actions []spec.CDPAction) {
 	for i, a := range actions {
 		aw := fmt.Sprintf("%s.cdp.actions[%d]", where, i)
 		if n := cdpActionCount(&a); n == 0 {
-			add("%s sets no recognized action", aw)
+			add(diag.ChooseExactlyOne, "%s sets no recognized action", aw)
 			continue
 		} else if n > 1 {
-			add("%s sets multiple actions; set exactly one", aw)
+			add(diag.ChooseExactlyOne, "%s sets multiple actions; set exactly one", aw)
 		}
 		switch {
 		case a.Press != nil:
 			if a.Press.Selector == "" || a.Press.Key == "" {
-				add("%s.press requires selector and key", aw)
+				add(diag.RequiredKey, "%s.press requires selector and key", aw)
 			}
 		case a.Select != nil:
 			if a.Select.Selector == "" {
-				add("%s.select requires a selector", aw)
+				add(diag.RequiredKey, "%s.select requires a selector", aw)
 			}
 		case a.Screenshot != nil:
 			if a.Screenshot.Path == "" {
-				add("%s.screenshot requires a path", aw)
+				add(diag.RequiredKey, "%s.screenshot requires a path", aw)
 			}
 		case a.Attribute != nil:
 			if a.Attribute.Selector == "" || a.Attribute.Name == "" {
-				add("%s.attribute requires selector and name", aw)
+				add(diag.RequiredKey, "%s.attribute requires selector and name", aw)
 			}
 		case a.SendKeys != nil:
 			if a.SendKeys.Selector == "" {
-				add("%s.send_keys requires a selector", aw)
+				add(diag.RequiredKey, "%s.send_keys requires a selector", aw)
 			}
 		case a.Upload != nil:
 			if a.Upload.Selector == "" || a.Upload.File == "" {
-				add("%s.upload requires selector and file", aw)
+				add(diag.RequiredKey, "%s.upload requires selector and file", aw)
 			}
 		case a.Download != nil:
 			if a.Download.Click == "" {
-				add("%s.download requires a click selector", aw)
+				add(diag.RequiredKey, "%s.download requires a click selector", aw)
 			}
 		}
 	}

--- a/internal/loader/validate_fixture.go
+++ b/internal/loader/validate_fixture.go
@@ -26,7 +26,7 @@ func validateFixture(add addFunc, where string, f *spec.Fixture) {
 		n++
 	}
 	if n > 1 {
-		add(diag.ChooseExactlyOne, "%s.fixture: set only one of content, base64, from, or symlink", where)
+		add(diag.ExclusiveKeys, "%s.fixture: set only one of content, base64, from, or symlink", where)
 	}
 	if f.Symlink != "" && f.Mode != "" {
 		add(diag.ExclusiveKeys, "%s.fixture: mode cannot be applied to a symlink", where)

--- a/internal/loader/validate_fixture.go
+++ b/internal/loader/validate_fixture.go
@@ -4,12 +4,13 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/spec"
 )
 
-func validateFixture(add func(string, ...any), where string, f *spec.Fixture) {
+func validateFixture(add addFunc, where string, f *spec.Fixture) {
 	if f.File == "" {
-		add("%s.fixture.file is required", where)
+		add(diag.RequiredKey, "%s.fixture.file is required", where)
 	}
 	n := 0
 	if f.Content != "" {
@@ -25,19 +26,19 @@ func validateFixture(add func(string, ...any), where string, f *spec.Fixture) {
 		n++
 	}
 	if n > 1 {
-		add("%s.fixture: set only one of content, base64, from, or symlink", where)
+		add(diag.ChooseExactlyOne, "%s.fixture: set only one of content, base64, from, or symlink", where)
 	}
 	if f.Symlink != "" && f.Mode != "" {
-		add("%s.fixture: mode cannot be applied to a symlink", where)
+		add(diag.ExclusiveKeys, "%s.fixture: mode cannot be applied to a symlink", where)
 	}
 	if f.Mode != "" {
 		if _, err := strconv.ParseUint(f.Mode, 8, 32); err != nil {
-			add("%s.fixture.mode %q is not an octal file mode (e.g. \"0444\")", where, f.Mode)
+			add(diag.BadFormat, "%s.fixture.mode %q is not an octal file mode (e.g. \"0444\")", where, f.Mode)
 		}
 	}
 	if f.Mtime != "" {
 		if _, err := time.Parse(time.RFC3339, f.Mtime); err != nil {
-			add("%s.fixture.mtime %q is not an RFC3339 timestamp (e.g. \"2026-01-02T15:04:05Z\")", where, f.Mtime)
+			add(diag.BadFormat, "%s.fixture.mtime %q is not an RFC3339 timestamp (e.g. \"2026-01-02T15:04:05Z\")", where, f.Mtime)
 		}
 	}
 }

--- a/internal/loader/validate_http.go
+++ b/internal/loader/validate_http.go
@@ -3,13 +3,14 @@ package loader
 import (
 	"strings"
 
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/spec"
 )
 
 // validateHTTPPayload enforces "a request has one payload": json, body,
 // body_file, and form/files are mutually exclusive families (form and files
 // combine into one multipart request, so they count as a single family).
-func validateHTTPPayload(add func(string, ...any), where string, h *spec.HTTP) {
+func validateHTTPPayload(add addFunc, where string, h *spec.HTTP) {
 	var set []string
 	if h.JSON != nil {
 		set = append(set, "json")
@@ -24,6 +25,6 @@ func validateHTTPPayload(add func(string, ...any), where string, h *spec.HTTP) {
 		set = append(set, "form/files")
 	}
 	if len(set) > 1 {
-		add("%s.http sets %s; a request has one payload — use json for a structured value, body for raw text, body_file for a file's raw content, or form (+ files) for a form submission", where, strings.Join(set, " and "))
+		add(diag.ExclusiveKeys, "%s.http sets %s; a request has one payload — use json for a structured value, body for raw text, body_file for a file's raw content, or form (+ files) for a form submission", where, strings.Join(set, " and "))
 	}
 }

--- a/internal/loader/validate_pty.go
+++ b/internal/loader/validate_pty.go
@@ -5,21 +5,22 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/spec"
 )
 
 // validatePTY checks a pty step (#8): a command, sane duration/size values,
 // and a session whose entries each set exactly one of expect/send/expect_screen.
-func validatePTY(add func(string, ...any), where string, p *spec.PTY) {
+func validatePTY(add addFunc, where string, p *spec.PTY) {
 	if p.Command == "" {
-		add("%s.pty.command is required", where)
+		add(diag.RequiredKey, "%s.pty.command is required", where)
 	}
 	positiveDuration(add, where+".pty.timeout", p.Timeout, "30s", "30s")
 	validateHermeticEnv(add, where+".pty", p.ClearEnv, p.PassEnv)
 	// A pty size is a uint16 on the wire; reject values the terminal cannot
 	// represent instead of silently truncating.
 	if p.Rows < 0 || p.Cols < 0 || p.Rows > 65535 || p.Cols > 65535 {
-		add("%s.pty: rows/cols must be between 0 and 65535", where)
+		add(diag.OutOfRange, "%s.pty: rows/cols must be between 0 and 65535", where)
 	}
 	for i, a := range p.Session {
 		aw := fmt.Sprintf("%s.pty.session[%d]", where, i)
@@ -30,18 +31,18 @@ func validatePTY(add func(string, ...any), where string, p *spec.PTY) {
 		hasExec := a.Exec != nil
 		switch {
 		case countBools(hasExpect, hasSend, hasExpectScreen, hasResize, hasExec) > 1:
-			add("%s: set exactly one of expect/send/expect_screen/resize/exec (got more than one)", aw)
+			add(diag.ChooseExactlyOne, "%s: set exactly one of expect/send/expect_screen/resize/exec (got more than one)", aw)
 		case !hasExpect && !hasSend && !hasExpectScreen && !hasResize && !hasExec:
-			add("%s: set exactly one of expect/send/expect_screen/resize/exec (an empty send: \"\" transmits EOF)", aw)
+			add(diag.ChooseExactlyOne, "%s: set exactly one of expect/send/expect_screen/resize/exec (an empty send: \"\" transmits EOF)", aw)
 		case hasExpect:
 			if _, err := regexp.Compile(a.Expect); err != nil {
-				add("%s.expect %q is not a valid regexp: %v", aw, a.Expect, err)
+				add(diag.BadRegexp, "%s.expect %q is not a valid regexp: %v", aw, a.Expect, err)
 			}
 		case hasSend:
 			// A named key must be in the vocabulary (#26); a typo'd key would
 			// otherwise silently send nothing.
 			if a.Send.Key != "" && !spec.ValidPTYKey(a.Send.Key) {
-				add("%s.send.key %q is not a supported key (supported: %s)", aw, a.Send.Key, spec.PTYKeyNames())
+				add(diag.NotAllowedValue, "%s.send.key %q is not a supported key (supported: %s)", aw, a.Send.Key, spec.PTYKeyNames())
 			}
 			if a.Send.Mouse != nil {
 				validatePTYMouse(add, aw+".send.mouse", a.Send.Mouse)
@@ -52,13 +53,13 @@ func validatePTY(add func(string, ...any), where string, p *spec.PTY) {
 			// Both dimensions are required: a resize that names one side would
 			// have to invent the other, and a terminal has no natural "keep".
 			if a.Resize.Rows < 1 || a.Resize.Cols < 1 {
-				add("%s.resize: rows and cols are both required and must be at least 1", aw)
+				add(diag.RequiredKey, "%s.resize: rows and cols are both required and must be at least 1", aw)
 			} else if a.Resize.Rows > 65535 || a.Resize.Cols > 65535 {
-				add("%s.resize: rows/cols must be between 1 and 65535", aw)
+				add(diag.OutOfRange, "%s.resize: rows/cols must be between 1 and 65535", aw)
 			}
 		case hasExec:
 			if a.Exec.Command == "" {
-				add("%s.exec.command is required", aw)
+				add(diag.RequiredKey, "%s.exec.command is required", aw)
 			}
 			positiveDuration(add, aw+".exec.timeout", a.Exec.Timeout, "10s", "10s")
 		}
@@ -69,45 +70,45 @@ func validatePTY(add func(string, ...any), where string, p *spec.PTY) {
 // screen cells with no upper bound checked here: a mid-session resize can change
 // the screen size, so the only honest claim at load time is that they name a
 // cell at all.
-func validatePTYMouse(add func(string, ...any), where string, m *spec.PTYMouse) {
+func validatePTYMouse(add addFunc, where string, m *spec.PTYMouse) {
 	if m.Row < 1 || m.Col < 1 {
-		add("%s: row and col are required 1-based screen cells (got row %d, col %d)", where, m.Row, m.Col)
+		add(diag.OutOfRange, "%s: row and col are required 1-based screen cells (got row %d, col %d)", where, m.Row, m.Col)
 	}
 	if m.Button != "" && !spec.ValidPTYMouseButton(m.Button) {
-		add("%s.button %q is not a supported button (supported: %s)", where, m.Button, spec.PTYMouseButtonNames())
+		add(diag.NotAllowedValue, "%s.button %q is not a supported button (supported: %s)", where, m.Button, spec.PTYMouseButtonNames())
 	}
 	if m.Action != "" && !spec.ValidPTYMouseAction(m.Action) {
-		add("%s.action %q is not a supported action (supported: %s)", where, m.Action, spec.PTYMouseActionNames())
+		add(diag.NotAllowedValue, "%s.action %q is not a supported action (supported: %s)", where, m.Action, spec.PTYMouseActionNames())
 	}
 	// A wheel notch is a single event in the SGR encoding — there is nothing to
 	// release — so asking for one is a mistake worth naming rather than a no-op.
 	if m.IsWheel() && m.Action == "release" {
-		add("%s: a wheel button has no release event; use action: press (the default click sends one notch)", where)
+		add(diag.ExclusiveKeys, "%s: a wheel button has no release event; use action: press (the default click sends one notch)", where)
 	}
 	seen := map[string]bool{}
 	for _, mod := range m.Mods {
 		if !spec.ValidPTYMouseMod(mod) {
-			add("%s.mods %q is not a supported modifier (supported: %s)", where, mod, spec.PTYMouseModNames())
+			add(diag.NotAllowedValue, "%s.mods %q is not a supported modifier (supported: %s)", where, mod, spec.PTYMouseModNames())
 			continue
 		}
 		// A modifier is a bit, so naming it twice says nothing new — and a spec
 		// that repeats one is far more likely to have meant two different ones.
 		if seen[mod] {
-			add("%s.mods lists %q twice", where, mod)
+			add(diag.DuplicateEntry, "%s.mods lists %q twice", where, mod)
 		}
 		seen[mod] = true
 	}
 }
 
-func validatePTYExpectScreen(add func(string, ...any), where string, es *spec.PTYExpectScreen) {
+func validatePTYExpectScreen(add addFunc, where string, es *spec.PTYExpectScreen) {
 	// Share the screen validator so a mid-session wait accepts exactly what the
 	// post-step assert does — including an attrs-only wait (#382).
 	validateScreen(add, where, &es.ScreenAssert)
 	if es.Snapshot != "" {
-		add("%s.snapshot is not supported in expect_screen; use a post-step assert screen snapshot or text matchers here", where)
+		add(diag.KeyNotHere, "%s.snapshot is not supported in expect_screen; use a post-step assert screen snapshot or text matchers here", where)
 	}
 	if es.Trim != nil {
-		add("%s.trim is not supported in expect_screen", where)
+		add(diag.KeyNotHere, "%s.trim is not supported in expect_screen", where)
 	}
 	positiveDuration(add, where+".timeout", es.Timeout, "", "")
 	positiveDuration(add, where+".stable_for", es.StableFor, "", "")
@@ -115,7 +116,7 @@ func validatePTYExpectScreen(add func(string, ...any), where string, es *spec.PT
 		timeout, terr := time.ParseDuration(es.Timeout)
 		stable, serr := time.ParseDuration(es.StableFor)
 		if terr == nil && serr == nil && stable > timeout {
-			add("%s.stable_for %q must not exceed %s.timeout %q", where, es.StableFor, where, es.Timeout)
+			add(diag.EmptyInterval, "%s.stable_for %q must not exceed %s.timeout %q", where, es.StableFor, where, es.Timeout)
 		}
 	}
 }

--- a/internal/loader/validate_run.go
+++ b/internal/loader/validate_run.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/spec"
 )
 
@@ -14,11 +15,11 @@ import (
 // scenario-only shell-metacharacter hint (on the command) and the ssh-only
 // field checks, so the two call sites stay a single source of truth (their
 // only difference was those two additions).
-func validateRunStep(add func(string, ...any), where string, r *spec.Run, runners map[string]spec.Runner, full bool) {
+func validateRunStep(add addFunc, where string, r *spec.Run, runners map[string]spec.Runner, full bool) {
 	validateRunnerRef(add, where, "run", r.Runner, runners)
 	nonNegativeDuration(add, where+".run.timeout", r.Timeout, "30s")
 	if r.Command == "" {
-		add("%s.run.command is required", where)
+		add(diag.RequiredKey, "%s.run.command is required", where)
 	} else if full && !r.ShellEnabled() && !runnerIsSSH(r.Runner, runners) {
 		// Without shell, the command is tokenized into argv, so shell operators
 		// (redirects, pipes, sequencing, substitution) are not honored. Rather
@@ -27,7 +28,7 @@ func validateRunStep(add func(string, ...any), where string, r *spec.Run, runner
 		// as one string and the REMOTE login shell always interprets it, so
 		// metacharacters are honored there without any shell: opt-in.
 		if tok := shellMetachar(r.Command); tok != "" {
-			add("%s.run.command contains the shell metacharacter %q but shell is not enabled; "+
+			add(diag.KeyNeedsAnother, "%s.run.command contains the shell metacharacter %q but shell is not enabled; "+
 				"set `shell: true` to run it through a shell, split it into multiple `run` steps, "+
 				"or use `stdout_to` / `stderr_to` for redirection", where, tok)
 		}
@@ -44,7 +45,7 @@ func validateRunStep(add func(string, ...any), where string, r *spec.Run, runner
 // validateStdin checks a run step's stdin source (#18): the mapping form must
 // set exactly one of file/base64, and a base64 payload must decode — at load
 // time, so a typo fails with a positioned message instead of mid-run.
-func validateStdin(add func(string, ...any), where string, s spec.Stdin) {
+func validateStdin(add addFunc, where string, s spec.Stdin) {
 	if s.IsMapping() {
 		set := 0
 		if s.File != "" {
@@ -54,12 +55,12 @@ func validateStdin(add func(string, ...any), where string, s spec.Stdin) {
 			set++
 		}
 		if set != 1 {
-			add("%s.stdin must set exactly one of file/base64 (or be a plain string for inline text)", where)
+			add(diag.ChooseExactlyOne, "%s.stdin must set exactly one of file/base64 (or be a plain string for inline text)", where)
 		}
 	}
 	if s.Base64 != "" {
 		if _, err := base64.StdEncoding.DecodeString(s.Base64); err != nil {
-			add("%s.stdin.base64 is not valid base64: %v", where, err)
+			add(diag.BadFormat, "%s.stdin.base64 is not valid base64: %v", where, err)
 		}
 	}
 }
@@ -68,16 +69,16 @@ func validateStdin(add func(string, ...any), where string, s spec.Stdin) {
 // only meaningful when clear_env starts the environment empty, so an
 // allowlist without clear_env: true is authoring confusion and is rejected
 // instead of silently ignored. Empty variable names are rejected too.
-func validateHermeticEnv(add func(string, ...any), where string, clearEnv *bool, passEnv []string) {
+func validateHermeticEnv(add addFunc, where string, clearEnv *bool, passEnv []string) {
 	if len(passEnv) == 0 {
 		return
 	}
 	if clearEnv == nil || !*clearEnv {
-		add("%s.pass_env requires clear_env: true (pass_env selects host vars for a cleared environment)", where)
+		add(diag.KeyNeedsAnother, "%s.pass_env requires clear_env: true (pass_env selects host vars for a cleared environment)", where)
 	}
 	for i, name := range passEnv {
 		if name == "" {
-			add("%s.pass_env[%d] must not be an empty variable name", where, i)
+			add(diag.EmptyValue, "%s.pass_env[%d] must not be an empty variable name", where, i)
 		}
 	}
 }
@@ -97,7 +98,7 @@ func runnerIsSSH(name string, runners map[string]spec.Runner) bool {
 // dropped by the engine's remote path (it forwards only the command). Rejecting
 // them at load time turns a silent no-op into a clear error. timeout and retry
 // are honored remotely and are intentionally absent here.
-func validateSSHRunFields(add func(string, ...any), where string, r *spec.Run, runners map[string]spec.Runner) {
+func validateSSHRunFields(add addFunc, where string, r *spec.Run, runners map[string]spec.Runner) {
 	if !runnerIsSSH(r.Runner, runners) {
 		return
 	}
@@ -105,7 +106,7 @@ func validateSSHRunFields(add func(string, ...any), where string, r *spec.Run, r
 	// shell ALWAYS interprets the command string, so the knob has nothing to
 	// switch and an authored value only misleads.
 	if r.Shell != nil {
-		add("%s.run.shell has no effect on an ssh runner (the remote login shell always interprets the command)", where)
+		add(diag.KeyNotHere, "%s.run.shell has no effect on an ssh runner (the remote login shell always interprets the command)", where)
 	}
 	fields := []struct {
 		set   bool
@@ -122,7 +123,7 @@ func validateSSHRunFields(add func(string, ...any), where string, r *spec.Run, r
 	}
 	for _, f := range fields {
 		if f.set {
-			add("%s.run.%s has no effect on an ssh runner (the command runs remotely; only command/runner/timeout apply)", where, f.field)
+			add(diag.KeyNotHere, "%s.run.%s has no effect on an ssh runner (the command runs remotely; only command/runner/timeout apply)", where, f.field)
 		}
 	}
 }
@@ -208,16 +209,16 @@ func metacharAt(runes []rune, i int) string {
 
 // validateRetry validates a retry block; where already names the owning step
 // action (".run" or ".http") so messages read e.g. "steps[0].http.retry.times".
-func validateRetry(add func(string, ...any), where string, r *spec.Retry) {
+func validateRetry(add addFunc, where string, r *spec.Retry) {
 	if r == nil {
 		return
 	}
 	if r.Times < 1 {
-		add("%s.retry.times must be >= 1 (got %d)", where, r.Times)
+		add(diag.OutOfRange, "%s.retry.times must be >= 1 (got %d)", where, r.Times)
 	}
 	nonNegativeDuration(add, where+".retry.interval", r.Interval, "500ms")
 	if r.Until == nil {
-		add("%s.retry.until is required", where)
+		add(diag.RequiredKey, "%s.retry.until is required", where)
 		return
 	}
 	validateAssert(add, where+".retry.until", r.Until, nil)
@@ -227,37 +228,37 @@ func validateRetry(add func(string, ...any), where string, r *spec.Retry) {
 	// run/http result is never a pty. Neither can ever hold here, so the step
 	// would only ever exhaust its budget: reject them at load time instead.
 	if r.Until.Changes != nil {
-		add("%s.retry.until.changes cannot be satisfied in a retry condition (the workdir delta is computed only for a top-level assert directly after the step, never for the exec result a retry polls); move it to an assert after the step", where)
+		add(diag.KeyNotHere, "%s.retry.until.changes cannot be satisfied in a retry condition (the workdir delta is computed only for a top-level assert directly after the step, never for the exec result a retry polls); move it to an assert after the step", where)
 	}
 	if r.Until.Screen != nil {
-		add("%s.retry.until.screen cannot be satisfied in a retry condition (screen renders a pty step's terminal, and a run/http result is never a pty); move it to an assert after a pty step", where)
+		add(diag.KeyNotHere, "%s.retry.until.screen cannot be satisfied in a retry condition (screen renders a pty step's terminal, and a run/http result is never a pty); move it to an assert after a pty step", where)
 	}
 }
 
 // validateDeterministic checks the same-input-same-output claim (#398): a
 // satisfiable run count, observables atago knows how to compare, and no
 // combination whose meaning would be self-contradictory.
-func validateDeterministic(add func(string, ...any), where string, r *spec.Run) {
+func validateDeterministic(add addFunc, where string, r *spec.Run) {
 	d := r.Deterministic
 	if d == nil {
 		return
 	}
 	if d.Runs != 0 && d.Runs < 2 {
-		add("%s.deterministic.runs must be at least 2 — comparing one run against itself proves nothing (got %d)", where, d.Runs)
+		add(diag.OutOfRange, "%s.deterministic.runs must be at least 2 — comparing one run against itself proves nothing (got %d)", where, d.Runs)
 	}
 	if d.Runs > spec.MaxDeterministicRuns {
-		add("%s.deterministic.runs is capped at %d; a larger number is a benchmark, not a test (got %d)",
+		add(diag.OutOfRange, "%s.deterministic.runs is capped at %d; a larger number is a benchmark, not a test (got %d)",
 			where, spec.MaxDeterministicRuns, d.Runs)
 	}
 	seen := map[string]bool{}
 	for _, name := range d.Compare {
 		if !slices.Contains(spec.DeterministicObservables, name) {
-			add("%s.deterministic.compare has unknown observable %q; use one of %s",
+			add(diag.NotAllowedValue, "%s.deterministic.compare has unknown observable %q; use one of %s",
 				where, name, strings.Join(spec.DeterministicObservables, "/"))
 			continue
 		}
 		if seen[name] {
-			add("%s.deterministic.compare lists %q more than once", where, name)
+			add(diag.DuplicateEntry, "%s.deterministic.compare lists %q more than once", where, name)
 		}
 		seen[name] = true
 	}
@@ -265,6 +266,6 @@ func validateDeterministic(add func(string, ...any), where string, r *spec.Run) 
 	// command converge on a different answer, which is the very thing this
 	// claims will not happen.
 	if r.Retry != nil {
-		add("%s: deterministic cannot be combined with retry — retry re-runs until the answer CHANGES, deterministic asserts it does not", where)
+		add(diag.ExclusiveKeys, "%s: deterministic cannot be combined with retry — retry re-runs until the answer CHANGES, deterministic asserts it does not", where)
 	}
 }

--- a/internal/loader/validate_runner.go
+++ b/internal/loader/validate_runner.go
@@ -3,43 +3,44 @@ package loader
 import (
 	"fmt"
 
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/runner/db"
 	"github.com/nao1215/atago/internal/spec"
 )
 
 var validRunnerType = map[string]bool{"cmd": true, "http": true, "db": true, "ssh": true, "grpc": true, "browser": true}
 
-func validateRunners(add func(string, ...any), runners map[string]spec.Runner) {
+func validateRunners(add addFunc, runners map[string]spec.Runner) {
 	for name, r := range runners {
 		where := fmt.Sprintf("runner %q", name)
 		if r.Type == "" {
-			add("%s.type is required", where)
+			add(diag.RequiredKey, "%s.type is required", where)
 			continue
 		}
 		if !validRunnerType[r.Type] {
-			add("%s.type %q is invalid (want cmd, http, db, ssh, grpc, or browser)", where, r.Type)
+			add(diag.NotAllowedValue, "%s.type %q is invalid (want cmd, http, db, ssh, grpc, or browser)", where, r.Type)
 			continue
 		}
 		switch r.Type {
 		case "db":
 			if r.DSN == "" {
-				add("%s (db) requires a dsn", where)
+				add(diag.RequiredKey, "%s (db) requires a dsn", where)
 			}
 			// A declared driver is authoritative: reject an unsupported value here so
 			// a typo fails at load time instead of silently inferring from the dsn.
 			if err := db.ValidateDriver(r.Driver); err != nil {
-				add("%s: %v", where, err)
+				add(diag.ExclusiveKeys, "%s: %v", where, err)
 			}
 		case "ssh":
 			if r.Host == "" {
-				add("%s (ssh) requires a host", where)
+				add(diag.RequiredKey, "%s (ssh) requires a host", where)
 			}
 			if r.User == "" {
-				add("%s (ssh) requires a user", where)
+				add(diag.RequiredKey, "%s (ssh) requires a user", where)
 			}
 		case "grpc":
 			if r.Target == "" {
-				add("%s (grpc) requires a target", where)
+				add(diag.RequiredKey, "%s (grpc) requires a target", where)
 			}
 		case "browser":
 			// no required fields; a browser runner launches a local headless Chrome.
@@ -55,7 +56,7 @@ func validateRunners(add func(string, ...any), runners map[string]spec.Runner) {
 // cross-type fields (an http runner with ssh fields, a grpc runner with db
 // fields, ...) are rejected instead of silently accepted (#44). type/cwd/timeout
 // are common to every runner and intentionally absent here.
-func validateRunnerFields(add func(string, ...any), where string, r *spec.Runner) {
+func validateRunnerFields(add addFunc, where string, r *spec.Runner) {
 	type fieldOwner struct {
 		owner string
 		set   bool
@@ -79,7 +80,7 @@ func validateRunnerFields(add func(string, ...any), where string, r *spec.Runner
 	}
 	for _, f := range fields {
 		if f.set && f.owner != r.Type {
-			add("%s: %q cannot be set on a %s runner (it is a %s-runner field)", where, f.field, r.Type, f.owner)
+			add(diag.KeyNotHere, "%s: %q cannot be set on a %s runner (it is a %s-runner field)", where, f.field, r.Type, f.owner)
 		}
 	}
 }

--- a/internal/loader/validate_screen.go
+++ b/internal/loader/validate_screen.go
@@ -5,12 +5,13 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/spec"
 )
 
 // validateScreen checks a rendered-screen assertion: the stream matchers it
 // shares with stdout/stderr, plus the attribute entries (#382).
-func validateScreen(add func(string, ...any), where string, sa *spec.ScreenAssert) {
+func validateScreen(add addFunc, where string, sa *spec.ScreenAssert) {
 	if sa == nil {
 		return
 	}
@@ -28,22 +29,22 @@ func validateScreen(add func(string, ...any), where string, sa *spec.ScreenAsser
 	}
 }
 
-func validateScreenAttr(add func(string, ...any), where string, a *spec.ScreenAttr) {
+func validateScreenAttr(add addFunc, where string, a *spec.ScreenAttr) {
 	if a.Text == "" {
-		add("%s.text is required (the substring whose cells are checked)", where)
+		add(diag.RequiredKey, "%s.text is required (the substring whose cells are checked)", where)
 	}
 	if !a.HasAttribute() {
-		add("%s needs at least one of fg/bg/bold/italic/underline/reverse/blink; naming text alone asserts nothing", where)
+		add(diag.ChooseAtLeastOne, "%s needs at least one of fg/bg/bold/italic/underline/reverse/blink; naming text alone asserts nothing", where)
 	}
 	if a.Row < 0 {
-		add("%s.row must be a 1-based screen row", where)
+		add(diag.OutOfRange, "%s.row must be a 1-based screen row", where)
 	}
 	validateScreenColor(add, where+".fg", a.FG)
 	validateScreenColor(add, where+".bg", a.BG)
 }
 
 // validateScreenColor accepts an ANSI name, a 256-palette index, or `default`.
-func validateScreenColor(add func(string, ...any), where, value string) {
+func validateScreenColor(add addFunc, where, value string) {
 	if value == "" {
 		return
 	}
@@ -53,8 +54,8 @@ func validateScreenColor(add func(string, ...any), where, value string) {
 	// A number outside the palette is the most likely mistake, so say so
 	// specifically rather than listing every name.
 	if n, err := strconv.Atoi(strings.TrimSpace(value)); err == nil {
-		add("%s %d is outside the 256-color palette (0-255)", where, n)
+		add(diag.OutOfRange, "%s %d is outside the 256-color palette (0-255)", where, n)
 		return
 	}
-	add("%s %q is not a color (use %s)", where, value, spec.ScreenColorNames())
+	add(diag.BadFormat, "%s %q is not a color (use %s)", where, value, spec.ScreenColorNames())
 }

--- a/internal/loader/validate_service.go
+++ b/internal/loader/validate_service.go
@@ -5,35 +5,36 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/spec"
 )
 
-func validateServices(add func(string, ...any), where string, services []spec.Service) {
+func validateServices(add addFunc, where string, services []spec.Service) {
 	seen := make(map[string]bool, len(services))
 	for i := range services {
 		svc := &services[i]
 		sw := fmt.Sprintf("%s.services[%d]", where, i)
 		if svc.Name == "" {
-			add("%s.name is required", sw)
+			add(diag.RequiredKey, "%s.name is required", sw)
 		} else {
 			if seen[svc.Name] {
-				add("%s: duplicate service name %q", where, svc.Name)
+				add(diag.DuplicateName, "%s: duplicate service name %q", where, svc.Name)
 			}
 			seen[svc.Name] = true
 			sw = fmt.Sprintf("%s service %q", where, svc.Name)
 		}
 		if svc.Command == "" {
-			add("%s.command is required", sw)
+			add(diag.RequiredKey, "%s.command is required", sw)
 		}
 		validateHermeticEnv(add, sw, svc.ClearEnv, svc.PassEnv)
 		if svc.MaxLogBytes < 0 {
-			add("%s.max_log_bytes must be positive (got %d); omit it for the 8 MiB default", sw, svc.MaxLogBytes)
+			add(diag.NonPositiveValue, "%s.max_log_bytes must be positive (got %d); omit it for the 8 MiB default", sw, svc.MaxLogBytes)
 		}
 		validateReady(add, sw, svc.Ready)
 	}
 }
 
-func validateReady(add func(string, ...any), where string, r *spec.Ready) {
+func validateReady(add addFunc, where string, r *spec.Ready) {
 	if r == nil {
 		return
 	}
@@ -44,16 +45,16 @@ func validateReady(add func(string, ...any), where string, r *spec.Ready) {
 		}
 	}
 	if n > 1 {
-		add("%s.ready: set only one of file/port/log/delay", where)
+		add(diag.ChooseExactlyOne, "%s.ready: set only one of file/port/log/delay", where)
 	}
 	if r.Store != "" && r.File == "" {
-		add("%s.ready.store requires file (the file whose content is captured)", where)
+		add(diag.KeyNeedsAnother, "%s.ready.store requires file (the file whose content is captured)", where)
 	}
 	nonNegativeDuration(add, where+".ready.timeout", r.Timeout, "5s")
 	nonNegativeDuration(add, where+".ready.delay", r.Delay, "500ms")
 	if r.Log != "" {
 		if _, err := regexp.Compile(r.Log); err != nil {
-			add("%s.ready.log %q is not a valid regexp: %v", where, r.Log, err)
+			add(diag.BadRegexp, "%s.ready.log %q is not a valid regexp: %v", where, r.Log, err)
 		}
 	}
 }
@@ -61,15 +62,15 @@ func validateReady(add func(string, ...any), where string, r *spec.Ready) {
 // validateMockServers checks a scenario's mock_servers block (#24) and adds
 // every declared name to mockNames (which arrives pre-seeded with the
 // suite-wide mock names).
-func validateMockServers(add func(string, ...any), where string, servers []spec.MockServer, mockNames map[string]bool) {
+func validateMockServers(add addFunc, where string, servers []spec.MockServer, mockNames map[string]bool) {
 	for i := range servers {
 		ms := &servers[i]
 		mw := fmt.Sprintf("%s.mock_servers[%d]", where, i)
 		if ms.Name == "" {
-			add("%s.name is required", mw)
+			add(diag.RequiredKey, "%s.name is required", mw)
 		} else {
 			if mockNames[ms.Name] {
-				add("%s: duplicate mock server name %q", where, ms.Name)
+				add(diag.DuplicateName, "%s: duplicate mock server name %q", where, ms.Name)
 			}
 			mockNames[ms.Name] = true
 			mw = fmt.Sprintf("%s mock server %q", where, ms.Name)
@@ -80,17 +81,17 @@ func validateMockServers(add func(string, ...any), where string, servers []spec.
 
 // validateMockRoutes checks each canned route (#24): method+path required, at
 // most one payload source, sane status, parseable delay.
-func validateMockRoutes(add func(string, ...any), where string, routes []spec.MockRoute) {
+func validateMockRoutes(add addFunc, where string, routes []spec.MockRoute) {
 	for i := range routes {
 		rt := &routes[i]
 		rw := fmt.Sprintf("%s.routes[%d]", where, i)
 		if rt.Method == "" {
-			add("%s.method is required", rw)
+			add(diag.RequiredKey, "%s.method is required", rw)
 		}
 		if rt.Path == "" {
-			add("%s.path is required", rw)
+			add(diag.RequiredKey, "%s.path is required", rw)
 		} else if !strings.HasPrefix(rt.Path, "/") {
-			add("%s.path %q must start with \"/\"", rw, rt.Path)
+			add(diag.BadFormat, "%s.path %q must start with \"/\"", rw, rt.Path)
 		}
 		payloads := 0
 		if rt.JSON != nil {
@@ -103,10 +104,10 @@ func validateMockRoutes(add func(string, ...any), where string, routes []spec.Mo
 			payloads++
 		}
 		if payloads > 1 {
-			add("%s: set at most one of json/body/body_file", rw)
+			add(diag.ExclusiveKeys, "%s: set at most one of json/body/body_file", rw)
 		}
 		if rt.Status != 0 && (rt.Status < 100 || rt.Status > 599) {
-			add("%s.status %d is not a valid HTTP status", rw, rt.Status)
+			add(diag.OutOfRange, "%s.status %d is not a valid HTTP status", rw, rt.Status)
 		}
 		nonNegativeDuration(add, rw+".delay", rt.Delay, "500ms")
 	}

--- a/internal/loader/validate_service.go
+++ b/internal/loader/validate_service.go
@@ -45,7 +45,7 @@ func validateReady(add addFunc, where string, r *spec.Ready) {
 		}
 	}
 	if n > 1 {
-		add(diag.ChooseExactlyOne, "%s.ready: set only one of file/port/log/delay", where)
+		add(diag.ExclusiveKeys, "%s.ready: set only one of file/port/log/delay", where)
 	}
 	if r.Store != "" && r.File == "" {
 		add(diag.KeyNeedsAnother, "%s.ready.store requires file (the file whose content is captured)", where)

--- a/internal/loader/validate_signal.go
+++ b/internal/loader/validate_signal.go
@@ -5,28 +5,29 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/spec"
 )
 
 // validateSignal checks a signal step (#23): a declared target service, an
 // accepted signal name, and a parseable wait timeout. A ${name}-referencing
 // target is resolved at run time and skips the declared-name check.
-func validateSignal(add func(string, ...any), where string, sg *spec.Signal, serviceNames map[string]bool) {
+func validateSignal(add addFunc, where string, sg *spec.Signal, serviceNames map[string]bool) {
 	switch {
 	case sg.Service == "":
-		add("%s.signal.service is required (the scenario or suite service to signal)", where)
+		add(diag.RequiredKey, "%s.signal.service is required (the scenario or suite service to signal)", where)
 	case !strings.Contains(sg.Service, "${") && !serviceNames[sg.Service]:
 		declared := "none"
 		if len(serviceNames) > 0 {
 			declared = strings.Join(slices.Sorted(maps.Keys(serviceNames)), ", ")
 		}
-		add("%s.signal.service %q is not a declared service (declared: %s)", where, sg.Service, declared)
+		add(diag.NameNotDeclared, "%s.signal.service %q is not a declared service (declared: %s)", where, sg.Service, declared)
 	}
 	switch {
 	case sg.Signal == "":
-		add("%s.signal.signal is required (TERM, INT, HUP, USR1, USR2, or KILL)", where)
+		add(diag.RequiredKey, "%s.signal.signal is required (TERM, INT, HUP, USR1, USR2, or KILL)", where)
 	case !spec.ValidSignalName(sg.Signal):
-		add("%s.signal.signal %q is not an accepted signal (TERM, INT, HUP, USR1, USR2, or KILL, with an optional SIG prefix)", where, sg.Signal)
+		add(diag.NotAllowedValue, "%s.signal.signal %q is not an accepted signal (TERM, INT, HUP, USR1, USR2, or KILL, with an optional SIG prefix)", where, sg.Signal)
 	}
 	if sg.Wait != nil {
 		positiveDuration(add, where+".signal.wait.timeout", sg.Wait.Timeout, "5s", "5s")

--- a/internal/loader/validate_store.go
+++ b/internal/loader/validate_store.go
@@ -3,6 +3,7 @@ package loader
 import (
 	"regexp"
 
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/spec"
 	"github.com/ohler55/ojg/jp"
 )
@@ -14,15 +15,15 @@ import (
 // the collision is rejected at load time.
 var reservedVarNames = map[string]bool{"atago": true, "workdir": true, "suitedir": true}
 
-func validateStore(add func(string, ...any), where string, s *spec.Store) {
+func validateStore(add addFunc, where string, s *spec.Store) {
 	if s.Name == "" {
-		add("%s.store.name is required", where)
+		add(diag.RequiredKey, "%s.store.name is required", where)
 	}
 	if reservedVarNames[s.Name] {
-		add("%s.store.name %q shadows a built-in variable (atago/workdir/suitedir); choose another name", where, s.Name)
+		add(diag.ReservedName, "%s.store.name %q shadows a built-in variable (atago/workdir/suitedir); choose another name", where, s.Name)
 	}
 	if s.From == nil {
-		add("%s.store.from is required", where)
+		add(diag.RequiredKey, "%s.store.from is required", where)
 		return
 	}
 	n := 0
@@ -49,10 +50,10 @@ func validateStore(add func(string, ...any), where string, s *spec.Store) {
 	}
 	switch n {
 	case 0:
-		add("%s.store.from must set one of stdout/body/file/header/rows/message/value", where)
+		add(diag.ChooseExactlyOne, "%s.store.from must set one of stdout/body/file/header/rows/message/value", where)
 	case 1:
 	default:
-		add("%s.store.from must set exactly one source", where)
+		add(diag.ChooseExactlyOne, "%s.store.from must set exactly one source", where)
 	}
 
 	// A store selector extracts a value via a json path or a matches regexp
@@ -81,7 +82,7 @@ func validateStore(add func(string, ...any), where string, s *spec.Store) {
 // validateStoreFileSelector checks a store.from.file selector: exactly one of a
 // json path (extract a value) or text: true (capture the whole file verbatim,
 // #158).
-func validateStoreFileSelector(add func(string, ...any), where string, f *spec.FileAssert) {
+func validateStoreFileSelector(add addFunc, where string, f *spec.FileAssert) {
 	n := 0
 	if len(f.JSON) > 0 {
 		n++
@@ -92,19 +93,19 @@ func validateStoreFileSelector(add func(string, ...any), where string, f *spec.F
 	}
 	switch n {
 	case 0:
-		add("%s must set a json path or text: true to capture a value", where)
+		add(diag.ChooseExactlyOne, "%s must set a json path or text: true to capture a value", where)
 	case 1:
 	default:
-		add("%s must set exactly one selector (json or text)", where)
+		add(diag.ChooseExactlyOne, "%s must set exactly one selector (json or text)", where)
 	}
 }
 
 // validateStoreJSONSelector checks the json selector of a store source: it
 // captures exactly one value, so a list of checks (#156) is rejected — a store
 // needs a single JSONPath, not several assertions.
-func validateStoreJSONSelector(add func(string, ...any), where string, list spec.JSONChecks) {
+func validateStoreJSONSelector(add addFunc, where string, list spec.JSONChecks) {
 	if len(list) > 1 {
-		add("%s must select a single value with one json path, not a list of checks", where)
+		add(diag.ChooseExactlyOne, "%s must select a single value with one json path, not a list of checks", where)
 		return
 	}
 	validateStoreJSONPath(add, where, list[0].Path)
@@ -114,7 +115,7 @@ func validateStoreJSONSelector(add func(string, ...any), where string, list spec
 // exactly one of a json path, a matches regexp, or trim (capture the whole
 // stream, #158) — the selectors the extractor understands — and whichever is
 // present must be well-formed.
-func validateStoreSelector(add func(string, ...any), where string, s *spec.StreamAssert) {
+func validateStoreSelector(add addFunc, where string, s *spec.StreamAssert) {
 	n := 0
 	if len(s.JSON) > 0 {
 		n++
@@ -123,7 +124,7 @@ func validateStoreSelector(add func(string, ...any), where string, s *spec.Strea
 	if s.Matches != nil {
 		n++
 		if _, err := regexp.Compile(*s.Matches); err != nil {
-			add("%s.matches %q is not a valid regexp: %v", where, *s.Matches, err)
+			add(diag.BadRegexp, "%s.matches %q is not a valid regexp: %v", where, *s.Matches, err)
 		}
 	}
 	if s.Trim != nil {
@@ -131,20 +132,20 @@ func validateStoreSelector(add func(string, ...any), where string, s *spec.Strea
 	}
 	switch n {
 	case 0:
-		add("%s must set a json path, a matches regexp, or trim to extract a value", where)
+		add(diag.ChooseExactlyOne, "%s must set a json path, a matches regexp, or trim to extract a value", where)
 	case 1:
 	default:
-		add("%s must set exactly one selector (json, matches, or trim)", where)
+		add(diag.ChooseExactlyOne, "%s must set exactly one selector (json, matches, or trim)", where)
 	}
 }
 
 // validateStoreJSONPath compile-checks a store selector's JSON path.
-func validateStoreJSONPath(add func(string, ...any), where, path string) {
+func validateStoreJSONPath(add addFunc, where, path string) {
 	if path == "" {
-		add("%s.path is required", where)
+		add(diag.RequiredKey, "%s.path is required", where)
 		return
 	}
 	if _, err := jp.ParseString(path); err != nil {
-		add("%s.path %q is not a valid JSON path: %v", where, path, err)
+		add(diag.BadFormat, "%s.path %q is not a valid JSON path: %v", where, path, err)
 	}
 }

--- a/test/e2e/atago/error_codes.atago.yaml
+++ b/test/e2e/atago/error_codes.atago.yaml
@@ -1,0 +1,668 @@
+version: "1"
+
+suite:
+  name: atago self-hosting / every spec-error diagnostic code
+
+# Diagnostic codes (#454, #455) are a published contract: ATG2103 has to keep
+# meaning the same thing across releases, or every bookmark, CI grep, and agent
+# prompt that matched on it breaks. A code documented in doc/errors.md but never
+# emitted would be worse than no code at all, so each scenario here provokes one
+# code from the real binary and asserts the code itself rather than the wording
+# around it — the message is free to improve, the code is not.
+#
+# The set is complete on purpose: TestE2E_EveryCodeIsProvoked fails when a
+# registered code has no scenario in this directory, so adding a code to the
+# registry without exercising it here cannot pass CI.
+#
+# Every scenario asserts exit 2 as well, which is the other half of the
+# contract: the thousands digit of an ATG2xxx code promises exit 2.
+scenarios:
+  # --- ATG20xx: the document itself -----------------------------------------
+
+  - name: ATG2001 is a spec file that cannot be read
+    # A dangling symlink is the portable way to make the file exist for the
+    # directory walk and vanish for the read; a mode-000 file would not work
+    # for a run as root, which some CI images are.
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: broken.atago.yaml
+          symlink: nowhere.yaml
+      - run: {command: "${atago} run ."}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2001"}
+
+  - name: ATG2002 is a spec file with no YAML document in it
+    steps:
+      - fixture: {file: bad.atago.yaml, content: "# only a comment\n"}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2002"}
+
+  - name: ATG2003 is a document that is not valid YAML
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+              suite: {name: x}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2003"}
+
+  - name: ATG2004 is an explicit YAML tag
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: !!str x}
+            scenarios: [{name: a, steps: [{run: {command: echo}}]}]
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2004"}
+
+  - name: ATG2005 is a key the schema does not define
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenariosss: []
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr:
+            contains:
+              - "ATG2005"
+              # The code is added to the message, never substituted for it.
+              - 'unknown field "scenariosss"'
+
+  - name: ATG2006 is a value written in a shape its key cannot take
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios: [{name: a, steps: [{assert: {stdout: hi}}]}]
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2006"}
+
+  - name: ATG2010 is an unsupported spec format version
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "9"
+            suite: {name: x}
+            scenarios: [{name: a, steps: [{run: {command: echo}}]}]
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2010"}
+
+  # --- ATG21xx: keys that should not be there, or contradict ----------------
+
+  - name: ATG2101 is a step that sets no action
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios: [{name: a, steps: [{}]}]
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2101"}
+
+  - name: ATG2102 is a step that sets more than one action
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios:
+              - name: a
+                steps:
+                  - run: {command: echo}
+                    fixture: {file: f, content: c}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2102"}
+
+  - name: ATG2103 is a pair of keys that contradict each other
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios:
+              - name: a
+                steps:
+                  - run: {command: echo}
+                  - assert: {file: {path: f, size: 1, snapshot: s}}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2103"}
+
+  - name: ATG2104 is a group that takes exactly one member and got two
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios:
+              - name: a
+                steps:
+                  - pty: {command: echo, session: [{expect: a, send: b}]}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2104"}
+
+  - name: ATG2105 is a real key in a position where it means nothing
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            defaults: {run: {command: echo}}
+            scenarios: [{name: a, steps: [{run: {command: echo}}]}]
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2105"}
+
+  - name: ATG2106 is a block at the wrong level of the spec
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios:
+              - name: a
+                steps:
+                  - service: {name: s, command: "sleep 1"}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2106"}
+
+  - name: ATG2107 is an assertion with no step to describe
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios:
+              - name: a
+                steps:
+                  - run: {command: echo}
+                  - assert: {screen: {contains: hi}}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2107"}
+
+  - name: ATG2108 is a key whose companion key is not set
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios:
+              - name: a
+                steps:
+                  - run: {command: echo}
+                  - assert: {image: {path: f, max_diff: 0.5}}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2108"}
+
+  # --- ATG22xx: something required is missing -------------------------------
+
+  - name: ATG2201 is a required key that is absent
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {}
+            scenarios: [{name: a, steps: [{run: {command: echo}}]}]
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2201"}
+
+  - name: ATG2202 is a list that must hold an entry and holds none
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios: []
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2202"}
+
+  - name: ATG2203 is a group that needs at least one member and got none
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios:
+              - name: a
+                steps:
+                  - run: {command: echo}
+                  - assert: {changes: {}}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2203"}
+
+  - name: ATG2204 is a key present with an empty value
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios:
+              - name: a
+                steps:
+                  - run: {command: echo}
+                  - assert: {file: {path: f, equals_file: ""}}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2204"}
+
+  # --- ATG23xx: a value that is present but wrong ---------------------------
+
+  - name: ATG2301 is a duration atago cannot read
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x, timeout: "soon"}
+            scenarios: [{name: a, steps: [{run: {command: echo}}]}]
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2301"}
+
+  - name: ATG2302 is a negative value where a negative means nothing
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x, timeout: "-1s"}
+            scenarios: [{name: a, steps: [{run: {command: echo}}]}]
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2302"}
+
+  - name: ATG2303 is a value that must be positive and is not
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios:
+              - name: a
+                services: [{name: s, command: "sleep 1", max_log_bytes: -1}]
+                steps:
+                  - run: {command: echo}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2303"}
+
+  - name: ATG2304 is a number outside the range its key accepts
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios:
+              - name: a
+                steps:
+                  - pty: {command: echo, session: [{expect: a}]}
+                  - assert: {screen: {attrs: [{text: hi, bold: true, row: -1}]}}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2304"}
+
+  - name: ATG2305 is a regular expression that does not compile
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios:
+              - name: a
+                steps:
+                  - run: {command: echo}
+                  - assert: {stdout: {matches: "["}}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2305"}
+
+  - name: ATG2306 is a glob pattern that does not parse
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios:
+              - name: a
+                steps:
+                  - run: {command: echo}
+                  - assert: {dir: {path: ".", glob: "["}}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2306"}
+
+  - name: ATG2307 is a value outside a closed vocabulary
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios: [{name: a, skip: {os: macos}, steps: [{run: {command: echo}}]}]
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2307"}
+
+  - name: ATG2308 is a range nothing could satisfy
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios:
+              - name: a
+                steps:
+                  - run: {command: echo}
+                  - assert: {file: {path: f, min_size: 10, max_size: 5}}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2308"}
+
+  - name: ATG2309 is an absolute path where a relative one is required
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios:
+              - name: a
+                steps:
+                  - run: {command: echo}
+                  - assert: {changes: {created: ["/tmp/x"]}}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2309"}
+
+  - name: ATG2310 is a path that climbs out of the workdir
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios:
+              - name: a
+                steps:
+                  - run: {command: echo}
+                  - assert: {changes: {created: ["../x"]}}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2310"}
+
+  - name: ATG2311 is a control character in a name
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: "x\ty"}
+            scenarios: [{name: a, steps: [{run: {command: echo}}]}]
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2311"}
+
+  - name: ATG2312 is a matcher that could never fail
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios:
+              - name: a
+                steps:
+                  - run: {command: echo}
+                  - assert: {stdout: {contains: ""}}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2312"}
+
+  - name: ATG2313 is a value in the wrong notation
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios:
+              - name: a
+                steps:
+                  - fixture: {file: f, content: c, mode: "99"}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2313"}
+
+  # --- ATG24xx: a name that does not resolve --------------------------------
+
+  - name: ATG2401 is a runner the spec never declared
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios:
+              - name: a
+                steps:
+                  - http: {runner: api, method: GET, path: /}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2401"}
+
+  - name: ATG2402 is a declared runner of the wrong type
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            runners: {api: {type: db, dsn: "sqlite://:memory:"}}
+            scenarios:
+              - name: a
+                steps:
+                  - http: {runner: api, method: GET, path: /}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2402"}
+
+  - name: ATG2403 is a reference to something the spec never declared
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios:
+              - name: a
+                steps:
+                  - signal: {service: ghost, signal: TERM}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2403"}
+
+  - name: ATG2404 is a stored value shadowing a built-in
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios:
+              - name: a
+                steps:
+                  - run: {command: echo}
+                  - store: {name: workdir, from: {stdout: {matches: "x"}}}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2404"}
+
+  - name: ATG2405 is a manifest path that resolves to nothing
+    steps:
+      - fixture:
+          file: atago.project.yaml
+          content: |
+            fixtures_dir: nowhere
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios: [{name: a, steps: [{run: {command: echo}}]}]
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2405"}
+
+  # --- ATG25xx: identity ----------------------------------------------------
+
+  - name: ATG2501 is two scenarios sharing a name
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios:
+              - {name: a, steps: [{run: {command: echo}}]}
+              - {name: a, steps: [{run: {command: echo}}]}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2501"}
+
+  - name: ATG2502 is a set listing the same entry twice
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios:
+              - name: a
+                steps:
+                  - run: {command: echo}
+                  - assert: {exit_code: {in: [0, 0]}}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr: {contains: "ATG2502"}
+
+  # --- the contract itself --------------------------------------------------
+
+  - name: a code is added to the message rather than replacing it
+    # The whole point of a code is that the prose stays free to improve, which
+    # only holds while both are printed. A change that replaced the sentence
+    # with its code would pass every scenario above.
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {}
+            scenarios: [{name: a, steps: [{run: {command: echo}}]}]
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr:
+            matches: "ATG2201: suite\\.name is required"
+
+  - name: several problems each report their own code in one pass
+    # Validation collects every problem before failing, and each line carries
+    # the code for the problem on that line — not one code for the whole file.
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "9"
+            suite: {name: x}
+            scenarios:
+              - name: a
+                steps:
+                  - run: {command: echo}
+                  - assert: {stdout: {matches: "["}}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 2
+          stderr:
+            contains:
+              - "ATG2010"
+              - "ATG2305"

--- a/website/content/_content.gotmpl
+++ b/website/content/_content.gotmpl
@@ -44,6 +44,22 @@
       "content" (dict "mediaType" "text/markdown" "value" $merged)) }}
 {{ end }}
 
+{{/* doc/errors.md -> /errors/ — the reference generated from the diagnostic
+     registry, so the published page cannot drift from the codes atago emits. */}}
+{{ with resources.Get "doc/errors.md" }}
+  {{ $md := .Content }}
+  {{ $md = replaceRE `\A# Error codes\n` "" $md }}
+  {{ $.AddPage (dict
+      "path" "errors"
+      "title" "Error codes"
+      "params" (dict
+        "seoTitle" "atago error codes — what each ATG code means and how to fix it"
+        "description" "Every error atago reports carries a searchable code. This is what each one means, what causes it, and what to change."
+        "toc" true
+        "filter" true)
+      "content" (dict "mediaType" "text/markdown" "value" $md)) }}
+{{ end }}
+
 {{/* doc/real-world.md -> /real-world/ (section index) */}}
 {{ with resources.Get "doc/real-world.md" }}
   {{ $md := .Content }}

--- a/website/content/_content.gotmpl
+++ b/website/content/_content.gotmpl
@@ -54,7 +54,7 @@
       "title" "Error codes"
       "params" (dict
         "seoTitle" "atago error codes — what each ATG code means and how to fix it"
-        "description" "Every error atago reports carries a searchable code. This is what each one means, what causes it, and what to change."
+        "description" "atago errors carry a searchable code such as ATG2201. This is what each one means, what causes it, and what to change."
         "toc" true
         "filter" true)
       "content" (dict "mediaType" "text/markdown" "value" $md)) }}

--- a/website/content/reference.md
+++ b/website/content/reference.md
@@ -129,4 +129,4 @@ The report and manifest outputs have schemas too: [report.schema.json](https://g
 
 `Ctrl-C`/`SIGTERM` stops the run cleanly: in-flight processes, services, and sessions are torn down, partial results are reported, and the run exits `4`.
 
-Every error atago reports also carries a diagnostic code such as `ATG2201`, whose first digit is the exit code above — so `ATG2xxx` always exits 2. The codes are searchable and stable across rewordings of the message; [Error codes](/errors/) lists what each one means and what to change. Assertion failures carry no code: exit 1 is a result, not an error.
+Errors also carry a diagnostic code such as `ATG2201`, whose first digit is the exit code above — so `ATG2xxx` always exits 2. The codes are searchable and stable across rewordings of the message; [Error codes](/errors/) lists what each one means, what to change, and which families carry codes today. Assertion failures carry none: exit 1 is a result, not an error.

--- a/website/content/reference.md
+++ b/website/content/reference.md
@@ -128,3 +128,5 @@ The report and manifest outputs have schemas too: [report.schema.json](https://g
 | `6`  | security policy violation |
 
 `Ctrl-C`/`SIGTERM` stops the run cleanly: in-flight processes, services, and sessions are torn down, partial results are reported, and the run exits `4`.
+
+Every error atago reports also carries a diagnostic code such as `ATG2201`, whose first digit is the exit code above — so `ATG2xxx` always exits 2. The codes are searchable and stable across rewordings of the message; [Error codes](/errors/) lists what each one means and what to change. Assertion failures carry no code: exit 1 is a result, not an error.

--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -56,6 +56,11 @@ pageRef = "/reference"
 weight = 60
 
 [[menus.main]]
+name = "Error codes"
+pageRef = "/errors"
+weight = 65
+
+[[menus.main]]
 name = "Real-world CLIs"
 pageRef = "/real-world"
 weight = 70
@@ -89,6 +94,10 @@ target = "assets/doc/examples.md"
 [[module.mounts]]
 source = "../doc/real-world.md"
 target = "assets/doc/real-world.md"
+
+[[module.mounts]]
+source = "../doc/errors.md"
+target = "assets/doc/errors.md"
 
 [[module.mounts]]
 source = "../schema/atago.schema.json"


### PR DESCRIPTION
## Summary

Spec errors now carry a stable diagnostic code — `spec.yaml: ATG2201: suite.name is required` — added to the message rather than replacing it, so a failure can be searched for, linked to, and branched on while the wording stays free to improve. The code's first digit is the exit status it produces, which makes ATG2xxx a refinement of the exit contract already published rather than a second contract beside it, and ATG1xxx is never assigned because exit 1 is an assertion failing rather than atago failing.

This is Phase A of #454: it builds the registry, the guards that keep a code from going missing, and the generated reference, then proves the machinery by converting the whole spec-error family.

## Changes

- `internal/diag/` — the registry: a `Code` type whose thousands digit is the exit status, `Lookup`/`All`/`Parse`/`Codes`, and the 39 spec-error entries in `codes_spec.go`, each with its summary, explanation, fix, and first version.
- `internal/diag/markdown.go` — renders the published reference from the registry, which is what `doc/errors.md` is generated from.
- `internal/loader/validate*.go`, `project.go` — the validation funnel takes the code as its first argument, and all 238 checks pass one.
- `internal/loader/loader.go` — parse failures carry a code too, classified structurally: if the parser cannot build a document the problem is syntax, and if it can, the spec model is what rejected it.
- `doc/errors.md`, `website/hugo.toml`, `website/content/_content.gotmpl` — the generated reference, mounted as the `/errors/` page and linked from the main menu.
- `test/e2e/atago/error_codes.atago.yaml` — 41 scenarios provoking every code from the real binary.
- `drift_test.go` — the reference drift guard and the E2E coverage gate.

## Design Decisions

Codes group by what the reader has to fix, never one per call site. Two errors share a code when the answer is the same, so a service with no command and an HTTP step with no method are both ATG2201, and the 238 checks in the loader map to 39 codes rather than 238. Assertion failures get no code at all: they are a spec doing its job, their message already says what was expected and what happened, and coding them would push people toward matching on codes where they should be reading the diff.

A code cannot go missing, and that is enforced in three places rather than asked for in a review. Codes are not constants that a registry then describes; they are what registering returns, and registration refuses an entry missing its summary, explanation, fix, or version — so a code with no documentation is unconstructable rather than merely untested. The funnel every `validate_*.go` check flows through takes the code first, so a check added later that forgets one does not compile. And `doc/errors.md` is generated from the registry and drift-guarded, so the published page cannot rot away from the codes atago actually emits.

On top of those, a coverage gate: every registered code must be provoked by a scenario in atago's own suite. It reads what the scenarios assert rather than the file text, because the first version of it passed on scenario titles alone and proved nothing. Two scenarios guard the contract itself rather than a single code — one pins the code and the sentence together, since a change that replaced the message with its code would otherwise pass everything else, and one checks that a spec with several problems reports a code per problem rather than one for the file.

Parse errors are classified by re-parsing the bytes rather than by matching the decoder's wording. If the parser cannot build a document at all it is ATG2003 (syntax); if it can, the YAML was fine and the spec model rejected it, which is ATG2005 for a key that does not exist and ATG2006 otherwise. That keeps the classification correct for schema errors raised by the `spec` package's own unmarshalers, whose wording the loader has no business knowing.

## Limitations

Only the spec-error family is coded. Configuration (#456), security (#457), execution and internal (#458) follow, and `atago explain ATG2201` plus the code as a field in the JSON, JUnit, and GitHub Actions reports is #459 — until then a code is looked up on the website rather than from the terminal. `familyOf` in `internal/diag/usage_test.go` lists only `internal/loader` for now; each later phase adds its package with the exit code it reports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stable diagnostic codes for specification-loading and validation errors.
  * Error messages now include codes that correspond to process exit-status categories.
  * Multiple errors can be reported with distinct diagnostic codes in a single run.

* **Documentation**
  * Added a complete error-code reference with explanations, fixes, exit statuses, and version information.
  * Added an Error Codes page to the website and linked it from the reference documentation.
  * Expanded end-to-end behavior documentation with specification-error examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->