### PR TITLE
feat(diag): code the execution and internal errors

### DIFF
--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-81 suites · 579 scenarios
+81 suites · 597 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -144,7 +144,7 @@
   - [file not_contains passes when the substring is absent](#scenario-file-not_contains-passes-when-the-substring-is-absent)
   - [not_contains fails when the substring is present](#scenario-not_contains-fails-when-the-substring-is-present)
   - [a shell metacharacter without shell is a load-time error](#scenario-a-shell-metacharacter-without-shell-is-a-load-time-error)
-- [atago self-hosting / every diagnostic code](#atago-self-hosting--every-diagnostic-code) — 57 scenarios
+- [atago self-hosting / every diagnostic code](#atago-self-hosting--every-diagnostic-code) — 75 scenarios
   - [ATG2001 is a spec file that cannot be read](#scenario-atg2001-is-a-spec-file-that-cannot-be-read)
   - [ATG2002 is a spec file with no YAML document in it](#scenario-atg2002-is-a-spec-file-with-no-yaml-document-in-it)
   - [ATG2003 is a document that is not valid YAML](#scenario-atg2003-is-a-document-that-is-not-valid-yaml)
@@ -202,6 +202,24 @@
   - [ATG3206 is a destination that cannot be written](#scenario-atg3206-is-a-destination-that-cannot-be-written)
   - [ATG3207 is atago's recorded state failing to load](#scenario-atg3207-is-atagos-recorded-state-failing-to-load)
   - [ATG6001 is a request to a host the network policy denies](#scenario-atg6001-is-a-request-to-a-host-the-network-policy-denies)
+  - [ATG4001 is a command line that cannot be split into arguments](#scenario-atg4001-is-a-command-line-that-cannot-be-split-into-arguments)
+  - [ATG4002 is a program that could not be started](#scenario-atg4002-is-a-program-that-could-not-be-started)
+  - [ATG4003 is an environment the step needs that could not be prepared](#scenario-atg4003-is-an-environment-the-step-needs-that-could-not-be-prepared)
+  - [ATG4004 is a file the step depends on that cannot be read](#scenario-atg4004-is-a-file-the-step-depends-on-that-cannot-be-read)
+  - [ATG4005 is a command run beside a terminal session that failed](#scenario-atg4005-is-a-command-run-beside-a-terminal-session-that-failed)
+  - [ATG4101 is a step that outlasted its timeout](#scenario-atg4101-is-a-step-that-outlasted-its-timeout)
+  - [ATG4102 is a service that never became ready](#scenario-atg4102-is-a-service-that-never-became-ready)
+  - [ATG4201 is a peer that could not be reached](#scenario-atg4201-is-a-peer-that-could-not-be-reached)
+  - [ATG4202 is a runner missing what it needs to connect](#scenario-atg4202-is-a-runner-missing-what-it-needs-to-connect)
+  - [ATG4203 is a peer that was reached and refused the request](#scenario-atg4203-is-a-peer-that-was-reached-and-refused-the-request)
+  - [ATG4204 is an address atago cannot make sense of](#scenario-atg4204-is-an-address-atago-cannot-make-sense-of)
+  - [ATG4301 is a service that failed before it became ready](#scenario-atg4301-is-a-service-that-failed-before-it-became-ready)
+  - [ATG4302 is a service addressed after it exited](#scenario-atg4302-is-a-service-addressed-after-it-exited)
+  - [ATG4403 is output that could not be captured](#scenario-atg4403-is-output-that-could-not-be-captured)
+  - [ATG4406 is input the program is not set up to receive](#scenario-atg4406-is-input-the-program-is-not-set-up-to-receive)
+  - [ATG4501 is a store step with no result behind it](#scenario-atg4501-is-a-store-step-with-no-result-behind-it)
+  - [ATG4502 is a store selector that found nothing](#scenario-atg4502-is-a-store-selector-that-found-nothing)
+  - [ATG4505 is a variable the step expands that is not defined](#scenario-atg4505-is-a-variable-the-step-expands-that-is-not-defined)
 - [atago self-hosting / exit_code in-set matcher](#atago-self-hosting--exit_code-in-set-matcher) — 4 scenarios
   - [a listed exit code passes](#scenario-a-listed-exit-code-passes)
   - [an unlisted exit code fails and the output lists the set](#scenario-an-unlisted-exit-code-fails-and-the-output-lists-the-set)
@@ -4347,6 +4365,413 @@ ${atago} run denied.atago.yaml
 #### Then
 - exit code is `6`
 - stdout contains `ATG6001`
+### Scenario: ATG4001 is a command line that cannot be split into arguments
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+
+scenarios:
+  - name: a
+    steps:
+      - run: {command: "echo 'unclosed"}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `4`
+- stdout contains `ATG4001`
+### Scenario: ATG4002 is a program that could not be started
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+
+scenarios:
+  - name: a
+    steps:
+      - run: {command: definitely-no-such-binary-xyz}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `4`
+- stdout contains `ATG4002`
+### Scenario: ATG4003 is an environment the step needs that could not be prepared
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+
+scenarios:
+  - name: a
+    steps:
+      - run: {command: cat, stdin: {file: never-created.txt}}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `4`
+- stdout contains `ATG4003`
+### Scenario: ATG4004 is a file the step depends on that cannot be read
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+
+suite:
+  name: x
+  setup:
+    - mock_server: {name: m, routes: [{method: POST, path: /p, status: 200}]}
+runners: {api: {type: http, base_url: "${m.url}"}}
+scenarios:
+  - name: a
+    steps:
+      - http: {runner: api, method: POST, path: /p, body_file: never-created.bin}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `4`
+- stdout contains `ATG4004`
+### Scenario: ATG4005 is a command run beside a terminal session that failed
+_skipped on Windows_
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+
+scenarios:
+  - name: a
+    steps:
+      - pty: {command: cat, timeout: 20s, session: [{exec: {command: "false"}}]}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `4`
+- stdout contains `ATG4005`
+### Scenario: ATG4101 is a step that outlasted its timeout
+_skipped on Windows_
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+
+scenarios:
+  - name: a
+    steps:
+      - pty: {command: cat, timeout: 20s, session: [{exec: {command: "sleep 5", timeout: 300ms}}]}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `4`
+- stdout contains `ATG4101`
+### Scenario: ATG4102 is a service that never became ready
+_skipped on Windows_
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+
+scenarios:
+  - name: a
+    services:
+      - {name: s, command: "sleep 30", ready: {port: "127.0.0.1:59991", timeout: 1s}}
+    steps:
+      - run: {command: echo}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `4`
+- stdout contains `ATG4102`
+### Scenario: ATG4201 is a peer that could not be reached
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+
+runners: {api: {type: http, base_url: "http://127.0.0.1:1"}}
+scenarios:
+  - name: a
+    steps:
+      - http: {runner: api, method: GET, path: /}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `4`
+- stdout contains `ATG4201`
+### Scenario: ATG4202 is a runner missing what it needs to connect
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+
+runners: {r: {type: ssh, host: "127.0.0.1:22", user: u, password: p}}
+scenarios:
+  - name: a
+    steps:
+      - run: {runner: r, command: echo}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `4`
+- stdout contains `ATG4202`
+### Scenario: ATG4203 is a peer that was reached and refused the request
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+
+runners: {db: {type: db, dsn: "sqlite://:memory:"}}
+scenarios:
+  - name: a
+    steps:
+      - query: {runner: db, sql: "SELECT * FROM no_such_table"}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `4`
+- stdout contains `ATG4203`
+### Scenario: ATG4204 is an address atago cannot make sense of
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+
+runners: {db: {type: db, dsn: "weird://x"}}
+scenarios:
+  - name: a
+    steps:
+      - query: {runner: db, sql: "SELECT 1"}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `4`
+- stdout contains `ATG4204`
+### Scenario: ATG4301 is a service that failed before it became ready
+_skipped on Windows_
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+
+scenarios:
+  - name: a
+    services:
+      - {name: s, command: "true", ready: {port: "127.0.0.1:59992", timeout: 5s}}
+    steps:
+      - run: {command: echo}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `4`
+- stdout contains `ATG4301`
+### Scenario: ATG4302 is a service addressed after it exited
+_skipped on Windows_
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+
+scenarios:
+  - name: a
+    services:
+      - {name: s, command: "sleep 1", ready: {delay: 100ms}}
+    steps:
+      - run: {command: "sleep 2"}
+      - signal: {service: s, signal: TERM}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `4`
+- stdout contains `ATG4302`
+### Scenario: ATG4403 is output that could not be captured
+_skipped on Windows_
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+
+scenarios:
+  - name: a
+    steps:
+      - run: {command: "sleep 4 &", shell: true, timeout: 30s}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `4`
+- stdout contains `ATG4403`
+### Scenario: ATG4406 is input the program is not set up to receive
+_skipped on Windows_
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+
+scenarios:
+  - name: a
+    steps:
+      - pty: {command: cat, timeout: 20s, session: [{send: {mouse: {row: 1, col: 1}}}]}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `4`
+- stdout contains `ATG4406`
+### Scenario: ATG4501 is a store step with no result behind it
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+
+scenarios:
+  - name: a
+    steps:
+      - run: {command: echo}
+      - store: {name: v, from: {body: {trim: true}}}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `4`
+- stdout contains `ATG4501`
+### Scenario: ATG4502 is a store selector that found nothing
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+
+scenarios:
+  - name: a
+    steps:
+      - run: {command: echo}
+      - store: {name: v, from: {stdout: {matches: "no-such-text-anywhere"}}}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `4`
+- stdout contains `ATG4502`
+### Scenario: ATG4505 is a variable the step expands that is not defined
+_skipped on Windows_
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+
+scenarios:
+  - name: a
+    steps:
+      - pty:
+          command: cat
+          timeout: 20s
+          session:
+            - send: "${env:ATAGO_DEFINITELY_UNSET_XYZ}"
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `4`
+- stdout contains `ATG4505`
 ## atago self-hosting / exit_code in-set matcher
 Source: `test/e2e/atago/exit_code_in.atago.yaml`
 ### Scenario: a listed exit code passes

--- a/doc/errors.md
+++ b/doc/errors.md
@@ -642,7 +642,7 @@ Exits 4. Since v0.21.0.
 
 ### ATG4302 — a service was addressed while it was not running
 
-A step signalled or otherwise acted on a service that had already exited, or had not been started. A service that ignores a stop signal and outlives its grace period is reported here too, since what follows is the same question: what is that process doing.
+A step signaled or otherwise acted on a service that had already exited, or had not been started. A service that ignores a stop signal and outlives its grace period is reported here too, since what follows is the same question: what is that process doing.
 
 Fix: Check whether the service exits on its own partway through the scenario, which its captured output usually shows. A service that will not stop on `TERM` may need `KILL`.
 

--- a/doc/errors.md
+++ b/doc/errors.md
@@ -10,8 +10,8 @@ Codes are being assigned one family at a time. The table says which families car
 |---|---|---|---|
 | `ATG2xxx` | 2 | spec error — the file could not be parsed, or does not describe a runnable suite | 39 codes |
 | `ATG3xxx` | 3 | configuration error — the command line, its flags, or the spec files it selected | 14 codes |
-| `ATG4xxx` | 4 | execution error — a step could not be carried out | not yet |
-| `ATG5xxx` | 5 | internal error — a bug in atago | not yet |
+| `ATG4xxx` | 4 | execution error — a step could not be carried out | 26 codes |
+| `ATG5xxx` | 5 | internal error — a bug in atago | 1 codes |
 | `ATG6xxx` | 6 | security policy violation — atago refused an operation on policy grounds | 1 codes |
 
 `ATG1xxx` is never assigned. Exit 1 means one or more scenarios failed, which is a result rather than an error.
@@ -77,6 +77,33 @@ Look a code up from the terminal with `atago explain ATG2201`, which prints this
 | [`ATG3205`](#atg3205--the-output-file-already-exists) | the output file already exists | 3 | v0.21.0 |
 | [`ATG3206`](#atg3206--a-destination-atago-was-asked-to-write-cannot-be-written) | a destination atago was asked to write cannot be written | 3 | v0.21.0 |
 | [`ATG3207`](#atg3207--atagos-recorded-state-from-a-previous-run-cannot-be-read) | atago's recorded state from a previous run cannot be read | 3 | v0.21.0 |
+| [`ATG4001`](#atg4001--a-command-line-could-not-be-split-into-arguments) | a command line could not be split into arguments | 4 | v0.21.0 |
+| [`ATG4002`](#atg4002--the-program-could-not-be-started) | the program could not be started | 4 | v0.21.0 |
+| [`ATG4003`](#atg4003--the-isolated-environment-for-the-step-could-not-be-prepared) | the isolated environment for the step could not be prepared | 4 | v0.21.0 |
+| [`ATG4004`](#atg4004--a-file-the-step-depends-on-could-not-be-read-or-written) | a file the step depends on could not be read or written | 4 | v0.21.0 |
+| [`ATG4005`](#atg4005--a-command-run-alongside-a-terminal-session-failed) | a command run alongside a terminal session failed | 4 | v0.21.0 |
+| [`ATG4101`](#atg4101--a-step-did-not-finish-within-its-timeout) | a step did not finish within its timeout | 4 | v0.21.0 |
+| [`ATG4102`](#atg4102--a-service-did-not-become-ready-within-its-timeout) | a service did not become ready within its timeout | 4 | v0.21.0 |
+| [`ATG4103`](#atg4103--the-run-was-interrupted-before-the-step-finished) | the run was interrupted before the step finished | 4 | v0.21.0 |
+| [`ATG4201`](#atg4201--a-peer-could-not-be-reached) | a peer could not be reached | 4 | v0.21.0 |
+| [`ATG4202`](#atg4202--a-runner-is-missing-something-it-needs-before-it-can-connect) | a runner is missing something it needs before it can connect | 4 | v0.21.0 |
+| [`ATG4203`](#atg4203--the-peer-was-reached-but-rejected-what-was-asked-of-it) | the peer was reached but rejected what was asked of it | 4 | v0.21.0 |
+| [`ATG4204`](#atg4204--an-address-or-connection-string-could-not-be-understood) | an address or connection string could not be understood | 4 | v0.21.0 |
+| [`ATG4301`](#atg4301--a-service-failed-before-it-became-ready) | a service failed before it became ready | 4 | v0.21.0 |
+| [`ATG4302`](#atg4302--a-service-was-addressed-while-it-was-not-running) | a service was addressed while it was not running | 4 | v0.21.0 |
+| [`ATG4303`](#atg4303--a-mock-server-could-not-be-started-or-could-not-answer) | a mock server could not be started or could not answer | 4 | v0.21.0 |
+| [`ATG4401`](#atg4401--a-pseudo-terminal-could-not-be-allocated-or-driven) | a pseudo-terminal could not be allocated or driven | 4 | v0.21.0 |
+| [`ATG4402`](#atg4402--atago-does-not-know-how-to-send-that-key-or-signal) | atago does not know how to send that key or signal | 4 | v0.21.0 |
+| [`ATG4403`](#atg4403--the-steps-output-could-not-be-captured) | the step's output could not be captured | 4 | v0.21.0 |
+| [`ATG4404`](#atg4404--the-step-is-not-supported-on-this-platform) | the step is not supported on this platform | 4 | v0.21.0 |
+| [`ATG4405`](#atg4405--a-browser-action-could-not-be-carried-out) | a browser action could not be carried out | 4 | v0.21.0 |
+| [`ATG4406`](#atg4406--the-session-sent-input-the-program-is-not-set-up-to-receive) | the session sent input the program is not set up to receive | 4 | v0.21.0 |
+| [`ATG4501`](#atg4501--a-store-step-has-no-result-to-capture-from) | a store step has no result to capture from | 4 | v0.21.0 |
+| [`ATG4502`](#atg4502--the-value-to-store-could-not-be-extracted) | the value to store could not be extracted | 4 | v0.21.0 |
+| [`ATG4503`](#atg4503--a-request-payload-could-not-be-built) | a request payload could not be built | 4 | v0.21.0 |
+| [`ATG4504`](#atg4504--the-peer-answered-with-something-that-could-not-be-read) | the peer answered with something that could not be read | 4 | v0.21.0 |
+| [`ATG4505`](#atg4505--a-variable-the-step-expands-is-not-defined) | a variable the step expands is not defined | 4 | v0.21.0 |
+| [`ATG5001`](#atg5001--atago-hit-a-state-it-does-not-handle) | atago hit a state it does not handle | 5 | v0.21.0 |
 | [`ATG6001`](#atg6001--a-request-targeted-a-host-the-specs-network-policy-does-not-allow) | a request targeted a host the spec's network policy does not allow | 6 | v0.21.0 |
 
 ## ATG2xxx — exit 2
@@ -506,6 +533,226 @@ Exits 3. Since v0.21.0.
 Fix: Delete the ledger and run the full suite once to record it again.
 
 Exits 3. Since v0.21.0.
+
+## ATG4xxx — exit 4
+
+### ATG4001 — a command line could not be split into arguments
+
+Without `shell: true`, atago splits the command itself using shell quoting rules rather than handing it to a shell, so that a spec means the same thing on every platform. An unbalanced quote leaves that split with no sensible answer. An empty command has the same problem for a different reason: there is nothing to run.
+
+Fix: Balance the quotes, or set `shell: true` on the step when the command genuinely needs a shell to interpret it (pipes, redirection, globbing).
+
+Exits 4. Since v0.21.0.
+
+### ATG4002 — the program could not be started
+
+The operating system refused to launch it. Almost always the executable is not on `PATH`, or is present but not marked executable. In CI this usually means the build step has not run, or the binary landed somewhere the run does not look.
+
+Fix: Check the program name and that it is on `PATH` for the run. A directory manifest's `subject:` block builds the binary under test before any scenario and puts it on `PATH`, which is the supported way to test something not installed system-wide.
+
+Exits 4. Since v0.21.0.
+
+### ATG4003 — the isolated environment for the step could not be prepared
+
+Before a step runs, atago builds what it runs inside: the scenario workdir, a suite scratch directory, a sandboxed `HOME` when one was asked for, and any stdin the step feeds in. One of those could not be created or read. A full or read-only temp filesystem is the usual cause.
+
+Fix: Check free space and permissions on the temp directory, and check any file the step names for its stdin.
+
+Exits 4. Since v0.21.0.
+
+### ATG4004 — a file the step depends on could not be read or written
+
+The step named a file it had to read — a request body, an upload, an SSH key, a known_hosts list, a readiness probe's target — or one it had to write, such as a screenshot or a download. The filesystem refused. A path relative to the scenario workdir that was never created is the usual cause, since each scenario starts in a fresh directory.
+
+Fix: Check the path, and check that whatever creates the file runs before the step that reads it. A `fixture:` step is the supported way to put a file into the scenario workdir.
+
+Exits 4. Since v0.21.0.
+
+### ATG4005 — a command run alongside a terminal session failed
+
+A `pty:` session's `exec:` runs a command beside the terminal, usually to cause the change the session is waiting to observe. It exited non-zero, so that change was not made and whatever the session expects next can never arrive.
+
+Fix: Run the command by hand to see why it fails. Its own output accompanies this message.
+
+Exits 4. Since v0.21.0.
+
+### ATG4101 — a step did not finish within its timeout
+
+The step was still running when its bound elapsed, so atago stopped it. Every step has a timeout, from the step's own `timeout:`, the suite's, or atago's default, because a test that hangs forever is worse than one that fails — CI notices the failure and never notices the hang.
+
+Fix: Raise `timeout:` if the work legitimately takes that long, or find out what the program is waiting for. A program waiting on input nobody sends is the usual cause: give the step a `stdin:`, or drive it as a `pty:` session.
+
+Exits 4. Since v0.21.0.
+
+### ATG4102 — a service did not become ready within its timeout
+
+The service was started and its readiness probe never succeeded before the bound elapsed. atago waits rather than racing, so that a scenario cannot pass or fail depending on how fast a machine happens to be. The service's own output is included with this message, because what it printed while failing to start is usually the whole answer.
+
+Fix: Read the service output above the message first. If the service is simply slow, raise `ready.timeout`; if the probe is wrong, check that `ready.port`, `ready.file`, or `ready.log` describes what the service actually does when it is up.
+
+Exits 4. Since v0.21.0.
+
+### ATG4103 — the run was interrupted before the step finished
+
+A `Ctrl-C` or `SIGTERM` reached atago, which stops scheduling new work and unwinds what is in flight: processes are stopped, services torn down, sessions closed, and partial results reported. The step that was running when the signal arrived reports this rather than a verdict, because it never reached one.
+
+Fix: Nothing, when the interruption was deliberate. In CI this usually means the job hit its own overall time limit, which is worth checking before the specs are.
+
+Exits 4. Since v0.21.0.
+
+### ATG4201 — a peer could not be reached
+
+An HTTP, database, SSH, gRPC, or browser connection failed to establish. The same code covers all of them because the reader's next move is the same: find out whether the thing being connected to is actually up and actually at that address. Connection refused means nothing is listening there; a timeout usually means a firewall or a wrong host.
+
+Fix: Check that the peer is running and that the runner's address matches. Where the peer is part of the test, declare it as a scenario `service:` so atago starts it and waits for readiness before the step runs.
+
+Exits 4. Since v0.21.0.
+
+### ATG4202 — a runner is missing something it needs before it can connect
+
+The runner declaration is short of a required piece: an SSH runner with no user or no credential, a database runner with no DSN, a gRPC runner with no target. SSH host-key verification belongs here too — a runner with no `known_hosts` is refused rather than connecting blind, since silently accepting any host key would make the check worthless.
+
+Fix: Complete the `runners:` entry with what the message names. For SSH, either point `known_hosts` at a real file or set `insecure_host_key: true` deliberately, for a throwaway host you control.
+
+Exits 4. Since v0.21.0.
+
+### ATG4203 — the peer was reached but rejected what was asked of it
+
+The connection worked and the request did not: a gRPC service or method that does not exist in the reflected schema, a method that streams where only unary calls are supported, a redirect chain that never settled. This is the peer disagreeing about what it offers, rather than a failure to reach it.
+
+Fix: Check the name against what the peer actually exposes. For gRPC, the message lists what reflection reported, which is the authoritative answer for the server actually running.
+
+Exits 4. Since v0.21.0.
+
+### ATG4204 — an address or connection string could not be understood
+
+A URL, DSN, or method name is malformed, or a driver could not be inferred from a DSN whose scheme atago does not recognize. A relative request path with no `base_url` on the runner is the same problem seen from the other side: there is not enough there to form an address.
+
+Fix: Correct the address to the form the message names. A database runner can also state its `driver:` explicitly rather than leaving it to be inferred.
+
+Exits 4. Since v0.21.0.
+
+### ATG4301 — a service failed before it became ready
+
+The service exited, or its readiness probe reported it unusable, before any step could depend on it. Unlike a readiness timeout this is not about waiting: the service made its answer clear early. Its captured output accompanies the message.
+
+Fix: Read the service's own output first — a bad configuration file or an occupied port is usually visible there.
+
+Exits 4. Since v0.21.0.
+
+### ATG4302 — a service was addressed while it was not running
+
+A step signalled or otherwise acted on a service that had already exited, or had not been started. A service that ignores a stop signal and outlives its grace period is reported here too, since what follows is the same question: what is that process doing.
+
+Fix: Check whether the service exits on its own partway through the scenario, which its captured output usually shows. A service that will not stop on `TERM` may need `KILL`.
+
+Exits 4. Since v0.21.0.
+
+### ATG4303 — a mock server could not be started or could not answer
+
+The mock server atago runs on the scenario's behalf failed to bind a port, or could not build the response a route declares. Unlike the services above, this is atago's own process, so the cause is either the environment refusing the port or the route being impossible to render.
+
+Fix: Check the route's declared response, and whether the port is already taken. Leaving the port unset lets atago choose a free one and expose it through the store.
+
+Exits 4. Since v0.21.0.
+
+### ATG4401 — a pseudo-terminal could not be allocated or driven
+
+A `pty:` step runs its program in a real terminal so that programs behaving differently when attached to one can be tested at all. Allocating that terminal, resizing it, or identifying it failed. A container with no `/dev/pts` mounted is the usual cause on Linux, and a terminal size outside what the kernel accepts is the usual cause everywhere.
+
+Fix: Check that the environment provides pseudo-terminals, and that any `rows`/`cols` are within range. In a container, mounting `/dev/pts` is what makes `pty:` steps possible.
+
+Exits 4. Since v0.21.0.
+
+### ATG4402 — atago does not know how to send that key or signal
+
+Named keys and signals come from a fixed vocabulary, so that a spec transmits the same bytes everywhere rather than depending on what a terminal happens to map. The name given is not in it.
+
+Fix: Use one of the names the message lists.
+
+Exits 4. Since v0.21.0.
+
+### ATG4403 — the step's output could not be captured
+
+The program ran but atago could not collect what it wrote. The usual cause is a program that leaves a child process holding the output pipe open after it exits: atago waits briefly and then reports this rather than blocking forever on a pipe nobody will close. Assertions on the output cannot be trusted when this happens, so the step errors instead of failing.
+
+Fix: Check for a background process the command leaves behind. Redirecting the child's output inside the command, or waiting for it before exiting, closes the pipe.
+
+Exits 4. Since v0.21.0.
+
+### ATG4404 — the step is not supported on this platform
+
+Some steps rest on facilities one platform has and another does not — POSIX signals being the clearest case. atago refuses rather than pretending, because a signal quietly not delivered would leave the scenario asserting against a program that never received it.
+
+Fix: Gate the scenario with `skip: {os: ...}` so it runs where the facility exists, or express the same intent with something portable.
+
+Exits 4. Since v0.21.0.
+
+### ATG4405 — a browser action could not be carried out
+
+A `cdp:` action failed against the page: a selector matching nothing, a click that never landed, a download the browser would not begin. The browser was running and reachable — this is about the page rather than the connection.
+
+Fix: Check the selector against the page as it is at that moment. A page still loading is the usual cause, and a `check:` action before the one that fails is how a scenario waits for it.
+
+Exits 4. Since v0.21.0.
+
+### ATG4406 — the session sent input the program is not set up to receive
+
+Mouse reporting and bracketed paste are modes a program turns on for itself, and a program that has not turned one on receives the bytes as ordinary keystrokes rather than as the event the session meant. atago refuses instead of sending them, because the result would be a scenario asserting against input the program interpreted as something else entirely.
+
+Fix: Wait for the program to enable the mode before sending: an `expect_screen:` on whatever it draws once it is ready is usually enough. A program that never enables it cannot be driven this way.
+
+Exits 4. Since v0.21.0.
+
+### ATG4501 — a store step has no result to capture from
+
+`store:` captures a value out of the step before it — a command's stdout, a response body, a query's rows — and no such step has run in this scenario yet. The usual cause is a store placed before the step it means to read, or after a step of a different kind.
+
+Fix: Move the store step directly after the step whose result it captures.
+
+Exits 4. Since v0.21.0.
+
+### ATG4502 — the value to store could not be extracted
+
+The source step ran, and the selector found nothing usable in it: a JSON path matching no value or several, a regexp that did not match, a body that is not the JSON it was read as. atago errors rather than storing an empty value, because an empty value would flow silently into every later step that expands it.
+
+Fix: Check the selector against what the step actually produced — `--verbose` prints each step's captured output, which is the quickest way to see it.
+
+Exits 4. Since v0.21.0.
+
+### ATG4503 — a request payload could not be built
+
+The step's body could not be encoded or assembled: a JSON value that will not marshal, a multipart form that could not be written, a gRPC message that does not fit the schema the peer reflected. Nothing was sent, so the peer never saw the request.
+
+Fix: Check the payload against the shape the peer expects. For gRPC, the reflected schema is what decides, not the local proto files.
+
+Exits 4. Since v0.21.0.
+
+### ATG4504 — the peer answered with something that could not be read
+
+A response arrived and could not be decoded — a body that is not the JSON it claims to be, a row that could not be scanned into a value, a gRPC message that will not unmarshal. The exchange succeeded at the transport level and failed at the content level.
+
+Fix: Look at the raw response, which `--verbose` prints. An HTML error page where JSON was expected is the most common version of this, and it usually means the request reached something other than the intended endpoint.
+
+Exits 4. Since v0.21.0.
+
+### ATG4505 — a variable the step expands is not defined
+
+The step referenced `${name}` or `${env:NAME}` and neither a stored value nor an environment variable of that name exists at that point. atago refuses rather than expanding to an empty string, which would silently send an empty password or an empty path and fail somewhere far from the cause.
+
+Fix: Set the environment variable, or add the `store:` step that defines the name before the step that reads it. `$${...}` writes a literal dollar-brace where no expansion is wanted.
+
+Exits 4. Since v0.21.0.
+
+## ATG5xxx — exit 5
+
+### ATG5001 — atago hit a state it does not handle
+
+This is a bug in atago. It means an invariant the code relies on did not hold — a step reaching a runner that cannot serve it, a generated document that could not be produced, a resource that should exist and does not. A spec cannot be at fault: everything a spec can get wrong is refused while loading, with an ATG2xxx code.
+
+Fix: Please report it at https://github.com/nao1215/atago/issues with the message, the atago version from `atago version`, and the spec if you can share it. There is no workaround to try first.
+
+Exits 5. Since v0.21.0.
 
 ## ATG6xxx — exit 6
 

--- a/drift_test.go
+++ b/drift_test.go
@@ -546,10 +546,37 @@ func TestE2E_EveryCodeIsProvoked(t *testing.T) {
 		}
 	}
 	for _, e := range diag.All() {
-		if !provoked[e.Code] {
-			t.Errorf("%s (%s) is a published code that no scenario in %s provokes; add one to error_codes.atago.yaml", e.Code, e.Name, dir)
+		if provoked[e.Code] {
+			if _, exempt := unprovokableFromASpec[e.Code]; exempt {
+				t.Errorf("%s (%s) is listed as unprovokable from a spec, but a scenario in %s provokes it; remove the exemption", e.Code, e.Name, dir)
+			}
+			continue
 		}
+		if _, exempt := unprovokableFromASpec[e.Code]; exempt {
+			continue
+		}
+		t.Errorf("%s (%s) is a published code that no scenario in %s provokes; add one to error_codes.atago.yaml", e.Code, e.Name, dir)
 	}
+}
+
+// unprovokableFromASpec lists the codes no spec can reach, each with the reason.
+// Everything else must be provoked by a scenario, and the gate above also fails
+// when a code listed here turns out to be reachable after all — so the list
+// shrinks as the ways to provoke them appear, and never quietly grows stale.
+//
+// This is the one place the coverage gate can be escaped, which is why it is a
+// table of prose rather than a flag: adding a code here is a claim a reviewer
+// can disagree with.
+var unprovokableFromASpec = map[diag.Code]string{
+	diag.RunInterrupted:        "needs a signal delivered to atago itself mid-run, which a scenario cannot arrange for its own runner",
+	diag.MockServerFailed:      "needs the mock server's port to be taken, and a spec cannot pin the port it binds",
+	diag.PTYFailed:             "needs the kernel to refuse a pseudo-terminal; every shape a spec can ask for is rejected by the loader first",
+	diag.InputNotSupported:     "the key and signal vocabularies are validated while loading, so a spec never reaches the runtime check",
+	diag.UnsupportedOnPlatform: "only raised on Windows, where the scenarios that would provoke it are the ones being refused",
+	diag.BrowserActionFailed:   "needs a real browser, which the hermetic self-hosted suite deliberately does not start",
+	diag.PayloadFailed:         "needs a value that will not marshal, which YAML cannot express",
+	diag.ResponseUnreadable:    "needs a peer that answers with a malformed body, which the mock server will not produce",
+	diag.InternalError:         "is unreachable by construction: every state it guards is refused while loading",
 }
 
 // assertedText collects the strings a spec's stream assertions compare

--- a/internal/diag/codes_exec.go
+++ b/internal/diag/codes_exec.go
@@ -1,0 +1,248 @@
+package diag
+
+// ATG4xxx — execution errors, which exit 4. A scenario started and something
+// stopped it from carrying out a step. These are distinct from a scenario
+// failing: a failure means the assertions ran and disagreed with what happened,
+// while an execution error means atago never got far enough to have an opinion.
+//
+// The sub-ranges group by what the reader has to do about it:
+//
+//	ATG40xx  starting the subject — the command, its arguments, its sandbox
+//	ATG41xx  time — something took longer than its bound, or was interrupted
+//	ATG42xx  reaching a peer — connecting, authenticating, addressing
+//	ATG43xx  services and mock servers a scenario brought up
+//	ATG44xx  session mechanics — terminals, signals, capture
+//	ATG45xx  the data a step depends on — stored values, payloads, encodings
+//
+// Codes are assigned to the site that names the problem, not to every site an
+// error passes through. "connection refused" from an HTTP runner and from a
+// database runner share a code because the reader's next move is the same;
+// a step that timed out and a service that never became ready do not, because
+// one is fixed in `timeout:` and the other in `ready:`.
+const execSince = "v0.21.0"
+
+// ATG40xx — starting the subject.
+var (
+	// CommandUnparsable is a command line atago cannot split into arguments.
+	CommandUnparsable = register(4001, "CommandUnparsable", Entry{
+		Summary: "a command line could not be split into arguments",
+		Detail:  "Without `shell: true`, atago splits the command itself using shell quoting rules rather than handing it to a shell, so that a spec means the same thing on every platform. An unbalanced quote leaves that split with no sensible answer. An empty command has the same problem for a different reason: there is nothing to run.",
+		Fix:     "Balance the quotes, or set `shell: true` on the step when the command genuinely needs a shell to interpret it (pipes, redirection, globbing).",
+		Since:   execSince,
+	})
+
+	// CommandNotStarted is a program that never began running.
+	CommandNotStarted = register(4002, "CommandNotStarted", Entry{
+		Summary: "the program could not be started",
+		Detail:  "The operating system refused to launch it. Almost always the executable is not on `PATH`, or is present but not marked executable. In CI this usually means the build step has not run, or the binary landed somewhere the run does not look.",
+		Fix:     "Check the program name and that it is on `PATH` for the run. A directory manifest's `subject:` block builds the binary under test before any scenario and puts it on `PATH`, which is the supported way to test something not installed system-wide.",
+		Since:   execSince,
+	})
+
+	// StepFileUnusable is a file the step depends on that cannot be used.
+	StepFileUnusable = register(4004, "StepFileUnusable", Entry{
+		Summary: "a file the step depends on could not be read or written",
+		Detail:  "The step named a file it had to read — a request body, an upload, an SSH key, a known_hosts list, a readiness probe's target — or one it had to write, such as a screenshot or a download. The filesystem refused. A path relative to the scenario workdir that was never created is the usual cause, since each scenario starts in a fresh directory.",
+		Fix:     "Check the path, and check that whatever creates the file runs before the step that reads it. A `fixture:` step is the supported way to put a file into the scenario workdir.",
+		Since:   execSince,
+	})
+
+	// SessionExecFailed is a helper command inside a session that failed.
+	SessionExecFailed = register(4005, "SessionExecFailed", Entry{
+		Summary: "a command run alongside a terminal session failed",
+		Detail:  "A `pty:` session's `exec:` runs a command beside the terminal, usually to cause the change the session is waiting to observe. It exited non-zero, so that change was not made and whatever the session expects next can never arrive.",
+		Fix:     "Run the command by hand to see why it fails. Its own output accompanies this message.",
+		Since:   execSince,
+	})
+
+	// SandboxSetupFailed is the scenario's own environment failing to build.
+	SandboxSetupFailed = register(4003, "SandboxSetupFailed", Entry{
+		Summary: "the isolated environment for the step could not be prepared",
+		Detail:  "Before a step runs, atago builds what it runs inside: the scenario workdir, a suite scratch directory, a sandboxed `HOME` when one was asked for, and any stdin the step feeds in. One of those could not be created or read. A full or read-only temp filesystem is the usual cause.",
+		Fix:     "Check free space and permissions on the temp directory, and check any file the step names for its stdin.",
+		Since:   execSince,
+	})
+)
+
+// ATG41xx — time.
+var (
+	// StepTimeout is a step that outlasted its bound.
+	StepTimeout = register(4101, "StepTimeout", Entry{
+		Summary: "a step did not finish within its timeout",
+		Detail:  "The step was still running when its bound elapsed, so atago stopped it. Every step has a timeout, from the step's own `timeout:`, the suite's, or atago's default, because a test that hangs forever is worse than one that fails — CI notices the failure and never notices the hang.",
+		Fix:     "Raise `timeout:` if the work legitimately takes that long, or find out what the program is waiting for. A program waiting on input nobody sends is the usual cause: give the step a `stdin:`, or drive it as a `pty:` session.",
+		Since:   execSince,
+	})
+
+	// ReadinessTimeout is a service that never came up.
+	ReadinessTimeout = register(4102, "ReadinessTimeout", Entry{
+		Summary: "a service did not become ready within its timeout",
+		Detail:  "The service was started and its readiness probe never succeeded before the bound elapsed. atago waits rather than racing, so that a scenario cannot pass or fail depending on how fast a machine happens to be. The service's own output is included with this message, because what it printed while failing to start is usually the whole answer.",
+		Fix:     "Read the service output above the message first. If the service is simply slow, raise `ready.timeout`; if the probe is wrong, check that `ready.port`, `ready.file`, or `ready.log` describes what the service actually does when it is up.",
+		Since:   execSince,
+	})
+
+	// RunInterrupted is a run stopped from outside.
+	RunInterrupted = register(4103, "RunInterrupted", Entry{
+		Summary: "the run was interrupted before the step finished",
+		Detail:  "A `Ctrl-C` or `SIGTERM` reached atago, which stops scheduling new work and unwinds what is in flight: processes are stopped, services torn down, sessions closed, and partial results reported. The step that was running when the signal arrived reports this rather than a verdict, because it never reached one.",
+		Fix:     "Nothing, when the interruption was deliberate. In CI this usually means the job hit its own overall time limit, which is worth checking before the specs are.",
+		Since:   execSince,
+	})
+)
+
+// ATG42xx — reaching a peer.
+var (
+	// ConnectFailed is a peer that could not be reached.
+	ConnectFailed = register(4201, "ConnectFailed", Entry{
+		Summary: "a peer could not be reached",
+		Detail:  "An HTTP, database, SSH, gRPC, or browser connection failed to establish. The same code covers all of them because the reader's next move is the same: find out whether the thing being connected to is actually up and actually at that address. Connection refused means nothing is listening there; a timeout usually means a firewall or a wrong host.",
+		Fix:     "Check that the peer is running and that the runner's address matches. Where the peer is part of the test, declare it as a scenario `service:` so atago starts it and waits for readiness before the step runs.",
+		Since:   execSince,
+	})
+
+	// RunnerConfigIncomplete is a runner missing what it needs to connect.
+	RunnerConfigIncomplete = register(4202, "RunnerConfigIncomplete", Entry{
+		Summary: "a runner is missing something it needs before it can connect",
+		Detail:  "The runner declaration is short of a required piece: an SSH runner with no user or no credential, a database runner with no DSN, a gRPC runner with no target. SSH host-key verification belongs here too — a runner with no `known_hosts` is refused rather than connecting blind, since silently accepting any host key would make the check worthless.",
+		Fix:     "Complete the `runners:` entry with what the message names. For SSH, either point `known_hosts` at a real file or set `insecure_host_key: true` deliberately, for a throwaway host you control.",
+		Since:   execSince,
+	})
+
+	// RemoteRejected is a peer that answered by refusing.
+	RemoteRejected = register(4203, "RemoteRejected", Entry{
+		Summary: "the peer was reached but rejected what was asked of it",
+		Detail:  "The connection worked and the request did not: a gRPC service or method that does not exist in the reflected schema, a method that streams where only unary calls are supported, a redirect chain that never settled. This is the peer disagreeing about what it offers, rather than a failure to reach it.",
+		Fix:     "Check the name against what the peer actually exposes. For gRPC, the message lists what reflection reported, which is the authoritative answer for the server actually running.",
+		Since:   execSince,
+	})
+
+	// BadEndpoint is an address atago cannot make sense of.
+	BadEndpoint = register(4204, "BadEndpoint", Entry{
+		Summary: "an address or connection string could not be understood",
+		Detail:  "A URL, DSN, or method name is malformed, or a driver could not be inferred from a DSN whose scheme atago does not recognize. A relative request path with no `base_url` on the runner is the same problem seen from the other side: there is not enough there to form an address.",
+		Fix:     "Correct the address to the form the message names. A database runner can also state its `driver:` explicitly rather than leaving it to be inferred.",
+		Since:   execSince,
+	})
+)
+
+// ATG43xx — services and mock servers.
+var (
+	// ServiceNotReady is a service that failed rather than started.
+	ServiceNotReady = register(4301, "ServiceNotReady", Entry{
+		Summary: "a service failed before it became ready",
+		Detail:  "The service exited, or its readiness probe reported it unusable, before any step could depend on it. Unlike a readiness timeout this is not about waiting: the service made its answer clear early. Its captured output accompanies the message.",
+		Fix:     "Read the service's own output first — a bad configuration file or an occupied port is usually visible there.",
+		Since:   execSince,
+	})
+
+	// ServiceNotRunning is an operation on a service that is not up.
+	ServiceNotRunning = register(4302, "ServiceNotRunning", Entry{
+		Summary: "a service was addressed while it was not running",
+		Detail:  "A step signalled or otherwise acted on a service that had already exited, or had not been started. A service that ignores a stop signal and outlives its grace period is reported here too, since what follows is the same question: what is that process doing.",
+		Fix:     "Check whether the service exits on its own partway through the scenario, which its captured output usually shows. A service that will not stop on `TERM` may need `KILL`.",
+		Since:   execSince,
+	})
+
+	// MockServerFailed is atago's own stub server failing.
+	MockServerFailed = register(4303, "MockServerFailed", Entry{
+		Summary: "a mock server could not be started or could not answer",
+		Detail:  "The mock server atago runs on the scenario's behalf failed to bind a port, or could not build the response a route declares. Unlike the services above, this is atago's own process, so the cause is either the environment refusing the port or the route being impossible to render.",
+		Fix:     "Check the route's declared response, and whether the port is already taken. Leaving the port unset lets atago choose a free one and expose it through the store.",
+		Since:   execSince,
+	})
+)
+
+// ATG44xx — session mechanics.
+var (
+	// PTYFailed is a pseudo-terminal that could not be set up or driven.
+	PTYFailed = register(4401, "PTYFailed", Entry{
+		Summary: "a pseudo-terminal could not be allocated or driven",
+		Detail:  "A `pty:` step runs its program in a real terminal so that programs behaving differently when attached to one can be tested at all. Allocating that terminal, resizing it, or identifying it failed. A container with no `/dev/pts` mounted is the usual cause on Linux, and a terminal size outside what the kernel accepts is the usual cause everywhere.",
+		Fix:     "Check that the environment provides pseudo-terminals, and that any `rows`/`cols` are within range. In a container, mounting `/dev/pts` is what makes `pty:` steps possible.",
+		Since:   execSince,
+	})
+
+	// InputNotSupported is a key or signal atago does not know how to send.
+	InputNotSupported = register(4402, "InputNotSupported", Entry{
+		Summary: "atago does not know how to send that key or signal",
+		Detail:  "Named keys and signals come from a fixed vocabulary, so that a spec transmits the same bytes everywhere rather than depending on what a terminal happens to map. The name given is not in it.",
+		Fix:     "Use one of the names the message lists.",
+		Since:   execSince,
+	})
+
+	// CaptureFailed is output that could not be collected.
+	CaptureFailed = register(4403, "CaptureFailed", Entry{
+		Summary: "the step's output could not be captured",
+		Detail:  "The program ran but atago could not collect what it wrote. The usual cause is a program that leaves a child process holding the output pipe open after it exits: atago waits briefly and then reports this rather than blocking forever on a pipe nobody will close. Assertions on the output cannot be trusted when this happens, so the step errors instead of failing.",
+		Fix:     "Check for a background process the command leaves behind. Redirecting the child's output inside the command, or waiting for it before exiting, closes the pipe.",
+		Since:   execSince,
+	})
+
+	// BrowserActionFailed is a browser instruction that did not take effect.
+	BrowserActionFailed = register(4405, "BrowserActionFailed", Entry{
+		Summary: "a browser action could not be carried out",
+		Detail:  "A `cdp:` action failed against the page: a selector matching nothing, a click that never landed, a download the browser would not begin. The browser was running and reachable — this is about the page rather than the connection.",
+		Fix:     "Check the selector against the page as it is at that moment. A page still loading is the usual cause, and a `check:` action before the one that fails is how a scenario waits for it.",
+		Since:   execSince,
+	})
+
+	// TerminalModeMismatch is input the program is not set up to receive.
+	TerminalModeMismatch = register(4406, "TerminalModeMismatch", Entry{
+		Summary: "the session sent input the program is not set up to receive",
+		Detail:  "Mouse reporting and bracketed paste are modes a program turns on for itself, and a program that has not turned one on receives the bytes as ordinary keystrokes rather than as the event the session meant. atago refuses instead of sending them, because the result would be a scenario asserting against input the program interpreted as something else entirely.",
+		Fix:     "Wait for the program to enable the mode before sending: an `expect_screen:` on whatever it draws once it is ready is usually enough. A program that never enables it cannot be driven this way.",
+		Since:   execSince,
+	})
+
+	// UnsupportedOnPlatform is a step the running platform cannot perform.
+	UnsupportedOnPlatform = register(4404, "UnsupportedOnPlatform", Entry{
+		Summary: "the step is not supported on this platform",
+		Detail:  "Some steps rest on facilities one platform has and another does not — POSIX signals being the clearest case. atago refuses rather than pretending, because a signal quietly not delivered would leave the scenario asserting against a program that never received it.",
+		Fix:     "Gate the scenario with `skip: {os: ...}` so it runs where the facility exists, or express the same intent with something portable.",
+		Since:   execSince,
+	})
+)
+
+// ATG45xx — the data a step depends on.
+var (
+	// StoreSourceMissing is a capture with nothing behind it.
+	StoreSourceMissing = register(4501, "StoreSourceMissing", Entry{
+		Summary: "a store step has no result to capture from",
+		Detail:  "`store:` captures a value out of the step before it — a command's stdout, a response body, a query's rows — and no such step has run in this scenario yet. The usual cause is a store placed before the step it means to read, or after a step of a different kind.",
+		Fix:     "Move the store step directly after the step whose result it captures.",
+		Since:   execSince,
+	})
+
+	// StoreExtractFailed is a capture that found nothing to store.
+	StoreExtractFailed = register(4502, "StoreExtractFailed", Entry{
+		Summary: "the value to store could not be extracted",
+		Detail:  "The source step ran, and the selector found nothing usable in it: a JSON path matching no value or several, a regexp that did not match, a body that is not the JSON it was read as. atago errors rather than storing an empty value, because an empty value would flow silently into every later step that expands it.",
+		Fix:     "Check the selector against what the step actually produced — `--verbose` prints each step's captured output, which is the quickest way to see it.",
+		Since:   execSince,
+	})
+
+	// PayloadFailed is a request body that could not be built or read.
+	PayloadFailed = register(4503, "PayloadFailed", Entry{
+		Summary: "a request payload could not be built",
+		Detail:  "The step's body could not be encoded or assembled: a JSON value that will not marshal, a multipart form that could not be written, a gRPC message that does not fit the schema the peer reflected. Nothing was sent, so the peer never saw the request.",
+		Fix:     "Check the payload against the shape the peer expects. For gRPC, the reflected schema is what decides, not the local proto files.",
+		Since:   execSince,
+	})
+
+	// VariableUnresolved is an expansion with nothing behind it.
+	VariableUnresolved = register(4505, "VariableUnresolved", Entry{
+		Summary: "a variable the step expands is not defined",
+		Detail:  "The step referenced `${name}` or `${env:NAME}` and neither a stored value nor an environment variable of that name exists at that point. atago refuses rather than expanding to an empty string, which would silently send an empty password or an empty path and fail somewhere far from the cause.",
+		Fix:     "Set the environment variable, or add the `store:` step that defines the name before the step that reads it. `$${...}` writes a literal dollar-brace where no expansion is wanted.",
+		Since:   execSince,
+	})
+
+	// ResponseUnreadable is a peer's answer that could not be decoded.
+	ResponseUnreadable = register(4504, "ResponseUnreadable", Entry{
+		Summary: "the peer answered with something that could not be read",
+		Detail:  "A response arrived and could not be decoded — a body that is not the JSON it claims to be, a row that could not be scanned into a value, a gRPC message that will not unmarshal. The exchange succeeded at the transport level and failed at the content level.",
+		Fix:     "Look at the raw response, which `--verbose` prints. An HTML error page where JSON was expected is the most common version of this, and it usually means the request reached something other than the intended endpoint.",
+		Since:   execSince,
+	})
+)

--- a/internal/diag/codes_exec.go
+++ b/internal/diag/codes_exec.go
@@ -139,7 +139,7 @@ var (
 	// ServiceNotRunning is an operation on a service that is not up.
 	ServiceNotRunning = register(4302, "ServiceNotRunning", Entry{
 		Summary: "a service was addressed while it was not running",
-		Detail:  "A step signalled or otherwise acted on a service that had already exited, or had not been started. A service that ignores a stop signal and outlives its grace period is reported here too, since what follows is the same question: what is that process doing.",
+		Detail:  "A step signaled or otherwise acted on a service that had already exited, or had not been started. A service that ignores a stop signal and outlives its grace period is reported here too, since what follows is the same question: what is that process doing.",
 		Fix:     "Check whether the service exits on its own partway through the scenario, which its captured output usually shows. A service that will not stop on `TERM` may need `KILL`.",
 		Since:   execSince,
 	})

--- a/internal/diag/codes_internal.go
+++ b/internal/diag/codes_internal.go
@@ -1,0 +1,19 @@
+package diag
+
+// ATG5xxx — internal errors, which exit 5. Reaching one of these is a bug in
+// atago, not something a spec can be written around.
+//
+// The family is deliberately blunt. A finer taxonomy would imply the reader can
+// act on the distinction, and they cannot: every one of these means atago got
+// into a state it does not handle, and the useful response is the same in all
+// of them. What matters is that the code is stable enough to search an issue
+// tracker with.
+const internalSince = "v0.21.0"
+
+// InternalError is atago failing in a way no spec can cause.
+var InternalError = register(5001, "InternalError", Entry{
+	Summary: "atago hit a state it does not handle",
+	Detail:  "This is a bug in atago. It means an invariant the code relies on did not hold — a step reaching a runner that cannot serve it, a generated document that could not be produced, a resource that should exist and does not. A spec cannot be at fault: everything a spec can get wrong is refused while loading, with an ATG2xxx code.",
+	Fix:     "Please report it at https://github.com/nao1215/atago/issues with the message, the atago version from `atago version`, and the spec if you can share it. There is no workaround to try first.",
+	Since:   internalSince,
+})

--- a/internal/diag/diag.go
+++ b/internal/diag/diag.go
@@ -63,6 +63,17 @@ func (c Code) Annotate(msg string) string {
 	return c.String() + ": " + msg
 }
 
+// Errorf builds an error whose message carries the code, and is the form used
+// where diagnostics are raised as errors rather than collected as strings. It
+// forwards to [fmt.Errorf], so a `%w` in the format still wraps.
+//
+// Only the site that names the problem carries a code. A wrapper that adds
+// context to someone else's error — "service %q: %w" — leaves the code to the
+// error it wraps, so a message never accumulates two of them.
+func (c Code) Errorf(format string, args ...any) error {
+	return fmt.Errorf(c.String()+": "+format, args...)
+}
+
 // Entry is a code's published documentation.
 type Entry struct {
 	// Code is the diagnostic's identity.

--- a/internal/diag/usage_test.go
+++ b/internal/diag/usage_test.go
@@ -26,10 +26,19 @@ import (
 // the spec errors it prints come from the loader with their codes already
 // attached; it raises only its own configuration diagnostics.
 var familyOf = map[string][]int{
-	"internal/loader":      {2},
-	"internal/cli":         {3},
-	"internal/security":    {6},
-	"internal/runner/http": {6},
+	"internal/loader":         {2},
+	"internal/cli":            {3},
+	"internal/security":       {6},
+	"internal/engine":         {4, 5},
+	"internal/runner/browser": {4, 5},
+	"internal/runner/cmd":     {4, 5},
+	"internal/runner/db":      {4},
+	"internal/runner/grpc":    {4},
+	"internal/runner/http":    {4, 6},
+	"internal/runner/mock":    {4},
+	"internal/runner/ptyrun":  {4, 5},
+	"internal/runner/service": {4, 5},
+	"internal/runner/ssh":     {4},
 }
 
 // TestCodes_AreReferenced is the guard against a code that exists only in the

--- a/internal/engine/conn.go
+++ b/internal/engine/conn.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/spec"
 )
 
@@ -35,10 +36,10 @@ func resolveConn[T io.Closer](
 	}
 	rdef, ok := rc.runners[name]
 	if !ok {
-		return zero, fmt.Errorf("%s references unknown runner %q", stepVerb, name)
+		return zero, diag.InternalError.Errorf("%s references unknown runner %q", stepVerb, name)
 	}
 	if rdef.Type != wantType {
-		return zero, fmt.Errorf("runner %q is not a %s runner (type %q)", name, wantType, rdef.Type)
+		return zero, diag.InternalError.Errorf("runner %q is not a %s runner (type %q)", name, wantType, rdef.Type)
 	}
 	timeoutStr := rdef.Timeout
 	if defaultBounded {
@@ -48,7 +49,7 @@ func resolveConn[T io.Closer](
 	if timeoutStr != "" {
 		d, err := time.ParseDuration(timeoutStr)
 		if err != nil {
-			return zero, fmt.Errorf("runner %q has invalid timeout %q: %w", name, timeoutStr, err)
+			return zero, diag.InternalError.Errorf("runner %q has invalid timeout %q: %w", name, timeoutStr, err)
 		}
 		timeout = d
 	}

--- a/internal/engine/grpc.go
+++ b/internal/engine/grpc.go
@@ -3,9 +3,9 @@ package engine
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"time"
 
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/runner"
 	grpcrunner "github.com/nao1215/atago/internal/runner/grpc"
 	"github.com/nao1215/atago/internal/security"
@@ -25,7 +25,7 @@ func (e *Engine) runGRPC(ctx context.Context, g *spec.GRPC, st *store.Store, rc 
 	if g.JSON != nil {
 		body, err = json.Marshal(g.JSON)
 		if err != nil {
-			return nil, fmt.Errorf("encoding grpc request body: %w", err)
+			return nil, diag.PayloadFailed.Errorf("encoding grpc request body: %w", err)
 		}
 	}
 	return conn.Invoke(ctx, g.Method, g.Header, body)

--- a/internal/engine/http.go
+++ b/internal/engine/http.go
@@ -3,11 +3,11 @@ package engine
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/url"
 	"time"
 
 	"github.com/nao1215/atago/internal/assert"
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/runner"
 	httprunner "github.com/nao1215/atago/internal/runner/http"
 	"github.com/nao1215/atago/internal/spec"
@@ -71,10 +71,10 @@ func resolveHTTPConfig(h *spec.HTTP, st *store.Store, rc runConfig) (httprunner.
 	if h.Runner != "" {
 		r, ok := rc.runners[h.Runner]
 		if !ok {
-			return cfg, fmt.Errorf("http step references unknown runner %q", h.Runner)
+			return cfg, diag.InternalError.Errorf("http step references unknown runner %q", h.Runner)
 		}
 		if r.Type != "http" {
-			return cfg, fmt.Errorf("runner %q is not an http runner (type %q)", h.Runner, r.Type)
+			return cfg, diag.InternalError.Errorf("runner %q is not an http runner (type %q)", h.Runner, r.Type)
 		}
 		cfg.BaseURL = st.Expand(r.BaseURL)
 		runnerTimeout = r.Timeout
@@ -85,7 +85,7 @@ func resolveHTTPConfig(h *spec.HTTP, st *store.Store, rc runConfig) (httprunner.
 	timeoutStr, _ := resolveTimeout("", runnerTimeout, rc.defaultsRunTimeout, rc.suiteTimeout)
 	d, err := time.ParseDuration(timeoutStr)
 	if err != nil {
-		return cfg, fmt.Errorf("runner %q has invalid timeout %q: %w", h.Runner, timeoutStr, err)
+		return cfg, diag.InternalError.Errorf("runner %q has invalid timeout %q: %w", h.Runner, timeoutStr, err)
 	}
 	cfg.Timeout = d
 	return cfg, nil

--- a/internal/engine/pty.go
+++ b/internal/engine/pty.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/nao1215/atago/internal/assert"
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/runner"
 	runnercmd "github.com/nao1215/atago/internal/runner/cmd"
 	"github.com/nao1215/atago/internal/runner/ptyrun"
@@ -151,12 +152,10 @@ func unresolvedRefError(idx int, field, text string, st *store.Store) error {
 	}
 	name := names[0]
 	if envName, isEnv := strings.CutPrefix(name, "env:"); isEnv {
-		return fmt.Errorf(
-			"pty session entry %[1]d (%[2]s) references ${env:%[3]s}, but the environment variable %[3]s is not set; set it or write $${env:%[3]s} for the literal text",
+		return diag.VariableUnresolved.Errorf("pty session entry %[1]d (%[2]s) references ${env:%[3]s}, but the environment variable %[3]s is not set; set it or write $${env:%[3]s} for the literal text",
 			idx, field, envName)
 	}
-	return fmt.Errorf(
-		"pty session entry %[1]d (%[2]s) references ${%[3]s}, but no variable with that name is defined (builtins, matrix vars, store, ready.store, env:); define the variable or write $${%[3]s} for the literal text",
+	return diag.VariableUnresolved.Errorf("pty session entry %[1]d (%[2]s) references ${%[3]s}, but no variable with that name is defined (builtins, matrix vars, store, ready.store, env:); define the variable or write $${%[3]s} for the literal text",
 		idx, field, name)
 }
 

--- a/internal/engine/signal.go
+++ b/internal/engine/signal.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/nao1215/atago/internal/diag"
 	servicerunner "github.com/nao1215/atago/internal/runner/service"
 	"github.com/nao1215/atago/internal/spec"
 	"github.com/nao1215/atago/internal/store"
@@ -22,7 +23,7 @@ func runSignal(sg *spec.Signal, st *store.Store, scenarioServices, suiteServices
 	name := st.Expand(sg.Service)
 	proc := findServiceProc(name, scenarioServices, suiteServices)
 	if proc == nil {
-		return fmt.Errorf("signal step targets unknown service %q (no scenario or suite service with that name is running)", name)
+		return diag.ServiceNotRunning.Errorf("signal step targets unknown service %q (no scenario or suite service with that name is running)", name)
 	}
 	sigName := spec.NormalizeSignalName(sg.Signal)
 	if err := proc.Signal(sigName); err != nil {
@@ -39,7 +40,7 @@ func runSignal(sg *spec.Signal, st *store.Store, scenarioServices, suiteServices
 		}
 	}
 	if !proc.WaitExit(timeout) {
-		return fmt.Errorf("service %q did not exit within %s after SIG%s", name, timeout, sigName)
+		return diag.ServiceNotRunning.Errorf("service %q did not exit within %s after SIG%s", name, timeout, sigName)
 	}
 	return nil
 }

--- a/internal/engine/stepexec.go
+++ b/internal/engine/stepexec.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/nao1215/atago/internal/assert"
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/fixture"
 	"github.com/nao1215/atago/internal/fsdelta"
 	"github.com/nao1215/atago/internal/runner"
@@ -508,7 +509,7 @@ func resolveRunTarget(run *spec.Run, st *store.Store, rc runConfig) (remote bool
 	if run.Runner != "" {
 		rdef, ok := rc.runners[run.Runner]
 		if !ok {
-			return false, fmt.Errorf("run step references unknown runner %q", run.Runner)
+			return false, diag.InternalError.Errorf("run step references unknown runner %q", run.Runner)
 		}
 		switch rdef.Type {
 		case "ssh":
@@ -522,7 +523,7 @@ func resolveRunTarget(run *spec.Run, st *store.Store, rc runConfig) (remote bool
 			}
 			runnerTimeout = rdef.Timeout
 		default:
-			return false, fmt.Errorf("runner %q (type %q) cannot run a command step; use a step matching its type", run.Runner, rdef.Type)
+			return false, diag.InternalError.Errorf("runner %q (type %q) cannot run a command step; use a step matching its type", run.Runner, rdef.Type)
 		}
 	}
 	if !remote {

--- a/internal/engine/store.go
+++ b/internal/engine/store.go
@@ -1,7 +1,6 @@
 package engine
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -10,6 +9,7 @@ import (
 	"github.com/ohler55/ojg/jp"
 	"github.com/ohler55/ojg/oj"
 
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/plural"
 	"github.com/nao1215/atago/internal/runner"
 	"github.com/nao1215/atago/internal/security"
@@ -22,12 +22,12 @@ import (
 func extractValue(sp *spec.Store, current *runner.Result, workdir string) (string, error) {
 	from := sp.From
 	if from == nil {
-		return "", fmt.Errorf("store %q: 'from' is required", sp.Name)
+		return "", diag.InternalError.Errorf("store %q: 'from' is required", sp.Name)
 	}
 	switch {
 	case from.Stdout != nil:
 		if current == nil {
-			return "", fmt.Errorf("store %q: no command has run in this scenario yet", sp.Name)
+			return "", diag.StoreSourceMissing.Errorf("store %q: no command has run in this scenario yet", sp.Name)
 		}
 		return extractStream(from.Stdout, current.Stdout)
 	case from.File != nil:
@@ -47,39 +47,39 @@ func extractValue(sp *spec.Store, current *runner.Result, workdir string) (strin
 		case len(from.File.JSON) > 0:
 			return jsonValue(data, from.File.JSON[0].Path)
 		default:
-			return "", fmt.Errorf("store %q: a file source needs a json or text selector", sp.Name)
+			return "", diag.InternalError.Errorf("store %q: a file source needs a json or text selector", sp.Name)
 		}
 	case from.Body != nil:
 		if current == nil || !current.IsHTTP {
-			return "", fmt.Errorf("store %q: no HTTP request has run in this scenario yet", sp.Name)
+			return "", diag.StoreSourceMissing.Errorf("store %q: no HTTP request has run in this scenario yet", sp.Name)
 		}
 		return extractStream(from.Body, current.Body)
 	case from.Header != "":
 		if current == nil || !current.IsHTTP {
-			return "", fmt.Errorf("store %q: no HTTP request has run in this scenario yet", sp.Name)
+			return "", diag.StoreSourceMissing.Errorf("store %q: no HTTP request has run in this scenario yet", sp.Name)
 		}
 		v := current.Header.Get(from.Header)
 		if v == "" {
-			return "", fmt.Errorf("store %q: response has no %q header", sp.Name, from.Header)
+			return "", diag.StoreExtractFailed.Errorf("store %q: response has no %q header", sp.Name, from.Header)
 		}
 		return v, nil
 	case from.Rows != nil:
 		if current == nil || !current.IsDB {
-			return "", fmt.Errorf("store %q: no query has run in this scenario yet", sp.Name)
+			return "", diag.StoreSourceMissing.Errorf("store %q: no query has run in this scenario yet", sp.Name)
 		}
 		return extractStream(from.Rows, current.RowsJSON)
 	case from.Message != nil:
 		if current == nil || !current.IsGRPC {
-			return "", fmt.Errorf("store %q: no gRPC call has run in this scenario yet", sp.Name)
+			return "", diag.StoreSourceMissing.Errorf("store %q: no gRPC call has run in this scenario yet", sp.Name)
 		}
 		return extractStream(from.Message, current.MessageJSON)
 	case from.Value != nil:
 		if current == nil || !current.IsCDP {
-			return "", fmt.Errorf("store %q: no cdp step has run in this scenario yet", sp.Name)
+			return "", diag.StoreSourceMissing.Errorf("store %q: no cdp step has run in this scenario yet", sp.Name)
 		}
 		return extractStream(from.Value, current.CDPValue)
 	default:
-		return "", fmt.Errorf("store %q: 'from' must set stdout, file, body, header, rows, message, or value", sp.Name)
+		return "", diag.InternalError.Errorf("store %q: 'from' must set stdout, file, body, header, rows, message, or value", sp.Name)
 	}
 }
 
@@ -99,7 +99,7 @@ func extractStream(s *spec.StreamAssert, data []byte) (string, error) {
 		}
 		return out, nil
 	default:
-		return "", fmt.Errorf("a stdout store source needs a json, matches, or trim selector")
+		return "", diag.InternalError.Errorf("a stdout store source needs a json, matches, or trim selector")
 	}
 }
 
@@ -111,7 +111,7 @@ func extractStream(s *spec.StreamAssert, data []byte) (string, error) {
 func parseJSON(data []byte) (v any, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			v, err = nil, errors.New("the parser could not decode it")
+			v, err = nil, diag.StoreExtractFailed.Errorf("the parser could not decode it")
 		}
 	}()
 	return oj.Parse(data)
@@ -121,22 +121,22 @@ func parseJSON(data []byte) (v any, err error) {
 func jsonValue(data []byte, path string) (string, error) {
 	v, err := parseJSON(data)
 	if err != nil {
-		return "", fmt.Errorf("invalid JSON: %w", err)
+		return "", diag.StoreExtractFailed.Errorf("invalid JSON: %w", err)
 	}
 	expr, err := jp.ParseString(path)
 	if err != nil {
-		return "", fmt.Errorf("invalid JSON path %q: %w", path, err)
+		return "", diag.StoreExtractFailed.Errorf("invalid JSON path %q: %w", path, err)
 	}
 	nodes := expr.Get(v)
 	if len(nodes) != 1 {
-		return "", fmt.Errorf("JSON path %q selected %s, want exactly 1", path, plural.Count(len(nodes), "value", "values"))
+		return "", diag.StoreExtractFailed.Errorf("JSON path %q selected %s, want exactly 1", path, plural.Count(len(nodes), "value", "values"))
 	}
 	// Why: a JSON null selects exactly one node whose Go value is nil, and
 	// fmt.Sprint(nil) yields the literal string "<nil>". Storing that would leak
 	// a Go-ism into a user-visible variable and silently mask "the field was
 	// null" as a captured value. Surface it as a clean error instead.
 	if nodes[0] == nil {
-		return "", fmt.Errorf("JSON path %q selected a null value", path)
+		return "", diag.StoreExtractFailed.Errorf("JSON path %q selected a null value", path)
 	}
 	return fmt.Sprint(nodes[0]), nil
 }
@@ -146,11 +146,11 @@ func jsonValue(data []byte, path string) (string, error) {
 func regexValue(data []byte, pattern string) (string, error) {
 	re, err := regexp.Compile(pattern)
 	if err != nil {
-		return "", fmt.Errorf("invalid regexp %q: %w", pattern, err)
+		return "", diag.StoreExtractFailed.Errorf("invalid regexp %q: %w", pattern, err)
 	}
 	m := re.FindSubmatch(data)
 	if m == nil {
-		return "", fmt.Errorf("regexp %q did not match", pattern)
+		return "", diag.StoreExtractFailed.Errorf("regexp %q did not match", pattern)
 	}
 	if len(m) > 1 {
 		return string(m[1]), nil

--- a/internal/engine/suite.go
+++ b/internal/engine/suite.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/nao1215/atago/internal/artifact"
 	"github.com/nao1215/atago/internal/assert"
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/fixture"
 	"github.com/nao1215/atago/internal/runner"
 	mockrunner "github.com/nao1215/atago/internal/runner/mock"
@@ -80,7 +81,7 @@ func (e *Engine) newSuiteRuntime(s *spec.Spec, specDir, fixturesDir string) (*su
 	}
 	dir, err := os.MkdirTemp("", "atago-suite-")
 	if err != nil {
-		return nil, fmt.Errorf("could not create suite dir: %w", err)
+		return nil, diag.SandboxSetupFailed.Errorf("could not create suite dir: %w", err)
 	}
 	rt := &suiteRuntime{
 		dir:      dir,

--- a/internal/runner/browser/browser.go
+++ b/internal/runner/browser/browser.go
@@ -9,7 +9,6 @@ package browser
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -18,6 +17,7 @@ import (
 	"github.com/chromedp/chromedp"
 	"github.com/chromedp/chromedp/kb"
 
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/runner"
 	"github.com/nao1215/atago/internal/security"
 	"github.com/nao1215/atago/internal/spec"
@@ -82,7 +82,7 @@ func Open(cfg Config) (*Runner, error) {
 	if err := chromedp.Run(browserCtx); err != nil {
 		browserStop()
 		allocCancel()
-		return nil, fmt.Errorf("launching headless browser: %w", err)
+		return nil, diag.ConnectFailed.Errorf("launching headless browser: %w", err)
 	}
 	return &Runner{
 		allocCtx:    allocCtx,
@@ -158,7 +158,7 @@ func (r *Runner) Run(ctx context.Context, actions []spec.CDPAction, workdir stri
 		// test may have planted at the target (issue #16), and binds the write to
 		// the workdir so an ancestor swapped for a link cannot redirect it (#430).
 		if err := security.WriteConfinedFile(workdir, s.path, *s.buf); err != nil {
-			return nil, fmt.Errorf("cdp screenshot: writing %q: %w", s.path, err)
+			return nil, diag.StepFileUnusable.Errorf("cdp screenshot: writing %q: %w", s.path, err)
 		}
 	}
 
@@ -241,7 +241,7 @@ func buildTasks(actions []spec.CDPAction, workdir string) (chromedp.Tasks, []cap
 				return nil, nil, nil, err
 			}
 			if _, statErr := os.Stat(file); statErr != nil {
-				return nil, nil, nil, fmt.Errorf("cdp action %d: upload file %q: %w", i, a.Upload.File, statErr)
+				return nil, nil, nil, diag.StepFileUnusable.Errorf("cdp action %d: upload file %q: %w", i, a.Upload.File, statErr)
 			}
 			tasks = append(tasks, chromedp.SetUploadFiles(a.Upload.Selector, []string{file}, chromedp.ByQuery))
 		case a.Download != nil:
@@ -276,11 +276,11 @@ func buildTasks(actions []spec.CDPAction, workdir string) (chromedp.Tasks, []cap
 			tasks = append(tasks, chromedp.Evaluate(a.Eval, j))
 			caps = append(caps, capture{js: j})
 		default:
-			return nil, nil, nil, fmt.Errorf("cdp action %d sets no recognized action", i)
+			return nil, nil, nil, diag.InternalError.Errorf("cdp action %d sets no recognized action", i)
 		}
 	}
 	if len(tasks) == 0 {
-		return nil, nil, nil, errors.New("cdp step has no actions")
+		return nil, nil, nil, diag.InternalError.Errorf("cdp step has no actions")
 	}
 	return tasks, caps, shots, nil
 }
@@ -325,5 +325,5 @@ func resolveKey(name string) (string, error) {
 	if len([]rune(name)) == 1 {
 		return name, nil
 	}
-	return "", fmt.Errorf("unsupported press key %q (use a single character or one of Enter/Tab/Escape/Backspace/Delete/Arrow*/Space)", name)
+	return "", diag.InputNotSupported.Errorf("unsupported press key %q (use a single character or one of Enter/Tab/Escape/Backspace/Delete/Arrow*/Space)", name)
 }

--- a/internal/runner/browser/download.go
+++ b/internal/runner/browser/download.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/chromedp/cdproto/browser"
 	"github.com/chromedp/chromedp"
+	"github.com/nao1215/atago/internal/diag"
 )
 
 // downloadAction returns a chromedp action that captures a click-triggered
@@ -33,18 +34,18 @@ func downloadAction(clickSelector, destDir string, name *string) chromedp.Action
 			WithDownloadPath(destDir).
 			WithEventsEnabled(true).
 			Do(ctx); err != nil {
-			return fmt.Errorf("cdp download: enabling downloads: %w", err)
+			return diag.BrowserActionFailed.Errorf("cdp download: enabling downloads: %w", err)
 		}
 
 		if err := chromedp.Click(clickSelector, chromedp.ByQuery).Do(ctx); err != nil {
-			return fmt.Errorf("cdp download: clicking %q: %w", clickSelector, err)
+			return diag.BrowserActionFailed.Errorf("cdp download: clicking %q: %w", clickSelector, err)
 		}
 
 		var guid string
 		select {
 		case guid = <-done:
 		case <-ctx.Done():
-			return fmt.Errorf("cdp download: timed out waiting for the download to finish: %w", ctx.Err())
+			return diag.StepTimeout.Errorf("cdp download: timed out waiting for the download to finish: %w", ctx.Err())
 		}
 
 		final := downloadFinalName(guid, willBegin)
@@ -52,7 +53,7 @@ func downloadAction(clickSelector, destDir string, name *string) chromedp.Action
 		dst := filepath.Join(destDir, final)
 		if src != dst {
 			if err := os.Rename(src, dst); err != nil {
-				return fmt.Errorf("cdp download: naming the downloaded file: %w", err)
+				return diag.StepFileUnusable.Errorf("cdp download: naming the downloaded file: %w", err)
 			}
 		}
 		*name = final

--- a/internal/runner/cmd/capture.go
+++ b/internal/runner/cmd/capture.go
@@ -1,11 +1,12 @@
 package cmd
 
 import (
-	"errors"
 	"io"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/nao1215/atago/internal/diag"
 )
 
 // captureDrainGrace bounds how long Run waits for a capture pipe to reach EOF
@@ -37,7 +38,7 @@ const earlyEOFMargin = 50 * time.Millisecond
 // os/exec no longer produces for these streams now that atago owns them: the
 // condition and the advice are identical, so captureFailure treats them alike
 // and the message a user sees is unchanged.
-var errDrainDeadline = errors.New("the capture pipe was still open 2s after the command exited")
+var errDrainDeadline = diag.CaptureFailed.Errorf("the capture pipe was still open 2s after the command exited")
 
 // capture owns one of the command's output streams end to end: the pipe handed
 // to the child, the goroutine draining it, and the bytes it collected.

--- a/internal/runner/cmd/cmd.go
+++ b/internal/runner/cmd/cmd.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -18,6 +17,7 @@ import (
 	"time"
 
 	shellwords "github.com/mattn/go-shellwords"
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/runner"
 	"github.com/nao1215/atago/internal/security"
 	"github.com/nao1215/atago/internal/spec"
@@ -86,12 +86,12 @@ func (r *Runner) Run(ctx context.Context, run *spec.Run, workdir string) (*runne
 	// and a child that printed nothing produced the identical observation (#344).
 	stdout, err := newCapture()
 	if err != nil {
-		return nil, fmt.Errorf("failed to execute %q: %w", run.Command, err)
+		return nil, diag.CommandNotStarted.Errorf("failed to execute %q: %w", run.Command, err)
 	}
 	defer stdout.close()
 	stderr, err := newCapture()
 	if err != nil {
-		return nil, fmt.Errorf("failed to execute %q: %w", run.Command, err)
+		return nil, diag.CommandNotStarted.Errorf("failed to execute %q: %w", run.Command, err)
 	}
 	defer stderr.close()
 	cmd.Stdout = stdout.writer()
@@ -110,11 +110,11 @@ func (r *Runner) Run(ctx context.Context, run *spec.Run, workdir string) (*runne
 			return res, nil
 		}
 		if cerr := ctx.Err(); cerr != nil {
-			return nil, fmt.Errorf("run %q canceled: %w", run.Command, cerr)
+			return nil, diag.RunInterrupted.Errorf("run %q canceled: %w", run.Command, cerr)
 		}
 		// Could not start the process at all (not found, permission, ...). Same
 		// message the combined Run() path produced for this case.
-		return nil, fmt.Errorf("failed to execute %q: %w", run.Command, err)
+		return nil, diag.CommandNotStarted.Errorf("failed to execute %q: %w", run.Command, err)
 	}
 	// The child now holds the write ends; drop atago's copies or the read side
 	// never sees EOF at all, and the drains below would never finish.
@@ -201,7 +201,7 @@ func (r *Runner) Run(ctx context.Context, run *spec.Run, workdir string) (*runne
 	// instead of asserting against the killed result (issue #30).
 	if err := ctx.Err(); err != nil {
 		res.ExitCode = -1
-		return res, fmt.Errorf("run %q canceled: %w", run.Command, err)
+		return res, diag.RunInterrupted.Errorf("run %q canceled: %w", run.Command, err)
 	}
 
 	var exitErr *exec.ExitError
@@ -214,7 +214,7 @@ func (r *Runner) Run(ctx context.Context, run *spec.Run, workdir string) (*runne
 		// Could not start the process at all (not found, permission, ...). A
 		// process that DID run and failed only to be captured returned above, so
 		// this message never claims a command that ran never started.
-		return nil, fmt.Errorf("failed to execute %q: %w", run.Command, runErr)
+		return nil, diag.CommandNotStarted.Errorf("failed to execute %q: %w", run.Command, runErr)
 	}
 	return res, nil
 }
@@ -258,7 +258,7 @@ func captureFailure(command string, exitCode int, err error) error {
 	if errors.Is(err, exec.ErrWaitDelay) || errors.Is(err, errDrainDeadline) {
 		hint = "; a process it started outlived it and kept the pipes open — declare a long-running program with a `service:` step instead of backgrounding it inside a run step"
 	}
-	return fmt.Errorf("run %q exited with code %d but its output could not be captured: %w%s", command, exitCode, err, hint)
+	return diag.CaptureFailed.Errorf("run %q exited with code %d but its output could not be captured: %w%s", command, exitCode, err, hint)
 }
 
 // stdinReader builds the reader fed to the command's standard input (#18):
@@ -277,14 +277,14 @@ func stdinReader(run *spec.Run, workdir string) (io.Reader, error) {
 		}
 		data, err := os.ReadFile(abs) //nolint:gosec // confined to the scenario workdir above
 		if err != nil {
-			return nil, fmt.Errorf("run.stdin.file: %w", err)
+			return nil, diag.SandboxSetupFailed.Errorf("run.stdin.file: %w", err)
 		}
 		return bytes.NewReader(data), nil
 	case s.Base64 != "":
 		data, err := base64.StdEncoding.DecodeString(s.Base64)
 		if err != nil {
 			// Unreachable for loader-validated specs; kept for direct API users.
-			return nil, fmt.Errorf("run.stdin.base64: %w", err)
+			return nil, diag.SandboxSetupFailed.Errorf("run.stdin.base64: %w", err)
 		}
 		return bytes.NewReader(data), nil
 	case s.Inline != "":
@@ -334,10 +334,10 @@ func CommandLine(command string, shell bool) (string, []string, error) {
 	}
 	fields, err := splitArgv(command)
 	if err != nil {
-		return "", nil, fmt.Errorf("cannot parse command %q: %w", command, err)
+		return "", nil, diag.CommandUnparsable.Errorf("cannot parse command %q: %w", command, err)
 	}
 	if len(fields) == 0 {
-		return "", nil, fmt.Errorf("empty command")
+		return "", nil, diag.CommandUnparsable.Errorf("empty command")
 	}
 	return fields[0], fields[1:], nil
 }
@@ -401,10 +401,10 @@ func windowsFields(command string) ([]string, error) {
 		}
 	}
 	if inDouble {
-		return nil, fmt.Errorf("unclosed double quote")
+		return nil, diag.CommandUnparsable.Errorf("unclosed double quote")
 	}
 	if inSingle {
-		return nil, fmt.Errorf("unclosed single quote")
+		return nil, diag.CommandUnparsable.Errorf("unclosed single quote")
 	}
 	if started {
 		fields = append(fields, cur.String())
@@ -448,7 +448,7 @@ func parseTimeout(s string) (time.Duration, error) {
 	}
 	d, err := time.ParseDuration(s)
 	if err != nil {
-		return 0, fmt.Errorf("invalid timeout %q: %w", s, err)
+		return 0, diag.InternalError.Errorf("invalid timeout %q: %w", s, err)
 	}
 	return d, nil
 }

--- a/internal/runner/cmd/sandbox.go
+++ b/internal/runner/cmd/sandbox.go
@@ -1,11 +1,12 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/nao1215/atago/internal/diag"
 )
 
 // SandboxHomeDirName is the fixed directory created inside the scenario workdir
@@ -71,7 +72,7 @@ func EnsureSandboxHome(workdir string) (map[string]string, error) {
 	vars, dirs := SandboxHomeVars(runtime.GOOS, home)
 	for _, d := range dirs {
 		if err := os.MkdirAll(d, 0o755); err != nil { //nolint:gosec // the sandbox home lives inside the scenario workdir
-			return nil, fmt.Errorf("sandbox_home: %w", err)
+			return nil, diag.SandboxSetupFailed.Errorf("sandbox_home: %w", err)
 		}
 	}
 	return vars, nil

--- a/internal/runner/db/db.go
+++ b/internal/runner/db/db.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/runner"
 
 	_ "github.com/go-sql-driver/mysql" // mysql driver (pure Go)
@@ -39,7 +40,7 @@ type Config struct {
 // driver.
 func Resolve(driver, dsn string) (Config, error) {
 	if strings.TrimSpace(dsn) == "" {
-		return Config{}, fmt.Errorf("db runner requires a dsn")
+		return Config{}, diag.RunnerConfigIncomplete.Errorf("db runner requires a dsn")
 	}
 	drv, err := resolveDriver(driver, dsn)
 	if err != nil {
@@ -63,7 +64,7 @@ type Runner struct {
 func Open(cfg Config) (*Runner, error) {
 	db, err := sql.Open(cfg.Driver, cfg.DataSource)
 	if err != nil {
-		return nil, fmt.Errorf("opening %s database: %w", cfg.Driver, err)
+		return nil, diag.ConnectFailed.Errorf("opening %s database: %w", cfg.Driver, err)
 	}
 	// A scenario runs its queries sequentially against its own pool, so a single
 	// connection is sufficient — and it is required for correctness with an
@@ -90,7 +91,7 @@ func (r *Runner) Query(ctx context.Context, query string) (*runner.Result, error
 	if isRowReturning(query) {
 		rows, err := r.db.QueryContext(ctx, query)
 		if err != nil {
-			return nil, fmt.Errorf("query failed: %w", err)
+			return nil, diag.RemoteRejected.Errorf("query failed: %w", err)
 		}
 		defer func() { _ = rows.Close() }()
 		data, err := rowsToJSON(rows)
@@ -98,14 +99,14 @@ func (r *Runner) Query(ctx context.Context, query string) (*runner.Result, error
 			return nil, err
 		}
 		if err := rows.Err(); err != nil {
-			return nil, fmt.Errorf("reading rows: %w", err)
+			return nil, diag.ResponseUnreadable.Errorf("reading rows: %w", err)
 		}
 		return &runner.Result{Command: query, IsDB: true, RowsJSON: data, Duration: time.Since(start)}, nil
 	}
 
 	res, err := r.db.ExecContext(ctx, query)
 	if err != nil {
-		return nil, fmt.Errorf("exec failed: %w", err)
+		return nil, diag.CommandNotStarted.Errorf("exec failed: %w", err)
 	}
 	affected, _ := res.RowsAffected() // not all drivers report it; best effort
 	return &runner.Result{Command: query, IsDB: true, RowsJSON: []byte("[]"), RowsAffected: affected, Duration: time.Since(start)}, nil
@@ -117,7 +118,7 @@ func (r *Runner) Query(ctx context.Context, query string) (*runner.Result, error
 func rowsToJSON(rows *sql.Rows) ([]byte, error) {
 	cols, err := rows.Columns()
 	if err != nil {
-		return nil, fmt.Errorf("reading columns: %w", err)
+		return nil, diag.ResponseUnreadable.Errorf("reading columns: %w", err)
 	}
 	out := make([]map[string]any, 0)
 	for rows.Next() {
@@ -127,7 +128,7 @@ func rowsToJSON(rows *sql.Rows) ([]byte, error) {
 			ptrs[i] = &vals[i]
 		}
 		if err := rows.Scan(ptrs...); err != nil {
-			return nil, fmt.Errorf("scanning row: %w", err)
+			return nil, diag.ResponseUnreadable.Errorf("scanning row: %w", err)
 		}
 		m := make(map[string]any, len(cols))
 		for i, c := range cols {
@@ -307,13 +308,13 @@ func resolveDriver(driver, dsn string) (string, error) {
 	if strings.TrimSpace(driver) == "" {
 		drv := driverForScheme(schemeOf(dsn))
 		if drv == "" {
-			return "", fmt.Errorf("cannot infer db driver from dsn %q; set runner.driver to sqlite, postgres, or mysql", dsn)
+			return "", diag.BadEndpoint.Errorf("cannot infer db driver from dsn %q; set runner.driver to sqlite, postgres, or mysql", dsn)
 		}
 		return drv, nil
 	}
 	drv := canonicalDriver(driver)
 	if drv == "" {
-		return "", fmt.Errorf("unsupported runner.driver %q; use sqlite, postgres, or mysql (aliases: sqlite3, postgresql, pgx)", driver)
+		return "", diag.BadEndpoint.Errorf("unsupported runner.driver %q; use sqlite, postgres, or mysql (aliases: sqlite3, postgresql, pgx)", driver)
 	}
 	return drv, nil
 }
@@ -327,7 +328,7 @@ func ValidateDriver(driver string) error {
 		return nil
 	}
 	if canonicalDriver(driver) == "" {
-		return fmt.Errorf("unsupported runner.driver %q; use sqlite, postgres, or mysql (aliases: sqlite3, postgresql, pgx)", driver)
+		return diag.BadEndpoint.Errorf("unsupported runner.driver %q; use sqlite, postgres, or mysql (aliases: sqlite3, postgresql, pgx)", driver)
 	}
 	return nil
 }
@@ -392,7 +393,7 @@ func dataSource(driver, dsn string) (string, error) {
 func mysqlNativeDSN(raw string) (string, error) {
 	u, err := url.Parse(raw)
 	if err != nil {
-		return "", fmt.Errorf("invalid mysql dsn %q: %w", raw, err)
+		return "", diag.BadEndpoint.Errorf("invalid mysql dsn %q: %w", raw, err)
 	}
 	var b strings.Builder
 	if u.User != nil {

--- a/internal/runner/grpc/grpc.go
+++ b/internal/runner/grpc/grpc.go
@@ -9,7 +9,6 @@ package grpc
 import (
 	"context"
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -25,6 +24,7 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/dynamicpb"
 
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/runner"
 )
 
@@ -48,7 +48,7 @@ type Runner struct {
 // dial until the first call).
 func Open(cfg Config) (*Runner, error) {
 	if strings.TrimSpace(cfg.Target) == "" {
-		return nil, errors.New("grpc runner requires a target")
+		return nil, diag.RunnerConfigIncomplete.Errorf("grpc runner requires a target")
 	}
 	var creds credentials.TransportCredentials
 	if cfg.TLS {
@@ -58,7 +58,7 @@ func Open(cfg Config) (*Runner, error) {
 	}
 	cc, err := grpc.NewClient(cfg.Target, grpc.WithTransportCredentials(creds))
 	if err != nil {
-		return nil, fmt.Errorf("grpc connect %s: %w", cfg.Target, err)
+		return nil, diag.ConnectFailed.Errorf("grpc connect %s: %w", cfg.Target, err)
 	}
 	return &Runner{cc: cc, timeout: cfg.Timeout}, nil
 }
@@ -88,7 +88,7 @@ func (r *Runner) Invoke(ctx context.Context, method string, header map[string]st
 	req := dynamicpb.NewMessage(md.Input())
 	if len(reqJSON) > 0 {
 		if err := protojson.Unmarshal(reqJSON, req); err != nil {
-			return nil, fmt.Errorf("encoding grpc request for %s: %w", method, err)
+			return nil, diag.PayloadFailed.Errorf("encoding grpc request for %s: %w", method, err)
 		}
 	}
 	if len(header) > 0 {
@@ -103,7 +103,7 @@ func (r *Runner) Invoke(ctx context.Context, method string, header map[string]st
 	invErr := r.cc.Invoke(ctx, "/"+service+"/"+methodName, req, res)
 	stat, ok := status.FromError(invErr)
 	if !ok {
-		return nil, fmt.Errorf("grpc invoke %s: %w", method, invErr)
+		return nil, diag.RemoteRejected.Errorf("grpc invoke %s: %w", method, invErr)
 	}
 	// OUR per-call deadline (run.timeout) or a cancel firing means the call never
 	// completed: a transport failure, not a captured status. status.FromError
@@ -118,7 +118,7 @@ func (r *Runner) Invoke(ctx context.Context, method string, header map[string]st
 	if stat.Code() == codes.OK {
 		b, err := protojson.MarshalOptions{UseProtoNames: true, EmitUnpopulated: true}.Marshal(res)
 		if err != nil {
-			return nil, fmt.Errorf("encoding grpc response for %s: %w", method, err)
+			return nil, diag.ResponseUnreadable.Errorf("encoding grpc response for %s: %w", method, err)
 		}
 		out.MessageJSON = b
 	} else {
@@ -162,7 +162,7 @@ func (r *Runner) resolveMethod(ctx context.Context, service, method string) (pro
 	defer refClient.Reset()
 	fd, err := refClient.FileContainingSymbol(protoreflect.FullName(service))
 	if err != nil {
-		return nil, fmt.Errorf("resolving grpc service %q via reflection (is server reflection enabled?): %w", service, err)
+		return nil, diag.RemoteRejected.Errorf("resolving grpc service %q via reflection (is server reflection enabled?): %w", service, err)
 	}
 	svcs := fd.Services()
 	for i := 0; i < svcs.Len(); i++ {
@@ -172,14 +172,14 @@ func (r *Runner) resolveMethod(ctx context.Context, service, method string) (pro
 		}
 		md := sd.Methods().ByName(protoreflect.Name(method))
 		if md == nil {
-			return nil, fmt.Errorf("grpc method %q not found in service %q", method, service)
+			return nil, diag.RemoteRejected.Errorf("grpc method %q not found in service %q", method, service)
 		}
 		if md.IsStreamingClient() || md.IsStreamingServer() {
-			return nil, fmt.Errorf("grpc method %q is streaming; only unary calls are supported", method)
+			return nil, diag.RemoteRejected.Errorf("grpc method %q is streaming; only unary calls are supported", method)
 		}
 		return md, nil
 	}
-	return nil, fmt.Errorf("grpc service %q not found in the reflected schema", service)
+	return nil, diag.RemoteRejected.Errorf("grpc service %q not found in the reflected schema", service)
 }
 
 // splitMethod parses "pkg.Service/Method" into its service and method parts. A
@@ -192,7 +192,7 @@ func splitMethod(method string) (string, string, error) {
 	m := strings.TrimPrefix(method, "/")
 	i := strings.IndexByte(m, '/')
 	if i <= 0 || i == len(m)-1 || strings.Contains(m[i+1:], "/") {
-		return "", "", fmt.Errorf("grpc method %q must be in the form pkg.Service/Method", method)
+		return "", "", diag.BadEndpoint.Errorf("grpc method %q must be in the form pkg.Service/Method", method)
 	}
 	return m[:i], m[i+1:], nil
 }

--- a/internal/runner/http/http.go
+++ b/internal/runner/http/http.go
@@ -94,7 +94,7 @@ func (r *Runner) Do(ctx context.Context, h *spec.HTTP) (*runner.Result, error) {
 	method := strings.ToUpper(strings.TrimSpace(h.Method))
 	req, err := http.NewRequestWithContext(ctx, method, target.String(), body)
 	if err != nil {
-		return nil, fmt.Errorf("building %s %s: %w", method, target, err)
+		return nil, diag.BadEndpoint.Errorf("building %s %s: %w", method, target, err)
 	}
 	if contentType != "" {
 		req.Header.Set("Content-Type", contentType)
@@ -125,7 +125,7 @@ func (r *Runner) Do(ctx context.Context, h *spec.HTTP) (*runner.Result, error) {
 				return err
 			}
 			if len(via) >= 10 { // preserve net/http's default hop limit
-				return fmt.Errorf("stopped after 10 redirects")
+				return diag.RemoteRejected.Errorf("stopped after 10 redirects")
 			}
 			return nil
 		}
@@ -136,13 +136,13 @@ func (r *Runner) Do(ctx context.Context, h *spec.HTTP) (*runner.Result, error) {
 	resp, err := client.Do(req)
 	elapsed := time.Since(start)
 	if err != nil {
-		return nil, fmt.Errorf("http %s %s: %w", method, target, err)
+		return nil, diag.ConnectFailed.Errorf("http %s %s: %w", method, target, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("reading response body from %s %s: %w", method, target, err)
+		return nil, diag.ResponseUnreadable.Errorf("reading response body from %s %s: %w", method, target, err)
 	}
 
 	// body_to persists the response for the file/image/pdf assertion targets —
@@ -169,16 +169,16 @@ func (r *Runner) resolveURL(path string) (*url.URL, error) {
 	raw := path
 	if !isAbsURL(path) {
 		if r.baseURL == "" {
-			return nil, fmt.Errorf("http path %q is relative but the runner has no base_url", path)
+			return nil, diag.BadEndpoint.Errorf("http path %q is relative but the runner has no base_url", path)
 		}
 		raw = strings.TrimRight(r.baseURL, "/") + "/" + strings.TrimLeft(path, "/")
 	}
 	u, err := url.Parse(raw)
 	if err != nil {
-		return nil, fmt.Errorf("invalid URL %q: %w", raw, err)
+		return nil, diag.BadEndpoint.Errorf("invalid URL %q: %w", raw, err)
 	}
 	if u.Host == "" {
-		return nil, fmt.Errorf("resolved URL %q has no host", raw)
+		return nil, diag.BadEndpoint.Errorf("resolved URL %q has no host", raw)
 	}
 	return u, nil
 }
@@ -222,7 +222,7 @@ func (r *Runner) encodeBody(h *spec.HTTP) (io.Reader, string, error) {
 		}
 		data, err := os.ReadFile(path) //nolint:gosec // path is confined to the workdir above
 		if err != nil {
-			return nil, "", fmt.Errorf("reading http.body_file %q: %w", h.BodyFile, err)
+			return nil, "", diag.StepFileUnusable.Errorf("reading http.body_file %q: %w", h.BodyFile, err)
 		}
 		return bytes.NewReader(data), detectContentType(data), nil
 	case h.Body != "":
@@ -230,7 +230,7 @@ func (r *Runner) encodeBody(h *spec.HTTP) (io.Reader, string, error) {
 	case h.JSON != nil:
 		b, err := json.Marshal(h.JSON)
 		if err != nil {
-			return nil, "", fmt.Errorf("encoding json body: %w", err)
+			return nil, "", diag.PayloadFailed.Errorf("encoding json body: %w", err)
 		}
 		return bytes.NewReader(b), "application/json", nil
 	default:
@@ -252,7 +252,7 @@ func (r *Runner) encodeMultipart(form map[string]string, files []spec.FilePart) 
 	sort.Strings(keys)
 	for _, k := range keys {
 		if err := w.WriteField(k, form[k]); err != nil {
-			return nil, "", fmt.Errorf("writing form field %q: %w", k, err)
+			return nil, "", diag.PayloadFailed.Errorf("writing form field %q: %w", k, err)
 		}
 	}
 
@@ -263,7 +263,7 @@ func (r *Runner) encodeMultipart(form map[string]string, files []spec.FilePart) 
 		}
 		data, err := os.ReadFile(path) //nolint:gosec // path is confined to the workdir above
 		if err != nil {
-			return nil, "", fmt.Errorf("reading http.files %q: %w", f.Path, err)
+			return nil, "", diag.StepFileUnusable.Errorf("reading http.files %q: %w", f.Path, err)
 		}
 		ct := f.ContentType
 		if ct == "" {
@@ -274,15 +274,15 @@ func (r *Runner) encodeMultipart(form map[string]string, files []spec.FilePart) 
 		hdr["Content-Type"] = []string{ct}
 		part, err := w.CreatePart(hdr)
 		if err != nil {
-			return nil, "", fmt.Errorf("creating multipart part %q: %w", f.Field, err)
+			return nil, "", diag.PayloadFailed.Errorf("creating multipart part %q: %w", f.Field, err)
 		}
 		if _, err := part.Write(data); err != nil {
-			return nil, "", fmt.Errorf("writing multipart part %q: %w", f.Field, err)
+			return nil, "", diag.PayloadFailed.Errorf("writing multipart part %q: %w", f.Field, err)
 		}
 	}
 
 	if err := w.Close(); err != nil {
-		return nil, "", fmt.Errorf("finalizing multipart body: %w", err)
+		return nil, "", diag.PayloadFailed.Errorf("finalizing multipart body: %w", err)
 	}
 	return &buf, w.FormDataContentType(), nil
 }

--- a/internal/runner/mock/mock.go
+++ b/internal/runner/mock/mock.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/security"
 	"github.com/nao1215/atago/internal/spec"
 )
@@ -54,7 +55,7 @@ type Server struct {
 func Start(ctx context.Context, ms *spec.MockServer, specDir string) (*Server, error) {
 	lis, err := (&net.ListenConfig{}).Listen(ctx, "tcp", "127.0.0.1:0")
 	if err != nil {
-		return nil, fmt.Errorf("mock server %q: listen: %w", ms.Name, err)
+		return nil, diag.MockServerFailed.Errorf("mock server %q: listen: %w", ms.Name, err)
 	}
 	s := &Server{name: ms.Name, specDir: specDir, routes: ms.Routes, lis: lis}
 	s.srv = &http.Server{Handler: s, ReadHeaderTimeout: 10 * time.Second}
@@ -166,7 +167,7 @@ func routePayload(rt *spec.MockRoute, specDir string) (body []byte, contentType 
 	case rt.JSON != nil:
 		b, err := json.Marshal(rt.JSON)
 		if err != nil {
-			return nil, "", fmt.Errorf("route %s %s: marshal json: %w", rt.Method, rt.Path, err)
+			return nil, "", diag.MockServerFailed.Errorf("route %s %s: marshal json: %w", rt.Method, rt.Path, err)
 		}
 		return b, "application/json", nil
 	case rt.BodyFile != "":
@@ -176,7 +177,7 @@ func routePayload(rt *spec.MockRoute, specDir string) (body []byte, contentType 
 		}
 		b, err := os.ReadFile(abs) //nolint:gosec // confined to the spec directory above
 		if err != nil {
-			return nil, "", fmt.Errorf("route %s %s: %w", rt.Method, rt.Path, err)
+			return nil, "", diag.MockServerFailed.Errorf("route %s %s: %w", rt.Method, rt.Path, err)
 		}
 		return b, "", nil
 	default:

--- a/internal/runner/ptyrun/decset.go
+++ b/internal/runner/ptyrun/decset.go
@@ -1,8 +1,9 @@
 package ptyrun
 
 import (
-	"fmt"
 	"strconv"
+
+	"github.com/nao1215/atago/internal/diag"
 )
 
 // DEC private modes atago tracks from the program's own output. A terminal
@@ -38,19 +39,17 @@ func checkMouseMode(term *transcriptDrain, command string, idx int) error {
 		term.modeEnabled(decsetMouseAny)
 	switch {
 	case !tracking:
-		return fmt.Errorf(
-			"pty %q: session[%d] sends a mouse event, but the program has not enabled mouse reporting "+
-				"(it never wrote ESC [?1000h, ESC [?1002h, or ESC [?1003h, or turned tracking back off). "+
-				"Programs that only read the keyboard want a key send instead; "+
-				"if this one does enable tracking, wait for it with an expect or expect_screen before clicking",
+		return diag.TerminalModeMismatch.Errorf("pty %q: session[%d] sends a mouse event, but the program has not enabled mouse reporting "+
+			"(it never wrote ESC [?1000h, ESC [?1002h, or ESC [?1003h, or turned tracking back off). "+
+			"Programs that only read the keyboard want a key send instead; "+
+			"if this one does enable tracking, wait for it with an expect or expect_screen before clicking",
 			command, idx)
 	case !term.modeEnabled(decsetMouseSGR):
-		return fmt.Errorf(
-			"pty %q: session[%d] sends a mouse event, but the program tracks the mouse in the legacy X10 "+
-				"encoding (it enabled tracking without ESC [?1006h). atago only sends SGR reports, whose "+
-				"coordinates are decimal and can address the whole screen; the X10 form packs them into "+
-				"single bytes and cannot. Modern TUI toolkits request SGR — please open an issue if you "+
-				"hit a real program that does not",
+		return diag.TerminalModeMismatch.Errorf("pty %q: session[%d] sends a mouse event, but the program tracks the mouse in the legacy X10 "+
+			"encoding (it enabled tracking without ESC [?1006h). atago only sends SGR reports, whose "+
+			"coordinates are decimal and can address the whole screen; the X10 form packs them into "+
+			"single bytes and cannot. Modern TUI toolkits request SGR — please open an issue if you "+
+			"hit a real program that does not",
 			command, idx)
 	}
 	return nil

--- a/internal/runner/ptyrun/exec.go
+++ b/internal/runner/ptyrun/exec.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nao1215/atago/internal/diag"
 	runnercmd "github.com/nao1215/atago/internal/runner/cmd"
 	"github.com/nao1215/atago/internal/spec"
 )
@@ -75,16 +76,16 @@ func runSessionExec(ctx context.Context, e *spec.PTYExec, dir string, env []stri
 	detail := out.String()
 	switch {
 	case errors.Is(runCtx.Err(), context.DeadlineExceeded):
-		return fmt.Errorf("exec %q did not finish within %s%s", e.Command, timeout, execOutputSuffix(detail))
+		return diag.StepTimeout.Errorf("exec %q did not finish within %s%s", e.Command, timeout, execOutputSuffix(detail))
 	case errors.Is(ctx.Err(), context.Canceled):
-		return fmt.Errorf("exec %q was canceled after %s: %w", e.Command, time.Since(start).Round(time.Millisecond), ctx.Err())
+		return diag.StepTimeout.Errorf("exec %q was canceled after %s: %w", e.Command, time.Since(start).Round(time.Millisecond), ctx.Err())
 	}
 	var exitErr *exec.ExitError
 	if errors.As(runErr, &exitErr) {
-		return fmt.Errorf("exec %q exited %d, so the change the session waits for was not made%s",
+		return diag.SessionExecFailed.Errorf("exec %q exited %d, so the change the session waits for was not made%s",
 			e.Command, exitErr.ExitCode(), execOutputSuffix(detail))
 	}
-	return fmt.Errorf("exec %q could not run: %w%s", e.Command, runErr, execOutputSuffix(detail))
+	return diag.CommandNotStarted.Errorf("exec %q could not run: %w%s", e.Command, runErr, execOutputSuffix(detail))
 }
 
 func execOutputSuffix(detail string) string {

--- a/internal/runner/ptyrun/ptyrun_unix.go
+++ b/internal/runner/ptyrun/ptyrun_unix.go
@@ -5,7 +5,6 @@ package ptyrun
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math"
 	"os"
 	"os/exec"
@@ -13,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/runner"
 	runnercmd "github.com/nao1215/atago/internal/runner/cmd"
 	"github.com/nao1215/atago/internal/spec"
@@ -54,7 +54,7 @@ func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runne
 	}
 	master, tty, err := OpenTerminal(rows, cols)
 	if err != nil {
-		return nil, nil, fmt.Errorf("pty: start %q: %w", p.Command, err)
+		return nil, nil, diag.CommandNotStarted.Errorf("pty: start %q: %w", p.Command, err)
 	}
 	// releaseTTY drops atago's own slave handle. It is deferred as a backstop and
 	// called explicitly at the points below, so it has to tolerate both.
@@ -77,7 +77,7 @@ func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runne
 		// for the drain would hang instead of surfacing the start failure.
 		releaseTTY()
 		term.waitDrain(func() { _ = master.Close() }, 0)
-		return nil, nil, fmt.Errorf("pty: start %q: %w", p.Command, err)
+		return nil, nil, diag.CommandNotStarted.Errorf("pty: start %q: %w", p.Command, err)
 	}
 	// atago's slave handle deliberately stays open until the child has been
 	// reaped (driveSession's finish calls releaseTTY). Handing the terminal to
@@ -108,7 +108,7 @@ func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runne
 		// would from a real window change (#379).
 		resize: func(rows, cols int) error {
 			if rows < 1 || cols < 1 || rows > math.MaxUint16 || cols > math.MaxUint16 {
-				return fmt.Errorf("size %dx%d is out of range for a terminal", rows, cols)
+				return diag.PTYFailed.Errorf("size %dx%d is out of range for a terminal", rows, cols)
 			}
 			return setTerminalSize(master, uint16(rows), uint16(cols))
 		},

--- a/internal/runner/ptyrun/ptyrun_windows.go
+++ b/internal/runner/ptyrun/ptyrun_windows.go
@@ -4,11 +4,11 @@ package ptyrun
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	runnercmd "github.com/nao1215/atago/internal/runner/cmd"
 	"os/exec"
 	"strconv"
+
+	"github.com/nao1215/atago/internal/diag"
+	runnercmd "github.com/nao1215/atago/internal/runner/cmd"
 
 	"github.com/nao1215/atago/internal/conpty"
 	"github.com/nao1215/atago/internal/runner"
@@ -23,7 +23,7 @@ import (
 // later — an older host gets one clear execution error (exit 4).
 func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runner.Result, *ExpectFailure, error) {
 	if !conpty.IsAvailable() {
-		return nil, nil, errors.New("pty steps need ConPTY, which requires Windows 10 version 1809 or later (gate the scenario with `skip: {os: windows}` for older hosts)")
+		return nil, nil, diag.UnsupportedOnPlatform.Errorf("pty steps need ConPTY, which requires Windows 10 version 1809 or later (gate the scenario with `skip: {os: windows}` for older hosts)")
 	}
 
 	cmdLine, err := conpty.CommandLine(p.Command, p.Shell != nil && *p.Shell)
@@ -49,7 +49,7 @@ func Run(ctx context.Context, p *spec.PTY, workdir string, env []string) (*runne
 	// from exactly that set.
 	cpty, err := conpty.Start(cmdLine, dir, env, rows, cols)
 	if err != nil {
-		return nil, nil, fmt.Errorf("pty: start %q: %w", p.Command, err)
+		return nil, nil, diag.CommandNotStarted.Errorf("pty: start %q: %w", p.Command, err)
 	}
 
 	pid := cpty.Pid()

--- a/internal/runner/ptyrun/session.go
+++ b/internal/runner/ptyrun/session.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/nao1215/atago/internal/assert"
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/runner"
 	"github.com/nao1215/atago/internal/spec"
 )
@@ -76,7 +77,7 @@ type ptyProcess struct {
 func driveSession(ctx context.Context, p *spec.PTY, proc ptyProcess) (*runner.Result, *ExpectFailure, error) {
 	expects, err := compileSession(p.Session)
 	if err != nil {
-		return nil, nil, fmt.Errorf("pty: invalid expect regexp: %w", err)
+		return nil, nil, diag.InternalError.Errorf("pty: invalid expect regexp: %w", err)
 	}
 
 	budget := sessionTimeout(p)
@@ -181,8 +182,7 @@ func (d *sessionDriver) finish(timedOut bool, code int, ef *ExpectFailure) *sess
 	// alone without racing the exit.
 	rerr := d.term.readError()
 	if rerr != nil {
-		return &sessionOutcome{err: fmt.Errorf(
-			"pty %q: the terminal transcript is incomplete — reading the terminal failed after %d bytes: %w",
+		return &sessionOutcome{err: diag.CaptureFailed.Errorf("pty %q: the terminal transcript is incomplete — reading the terminal failed after %d bytes: %w",
 			d.p.Command, len(tr), rerr)}
 	}
 	screenTextStr, screenCells := renderScreenCells(tr, d.p, d.term.snapshotResizes())
@@ -235,7 +235,7 @@ func (d *sessionDriver) failHard(err error) *sessionOutcome {
 // against a killed terminal — mirroring the cmd runner's cancel/timeout split
 // (#30).
 func (d *sessionDriver) canceled(ctx context.Context) *sessionOutcome {
-	return d.failHard(fmt.Errorf("pty %q canceled: %w", d.p.Command, ctx.Err()))
+	return d.failHard(diag.RunInterrupted.Errorf("pty %q canceled: %w", d.p.Command, ctx.Err()))
 }
 
 // waitExpect polls the transcript past the previous match until re matches,
@@ -388,7 +388,7 @@ func (d *sessionDriver) runExec(ctx context.Context, i int, e *spec.PTYExec) *se
 func (d *sessionDriver) applyResize(i int, r *spec.PTYResize) *sessionOutcome {
 	d.term.markResize(r.Rows, r.Cols)
 	if rerr := d.proc.resize(r.Rows, r.Cols); rerr != nil {
-		return d.failHard(fmt.Errorf("pty %q: session[%d] resize to %dx%d: %w",
+		return d.failHard(diag.PTYFailed.Errorf("pty %q: session[%d] resize to %dx%d: %w",
 			d.p.Command, i, r.Rows, r.Cols, rerr))
 	}
 	return nil
@@ -403,11 +403,10 @@ func (d *sessionDriver) send(i int, s *spec.PTYSend) *sessionOutcome {
 	// line by line, or as "[200~" typed into a prompt — so refuse here,
 	// where the mistake is (#378).
 	if s.Paste != nil && !d.term.modeEnabled(decsetBracketedPaste) {
-		return d.failHard(fmt.Errorf(
-			"pty %q: session[%d] sends a paste, but the program has not enabled bracketed paste "+
-				"(it never wrote ESC [?2004h, or turned the mode back off). "+
-				"Programs that do not distinguish a paste from typing take a plain send instead; "+
-				"if this one does enable the mode, wait for it with an expect or expect_screen before pasting",
+		return d.failHard(diag.TerminalModeMismatch.Errorf("pty %q: session[%d] sends a paste, but the program has not enabled bracketed paste "+
+			"(it never wrote ESC [?2004h, or turned the mode back off). "+
+			"Programs that do not distinguish a paste from typing take a plain send instead; "+
+			"if this one does enable the mode, wait for it with an expect or expect_screen before pasting",
 			d.p.Command, i))
 	}
 	// A mouse event only means something to a program that asked to be
@@ -421,7 +420,7 @@ func (d *sessionDriver) send(i int, s *spec.PTYSend) *sessionOutcome {
 	// in its markers, and keeps the historical rule that an empty
 	// verbatim send transmits EOF (^D).
 	if _, werr := d.term.write(s.Bytes()); werr != nil {
-		return d.failHard(fmt.Errorf("pty: send: %w", werr))
+		return d.failHard(diag.PTYFailed.Errorf("pty: send: %w", werr))
 	}
 	return nil
 }

--- a/internal/runner/ptyrun/terminal_linux.go
+++ b/internal/runner/ptyrun/terminal_linux.go
@@ -1,11 +1,11 @@
 package ptyrun
 
 import (
-	"fmt"
 	"os"
 	"strconv"
 	"syscall"
 
+	"github.com/nao1215/atago/internal/diag"
 	"golang.org/x/sys/unix"
 )
 
@@ -59,14 +59,14 @@ func openTerminalPair() (master, tty *os.File, err error) {
 		index, gerr = unix.IoctlGetInt(fd, unix.TIOCGPTN)
 		return gerr
 	}); ierr != nil {
-		return nil, nil, fmt.Errorf("asking the kernel which terminal /dev/ptmx just handed out: %w", ierr)
+		return nil, nil, diag.PTYFailed.Errorf("asking the kernel which terminal /dev/ptmx just handed out: %w", ierr)
 	}
 	// TIOCSPTLCK with a zero clears the lock the kernel puts on a freshly
 	// allocated slave; until it is cleared, opening the slave fails with EIO.
 	if ierr := ControlFD(master, func(fd int) error {
 		return unix.IoctlSetPointerInt(fd, unix.TIOCSPTLCK, 0)
 	}); ierr != nil {
-		return nil, nil, fmt.Errorf("unlocking terminal /dev/pts/%d: %w", index, ierr)
+		return nil, nil, diag.PTYFailed.Errorf("unlocking terminal /dev/pts/%d: %w", index, ierr)
 	}
 
 	name := "/dev/pts/" + strconv.Itoa(index)

--- a/internal/runner/service/process_unix.go
+++ b/internal/runner/service/process_unix.go
@@ -4,10 +4,11 @@ package service
 
 import (
 	"context"
-	"fmt"
 	"os/exec"
 	"syscall"
 	"time"
+
+	"github.com/nao1215/atago/internal/diag"
 )
 
 // processCmd wraps an *exec.Cmd whose children are placed in their own process
@@ -52,7 +53,7 @@ var namedSignals = map[string]syscall.Signal{
 func (p *processCmd) signalByName(name string) error {
 	sig, ok := namedSignals[name]
 	if !ok {
-		return fmt.Errorf("unknown signal %q (accepted: TERM, INT, HUP, USR1, USR2, KILL)", name)
+		return diag.InputNotSupported.Errorf("unknown signal %q (accepted: TERM, INT, HUP, USR1, USR2, KILL)", name)
 	}
 	return signalGroup(p.cmd, sig)
 }

--- a/internal/runner/service/process_windows.go
+++ b/internal/runner/service/process_windows.go
@@ -4,13 +4,13 @@ package service
 
 import (
 	"context"
-	"errors"
 	"os/exec"
 	"strconv"
 	"sync"
 	"time"
 	"unsafe"
 
+	"github.com/nao1215/atago/internal/diag"
 	"golang.org/x/sys/windows"
 )
 
@@ -121,5 +121,5 @@ func (p *processCmd) killTree() {
 // to deliver. The loader accepts the step everywhere; execution reports a clear
 // error, mirroring the pty runner's contract.
 func (p *processCmd) signalByName(string) error {
-	return errors.New("signal steps are not supported on Windows (POSIX-only; gate the scenario with `skip: {os: windows}`)")
+	return diag.UnsupportedOnPlatform.Errorf("signal steps are not supported on Windows (POSIX-only; gate the scenario with `skip: {os: windows}`)")
 }

--- a/internal/runner/service/service.go
+++ b/internal/runner/service/service.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/runner/cmd"
 	"github.com/nao1215/atago/internal/security"
 	"github.com/nao1215/atago/internal/spec"
@@ -26,7 +27,7 @@ import (
 // errExitedEarly is the readiness failure when the service process exits before
 // its probe (delay/file/port/log) succeeds. Shared so every wait path words it
 // identically; exitedEarly wraps it with how the process ended.
-var errExitedEarly = errors.New("service exited before it became ready")
+var errExitedEarly = diag.ServiceNotReady.Errorf("service exited before it became ready")
 
 // exitedEarly is the error a readiness wait returns when the process is gone. It
 // names the exit status, which is the first thing an author needs: a service that
@@ -107,7 +108,7 @@ func Start(ctx context.Context, svc *spec.Service, workdir string) (*Proc, strin
 	pc.cmd.Stderr = out
 
 	if err := pc.cmd.Start(); err != nil {
-		return nil, "", fmt.Errorf("service %q: failed to start %q: %w", svc.Name, svc.Command, err)
+		return nil, "", diag.CommandNotStarted.Errorf("service %q: failed to start %q: %w", svc.Name, svc.Command, err)
 	}
 	// Tie the process to its teardown mechanism now that it has a pid: a job
 	// object on Windows, a no-op on POSIX (the process group was set at spawn).
@@ -166,11 +167,11 @@ func (p *Proc) Stop() {
 // asserting against nothing.
 func (p *Proc) Signal(name string) error {
 	if p == nil || p.c == nil {
-		return fmt.Errorf("service is not running")
+		return diag.ServiceNotRunning.Errorf("service is not running")
 	}
 	select {
 	case <-p.done:
-		return fmt.Errorf("service %q already exited", p.name)
+		return diag.ServiceNotRunning.Errorf("service %q already exited", p.name)
 	default:
 	}
 	return p.c.signalByName(name)
@@ -201,7 +202,7 @@ func (p *Proc) waitReady(ctx context.Context, r *spec.Ready, workdir string) (st
 	if r.Timeout != "" {
 		d, err := time.ParseDuration(r.Timeout)
 		if err != nil {
-			return "", fmt.Errorf("invalid ready.timeout %q: %w", r.Timeout, err)
+			return "", diag.InternalError.Errorf("invalid ready.timeout %q: %w", r.Timeout, err)
 		}
 		timeout = d
 	}
@@ -210,7 +211,7 @@ func (p *Proc) waitReady(ctx context.Context, r *spec.Ready, workdir string) (st
 	case r.Delay != "":
 		d, err := time.ParseDuration(r.Delay)
 		if err != nil {
-			return "", fmt.Errorf("invalid ready.delay %q: %w", r.Delay, err)
+			return "", diag.InternalError.Errorf("invalid ready.delay %q: %w", r.Delay, err)
 		}
 		// Timeout is the ceiling on any readiness wait (documented on ready), so a
 		// delay longer than the timeout can never be reached — wait only up to the
@@ -231,7 +232,7 @@ func (p *Proc) waitReady(ctx context.Context, r *spec.Ready, workdir string) (st
 			return "", p.exitedEarly()
 		case <-time.After(wait):
 			if cappedByTimeout {
-				return "", fmt.Errorf("timed out after %s waiting for readiness (ready.delay %s exceeds ready.timeout)", timeout, r.Delay)
+				return "", diag.ReadinessTimeout.Errorf("timed out after %s waiting for readiness (ready.delay %s exceeds ready.timeout)", timeout, r.Delay)
 			}
 			// Delay elapsed with the process still running — unless it exited in the
 			// same instant; check once more so a crash at the boundary is not missed.
@@ -254,7 +255,7 @@ func (p *Proc) waitReady(ctx context.Context, r *spec.Ready, workdir string) (st
 		// a slow, misleading failure. Reject a host-less value up front with a
 		// clear message (":9997" for any host, "127.0.0.1:9997" for loopback).
 		if _, _, err := net.SplitHostPort(r.Port); err != nil {
-			return "", fmt.Errorf("invalid ready.port %q (use host:port, e.g. 127.0.0.1:8080 or :8080): %w", r.Port, err)
+			return "", diag.BadEndpoint.Errorf("invalid ready.port %q (use host:port, e.g. 127.0.0.1:8080 or :8080): %w", r.Port, err)
 		}
 		dialer := net.Dialer{Timeout: pollInterval}
 		return "", p.poll(ctx, timeout, func() bool {
@@ -268,7 +269,7 @@ func (p *Proc) waitReady(ctx context.Context, r *spec.Ready, workdir string) (st
 	case r.Log != "":
 		re, err := regexp.Compile(r.Log)
 		if err != nil {
-			return "", fmt.Errorf("invalid ready.log regexp %q: %w", r.Log, err)
+			return "", diag.InternalError.Errorf("invalid ready.log regexp %q: %w", r.Log, err)
 		}
 		// Rescan only when new bytes arrived: the probe polls every 20ms, and
 		// copying + re-matching the whole capture on every idle tick is
@@ -305,7 +306,7 @@ func (p *Proc) waitFile(ctx context.Context, path, store string, timeout time.Du
 	}
 	data, err := os.ReadFile(path) //nolint:gosec // path is the user-declared ready file under the scenario workdir
 	if err != nil {
-		return "", fmt.Errorf("read ready file %q: %w", path, err)
+		return "", diag.StepFileUnusable.Errorf("read ready file %q: %w", path, err)
 	}
 	return strings.TrimSpace(string(data)), nil
 }
@@ -340,7 +341,7 @@ func (p *Proc) poll(ctx context.Context, timeout time.Duration, check func() boo
 			}
 			return p.exitedEarly()
 		case <-deadlineC:
-			return fmt.Errorf("timed out after %s waiting for readiness", timeout)
+			return diag.ReadinessTimeout.Errorf("timed out after %s waiting for readiness", timeout)
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-tick.C:

--- a/internal/runner/ssh/ssh.go
+++ b/internal/runner/ssh/ssh.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/knownhosts"
 
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/runner"
 )
 
@@ -52,7 +53,7 @@ type Runner struct {
 // Open dials the host and authenticates, returning a connected runner.
 func Open(cfg Config) (*Runner, error) {
 	if cfg.User == "" {
-		return nil, errors.New("ssh runner requires a user")
+		return nil, diag.RunnerConfigIncomplete.Errorf("ssh runner requires a user")
 	}
 	auth, err := authMethods(cfg)
 	if err != nil {
@@ -70,7 +71,7 @@ func Open(cfg Config) (*Runner, error) {
 	}
 	client, err := ssh.Dial("tcp", withDefaultPort(cfg.Addr), clientCfg)
 	if err != nil {
-		return nil, fmt.Errorf("ssh dial %s: %w", cfg.Addr, err)
+		return nil, diag.ConnectFailed.Errorf("ssh dial %s: %w", cfg.Addr, err)
 	}
 	return &Runner{client: client, timeout: cfg.Timeout}, nil
 }
@@ -84,7 +85,7 @@ func (r *Runner) Close() error { return r.client.Close() }
 func (r *Runner) Run(ctx context.Context, command string) (*runner.Result, error) {
 	sess, err := r.client.NewSession()
 	if err != nil {
-		return nil, fmt.Errorf("ssh session: %w", err)
+		return nil, diag.ConnectFailed.Errorf("ssh session: %w", err)
 	}
 	defer func() { _ = sess.Close() }()
 
@@ -183,11 +184,11 @@ func authMethods(cfg Config) ([]ssh.AuthMethod, error) {
 	if cfg.KeyFile != "" {
 		key, err := os.ReadFile(cfg.KeyFile)
 		if err != nil {
-			return nil, fmt.Errorf("reading ssh key %q: %w", cfg.KeyFile, err)
+			return nil, diag.StepFileUnusable.Errorf("reading ssh key %q: %w", cfg.KeyFile, err)
 		}
 		signer, err := ssh.ParsePrivateKey(key)
 		if err != nil {
-			return nil, fmt.Errorf("parsing ssh key %q: %w", cfg.KeyFile, err)
+			return nil, diag.StepFileUnusable.Errorf("parsing ssh key %q: %w", cfg.KeyFile, err)
 		}
 		methods = append(methods, ssh.PublicKeys(signer))
 	}
@@ -195,7 +196,7 @@ func authMethods(cfg Config) ([]ssh.AuthMethod, error) {
 		methods = append(methods, ssh.Password(cfg.Password))
 	}
 	if len(methods) == 0 {
-		return nil, errors.New("ssh runner requires a password or key_file")
+		return nil, diag.RunnerConfigIncomplete.Errorf("ssh runner requires a password or key_file")
 	}
 	return methods, nil
 }
@@ -203,13 +204,13 @@ func authMethods(cfg Config) ([]ssh.AuthMethod, error) {
 func hostKeyCallback(knownHosts string, insecure bool) (ssh.HostKeyCallback, error) {
 	if knownHosts == "" {
 		if !insecure {
-			return nil, errors.New("ssh runner requires known_hosts to verify the host key; set insecure_host_key: true to connect without verification (test/lab only)")
+			return nil, diag.RunnerConfigIncomplete.Errorf("ssh runner requires known_hosts to verify the host key; set insecure_host_key: true to connect without verification (test/lab only)")
 		}
 		return ssh.InsecureIgnoreHostKey(), nil //nolint:gosec // opt-in via insecure_host_key: disables checking for test infra
 	}
 	cb, err := knownhosts.New(knownHosts)
 	if err != nil {
-		return nil, fmt.Errorf("reading known_hosts %q: %w", knownHosts, err)
+		return nil, diag.StepFileUnusable.Errorf("reading known_hosts %q: %w", knownHosts, err)
 	}
 	return cb, nil
 }

--- a/test/e2e/atago/error_codes.atago.yaml
+++ b/test/e2e/atago/error_codes.atago.yaml
@@ -875,3 +875,348 @@ scenarios:
       - assert:
           exit_code: 6
           stdout: {contains: "ATG6001"}
+
+  # --- ATG4xxx: execution ---------------------------------------------------
+
+  - name: ATG4001 is a command line that cannot be split into arguments
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+
+            scenarios:
+              - name: a
+                steps:
+                  - run: {command: "echo 'unclosed"}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 4
+          stdout: {contains: "ATG4001"}
+
+  - name: ATG4002 is a program that could not be started
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+
+            scenarios:
+              - name: a
+                steps:
+                  - run: {command: definitely-no-such-binary-xyz}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 4
+          stdout: {contains: "ATG4002"}
+
+  - name: ATG4003 is an environment the step needs that could not be prepared
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+
+            scenarios:
+              - name: a
+                steps:
+                  - run: {command: cat, stdin: {file: never-created.txt}}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 4
+          stdout: {contains: "ATG4003"}
+
+  - name: ATG4004 is a file the step depends on that cannot be read
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+
+            suite:
+              name: x
+              setup:
+                - mock_server: {name: m, routes: [{method: POST, path: /p, status: 200}]}
+            runners: {api: {type: http, base_url: "${m.url}"}}
+            scenarios:
+              - name: a
+                steps:
+                  - http: {runner: api, method: POST, path: /p, body_file: never-created.bin}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 4
+          stdout: {contains: "ATG4004"}
+
+  - name: ATG4005 is a command run beside a terminal session that failed
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+
+            scenarios:
+              - name: a
+                steps:
+                  - pty: {command: cat, timeout: 20s, session: [{exec: {command: "false"}}]}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 4
+          stdout: {contains: "ATG4005"}
+
+  - name: ATG4101 is a step that outlasted its timeout
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+
+            scenarios:
+              - name: a
+                steps:
+                  - pty: {command: cat, timeout: 20s, session: [{exec: {command: "sleep 5", timeout: 300ms}}]}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 4
+          stdout: {contains: "ATG4101"}
+
+  - name: ATG4102 is a service that never became ready
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+
+            scenarios:
+              - name: a
+                services:
+                  - {name: s, command: "sleep 30", ready: {port: "127.0.0.1:59991", timeout: 1s}}
+                steps:
+                  - run: {command: echo}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 4
+          stdout: {contains: "ATG4102"}
+
+  - name: ATG4201 is a peer that could not be reached
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+
+            runners: {api: {type: http, base_url: "http://127.0.0.1:1"}}
+            scenarios:
+              - name: a
+                steps:
+                  - http: {runner: api, method: GET, path: /}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 4
+          stdout: {contains: "ATG4201"}
+
+  - name: ATG4202 is a runner missing what it needs to connect
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+
+            runners: {r: {type: ssh, host: "127.0.0.1:22", user: u, password: p}}
+            scenarios:
+              - name: a
+                steps:
+                  - run: {runner: r, command: echo}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 4
+          stdout: {contains: "ATG4202"}
+
+  - name: ATG4203 is a peer that was reached and refused the request
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+
+            runners: {db: {type: db, dsn: "sqlite://:memory:"}}
+            scenarios:
+              - name: a
+                steps:
+                  - query: {runner: db, sql: "SELECT * FROM no_such_table"}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 4
+          stdout: {contains: "ATG4203"}
+
+  - name: ATG4204 is an address atago cannot make sense of
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+
+            runners: {db: {type: db, dsn: "weird://x"}}
+            scenarios:
+              - name: a
+                steps:
+                  - query: {runner: db, sql: "SELECT 1"}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 4
+          stdout: {contains: "ATG4204"}
+
+  - name: ATG4301 is a service that failed before it became ready
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+
+            scenarios:
+              - name: a
+                services:
+                  - {name: s, command: "true", ready: {port: "127.0.0.1:59992", timeout: 5s}}
+                steps:
+                  - run: {command: echo}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 4
+          stdout: {contains: "ATG4301"}
+
+  - name: ATG4302 is a service addressed after it exited
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+
+            scenarios:
+              - name: a
+                services:
+                  - {name: s, command: "sleep 1", ready: {delay: 100ms}}
+                steps:
+                  - run: {command: "sleep 2"}
+                  - signal: {service: s, signal: TERM}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 4
+          stdout: {contains: "ATG4302"}
+
+  - name: ATG4403 is output that could not be captured
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+
+            scenarios:
+              - name: a
+                steps:
+                  - run: {command: "sleep 4 &", shell: true, timeout: 30s}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 4
+          stdout: {contains: "ATG4403"}
+
+  - name: ATG4406 is input the program is not set up to receive
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+
+            scenarios:
+              - name: a
+                steps:
+                  - pty: {command: cat, timeout: 20s, session: [{send: {mouse: {row: 1, col: 1}}}]}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 4
+          stdout: {contains: "ATG4406"}
+
+  - name: ATG4501 is a store step with no result behind it
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+
+            scenarios:
+              - name: a
+                steps:
+                  - run: {command: echo}
+                  - store: {name: v, from: {body: {trim: true}}}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 4
+          stdout: {contains: "ATG4501"}
+
+  - name: ATG4502 is a store selector that found nothing
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+
+            scenarios:
+              - name: a
+                steps:
+                  - run: {command: echo}
+                  - store: {name: v, from: {stdout: {matches: "no-such-text-anywhere"}}}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 4
+          stdout: {contains: "ATG4502"}
+
+  - name: ATG4505 is a variable the step expands that is not defined
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+
+            scenarios:
+              - name: a
+                steps:
+                  - pty:
+                      command: cat
+                      timeout: 20s
+                      session:
+                        - send: "${env:ATAGO_DEFINITELY_UNSET_XYZ}"
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 4
+          stdout: {contains: "ATG4505"}


### PR DESCRIPTION
## Summary

Exit 4 is raised from around 130 places across the engine and the runners, covering everything that stops a step being carried out — a binary that is not on PATH, a peer that will not answer, a service that never came up, a terminal that could not be driven, a value that could not be stored. Twenty codes cover them, plus one for exit 5.

This is the last family. Phase D of #454.

## Changes

- `internal/diag/codes_exec.go`, `codes_internal.go` — twenty ATG4xxx entries grouped by what the reader has to do about them, and a single ATG5001.
- `internal/diag/diag.go` — `Code.Errorf`, which forwards to `fmt.Errorf` so a `%w` still wraps.
- `internal/engine/`, `internal/runner/` — every site that names a problem raises it under its code.
- `internal/diag/usage_test.go` — the raising packages and the families they may report.
- `test/e2e/atago/error_codes.atago.yaml` — eighteen more scenarios.
- `drift_test.go` — the coverage gate gains a table of codes no spec can reach.

## Design Decisions

Codes group by what the reader does next, and that is what decides how many there are. A refused connection from the HTTP runner and from the database runner are both ATG4201, because in both cases the question is whether the thing being connected to is up. A step that outlasted its timeout and a service that never became ready are separate codes, because one is fixed in `timeout:` and the other in `ready:`. One hundred and thirty sites map to twenty codes; one per site would have produced a reference nobody could read.

Exit 5 gets a single code on purpose. A finer taxonomy would imply the reader can act on the distinction and they cannot — every one of them means atago got into a state it does not handle, and the useful response is to report it. What matters is that the code is stable enough to search an issue tracker with. Several runtime checks that guard against states the loader already refuses are labelled ATG5001 rather than given execution codes, which is what they are: if one fires, the loader's contract was broken.

Only the site that names a problem carries a code. A wrapper that adds context to someone else's error keeps `fmt.Errorf`, so a message never accumulates two codes. The service-readiness wrapper was the one place that did — `service %q not ready: ATG4102: timed out ...` — and it now leaves the code to the error it wraps.

Nine codes cannot be reached from any spec: a signal delivered to atago itself, a port a spec cannot pin, a browser the hermetic suite will not start, a value YAML cannot express. Rather than dropping the gate or the codes, they are listed in a table with a reason each, which a reviewer can disagree with. The gate fails in both directions — an unlisted code with no scenario, and a listed code that some scenario turns out to provoke — so the table shrinks as ways to reach them appear instead of quietly going stale.

## Limitations

`atago explain ATG4201` and the code as a field in the JSON, JUnit, and GitHub Actions reports are #459, which is what makes the codes useful from a terminal and from a dashboard rather than only from the website.
