### PR TITLE
feat(diag): code the configuration and CLI-invocation errors

### DIFF
--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-81 suites · 563 scenarios
+81 suites · 578 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -144,7 +144,7 @@
   - [file not_contains passes when the substring is absent](#scenario-file-not_contains-passes-when-the-substring-is-absent)
   - [not_contains fails when the substring is present](#scenario-not_contains-fails-when-the-substring-is-present)
   - [a shell metacharacter without shell is a load-time error](#scenario-a-shell-metacharacter-without-shell-is-a-load-time-error)
-- [atago self-hosting / every spec-error diagnostic code](#atago-self-hosting--every-spec-error-diagnostic-code) — 41 scenarios
+- [atago self-hosting / every diagnostic code](#atago-self-hosting--every-diagnostic-code) — 56 scenarios
   - [ATG2001 is a spec file that cannot be read](#scenario-atg2001-is-a-spec-file-that-cannot-be-read)
   - [ATG2002 is a spec file with no YAML document in it](#scenario-atg2002-is-a-spec-file-with-no-yaml-document-in-it)
   - [ATG2003 is a document that is not valid YAML](#scenario-atg2003-is-a-document-that-is-not-valid-yaml)
@@ -186,6 +186,21 @@
   - [ATG2502 is a set listing the same entry twice](#scenario-atg2502-is-a-set-listing-the-same-entry-twice)
   - [a code is added to the message rather than replacing it](#scenario-a-code-is-added-to-the-message-rather-than-replacing-it)
   - [several problems each report their own code in one pass](#scenario-several-problems-each-report-their-own-code-in-one-pass)
+  - [ATG3001 is a subcommand atago does not have](#scenario-atg3001-is-a-subcommand-atago-does-not-have)
+  - [ATG3001 is also atago with no subcommand at all](#scenario-atg3001-is-also-atago-with-no-subcommand-at-all)
+  - [ATG3002 is a subcommand called in a shape it does not accept](#scenario-atg3002-is-a-subcommand-called-in-a-shape-it-does-not-accept)
+  - [ATG3101 is an option atago does not define](#scenario-atg3101-is-an-option-atago-does-not-define)
+  - [ATG3102 is an option given a value it does not accept](#scenario-atg3102-is-an-option-given-a-value-it-does-not-accept)
+  - [ATG3103 is an option whose companion option is not set](#scenario-atg3103-is-an-option-whose-companion-option-is-not-set)
+  - [ATG3104 is two options that contradict each other](#scenario-atg3104-is-two-options-that-contradict-each-other)
+  - [ATG3105 is a numeric option outside its range](#scenario-atg3105-is-a-numeric-option-outside-its-range)
+  - [ATG3201 is a path that cannot be reached](#scenario-atg3201-is-a-path-that-cannot-be-reached)
+  - [ATG3202 is a directory holding no specs](#scenario-atg3202-is-a-directory-holding-no-specs)
+  - [ATG3203 is a selection that matched nothing under --ci](#scenario-atg3203-is-a-selection-that-matched-nothing-under---ci)
+  - [ATG3204 is a rerun whose recorded failures no longer exist](#scenario-atg3204-is-a-rerun-whose-recorded-failures-no-longer-exist)
+  - [ATG3205 is a write that would replace an existing file](#scenario-atg3205-is-a-write-that-would-replace-an-existing-file)
+  - [ATG3206 is a destination that cannot be written](#scenario-atg3206-is-a-destination-that-cannot-be-written)
+  - [ATG3207 is atago's recorded state failing to load](#scenario-atg3207-is-atagos-recorded-state-failing-to-load)
 - [atago self-hosting / exit_code in-set matcher](#atago-self-hosting--exit_code-in-set-matcher) — 4 scenarios
   - [a listed exit code passes](#scenario-a-listed-exit-code-passes)
   - [an unlisted exit code fails and the output lists the set](#scenario-an-unlisted-exit-code-fails-and-the-output-lists-the-set)
@@ -3187,7 +3202,7 @@ ${atago} snapshot update no-such-spec.atago.yaml
 ```
 #### Then
 - exit code is `3`
-- stderr contains `atago snapshot update: cannot access`, does not contain `atago run:`
+- stderr contains `atago snapshot update: `, `cannot access`, does not contain `atago run:`
 ### Scenario: a json assertion on malformed input fails cleanly, without a crash
 #### Given
 - Fixture file `bad.atago.yaml` is created.
@@ -3300,7 +3315,7 @@ ${atago} run bad.atago.yaml
 #### Then
 - exit code is `2`
 - stderr contains `shell is not enabled`, `shell: true`, `stdout_to`
-## atago self-hosting / every spec-error diagnostic code
+## atago self-hosting / every diagnostic code
 Source: `test/e2e/atago/error_codes.atago.yaml`
 ### Scenario: ATG2001 is a spec file that cannot be read
 _skipped on Windows_
@@ -4085,6 +4100,224 @@ ${atago} run bad.atago.yaml
 #### Then
 - exit code is `2`
 - stderr contains `ATG2010`, `ATG2305`
+### Scenario: ATG3001 is a subcommand atago does not have
+#### When
+```shell
+${atago} frobnicate
+```
+#### Then
+- exit code is `3`
+- stderr contains `ATG3001`
+### Scenario: ATG3001 is also atago with no subcommand at all
+#### When
+```shell
+${atago}
+```
+#### Then
+- exit code is `3`
+- stderr contains `ATG3001`
+### Scenario: ATG3002 is a subcommand called in a shape it does not accept
+#### When
+```shell
+${atago} snapshot
+```
+#### Then
+- exit code is `3`
+- stderr contains `ATG3002`
+### Scenario: ATG3101 is an option atago does not define
+#### When
+```shell
+${atago} run --definitely-not-a-flag .
+```
+#### Then
+- exit code is `3`
+- stderr contains `ATG3101`, `flag provided but not defined`, `Usage: atago run`
+### Scenario: ATG3102 is an option given a value it does not accept
+#### Given
+- Fixture file `ok.atago.yaml` is created.
+#### Inputs
+_Fixture `ok.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios: [{name: a, steps: [{run: {command: echo}}]}]
+```
+#### When
+```shell
+${atago} run --report jnit ok.atago.yaml
+```
+#### Then
+- exit code is `3`
+- stderr contains `ATG3102`
+### Scenario: ATG3103 is an option whose companion option is not set
+#### When
+```shell
+${atago} doc --split-by-spec .
+```
+#### Then
+- exit code is `3`
+- stderr contains `ATG3103`
+### Scenario: ATG3104 is two options that contradict each other
+#### Given
+- Fixture file `ok.atago.yaml` is created.
+#### Inputs
+_Fixture `ok.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios: [{name: a, steps: [{run: {command: echo}}]}]
+```
+#### When
+```shell
+${atago} run --repeat 2 --retry-failed 1 ok.atago.yaml
+```
+#### Then
+- exit code is `3`
+- stderr contains `ATG3104`
+### Scenario: ATG3105 is a numeric option outside its range
+#### Given
+- Fixture file `ok.atago.yaml` is created.
+#### Inputs
+_Fixture `ok.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios: [{name: a, steps: [{run: {command: echo}}]}]
+```
+#### When
+```shell
+${atago} run --parallel -1 ok.atago.yaml
+```
+#### Then
+- exit code is `3`
+- stderr contains `ATG3105`
+### Scenario: ATG3201 is a path that cannot be reached
+#### When
+```shell
+${atago} run ./nowhere
+```
+#### Then
+- exit code is `3`
+- stderr contains `ATG3201`
+### Scenario: ATG3202 is a directory holding no specs
+#### When
+```shell
+${atago} run .
+```
+#### Then
+- exit code is `3`
+- stderr contains `ATG3202`
+### Scenario: ATG3203 is a selection that matched nothing under --ci
+#### Given
+- Fixture file `ok.atago.yaml` is created.
+#### Inputs
+_Fixture `ok.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios: [{name: a, steps: [{run: {command: echo}}]}]
+```
+#### When
+```shell
+${atago} run --ci --tag no-such-tag ok.atago.yaml
+```
+#### Then
+- exit code is `3`
+- stderr contains `ATG3203`
+### Scenario: ATG3204 is a rerun whose recorded failures no longer exist
+#### Given
+- Fixture file `ok.atago.yaml` is created.
+- Fixture file `ok.atago.yaml` is created.
+#### Inputs
+_Fixture `ok.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios:
+  - name: before
+    steps:
+      - run: {command: "false"}
+      - assert: {exit_code: 0}
+```
+_Fixture `ok.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios:
+  - name: after
+    steps:
+      - run: {command: echo}
+```
+#### When
+```shell
+${atago} run ok.atago.yaml
+${atago} run --rerun-failed ok.atago.yaml
+```
+#### Then
+- after `${atago} run ok.atago.yaml`:
+  - exit code is `1`
+- after `${atago} run --rerun-failed ok.atago.yaml`:
+  - exit code is `3`
+  - stderr contains `ATG3204`
+### Scenario: ATG3205 is a write that would replace an existing file
+#### Given
+- Fixture file `taken.atago.yaml` is created.
+#### Inputs
+_Fixture `taken.atago.yaml`:_
+```text
+already here
+```
+#### When
+```shell
+${atago} init taken.atago.yaml
+```
+#### Then
+- exit code is `3`
+- stderr contains `ATG3205`
+### Scenario: ATG3206 is a destination that cannot be written
+#### Given
+- Fixture file `occupied` is created.
+- Fixture file `ok.atago.yaml` is created.
+#### Inputs
+_Fixture `occupied`:_
+```text
+not a directory
+```
+_Fixture `ok.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios: [{name: a, steps: [{run: {command: echo}}]}]
+```
+#### When
+```shell
+${atago} run --artifacts-dir occupied ok.atago.yaml
+```
+#### Then
+- exit code is `3`
+- stderr contains `ATG3206`
+### Scenario: ATG3207 is atago's recorded state failing to load
+#### Given
+- Fixture file `.atago/last-failed.json` is created.
+- Fixture file `ok.atago.yaml` is created.
+#### Inputs
+_Fixture `.atago/last-failed.json`:_
+```text
+not json at all
+```
+_Fixture `ok.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios: [{name: a, steps: [{run: {command: echo}}]}]
+```
+#### When
+```shell
+${atago} run --rerun-failed ok.atago.yaml
+```
+#### Then
+- exit code is `3`
+- stderr contains `ATG3207`
 ## atago self-hosting / exit_code in-set matcher
 Source: `test/e2e/atago/exit_code_in.atago.yaml`
 ### Scenario: a listed exit code passes

--- a/doc/errors.md
+++ b/doc/errors.md
@@ -9,7 +9,7 @@ Codes are being assigned one family at a time. The table says which families car
 | Codes | Exit | Meaning | Assigned |
 |---|---|---|---|
 | `ATG2xxx` | 2 | spec error — the file could not be parsed, or does not describe a runnable suite | 39 codes |
-| `ATG3xxx` | 3 | configuration error — the command line, its flags, or the spec files it selected | not yet |
+| `ATG3xxx` | 3 | configuration error — the command line, its flags, or the spec files it selected | 14 codes |
 | `ATG4xxx` | 4 | execution error — a step could not be carried out | not yet |
 | `ATG5xxx` | 5 | internal error — a bug in atago | not yet |
 | `ATG6xxx` | 6 | security policy violation — atago refused an operation on policy grounds | not yet |
@@ -63,6 +63,20 @@ Look a code up from the terminal with `atago explain ATG2201`, which prints this
 | [`ATG2405`](#atg2405--a-path-does-not-exist-or-is-not-the-kind-of-thing-the-key-needs) | a path does not exist, or is not the kind of thing the key needs | 2 | v0.21.0 |
 | [`ATG2501`](#atg2501--two-entries-in-the-same-spec-share-a-name) | two entries in the same spec share a name | 2 | v0.21.0 |
 | [`ATG2502`](#atg2502--a-list-repeats-an-entry-that-must-appear-once) | a list repeats an entry that must appear once | 2 | v0.21.0 |
+| [`ATG3001`](#atg3001--there-is-no-such-atago-subcommand) | there is no such atago subcommand | 3 | v0.21.0 |
+| [`ATG3002`](#atg3002--a-subcommand-was-called-in-a-shape-it-does-not-accept) | a subcommand was called in a shape it does not accept | 3 | v0.21.0 |
+| [`ATG3101`](#atg3101--the-command-line-sets-an-option-atago-does-not-define) | the command line sets an option atago does not define | 3 | v0.21.0 |
+| [`ATG3102`](#atg3102--an-option-was-given-a-value-it-does-not-accept) | an option was given a value it does not accept | 3 | v0.21.0 |
+| [`ATG3103`](#atg3103--an-option-needs-another-option-that-is-not-set) | an option needs another option that is not set | 3 | v0.21.0 |
+| [`ATG3104`](#atg3104--two-options-that-contradict-each-other-are-both-set) | two options that contradict each other are both set | 3 | v0.21.0 |
+| [`ATG3105`](#atg3105--a-numeric-option-is-outside-the-range-it-accepts) | a numeric option is outside the range it accepts | 3 | v0.21.0 |
+| [`ATG3201`](#atg3201--a-path-on-the-command-line-cannot-be-reached) | a path on the command line cannot be reached | 3 | v0.21.0 |
+| [`ATG3202`](#atg3202--no-spec-files-were-found-under-the-paths-given) | no spec files were found under the paths given | 3 | v0.21.0 |
+| [`ATG3203`](#atg3203--the-scenario-selection-matched-nothing-and---ci-refuses-to-call-that-success) | the scenario selection matched nothing, and --ci refuses to call that success | 3 | v0.21.0 |
+| [`ATG3204`](#atg3204--no-recorded-failing-scenario-matched-the-current-specs) | no recorded failing scenario matched the current specs | 3 | v0.21.0 |
+| [`ATG3205`](#atg3205--the-output-file-already-exists) | the output file already exists | 3 | v0.21.0 |
+| [`ATG3206`](#atg3206--a-destination-atago-was-asked-to-write-cannot-be-written) | a destination atago was asked to write cannot be written | 3 | v0.21.0 |
+| [`ATG3207`](#atg3207--atagos-recorded-state-from-a-previous-run-cannot-be-read) | atago's recorded state from a previous run cannot be read | 3 | v0.21.0 |
 
 ## ATG2xxx — exit 2
 
@@ -377,4 +391,118 @@ Some lists are sets: the exit codes `in` accepts, the observables `deterministic
 Fix: Remove the repeat, or change it to the value that was meant.
 
 Exits 2. Since v0.21.0.
+
+## ATG3xxx — exit 3
+
+### ATG3001 — there is no such atago subcommand
+
+The first argument names a subcommand, and this one is not in the inventory. Running atago with no arguments at all reports the same thing, since there is no default subcommand — a bare `atago` that started running specs would be a surprising thing for a tool that writes files.
+
+Fix: Run `atago help` for the list of subcommands.
+
+Exits 3. Since v0.21.0.
+
+### ATG3002 — a subcommand was called in a shape it does not accept
+
+The subcommand exists but its arguments are not what it takes: `atago snapshot` without `update`, `atago completion` without a shell to generate for, `atago record` with no command after the `--`, or `atago init` given several paths when it writes one file. This is about the arguments' shape rather than their values, which is why it is separate from an option given a value it does not accept.
+
+Fix: Run the subcommand with `--help` for its usage line.
+
+Exits 3. Since v0.21.0.
+
+### ATG3101 — the command line sets an option atago does not define
+
+The option is not one this subcommand takes. Options are per-subcommand, so a flag that works for `atago run` is not necessarily accepted by `atago doc`, and a flag from a newer atago than the one running produces this too.
+
+Fix: Check the option against the usage printed below the message, or run the subcommand with `--help`.
+
+Exits 3. Since v0.21.0.
+
+### ATG3102 — an option was given a value it does not accept
+
+The option exists and takes a value from a fixed vocabulary, and this value is not in it — a report format, a shell to generate completion for, a scaffolding template. atago refuses rather than falling back to a default, because a misspelled `--report jnit` that quietly produced console output would leave a CI job collecting a report file that was never written.
+
+Fix: Use one of the values the message lists.
+
+Exits 3. Since v0.21.0.
+
+### ATG3103 — an option needs another option that is not set
+
+Some options only mean something in company: `--split-by-spec` writes one file per spec and needs the `--out-dir` to write them into, and `--snapshot` on `record` writes a golden next to the spec, which needs `--out` to say where the spec is going.
+
+Fix: Add the option the message names, or drop the one that depends on it.
+
+Exits 3. Since v0.21.0.
+
+### ATG3104 — two options that contradict each other are both set
+
+The two options ask for incompatible things. `--repeat` and `--retry-failed` are the clearest pair: one re-runs scenarios to find out whether they flake, the other re-runs them so that flakiness does not fail the build, and a run cannot both detect and tolerate the same instability. `--out` and `--split-by-spec` disagree about whether the output is one file or many.
+
+Fix: Keep the option that expresses what you want and drop the other.
+
+Exits 3. Since v0.21.0.
+
+### ATG3105 — a numeric option is outside the range it accepts
+
+Counts are never negative. A negative `--parallel` would otherwise be clamped to sequential and exit 0, so the typo would run the suite in a way nobody asked for and report success; the same applies to `--repeat` and `--retry-failed`.
+
+Fix: Use zero or a positive number. Zero means atago's default for these options rather than none.
+
+Exits 3. Since v0.21.0.
+
+### ATG3201 — a path on the command line cannot be reached
+
+atago was pointed at a file or directory that does not exist, or that it is not allowed to look at. In CI this is usually a working directory that is not what the workflow assumed, or a checkout step that has not run yet.
+
+Fix: Check the path as spelled, and the directory the command runs from.
+
+Exits 3. Since v0.21.0.
+
+### ATG3202 — no spec files were found under the paths given
+
+The paths exist but hold no `*.atago.yaml` or `*.atago.yml` files. Directories are searched recursively, so this means there genuinely are none below them. Reporting success here would let a CI job that lost its specs go green forever.
+
+Fix: Point atago at the directory holding the specs, or run `atago init` to scaffold one. The file name matters: a spec must end in `.atago.yaml` or `.atago.yml`.
+
+Exits 3. Since v0.21.0.
+
+### ATG3203 — the scenario selection matched nothing, and --ci refuses to call that success
+
+Specs were found and loaded, but `--filter`, `--tag`, or `--skip-tag` selected none of their scenarios. Outside `--ci` this is a warning; under `--ci` it fails, because a selection that silently stops matching is how a suite disables itself without anyone noticing — a renamed tag keeps the build green while testing nothing. The two selectors match differently: `--filter` is a case-sensitive substring of the name, while `--tag` and `--skip-tag` compare tags for exact equality.
+
+Fix: Run `atago list` to see the scenario names and tags actually present, and correct the selector.
+
+Exits 3. Since v0.21.0.
+
+### ATG3204 — no recorded failing scenario matched the current specs
+
+`--rerun-failed` re-runs what failed last time, and none of the recorded names exist any more — they were renamed or removed since the run that recorded them. The recorded failures are kept rather than cleared, because the work they represent is still unverified, and exiting 0 here would report a green run that tested nothing.
+
+Fix: Run the full suite once to record failures against the current names, or drop the recorded state and start again.
+
+Exits 3. Since v0.21.0.
+
+### ATG3205 — the output file already exists
+
+`atago init` and `atago record` write a new spec, and neither overwrites one by default. Silently replacing a spec someone has edited is the kind of loss a tool should never cause without being asked.
+
+Fix: Choose another path, or pass `--force` to overwrite the existing file deliberately.
+
+Exits 3. Since v0.21.0.
+
+### ATG3206 — a destination atago was asked to write cannot be written
+
+The generated documentation, or the artifacts directory a run was told to use, could not be created or written. The artifacts directory is checked before the run starts rather than at the first failure: a directory that cannot be written would otherwise make every artifact write fail quietly, leaving a run that looks like it produced nothing to review when in fact nothing could be saved.
+
+Fix: Check that the parent directory exists and is writable, and that nothing else already occupies the path as a file.
+
+Exits 3. Since v0.21.0.
+
+### ATG3207 — atago's recorded state from a previous run cannot be read
+
+`--rerun-failed` reads a small ledger written by the previous run, and that file could not be read or decoded. A truncated or hand-edited ledger is the usual cause.
+
+Fix: Delete the ledger and run the full suite once to record it again.
+
+Exits 3. Since v0.21.0.
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -3,11 +3,15 @@
 package cli
 
 import (
+	"bytes"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/nao1215/atago/internal/buildinfo"
+	"github.com/nao1215/atago/internal/diag"
 )
 
 // Exit codes. These are part of the stable user-facing contract.
@@ -65,6 +69,7 @@ func Subcommands() []string {
 // Main is the CLI entry point. It returns the process exit code.
 func Main(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
+		fmt.Fprintf(stderr, "atago: %s\n\n", diag.UnknownCommand.Annotate("no subcommand given"))
 		usage(stderr)
 		return ExitConfig
 	}
@@ -82,7 +87,7 @@ func Main(args []string, stdout, stderr io.Writer) int {
 			return sc.run(rest, stdout, stderr)
 		}
 	}
-	fmt.Fprintf(stderr, "atago: unknown command %q\n\n", cmd)
+	fmt.Fprintf(stderr, "atago: %s\n\n", diag.UnknownCommand.Annotate(fmt.Sprintf("unknown command %q", cmd)))
 	usage(stderr)
 	return ExitConfig
 }
@@ -161,6 +166,75 @@ func wantsHelp(args []string) bool {
 // there the trailing arguments are another program's command line, and its
 // flags belong to it.
 func parseFlagsAnywhere(fs *flag.FlagSet, args []string) ([]string, error) {
+	// The FlagSet's own output is captured rather than left to reach the
+	// terminal directly, so the caller can put the diagnostic code in front of
+	// the message instead of after the usage block the failure triggers. What
+	// the user sees is unchanged apart from that ordering: reportFlagError
+	// replays everything the FlagSet wrote.
+	var captured bytes.Buffer
+	prev := fs.Output()
+	fs.SetOutput(&captured)
+	defer fs.SetOutput(prev)
+
+	operands, err := parseOperands(fs, args)
+	if err != nil {
+		return nil, &flagError{err: err, output: captured.String()}
+	}
+	return operands, nil
+}
+
+// flagError carries a flag-parsing failure together with everything the
+// FlagSet printed about it, so the caller decides the order and destination.
+type flagError struct {
+	err    error
+	output string
+}
+
+func (e *flagError) Error() string { return e.err.Error() }
+func (e *flagError) Unwrap() error { return e.err }
+
+// reportFlagError prints a flag-parsing failure: the coded message first, then
+// whatever usage the FlagSet produced. The FlagSet writes its message as a line
+// of its own before the usage, so dropping that exact line is what keeps the
+// message from appearing twice.
+func reportFlagError(label string, err error, stderr io.Writer) {
+	var fe *flagError
+	if !errors.As(err, &fe) {
+		fmt.Fprintf(stderr, "%s: %s\n", label, diag.UnknownOption.Annotate(err.Error()))
+		return
+	}
+	fmt.Fprintf(stderr, "%s: %s\n", label, diag.UnknownOption.Annotate(fe.err.Error()))
+	fmt.Fprint(stderr, strings.TrimPrefix(fe.output, fe.err.Error()+"\n"))
+}
+
+// replayFlagOutput writes what the FlagSet printed to w unchanged. It is the
+// help path, where the FlagSet's output is already what the user asked for.
+func replayFlagOutput(err error, w io.Writer) {
+	var fe *flagError
+	if errors.As(err, &fe) {
+		fmt.Fprint(w, fe.output)
+	}
+}
+
+// parseFlagsStrict parses args with fs, capturing the FlagSet's output the way
+// parseFlagsAnywhere does. `atago record` cannot use parseFlagsAnywhere — its
+// trailing arguments are another program's command line — but a bad flag
+// should read the same there as everywhere else.
+func parseFlagsStrict(fs *flag.FlagSet, args []string) error {
+	var captured bytes.Buffer
+	prev := fs.Output()
+	fs.SetOutput(&captured)
+	defer fs.SetOutput(prev)
+
+	if err := fs.Parse(args); err != nil {
+		return &flagError{err: err, output: captured.String()}
+	}
+	return nil
+}
+
+// parseOperands is parseFlagsAnywhere's loop, split out so the output capture
+// around it stays readable.
+func parseOperands(fs *flag.FlagSet, args []string) ([]string, error) {
 	var operands []string
 	for {
 		if err := fs.Parse(args); err != nil {
@@ -189,6 +263,7 @@ func snapshotCmd(args []string, stdout, stderr io.Writer) int {
 		return ExitOK
 	}
 	if len(args) == 0 || args[0] != "update" {
+		fmt.Fprintf(stderr, "atago snapshot: %s\n", diag.BadUsage.Annotate("update is the only subcommand"))
 		fmt.Fprintln(stderr, "Usage: atago snapshot update <path | dir>...")
 		return ExitConfig
 	}

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"sort"
 	"strings"
+
+	"github.com/nao1215/atago/internal/diag"
 )
 
 // subcommandNames is the stable, sorted list of top-level subcommands that shell
@@ -58,13 +60,14 @@ func completionCmd(args []string, stdout, stderr io.Writer) int {
 		return ExitOK
 	}
 	if len(args) != 1 {
+		fmt.Fprintf(stderr, "atago completion: %s\n", diag.BadUsage.Annotate("no shell named"))
 		fmt.Fprintf(stderr, "Usage: atago completion <%s>\n", strings.Join(completionShells, "|"))
 		return ExitConfig
 	}
 	shell := args[0]
 	script, ok := completionScript(shell)
 	if !ok {
-		fmt.Fprintf(stderr, "atago completion: unknown shell %q (want %s)\n", shell, strings.Join(completionShells, ", "))
+		fmt.Fprintf(stderr, "atago completion: %s\n", diag.BadOptionValue.Annotate(fmt.Sprintf("unknown shell %q (want %s)", shell, strings.Join(completionShells, ", "))))
 		return ExitConfig
 	}
 	fmt.Fprint(stdout, script)

--- a/internal/cli/doc.go
+++ b/internal/cli/doc.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/docgen"
 	"github.com/nao1215/atago/internal/loader"
 )
@@ -36,22 +37,23 @@ func docCmd(args []string, stdout, stderr io.Writer) int {
 			printUsage(stdout)
 			return ExitOK
 		}
+		reportFlagError("atago doc", err, stderr)
 		printUsage(stderr)
 		return ExitConfig
 	}
 	if *split && *outDir == "" {
-		fmt.Fprintln(stderr, "atago doc: --split-by-spec requires --out-dir DIR")
+		fmt.Fprintf(stderr, "atago doc: %s\n", diag.OptionNeedsAnother.Annotate("--split-by-spec requires --out-dir DIR"))
 		return ExitConfig
 	}
 	if *outDir != "" && !*split {
-		fmt.Fprintln(stderr, "atago doc: --out-dir requires --split-by-spec")
+		fmt.Fprintf(stderr, "atago doc: %s\n", diag.OptionNeedsAnother.Annotate("--out-dir requires --split-by-spec"))
 		return ExitConfig
 	}
 	if *split && *out != "" {
 		// The split branch writes into --out-dir and never honors --out; rejecting
 		// the combination stops a silently-ignored --out (the file is never
 		// written and no docs land where the user asked).
-		fmt.Fprintln(stderr, "atago doc: --out and --split-by-spec are mutually exclusive (--split-by-spec writes one file per spec into --out-dir)")
+		fmt.Fprintf(stderr, "atago doc: %s\n", diag.OptionsExclusive.Annotate("--out and --split-by-spec are mutually exclusive (--split-by-spec writes one file per spec into --out-dir)"))
 		return ExitConfig
 	}
 

--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -30,6 +30,7 @@ func explainCmd(args []string, stdout, stderr io.Writer) int {
 			printUsage(stdout)
 			return ExitOK
 		}
+		reportFlagError("atago explain", err, stderr)
 		printUsage(stderr)
 		return ExitConfig
 	}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/nao1215/atago/internal/buildinfo"
+	"github.com/nao1215/atago/internal/diag"
 )
 
 // starterSpec is the default scaffold written by `atago init` (the `cli`
@@ -405,6 +406,7 @@ func initCmd(args []string, stdout, stderr io.Writer) int {
 			printUsage(stdout)
 			return ExitOK
 		}
+		reportFlagError("atago init", err, stderr)
 		printUsage(stderr)
 		return ExitConfig
 	}
@@ -419,12 +421,12 @@ func initCmd(args []string, stdout, stderr io.Writer) int {
 
 	tmpl, ok := initTemplates[*template]
 	if !ok {
-		fmt.Fprintf(stderr, "atago init: unknown template %q (want %s)\n", *template, strings.Join(initTemplateNames(), ", "))
+		fmt.Fprintf(stderr, "atago init: %s\n", diag.BadOptionValue.Annotate(fmt.Sprintf("unknown template %q (want %s)", *template, strings.Join(initTemplateNames(), ", "))))
 		return ExitConfig
 	}
 
 	if len(operands) > 1 {
-		fmt.Fprintf(stderr, "atago init: too many paths — init writes one spec file, got %d (%s)\n", len(operands), strings.Join(operands, ", "))
+		fmt.Fprintf(stderr, "atago init: %s\n", diag.BadUsage.Annotate(fmt.Sprintf("too many paths — init writes one spec file, got %d (%s)", len(operands), strings.Join(operands, ", "))))
 		return ExitConfig
 	}
 	path := defaultInitFilename(*template)
@@ -433,7 +435,7 @@ func initCmd(args []string, stdout, stderr io.Writer) int {
 	}
 
 	if _, err := os.Stat(path); err == nil && !*force {
-		fmt.Fprintf(stderr, "atago init: %q already exists (use --force to overwrite)\n", path)
+		fmt.Fprintf(stderr, "atago init: %s\n", diag.OutputExists.Annotate(fmt.Sprintf("%q already exists (use --force to overwrite)", path)))
 		return ExitConfig
 	}
 

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -41,6 +41,7 @@ func listCmd(args []string, stdout, stderr io.Writer) int {
 			printUsage(stdout)
 			return ExitOK
 		}
+		reportFlagError("atago list", err, stderr)
 		printUsage(stderr)
 		return ExitConfig
 	}

--- a/internal/cli/manifest.go
+++ b/internal/cli/manifest.go
@@ -34,6 +34,7 @@ func manifestCmd(args []string, stdout, stderr io.Writer) int {
 			printUsage(stdout)
 			return ExitOK
 		}
+		reportFlagError("atago manifest", err, stderr)
 		printUsage(stderr)
 		return ExitConfig
 	}

--- a/internal/cli/record.go
+++ b/internal/cli/record.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/plural"
 	"github.com/nao1215/atago/internal/record"
 	runnercmd "github.com/nao1215/atago/internal/runner/cmd"
@@ -35,7 +36,7 @@ func recordCmd(args []string, stdout, stderr io.Writer) int {
 	ptyMode := fs.Bool("pty", false, "record an interactive pty session and generate an expect/send spec")
 	ptyTimeout := fs.Duration("timeout", record.DefaultCaptureTimeout, "kill the pty session and fail if the program does not exit within this bound (--pty only)")
 	fs.Usage = func() {
-		fmt.Fprint(stderr, `Usage: atago record [--out FILE] [--force] [--shell] [--snapshot] -- <command> [args...]
+		fmt.Fprint(fs.Output(), `Usage: atago record [--out FILE] [--force] [--shell] [--snapshot] -- <command> [args...]
        atago record --pty [--out FILE] [--force] [--shell] [--timeout DUR] -- <command> [args...]
 
 Runs the command once in a scratch directory and prints a spec skeleton
@@ -53,24 +54,26 @@ non-goal for now — write those steps by hand.
 `)
 		fs.PrintDefaults()
 	}
-	if err := fs.Parse(args); err != nil {
+	if err := parseFlagsStrict(fs, args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
+			replayFlagOutput(err, stderr)
 			return ExitOK
 		}
+		reportFlagError("atago record", err, stderr)
 		return ExitConfig
 	}
 	cmdArgs := fs.Args()
 	if len(cmdArgs) == 0 {
-		fmt.Fprintln(stderr, "atago record: no command given (usage: atago record [flags] -- <command> [args...])")
+		fmt.Fprintf(stderr, "atago record: %s\n", diag.BadUsage.Annotate("no command given (usage: atago record [flags] -- <command> [args...])"))
 		return ExitConfig
 	}
 	if *snap && *out == "" {
-		fmt.Fprintln(stderr, "atago record: --snapshot needs --out (the golden is written next to the spec)")
+		fmt.Fprintf(stderr, "atago record: %s\n", diag.OptionNeedsAnother.Annotate("--snapshot needs --out (the golden is written next to the spec)"))
 		return ExitConfig
 	}
 	if *ptyMode && *snap {
 		// A hand-driven screen golden is too brittle to auto-record in v1.
-		fmt.Fprintln(stderr, "atago record: --snapshot cannot be combined with --pty")
+		fmt.Fprintf(stderr, "atago record: %s\n", diag.OptionsExclusive.Annotate("--snapshot cannot be combined with --pty"))
 		return ExitConfig
 	}
 	if *ptyMode {

--- a/internal/cli/rerun.go
+++ b/internal/cli/rerun.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/engine"
 )
 
@@ -274,7 +275,7 @@ func collectFailures(results []*engine.SuiteResult, allowXPass bool) []failedEnt
 func applyRerunSelection(label string, stderr io.Writer, paths []string, eng *engine.Engine) (narrowed []string, exitNow int, done bool) {
 	state, lerr := loadRerunState()
 	if lerr != nil {
-		fmt.Fprintf(stderr, label+": cannot read %s: %v\n", rerunStatePath(), lerr)
+		fmt.Fprintf(stderr, "%s: %s\n", label, diag.StateUnreadable.Annotate(fmt.Sprintf("cannot read %s: %v", rerunStatePath(), lerr)))
 		return nil, ExitConfig, true
 	}
 	for i := range state.Failed {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/nao1215/atago/internal/artifact"
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/engine"
 	"github.com/nao1215/atago/internal/loader"
 	"github.com/nao1215/atago/internal/report"
@@ -187,14 +188,16 @@ func parseRunFlags(label string, args []string, stdout, stderr io.Writer) (*runO
 	allowXPass := fs.Bool("allow-xpass", false, "exit 0 when an expect_fail scenario passed (XPASS); by default a fixed known bug fails the run so the spec gets promoted")
 	verbose := fs.Bool("verbose", false, "trace every scenario as it finishes: commands, exit codes, captured output, and per-assertion verdicts — for passing scenarios too")
 	fs.Usage = func() {
-		fmt.Fprint(stderr, "Usage: atago run [--report console|json|junit|gha|tap] [--update-snapshots] [--parallel N] [--fail-fast] [--filter S] [--tag T] [--skip-tag T] [--rerun-failed] [--repeat N] [--retry-failed N] [--allow-flaky] [--allow-xpass] [--profile NAME] [--artifacts-dir DIR] [--verbose] [--ci] <path | dir>...\n  (directories are searched recursively)\n")
+		fmt.Fprint(fs.Output(), "Usage: atago run [--report console|json|junit|gha|tap] [--update-snapshots] [--parallel N] [--fail-fast] [--filter S] [--tag T] [--skip-tag T] [--rerun-failed] [--repeat N] [--retry-failed N] [--allow-flaky] [--allow-xpass] [--profile NAME] [--artifacts-dir DIR] [--verbose] [--ci] <path | dir>...\n  (directories are searched recursively)\n")
 		fs.PrintDefaults()
 	}
 	operands, err := parseFlagsAnywhere(fs, args)
 	if err != nil {
 		if errors.Is(err, flag.ErrHelp) {
+			replayFlagOutput(err, stderr)
 			return nil, ExitOK, true
 		}
+		reportFlagError(label, err, stderr)
 		return nil, ExitConfig, true
 	}
 	if *ci {
@@ -204,7 +207,7 @@ func parseRunFlags(label string, args []string, stdout, stderr io.Writer) (*runO
 
 	format := report.Format(*reportFmt)
 	if !format.Valid() {
-		fmt.Fprintf(stderr, label+": unknown --report %q (want console, json, junit, gha, or tap)\n", *reportFmt)
+		fmt.Fprintf(stderr, "%s: %s\n", label, diag.BadOptionValue.Annotate(fmt.Sprintf("unknown --report %q (want console, json, junit, gha, or tap)", *reportFmt)))
 		return nil, ExitConfig, true
 	}
 
@@ -218,11 +221,11 @@ func parseRunFlags(label string, args []string, stdout, stderr io.Writer) (*runO
 	// only ACTIVATES at > 1 (a value < 2 is a documented no-op), so --repeat 1
 	// changes nothing and must not be rejected alongside --retry-failed.
 	if *repeat > 1 && *retryFailed > 0 {
-		fmt.Fprintln(stderr, label+": --repeat and --retry-failed are mutually exclusive (repeat detects flakiness, retry-failed tolerates it)")
+		fmt.Fprintf(stderr, "%s: %s\n", label, diag.OptionsExclusive.Annotate("--repeat and --retry-failed are mutually exclusive (repeat detects flakiness, retry-failed tolerates it)"))
 		return nil, ExitConfig, true
 	}
 	if *repeat < 0 || *retryFailed < 0 {
-		fmt.Fprintln(stderr, label+": --repeat and --retry-failed must be >= 0")
+		fmt.Fprintf(stderr, "%s: %s\n", label, diag.OptionOutOfRange.Annotate("--repeat and --retry-failed must be >= 0"))
 		return nil, ExitConfig, true
 	}
 	// A negative --parallel is a typo, not a request: the engine would clamp it to
@@ -230,7 +233,7 @@ func parseRunFlags(label string, args []string, stdout, stderr io.Writer) (*runO
 	// config error as --repeat/--retry-failed for consistent bounds checking. Zero
 	// is left to mean the default (like repeat/retry allow 0).
 	if *parallel < 0 {
-		fmt.Fprintln(stderr, label+": --parallel must be >= 0")
+		fmt.Fprintf(stderr, "%s: %s\n", label, diag.OptionOutOfRange.Annotate("--parallel must be >= 0"))
 		return nil, ExitConfig, true
 	}
 	if strings.TrimSpace(*artifactsDir) != "" {
@@ -239,7 +242,7 @@ func parseRunFlags(label string, args []string, stdout, stderr io.Writer) (*runO
 		// every artifact write fail silently, leaving the user to believe a run
 		// produced no reviewable failures when in fact none could be written.
 		if err := ensureArtifactsDir(*artifactsDir); err != nil {
-			fmt.Fprintf(stderr, label+": --artifacts-dir %q is not usable: %v\n", *artifactsDir, err)
+			fmt.Fprintf(stderr, "%s: %s\n", label, diag.OutputNotWritable.Annotate(fmt.Sprintf("--artifacts-dir %q is not usable: %v", *artifactsDir, err)))
 			return nil, ExitConfig, true
 		}
 	}

--- a/internal/cli/run_finish.go
+++ b/internal/cli/run_finish.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/engine"
 	"github.com/nao1215/atago/internal/report"
 )
@@ -120,7 +121,7 @@ func settleRerunLedger(ctx context.Context, opts *runOptions, results []*engine.
 	// contradicts the empty-selection warning). The excluded failures are still
 	// preserved into the ledger via rerunPreserved, so no work is lost.
 	if opts.rerunFailed && !opts.selectionActive() && len(results) > 0 && ranScenarios == 0 && ctx.Err() == nil {
-		fmt.Fprintln(opts.stderr, opts.label+": warning: no recorded failing scenarios matched the current specs (renamed or removed?); the recorded failures were kept, not cleared")
+		fmt.Fprintf(opts.stderr, "%s: %s\n", opts.label, diag.RerunNothingMatched.Annotate("no recorded failing scenarios matched the current specs (renamed or removed?); the recorded failures were kept, not cleared"))
 		return ExitConfig
 	}
 
@@ -177,7 +178,7 @@ func emptySelectionExit(ctx context.Context, opts *runOptions, results []*engine
 	// users fixing the wrong thing, so name each selector's real rule.
 	note := selectorNoMatchNote(len(opts.filter) > 0, tagActive)
 	if opts.ci {
-		fmt.Fprintf(opts.stderr, opts.label+": no scenarios matched %s under --ci; refusing to exit 0 (an empty selection would silently disable the suite). %s. Run `atago list` to see available scenarios and tags.\n", strings.Join(sel, " "), note)
+		fmt.Fprintf(opts.stderr, "%s: %s\n", opts.label, diag.EmptySelection.Annotate(fmt.Sprintf("no scenarios matched %s under --ci; refusing to exit 0 (an empty selection would silently disable the suite). %s. Run `atago list` to see available scenarios and tags.", strings.Join(sel, " "), note)))
 		return ExitConfig
 	}
 	hint := note

--- a/internal/cli/run_targets.go
+++ b/internal/cli/run_targets.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/nao1215/atago/internal/diag"
 )
 
 // specTargets resolves a subcommand's positional arguments into the spec files
@@ -27,12 +29,12 @@ func specTargets(label string, args []string, stderr io.Writer) (paths []string,
 	}
 	paths, err := collectSpecFiles(targets)
 	if err != nil {
-		fmt.Fprintf(stderr, "%s: %v\n", label, err)
+		fmt.Fprintf(stderr, "%s: %s\n", label, diag.TargetNotFound.Annotate(err.Error()))
 		return nil, ExitConfig, false
 	}
 	if len(paths) == 0 {
-		fmt.Fprintf(stderr, "%s: no *.atago.yaml (or *.atago.yml) files found in %s; run `atago init` to scaffold one\n",
-			label, quotedList(targets))
+		fmt.Fprintf(stderr, "%s: %s\n", label,
+			diag.NoSpecFiles.Annotate(fmt.Sprintf("no *.atago.yaml (or *.atago.yml) files found in %s; run `atago init` to scaffold one", quotedList(targets))))
 		return nil, ExitConfig, false
 	}
 	return paths, ExitOK, true

--- a/internal/diag/codes_config.go
+++ b/internal/diag/codes_config.go
@@ -1,0 +1,138 @@
+package diag
+
+// ATG3xxx — configuration errors, which exit 3. These are raised before any
+// spec is read: the command line itself, the options on it, or the files and
+// scenarios it selected. Nothing has been loaded or executed when one of these
+// is reported.
+//
+// The sub-ranges group by what the reader has to do about it:
+//
+//	ATG30xx  the shape of the command — which subcommand, and what it takes
+//	ATG31xx  options — unknown, wrong value, wrong combination, out of range
+//	ATG32xx  what the command was pointed at — targets, selections, outputs
+//
+// The distinction from ATG2xxx is who wrote the mistake and where: a spec error
+// is in a file under version control that a team reviews, while a configuration
+// error is in the invocation, usually in a CI workflow or a shell history.
+const configSince = "v0.21.0"
+
+// ATG30xx — the shape of the command.
+var (
+	// UnknownCommand is a subcommand atago does not have.
+	UnknownCommand = register(3001, "UnknownCommand", Entry{
+		Summary: "there is no such atago subcommand",
+		Detail:  "The first argument names a subcommand, and this one is not in the inventory. Running atago with no arguments at all reports the same thing, since there is no default subcommand — a bare `atago` that started running specs would be a surprising thing for a tool that writes files.",
+		Fix:     "Run `atago help` for the list of subcommands.",
+		Since:   configSince,
+	})
+
+	// BadUsage is a subcommand called in a shape it does not accept.
+	BadUsage = register(3002, "BadUsage", Entry{
+		Summary: "a subcommand was called in a shape it does not accept",
+		Detail:  "The subcommand exists but its arguments are not what it takes: `atago snapshot` without `update`, `atago completion` without a shell to generate for, `atago record` with no command after the `--`, or `atago init` given several paths when it writes one file. This is about the arguments' shape rather than their values, which is why it is separate from an option given a value it does not accept.",
+		Fix:     "Run the subcommand with `--help` for its usage line.",
+		Since:   configSince,
+	})
+)
+
+// ATG31xx — options.
+var (
+	// UnknownOption is a flag atago does not define.
+	UnknownOption = register(3101, "UnknownOption", Entry{
+		Summary: "the command line sets an option atago does not define",
+		Detail:  "The option is not one this subcommand takes. Options are per-subcommand, so a flag that works for `atago run` is not necessarily accepted by `atago doc`, and a flag from a newer atago than the one running produces this too.",
+		Fix:     "Check the option against the usage printed below the message, or run the subcommand with `--help`.",
+		Since:   configSince,
+	})
+
+	// BadOptionValue is a value outside what an option accepts.
+	BadOptionValue = register(3102, "BadOptionValue", Entry{
+		Summary: "an option was given a value it does not accept",
+		Detail:  "The option exists and takes a value from a fixed vocabulary, and this value is not in it — a report format, a shell to generate completion for, a scaffolding template. atago refuses rather than falling back to a default, because a misspelled `--report jnit` that quietly produced console output would leave a CI job collecting a report file that was never written.",
+		Fix:     "Use one of the values the message lists.",
+		Since:   configSince,
+	})
+
+	// OptionNeedsAnother is an option that only works alongside another.
+	OptionNeedsAnother = register(3103, "OptionNeedsAnother", Entry{
+		Summary: "an option needs another option that is not set",
+		Detail:  "Some options only mean something in company: `--split-by-spec` writes one file per spec and needs the `--out-dir` to write them into, and `--snapshot` on `record` writes a golden next to the spec, which needs `--out` to say where the spec is going.",
+		Fix:     "Add the option the message names, or drop the one that depends on it.",
+		Since:   configSince,
+	})
+
+	// OptionsExclusive is a pair of options that cannot both apply.
+	OptionsExclusive = register(3104, "OptionsExclusive", Entry{
+		Summary: "two options that contradict each other are both set",
+		Detail:  "The two options ask for incompatible things. `--repeat` and `--retry-failed` are the clearest pair: one re-runs scenarios to find out whether they flake, the other re-runs them so that flakiness does not fail the build, and a run cannot both detect and tolerate the same instability. `--out` and `--split-by-spec` disagree about whether the output is one file or many.",
+		Fix:     "Keep the option that expresses what you want and drop the other.",
+		Since:   configSince,
+	})
+
+	// OptionOutOfRange is a numeric option outside what it accepts.
+	OptionOutOfRange = register(3105, "OptionOutOfRange", Entry{
+		Summary: "a numeric option is outside the range it accepts",
+		Detail:  "Counts are never negative. A negative `--parallel` would otherwise be clamped to sequential and exit 0, so the typo would run the suite in a way nobody asked for and report success; the same applies to `--repeat` and `--retry-failed`.",
+		Fix:     "Use zero or a positive number. Zero means atago's default for these options rather than none.",
+		Since:   configSince,
+	})
+)
+
+// ATG32xx — what the command was pointed at.
+var (
+	// TargetNotFound is a path that cannot be reached.
+	TargetNotFound = register(3201, "TargetNotFound", Entry{
+		Summary: "a path on the command line cannot be reached",
+		Detail:  "atago was pointed at a file or directory that does not exist, or that it is not allowed to look at. In CI this is usually a working directory that is not what the workflow assumed, or a checkout step that has not run yet.",
+		Fix:     "Check the path as spelled, and the directory the command runs from.",
+		Since:   configSince,
+	})
+
+	// NoSpecFiles is a search that found nothing to run.
+	NoSpecFiles = register(3202, "NoSpecFiles", Entry{
+		Summary: "no spec files were found under the paths given",
+		Detail:  "The paths exist but hold no `*.atago.yaml` or `*.atago.yml` files. Directories are searched recursively, so this means there genuinely are none below them. Reporting success here would let a CI job that lost its specs go green forever.",
+		Fix:     "Point atago at the directory holding the specs, or run `atago init` to scaffold one. The file name matters: a spec must end in `.atago.yaml` or `.atago.yml`.",
+		Since:   configSince,
+	})
+
+	// EmptySelection is a filter that matched nothing under --ci.
+	EmptySelection = register(3203, "EmptySelection", Entry{
+		Summary: "the scenario selection matched nothing, and --ci refuses to call that success",
+		Detail:  "Specs were found and loaded, but `--filter`, `--tag`, or `--skip-tag` selected none of their scenarios. Outside `--ci` this is a warning; under `--ci` it fails, because a selection that silently stops matching is how a suite disables itself without anyone noticing — a renamed tag keeps the build green while testing nothing. The two selectors match differently: `--filter` is a case-sensitive substring of the name, while `--tag` and `--skip-tag` compare tags for exact equality.",
+		Fix:     "Run `atago list` to see the scenario names and tags actually present, and correct the selector.",
+		Since:   configSince,
+	})
+
+	// RerunNothingMatched is a --rerun-failed run whose ledger no longer maps.
+	RerunNothingMatched = register(3204, "RerunNothingMatched", Entry{
+		Summary: "no recorded failing scenario matched the current specs",
+		Detail:  "`--rerun-failed` re-runs what failed last time, and none of the recorded names exist any more — they were renamed or removed since the run that recorded them. The recorded failures are kept rather than cleared, because the work they represent is still unverified, and exiting 0 here would report a green run that tested nothing.",
+		Fix:     "Run the full suite once to record failures against the current names, or drop the recorded state and start again.",
+		Since:   configSince,
+	})
+
+	// OutputExists is a write that would destroy an existing file.
+	OutputExists = register(3205, "OutputExists", Entry{
+		Summary: "the output file already exists",
+		Detail:  "`atago init` and `atago record` write a new spec, and neither overwrites one by default. Silently replacing a spec someone has edited is the kind of loss a tool should never cause without being asked.",
+		Fix:     "Choose another path, or pass `--force` to overwrite the existing file deliberately.",
+		Since:   configSince,
+	})
+
+	// OutputNotWritable is a destination that cannot be written.
+	OutputNotWritable = register(3206, "OutputNotWritable", Entry{
+		Summary: "a destination atago was asked to write cannot be written",
+		Detail:  "The generated documentation, or the artifacts directory a run was told to use, could not be created or written. The artifacts directory is checked before the run starts rather than at the first failure: a directory that cannot be written would otherwise make every artifact write fail quietly, leaving a run that looks like it produced nothing to review when in fact nothing could be saved.",
+		Fix:     "Check that the parent directory exists and is writable, and that nothing else already occupies the path as a file.",
+		Since:   configSince,
+	})
+
+	// StateUnreadable is atago's own run-to-run state failing to load.
+	StateUnreadable = register(3207, "StateUnreadable", Entry{
+		Summary: "atago's recorded state from a previous run cannot be read",
+		Detail:  "`--rerun-failed` reads a small ledger written by the previous run, and that file could not be read or decoded. A truncated or hand-edited ledger is the usual cause.",
+		Fix:     "Delete the ledger and run the full suite once to record it again.",
+		Since:   configSince,
+	})
+)

--- a/internal/diag/usage_test.go
+++ b/internal/diag/usage_test.go
@@ -12,17 +12,22 @@ import (
 	"testing"
 )
 
-// familyOf maps a package to the exit code the diagnostics it raises must
+// familyOf maps a package to the exit codes the diagnostics it raises may
 // belong to. A package that raises coded errors has to appear here, so adding
-// one is a deliberate statement about which family it reports in rather than
+// one is a deliberate statement about which families it reports in rather than
 // something that happens by accident.
 //
 // The point is the thousands digit: ATG2103 promises the process exits 2, and
 // that promise is only true if the package raising it exits 2. A loader
 // reporting an ATG4xxx would make the code lie about what the reader is
 // looking at.
-var familyOf = map[string]int{
-	"internal/loader": 2,
+//
+// Most packages report one family. internal/cli is listed with 3 alone because
+// the spec errors it prints come from the loader with their codes already
+// attached; it raises only its own configuration diagnostics.
+var familyOf = map[string][]int{
+	"internal/loader": {2},
+	"internal/cli":    {3},
 }
 
 // TestCodes_AreReferenced is the guard against a code that exists only in the
@@ -54,11 +59,11 @@ func TestCodes_MatchTheirPackageFamily(t *testing.T) {
 		for _, pkg := range pkgs {
 			want, ok := familyOf[pkg]
 			if !ok {
-				t.Errorf("%s raises diagnostics but is not listed in familyOf; add it with the exit code it reports", pkg)
+				t.Errorf("%s raises diagnostics but is not listed in familyOf; add it with the exit codes it reports", pkg)
 				continue
 			}
-			if got := e.Code.ExitCode(); got != want {
-				t.Errorf("%s raises %s (diag.%s), which is family %d, but %s reports exit %d", pkg, e.Code, e.Name, got, pkg, want)
+			if got := e.Code.ExitCode(); !slices.Contains(want, got) {
+				t.Errorf("%s raises %s (diag.%s), which is family %d, but %s reports exit %v", pkg, e.Code, e.Name, got, pkg, want)
 			}
 		}
 	}

--- a/test/e2e/atago/edge.atago.yaml
+++ b/test/e2e/atago/edge.atago.yaml
@@ -101,7 +101,9 @@ scenarios:
       - assert:
           exit_code: 3
           stderr:
-            contains: "atago snapshot update: cannot access"
+            contains:
+              - "atago snapshot update: "
+              - "cannot access"
             not_contains: "atago run:"
 
   # Malformed JSON from the program under test must be reported as invalid JSON,

--- a/test/e2e/atago/error_codes.atago.yaml
+++ b/test/e2e/atago/error_codes.atago.yaml
@@ -1,7 +1,7 @@
 version: "1"
 
 suite:
-  name: atago self-hosting / every spec-error diagnostic code
+  name: atago self-hosting / every diagnostic code
 
 # Diagnostic codes (#454, #455) are a published contract: ATG2103 has to keep
 # meaning the same thing across releases, or every bookmark, CI grep, and agent
@@ -14,8 +14,9 @@ suite:
 # registered code has no scenario in this directory, so adding a code to the
 # registry without exercising it here cannot pass CI.
 #
-# Every scenario asserts exit 2 as well, which is the other half of the
-# contract: the thousands digit of an ATG2xxx code promises exit 2.
+# Every scenario asserts the exit code as well, which is the other half of the
+# contract: the thousands digit of a code promises the exit status, so an
+# ATG2xxx exits 2 and an ATG3xxx exits 3.
 scenarios:
   # --- ATG20xx: the document itself -----------------------------------------
 
@@ -666,3 +667,182 @@ scenarios:
             contains:
               - "ATG2010"
               - "ATG2305"
+
+  # --- ATG30xx: the shape of the command ------------------------------------
+
+  - name: ATG3001 is a subcommand atago does not have
+    steps:
+      - run: {command: "${atago} frobnicate"}
+      - assert:
+          exit_code: 3
+          stderr: {contains: "ATG3001"}
+
+  - name: ATG3001 is also atago with no subcommand at all
+    steps:
+      - run: {command: "${atago}"}
+      - assert:
+          exit_code: 3
+          stderr: {contains: "ATG3001"}
+
+  - name: ATG3002 is a subcommand called in a shape it does not accept
+    steps:
+      - run: {command: "${atago} snapshot"}
+      - assert:
+          exit_code: 3
+          stderr: {contains: "ATG3002"}
+
+  # --- ATG31xx: options -----------------------------------------------------
+
+  - name: ATG3101 is an option atago does not define
+    steps:
+      - run: {command: "${atago} run --definitely-not-a-flag ."}
+      - assert:
+          exit_code: 3
+          stderr:
+            contains:
+              - "ATG3101"
+              # The code goes in front of the message, and the usage the
+              # failure triggers still follows it.
+              - "flag provided but not defined"
+              - "Usage: atago run"
+
+  - name: ATG3102 is an option given a value it does not accept
+    steps:
+      - fixture:
+          file: ok.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios: [{name: a, steps: [{run: {command: echo}}]}]
+      - run: {command: "${atago} run --report jnit ok.atago.yaml"}
+      - assert:
+          exit_code: 3
+          stderr: {contains: "ATG3102"}
+
+  - name: ATG3103 is an option whose companion option is not set
+    steps:
+      - run: {command: "${atago} doc --split-by-spec ."}
+      - assert:
+          exit_code: 3
+          stderr: {contains: "ATG3103"}
+
+  - name: ATG3104 is two options that contradict each other
+    steps:
+      - fixture:
+          file: ok.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios: [{name: a, steps: [{run: {command: echo}}]}]
+      - run: {command: "${atago} run --repeat 2 --retry-failed 1 ok.atago.yaml"}
+      - assert:
+          exit_code: 3
+          stderr: {contains: "ATG3104"}
+
+  - name: ATG3105 is a numeric option outside its range
+    steps:
+      - fixture:
+          file: ok.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios: [{name: a, steps: [{run: {command: echo}}]}]
+      - run: {command: "${atago} run --parallel -1 ok.atago.yaml"}
+      - assert:
+          exit_code: 3
+          stderr: {contains: "ATG3105"}
+
+  # --- ATG32xx: what the command was pointed at -----------------------------
+
+  - name: ATG3201 is a path that cannot be reached
+    steps:
+      - run: {command: "${atago} run ./nowhere"}
+      - assert:
+          exit_code: 3
+          stderr: {contains: "ATG3201"}
+
+  - name: ATG3202 is a directory holding no specs
+    steps:
+      - run: {command: "${atago} run ."}
+      - assert:
+          exit_code: 3
+          stderr: {contains: "ATG3202"}
+
+  - name: ATG3203 is a selection that matched nothing under --ci
+    steps:
+      - fixture:
+          file: ok.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios: [{name: a, steps: [{run: {command: echo}}]}]
+      - run: {command: "${atago} run --ci --tag no-such-tag ok.atago.yaml"}
+      - assert:
+          exit_code: 3
+          stderr: {contains: "ATG3203"}
+
+  - name: ATG3204 is a rerun whose recorded failures no longer exist
+    steps:
+      # Record a real failure, then rename the scenario out from under it.
+      - fixture:
+          file: ok.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios:
+              - name: before
+                steps:
+                  - run: {command: "false"}
+                  - assert: {exit_code: 0}
+      - run: {command: "${atago} run ok.atago.yaml"}
+      - assert:
+          exit_code: 1
+      - fixture:
+          file: ok.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios:
+              - name: after
+                steps:
+                  - run: {command: echo}
+      - run: {command: "${atago} run --rerun-failed ok.atago.yaml"}
+      - assert:
+          exit_code: 3
+          stderr: {contains: "ATG3204"}
+
+  - name: ATG3205 is a write that would replace an existing file
+    steps:
+      - fixture: {file: taken.atago.yaml, content: "already here\n"}
+      - run: {command: "${atago} init taken.atago.yaml"}
+      - assert:
+          exit_code: 3
+          stderr: {contains: "ATG3205"}
+
+  - name: ATG3206 is a destination that cannot be written
+    steps:
+      - fixture: {file: occupied, content: "not a directory\n"}
+      - fixture:
+          file: ok.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios: [{name: a, steps: [{run: {command: echo}}]}]
+      - run: {command: "${atago} run --artifacts-dir occupied ok.atago.yaml"}
+      - assert:
+          exit_code: 3
+          stderr: {contains: "ATG3206"}
+
+  - name: ATG3207 is atago's recorded state failing to load
+    steps:
+      - fixture: {file: .atago/last-failed.json, content: "not json at all\n"}
+      - fixture:
+          file: ok.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios: [{name: a, steps: [{run: {command: echo}}]}]
+      - run: {command: "${atago} run --rerun-failed ok.atago.yaml"}
+      - assert:
+          exit_code: 3
+          stderr: {contains: "ATG3207"}


### PR DESCRIPTION
## Summary

Exit 3 is everything that goes wrong before a spec is read: an unknown subcommand, a flag that does not exist or was handed a value it cannot take, a path matching no specs, a selection that quietly matched nothing. It is the family a first-time user is most likely to meet, and until now every one of them was an unsearchable sentence. Fourteen codes cover it.

Phase B of #454, on the machinery #460 built.

## Changes

- `internal/diag/codes_config.go` — the fourteen entries, grouped as ATG30xx for the shape of the command, ATG31xx for options, ATG32xx for what the command was pointed at.
- `internal/cli/*.go` — every exit-3 path carries its code. These do not share a funnel the way the loader's checks do, so the codes are threaded through at each site.
- `internal/cli/cli.go` — `parseFlagsAnywhere` captures what the FlagSet writes, and `reportFlagError`/`replayFlagOutput` decide where it goes.
- `internal/diag/usage_test.go` — `familyOf` maps a package to the exit codes it may report rather than a single one.
- `test/e2e/atago/error_codes.atago.yaml` — a scenario per code, fifteen more.

## Design Decisions

An unknown flag needed the flag package's output to move. It writes its message and then the usage block straight to the terminal during `Parse`, which would have left the code stranded after thirty lines of usage rather than in front of the message it names. The FlagSet's output is now captured during parsing and handed back with the error, so the caller prints the coded message first and replays the usage after it. Destination and content are otherwise unchanged, and the exact message the FlagSet emitted is dropped from the replay rather than matched loosely, so it cannot appear twice.

`--tag` matching nothing gets its own code rather than sharing one with a bad path. A CI job whose filter silently stopped matching is the failure this is most useful for, and it is a different problem from a typo in a directory name.

`familyOf` becoming a list is what lets a package raise more than one family later; `internal/cli` stays a single family because the spec errors it prints arrive from the loader with their codes already attached.

## Limitations

Execution and internal errors (#458) are the remaining families, and `atago explain ATG3001` plus the code as a report field is #459. The reference page states which families carry codes today, so it is accurate at each step rather than only at the end.
