### PR TITLE
feat(diag): code the security policy violations

### DIFF
--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-81 suites · 578 scenarios
+81 suites · 579 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -144,7 +144,7 @@
   - [file not_contains passes when the substring is absent](#scenario-file-not_contains-passes-when-the-substring-is-absent)
   - [not_contains fails when the substring is present](#scenario-not_contains-fails-when-the-substring-is-present)
   - [a shell metacharacter without shell is a load-time error](#scenario-a-shell-metacharacter-without-shell-is-a-load-time-error)
-- [atago self-hosting / every diagnostic code](#atago-self-hosting--every-diagnostic-code) — 56 scenarios
+- [atago self-hosting / every diagnostic code](#atago-self-hosting--every-diagnostic-code) — 57 scenarios
   - [ATG2001 is a spec file that cannot be read](#scenario-atg2001-is-a-spec-file-that-cannot-be-read)
   - [ATG2002 is a spec file with no YAML document in it](#scenario-atg2002-is-a-spec-file-with-no-yaml-document-in-it)
   - [ATG2003 is a document that is not valid YAML](#scenario-atg2003-is-a-document-that-is-not-valid-yaml)
@@ -201,6 +201,7 @@
   - [ATG3205 is a write that would replace an existing file](#scenario-atg3205-is-a-write-that-would-replace-an-existing-file)
   - [ATG3206 is a destination that cannot be written](#scenario-atg3206-is-a-destination-that-cannot-be-written)
   - [ATG3207 is atago's recorded state failing to load](#scenario-atg3207-is-atagos-recorded-state-failing-to-load)
+  - [ATG6001 is a request to a host the network policy denies](#scenario-atg6001-is-a-request-to-a-host-the-network-policy-denies)
 - [atago self-hosting / exit_code in-set matcher](#atago-self-hosting--exit_code-in-set-matcher) — 4 scenarios
   - [a listed exit code passes](#scenario-a-listed-exit-code-passes)
   - [an unlisted exit code fails and the output lists the set](#scenario-an-unlisted-exit-code-fails-and-the-output-lists-the-set)
@@ -4318,6 +4319,34 @@ ${atago} run --rerun-failed ok.atago.yaml
 #### Then
 - exit code is `3`
 - stderr contains `ATG3207`
+### Scenario: ATG6001 is a request to a host the network policy denies
+#### Given
+- Fixture file `denied.atago.yaml` is created.
+#### Inputs
+_Fixture `denied.atago.yaml`:_
+```text
+version: "1"
+suite: {name: denied}
+permissions:
+  network:
+    allow:
+      - allowed.example
+runners:
+  api:
+    type: http
+    base_url: http://127.0.0.1:1
+scenarios:
+  - name: reaches elsewhere
+    steps:
+      - http: {runner: api, method: GET, path: /ping}
+```
+#### When
+```shell
+${atago} run denied.atago.yaml
+```
+#### Then
+- exit code is `6`
+- stdout contains `ATG6001`
 ## atago self-hosting / exit_code in-set matcher
 Source: `test/e2e/atago/exit_code_in.atago.yaml`
 ### Scenario: a listed exit code passes

--- a/doc/errors.md
+++ b/doc/errors.md
@@ -12,7 +12,7 @@ Codes are being assigned one family at a time. The table says which families car
 | `ATG3xxx` | 3 | configuration error — the command line, its flags, or the spec files it selected | 14 codes |
 | `ATG4xxx` | 4 | execution error — a step could not be carried out | not yet |
 | `ATG5xxx` | 5 | internal error — a bug in atago | not yet |
-| `ATG6xxx` | 6 | security policy violation — atago refused an operation on policy grounds | not yet |
+| `ATG6xxx` | 6 | security policy violation — atago refused an operation on policy grounds | 1 codes |
 
 `ATG1xxx` is never assigned. Exit 1 means one or more scenarios failed, which is a result rather than an error.
 
@@ -77,6 +77,7 @@ Look a code up from the terminal with `atago explain ATG2201`, which prints this
 | [`ATG3205`](#atg3205--the-output-file-already-exists) | the output file already exists | 3 | v0.21.0 |
 | [`ATG3206`](#atg3206--a-destination-atago-was-asked-to-write-cannot-be-written) | a destination atago was asked to write cannot be written | 3 | v0.21.0 |
 | [`ATG3207`](#atg3207--atagos-recorded-state-from-a-previous-run-cannot-be-read) | atago's recorded state from a previous run cannot be read | 3 | v0.21.0 |
+| [`ATG6001`](#atg6001--a-request-targeted-a-host-the-specs-network-policy-does-not-allow) | a request targeted a host the spec's network policy does not allow | 6 | v0.21.0 |
 
 ## ATG2xxx — exit 2
 
@@ -505,4 +506,14 @@ Exits 3. Since v0.21.0.
 Fix: Delete the ledger and run the full suite once to record it again.
 
 Exits 3. Since v0.21.0.
+
+## ATG6xxx — exit 6
+
+### ATG6001 — a request targeted a host the spec's network policy does not allow
+
+The spec declares `permissions.network.allow`, and this request went somewhere else. The check covers HTTP, gRPC, and SSH alike, and an HTTP redirect is re-checked against the same list before it is followed — otherwise an allowed host could bounce a request to a denied one and the restriction would mean nothing. Comparison is exact on the host, or on host and port when the entry names one; there is no wildcard.
+
+Fix: Add the host to `permissions.network.allow` if the scenario is meant to reach it, or point the runner at a mock server or a scenario service instead. Removing the allowlist entirely turns the policy off, which is the default when no `permissions.network` block is declared.
+
+Exits 6. Since v0.21.0.
 

--- a/internal/diag/codes_security.go
+++ b/internal/diag/codes_security.go
@@ -1,0 +1,27 @@
+package diag
+
+// ATG6xxx — security policy violations, which exit 6. These are operations
+// atago refused on policy grounds rather than failures of the thing under
+// test, and they take precedence over the execution-error code so a run cannot
+// report a plain failure when a declared restriction was breached.
+//
+// The family is deliberately small. A refusal that the reader is likely to
+// believe is atago being wrong needs room to explain the reasoning and to say
+// how to do the thing legitimately, and a code is what gives it that room —
+// one line at the terminal, the rest on a page it can be looked up on.
+//
+// Refusals that happen while loading a spec are reported as spec errors
+// instead, since nothing has run: a path that leaves the workdir is ATG2310.
+// Refusals that happen mid-run without a declared policy behind them —
+// resolving a path through a symlink out of the scenario root, for instance —
+// are execution errors, because they are atago protecting the isolation every
+// scenario depends on rather than enforcing something the spec asked for.
+const securitySince = "v0.21.0"
+
+// NetworkPolicyDenied is a request to a host outside the declared allowlist.
+var NetworkPolicyDenied = register(6001, "NetworkPolicyDenied", Entry{
+	Summary: "a request targeted a host the spec's network policy does not allow",
+	Detail:  "The spec declares `permissions.network.allow`, and this request went somewhere else. The check covers HTTP, gRPC, and SSH alike, and an HTTP redirect is re-checked against the same list before it is followed — otherwise an allowed host could bounce a request to a denied one and the restriction would mean nothing. Comparison is exact on the host, or on host and port when the entry names one; there is no wildcard.",
+	Fix:     "Add the host to `permissions.network.allow` if the scenario is meant to reach it, or point the runner at a mock server or a scenario service instead. Removing the allowlist entirely turns the policy off, which is the default when no `permissions.network` block is declared.",
+	Since:   securitySince,
+})

--- a/internal/diag/usage_test.go
+++ b/internal/diag/usage_test.go
@@ -26,8 +26,10 @@ import (
 // the spec errors it prints come from the loader with their codes already
 // attached; it raises only its own configuration diagnostics.
 var familyOf = map[string][]int{
-	"internal/loader": {2},
-	"internal/cli":    {3},
+	"internal/loader":      {2},
+	"internal/cli":         {3},
+	"internal/security":    {6},
+	"internal/runner/http": {6},
 }
 
 // TestCodes_AreReferenced is the guard against a code that exists only in the

--- a/internal/runner/http/http.go
+++ b/internal/runner/http/http.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/runner"
 	"github.com/nao1215/atago/internal/security"
 	"github.com/nao1215/atago/internal/spec"
@@ -34,7 +35,7 @@ type PolicyError struct {
 }
 
 func (e *PolicyError) Error() string {
-	return fmt.Sprintf("network policy denies host %q (allowed: %s)", e.Host, strings.Join(e.Allow, ", "))
+	return diag.NetworkPolicyDenied.Annotate(fmt.Sprintf("network policy denies host %q (allowed: %s)", e.Host, strings.Join(e.Allow, ", ")))
 }
 
 // Config is the resolved configuration for an HTTP runner, derived from a named

--- a/internal/security/masker.go
+++ b/internal/security/masker.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/spec"
 )
 
@@ -21,7 +22,7 @@ type PolicyError struct {
 }
 
 func (e *PolicyError) Error() string {
-	return fmt.Sprintf("network policy denies host %q (allowed: %s)", e.Host, strings.Join(e.Allow, ", "))
+	return diag.NetworkPolicyDenied.Annotate(fmt.Sprintf("network policy denies host %q (allowed: %s)", e.Host, strings.Join(e.Allow, ", ")))
 }
 
 // CheckHost reports whether hostport (a "host" or "host:port") is permitted by

--- a/test/e2e/atago/error_codes.atago.yaml
+++ b/test/e2e/atago/error_codes.atago.yaml
@@ -846,3 +846,32 @@ scenarios:
       - assert:
           exit_code: 3
           stderr: {contains: "ATG3207"}
+
+  # --- ATG60xx: security policy ---------------------------------------------
+
+  - name: ATG6001 is a request to a host the network policy denies
+    # A policy violation is reported inside the run's own report on stdout
+    # rather than as a startup diagnostic on stderr, because the run started
+    # and a scenario reached the refusal.
+    steps:
+      - fixture:
+          file: denied.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: denied}
+            permissions:
+              network:
+                allow:
+                  - allowed.example
+            runners:
+              api:
+                type: http
+                base_url: http://127.0.0.1:1
+            scenarios:
+              - name: reaches elsewhere
+                steps:
+                  - http: {runner: api, method: GET, path: /ping}
+      - run: {command: "${atago} run denied.atago.yaml"}
+      - assert:
+          exit_code: 6
+          stdout: {contains: "ATG6001"}


### PR DESCRIPTION
## Summary

Exit 6 has exactly one source today: a request to a host outside a spec's declared `permissions.network.allow`. It is checked identically for HTTP, gRPC, and SSH, and re-checked on an HTTP redirect so an allowed host cannot bounce a request to a denied one. One refusal, one code.

Phase C of #454. Stacked on #461; the diff of interest is the last commit.

## Changes

- `internal/diag/codes_security.go` — ATG6001, and a package comment stating where the neighbouring refusals live.
- `internal/runner/http/http.go`, `internal/security/masker.go` — both `PolicyError` types carry the code in their message.
- `test/e2e/atago/error_codes.atago.yaml` — a scenario provoking it, asserting exit 6.

## Design Decisions

The code goes in `PolicyError.Error()` rather than at the call sites, because the message is the error type's own and every path that reports it should carry the code. There are two such types — one in the HTTP runner, one in `security` for gRPC and SSH — and they stay separate here rather than being unified, which is a refactor with nothing to do with codes.

Most of ATG6001's entry is about what to do instead of the refusal. A security refusal is the diagnostic a reader is most likely to believe is the tool being wrong, and one line at a terminal has no room to argue otherwise: widen the allowlist deliberately, point the runner at a mock server or a scenario service, or drop the policy, which is what a spec declaring no `permissions.network` block already has.

The family comment states the boundary explicitly, because it is not obvious from the codes alone. A path that leaves the workdir is caught while loading and is ATG2310; a path that escapes the scenario root mid-run is an execution error, since that is atago protecting the isolation every scenario depends on rather than enforcing something the spec asked for. Moving either into exit 6 would be a behaviour change with no request behind it.

The scenario asserts on stdout rather than stderr: a policy violation is reported inside the run's own report, because the run started and a scenario reached the refusal.
