### PR TITLE
feat(diag): look a code up from the terminal, and carry it in the reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project follows [Semantic Versioning](https://semver.org/).
 ### Added
 
 - Diagnostic codes on spec errors. Every error atago raises while loading a spec now carries a stable, searchable code such as `ATG2201`, added to the message rather than replacing it, so the wording stays free to improve while `ATG2201` keeps meaning the same thing. The first digit is the exit code the run produces, making `ATG2xxx` a refinement of the exit contract rather than a second contract beside it. Assertion failures deliberately carry no code: exit 1 is a spec doing its job.
+- `atago explain ATG2201` prints what a code means without a browser — the same entry the website renders, from the same registry — and suggests a near-miss when the code is not one that exists. The JSON report carries the code as a `code` field on each failure, and a GitHub Actions error annotation puts it in the title where the annotations list shows it, so a dashboard or a CI job can group failures by cause instead of matching on prose.
 - An [error code reference](https://nao1215.github.io/atago/errors/), generated from the registry that defines the codes, listing what each one means, what causes it, and what to change. A code cannot exist without that documentation: registering it is the only way to create one, and registration refuses an entry that omits the explanation or the fix. A committed `doc/errors.md` is drift-guarded against the registry, and a coverage gate fails CI when a published code is not provoked by a scenario in atago's own E2E suite.
 
 ## [0.20.1] - 2026-08-15

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-81 suites · 597 scenarios
+81 suites · 602 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -144,7 +144,7 @@
   - [file not_contains passes when the substring is absent](#scenario-file-not_contains-passes-when-the-substring-is-absent)
   - [not_contains fails when the substring is present](#scenario-not_contains-fails-when-the-substring-is-present)
   - [a shell metacharacter without shell is a load-time error](#scenario-a-shell-metacharacter-without-shell-is-a-load-time-error)
-- [atago self-hosting / every diagnostic code](#atago-self-hosting--every-diagnostic-code) — 75 scenarios
+- [atago self-hosting / every diagnostic code](#atago-self-hosting--every-diagnostic-code) — 80 scenarios
   - [ATG2001 is a spec file that cannot be read](#scenario-atg2001-is-a-spec-file-that-cannot-be-read)
   - [ATG2002 is a spec file with no YAML document in it](#scenario-atg2002-is-a-spec-file-with-no-yaml-document-in-it)
   - [ATG2003 is a document that is not valid YAML](#scenario-atg2003-is-a-document-that-is-not-valid-yaml)
@@ -220,6 +220,11 @@
   - [ATG4501 is a store step with no result behind it](#scenario-atg4501-is-a-store-step-with-no-result-behind-it)
   - [ATG4502 is a store selector that found nothing](#scenario-atg4502-is-a-store-selector-that-found-nothing)
   - [ATG4505 is a variable the step expands that is not defined](#scenario-atg4505-is-a-variable-the-step-expands-that-is-not-defined)
+  - [atago explain prints what a code means, offline](#scenario-atago-explain-prints-what-a-code-means-offline)
+  - [atago explain refuses a code nobody assigned, and suggests one](#scenario-atago-explain-refuses-a-code-nobody-assigned-and-suggests-one)
+  - [the JSON report carries the code as a field](#scenario-the-json-report-carries-the-code-as-a-field)
+  - [an assertion failure carries no code in the JSON report](#scenario-an-assertion-failure-carries-no-code-in-the-json-report)
+  - [a wrapped error reports one code, not two](#scenario-a-wrapped-error-reports-one-code-not-two)
 - [atago self-hosting / exit_code in-set matcher](#atago-self-hosting--exit_code-in-set-matcher) — 4 scenarios
   - [a listed exit code passes](#scenario-a-listed-exit-code-passes)
   - [an unlisted exit code fails and the output lists the set](#scenario-an-unlisted-exit-code-fails-and-the-output-lists-the-set)
@@ -4772,6 +4777,86 @@ ${atago} run bad.atago.yaml
 #### Then
 - exit code is `4`
 - stdout contains `ATG4505`
+### Scenario: atago explain prints what a code means, offline
+#### When
+```shell
+${atago} explain ATG2201
+```
+#### Then
+- exit code is `0`
+- stdout contains `ATG2201`, `a required key is missing`, `Fix`, `Exits 2.`
+### Scenario: atago explain refuses a code nobody assigned, and suggests one
+#### When
+```shell
+${atago} explain ATG2999
+```
+#### Then
+- exit code is `3`
+- stderr contains `ATG3102`, `unknown diagnostic code`, `did you mean`
+### Scenario: the JSON report carries the code as a field
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps:
+      - run: {command: definitely-no-such-binary-xyz}
+```
+#### When
+```shell
+${atago} run --report json bad.atago.yaml
+```
+#### Then
+- exit code is `4`
+- stdout at `$.suites[0].failures[0].code` equals `ATG4002`
+### Scenario: an assertion failure carries no code in the JSON report
+#### Given
+- Fixture file `fails.atago.yaml` is created.
+#### Inputs
+_Fixture `fails.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    steps:
+      - run: {command: "false"}
+      - assert: {exit_code: 0}
+```
+#### When
+```shell
+${atago} run --report json fails.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout does not contain `"code"`
+### Scenario: a wrapped error reports one code, not two
+_skipped on Windows_
+#### Given
+- Fixture file `bad.atago.yaml` is created.
+#### Inputs
+_Fixture `bad.atago.yaml`:_
+```text
+version: "1"
+suite: {name: x}
+scenarios:
+  - name: a
+    services:
+      - {name: s, command: "sleep 30", ready: {port: "127.0.0.1:59993", timeout: 1s}}
+    steps:
+      - run: {command: echo}
+```
+#### When
+```shell
+${atago} run bad.atago.yaml
+```
+#### Then
+- exit code is `4`
+- stdout contains `ATG4102`, does not contain `ATG4301: service`
 ## atago self-hosting / exit_code in-set matcher
 Source: `test/e2e/atago/exit_code_in.atago.yaml`
 ### Scenario: a listed exit code passes

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -119,7 +119,7 @@ Commands:
   init        Scaffold a starter spec file (--template browser|cli|db|grpc|http|mock|services|ssh)
   record      Generate a spec skeleton from one observed command run (record -- <cmd>)
   list        List suites, scenarios, tags, and generated artifacts (--json)
-  explain     Describe what a spec does without running it
+  explain     Describe what a spec does without running it, or what an ATG code means
   doc         Generate Markdown documentation from specs
   manifest    Emit a stable machine-readable JSON summary of specs
   completion  Generate a shell completion script (bash|zsh|fish|powershell)

--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -5,10 +5,75 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"regexp"
+	"strconv"
+	"strings"
 
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/explain"
 	"github.com/nao1215/atago/internal/loader"
 )
+
+// codeArgRe matches an argument written like a diagnostic code, whether or not
+// any such code is assigned. It decides which of the two things `atago explain`
+// was asked about, so an unassigned number is reported as an unknown code
+// rather than as a missing file.
+var codeArgRe = regexp.MustCompile(`^(?i:atg)[0-9]{4}$`)
+
+// explainCodes reports whether the operands name diagnostic codes rather than
+// spec paths. Mixing the two is refused by returning false, which sends the
+// arguments down the spec path and lets it complain about the code as a file —
+// there is no sensible output for "explain this spec and also this code".
+func explainCodes(operands []string) (string, bool) {
+	if len(operands) != 1 || !codeArgRe.MatchString(strings.TrimSpace(operands[0])) {
+		return "", false
+	}
+	return strings.TrimSpace(operands[0]), true
+}
+
+// explainCode prints one diagnostic's entry from the same registry the website
+// is generated from. It exists so that a code found in a CI log can be looked
+// up where the log is — in a container, over ssh, with no browser.
+func explainCode(arg string, stdout, stderr io.Writer) int {
+	code, ok := diag.Parse(arg)
+	if !ok {
+		msg := fmt.Sprintf("unknown diagnostic code %q", arg)
+		if near, found := nearestCode(arg); found {
+			msg += fmt.Sprintf(" (did you mean %s?)", near)
+		}
+		fmt.Fprintf(stderr, "atago explain: %s\n", diag.BadOptionValue.Annotate(msg))
+		fmt.Fprintln(stderr, "Every code is listed at https://nao1215.github.io/atago/errors/")
+		return ExitConfig
+	}
+	e, _ := diag.Lookup(code)
+	fmt.Fprint(stdout, diag.Text(e))
+	return ExitOK
+}
+
+// nearestCode finds the assigned code closest in number to an unassigned one,
+// so a mistyped digit points somewhere useful instead of nowhere.
+func nearestCode(arg string) (diag.Code, bool) {
+	n, err := strconv.Atoi(strings.TrimSpace(arg)[3:])
+	if err != nil {
+		return 0, false
+	}
+	best, bestDist := diag.Code(0), 0
+	for _, e := range diag.All() {
+		d := int(e.Code) - n
+		if d < 0 {
+			d = -d
+		}
+		// Only within the same family: ATG4999 is a mistyped exec code, and
+		// pointing it at a spec code would be worse than saying nothing.
+		if e.Code.ExitCode() != n/1000 {
+			continue
+		}
+		if best == 0 || d < bestDist {
+			best, bestDist = e.Code, d
+		}
+	}
+	return best, best != 0
+}
 
 // explainCmd implements `atago explain`: describe what one or more
 // specs do without executing them.
@@ -17,6 +82,7 @@ func explainCmd(args []string, stdout, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 	printUsage := func(w io.Writer) {
 		fmt.Fprint(w, "Usage: atago explain <path | dir>...  (directories are searched recursively; default \".\")\n")
+		fmt.Fprint(w, "       atago explain ATG2201            (what a diagnostic code means)\n")
 		fs.SetOutput(w)
 		fs.PrintDefaults()
 	}
@@ -33,6 +99,13 @@ func explainCmd(args []string, stdout, stderr io.Writer) int {
 		reportFlagError("atago explain", err, stderr)
 		printUsage(stderr)
 		return ExitConfig
+	}
+
+	// A diagnostic code where a path would go looks up what the code means.
+	// The two cannot be confused: a spec path never spells ATG followed by four
+	// digits, and a code is never a file on disk.
+	if code, ok := explainCodes(operands); ok {
+		return explainCode(code, stdout, stderr)
 	}
 
 	paths, exitCode, ok := specTargets("atago explain", operands, stderr)

--- a/internal/diag/markdown.go
+++ b/internal/diag/markdown.go
@@ -71,6 +71,41 @@ func Markdown() []byte {
 	return []byte(b.String())
 }
 
+// Text renders one entry the way `atago explain` prints it: the same registry
+// the published page is generated from, so a code cannot mean one thing in a
+// terminal and another in a browser.
+func Text(e Entry) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s  %s\n\n", e.Code, e.Summary)
+	b.WriteString(wrap(e.Detail, 76))
+	b.WriteString("\n\nFix\n")
+	b.WriteString(wrap(e.Fix, 76))
+	fmt.Fprintf(&b, "\n\nExits %d. Since %s.\n", e.Code.ExitCode(), e.Since)
+	fmt.Fprintf(&b, "https://nao1215.github.io/atago/errors/#%s\n", anchor(e))
+	return b.String()
+}
+
+// wrap breaks prose at width for a terminal. The registry stores each field as
+// one paragraph, since that is what Markdown wants; a terminal wants lines.
+func wrap(s string, width int) string {
+	var b strings.Builder
+	col := 0
+	for i, word := range strings.Fields(s) {
+		switch {
+		case i == 0:
+			col = len(word)
+		case col+1+len(word) > width:
+			b.WriteByte('\n')
+			col = len(word)
+		default:
+			b.WriteByte(' ')
+			col += 1 + len(word)
+		}
+		b.WriteString(word)
+	}
+	return b.String()
+}
+
 // entriesOf returns the entries belonging to one exit-code family, in order.
 func entriesOf(all []Entry, exit int) []Entry {
 	var out []Entry

--- a/internal/report/gha.go
+++ b/internal/report/gha.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/engine"
 )
 
@@ -24,8 +25,16 @@ func writeGHA(w io.Writer, results []*engine.SuiteResult, allowXPass bool) error
 				fmt.Fprintf(&b, "::error title=%s::%s\n",
 					ghaEscapeProp(res.Suite+" / "+sc.Name), ghaEscapeData(firstFailureMessage(sc)+" — "+oneLine(detailText(sc))))
 			case engine.StatusError:
+				// The code goes in the title, which is what GitHub renders in the
+				// annotations list; buried in the body it would only be visible to
+				// someone who already opened the annotation.
+				msg := firstErrorMessage(sc)
+				title := res.Suite + " / " + sc.Name
+				if codes := diag.Codes(msg); len(codes) > 0 {
+					title = codes[0].String() + " " + title
+				}
 				fmt.Fprintf(&b, "::error title=%s::%s\n",
-					ghaEscapeProp(res.Suite+" / "+sc.Name), ghaEscapeData(firstErrorMessage(sc)))
+					ghaEscapeProp(title), ghaEscapeData(msg))
 			case engine.StatusFlaky:
 				// Green for the job, loud in the annotations (#29, #138).
 				fmt.Fprintf(&b, "::warning title=%s::%s\n",

--- a/internal/report/json.go
+++ b/internal/report/json.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 
 	"github.com/nao1215/atago/internal/assert"
+	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/engine"
 	"github.com/nao1215/atago/internal/spec"
 )
@@ -72,9 +73,13 @@ type jsonFailure struct {
 	Actual   string `json:"actual,omitempty"`
 	// Diff is the uncolored unified diff for multi-line equals/snapshot
 	// failures (#28) — additive, so schema_version stays "1".
-	Diff      string         `json:"diff,omitempty"`
-	Hint      string         `json:"hint,omitempty"`
-	Error     string         `json:"error,omitempty"`
+	Diff  string `json:"diff,omitempty"`
+	Hint  string `json:"hint,omitempty"`
+	Error string `json:"error,omitempty"`
+	// Code is the diagnostic code carried by Error, when it has one. It lets a
+	// consumer group failures by cause without matching on prose that is free
+	// to be reworded. An assertion failing carries none by design.
+	Code      string         `json:"code,omitempty"`
 	Artifacts []jsonArtifact `json:"artifacts,omitempty"`
 }
 
@@ -197,6 +202,7 @@ func suiteStepFailures(suite string, steps []engine.StepResult) []jsonFailure {
 				Scenario: suite,
 				Step:     stepPhase(step),
 				Error:    step.ErrMsg,
+				Code:     firstCode(step.ErrMsg),
 			})
 		}
 	}
@@ -228,6 +234,7 @@ func teardownFailuresOf(sc *engine.ScenarioResult) []jsonFailure {
 				Scenario: sc.Name,
 				Step:     stepPhase(step),
 				Error:    step.ErrMsg,
+				Code:     firstCode(step.ErrMsg),
 			})
 		}
 	}
@@ -265,6 +272,7 @@ func failuresOf(sc *engine.ScenarioResult) []jsonFailure {
 				Step:     stepPhase(step),
 				Command:  cmd,
 				Error:    step.ErrMsg,
+				Code:     firstCode(step.ErrMsg),
 			})
 		}
 	}
@@ -282,4 +290,15 @@ func jsonExpectFailOf(ef *spec.ExpectFail) *jsonExpectFail {
 		return nil
 	}
 	return &jsonExpectFail{Reason: ef.Reason, Issue: ef.Issue}
+}
+
+// firstCode returns the diagnostic code a message carries, or "" when it has
+// none. Assertion failures deliberately carry none: exit 1 is a spec doing its
+// job, so there is nothing for a consumer to branch on beyond the verdict.
+func firstCode(msg string) string {
+	codes := diag.Codes(msg)
+	if len(codes) == 0 {
+		return ""
+	}
+	return codes[0].String()
 }

--- a/schema/report.schema.json
+++ b/schema/report.schema.json
@@ -105,6 +105,7 @@
         },
         "hint": {"type": "string"},
         "error": {"type": "string"},
+        "code": {"description": "The diagnostic code the error carries (e.g. ATG4201), when it has one. Assertion failures carry none.", "type": "string", "pattern": "^ATG[0-9]{4}$"},
         "artifacts": {
           "description": "Durable sidecar files written for a failed assertion when --artifacts-dir is set (#48); omitted when none.",
           "type": "array",

--- a/test/e2e/atago/error_codes.atago.yaml
+++ b/test/e2e/atago/error_codes.atago.yaml
@@ -1220,3 +1220,94 @@ scenarios:
       - assert:
           exit_code: 4
           stdout: {contains: "ATG4505"}
+
+  # --- looking a code up, and reporting it ----------------------------------
+
+  - name: atago explain prints what a code means, offline
+    steps:
+      - run: {command: "${atago} explain ATG2201"}
+      - assert:
+          exit_code: 0
+          stdout:
+            contains:
+              - "ATG2201"
+              - "a required key is missing"
+              # The entry says what to change, not only what went wrong.
+              - "Fix"
+              - "Exits 2."
+
+  - name: atago explain refuses a code nobody assigned, and suggests one
+    steps:
+      - run: {command: "${atago} explain ATG2999"}
+      - assert:
+          exit_code: 3
+          stderr:
+            contains:
+              - "ATG3102"
+              - "unknown diagnostic code"
+              - "did you mean"
+
+  - name: the JSON report carries the code as a field
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios:
+              - name: a
+                steps:
+                  - run: {command: definitely-no-such-binary-xyz}
+      - run: {command: "${atago} run --report json bad.atago.yaml"}
+      - assert:
+          exit_code: 4
+          stdout:
+            json:
+              - path: "$.suites[0].failures[0].code"
+                equals: "ATG4002"
+
+  - name: an assertion failure carries no code in the JSON report
+    # Exit 1 is a spec doing its job. A code there would invite consumers to
+    # branch on one where they should be reading the diff.
+    steps:
+      - fixture:
+          file: fails.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios:
+              - name: a
+                steps:
+                  - run: {command: "false"}
+                  - assert: {exit_code: 0}
+      - run: {command: "${atago} run --report json fails.atago.yaml"}
+      - assert:
+          exit_code: 1
+          stdout:
+            not_contains: '"code"'
+
+  - name: a wrapped error reports one code, not two
+    # A wrapper that adds context to someone else's error leaves the code to the
+    # error it wraps. The service readiness path is where this went wrong once:
+    # it reported its own code in front of the timeout's, so one failure carried
+    # two codes and neither was the whole answer.
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: bad.atago.yaml
+          content: |
+            version: "1"
+            suite: {name: x}
+            scenarios:
+              - name: a
+                services:
+                  - {name: s, command: "sleep 30", ready: {port: "127.0.0.1:59993", timeout: 1s}}
+                steps:
+                  - run: {command: echo}
+      - run: {command: "${atago} run bad.atago.yaml"}
+      - assert:
+          exit_code: 4
+          stdout:
+            contains: "ATG4102"
+            not_contains: "ATG4301: service"

--- a/website/content/reference.md
+++ b/website/content/reference.md
@@ -12,7 +12,7 @@ description: atago subcommands, scenario selection flags, snapshot updating and 
 | `atago record` | run a command once and write a spec from what it observed (`--pty` for interactive sessions) |
 | `atago init` | scaffold a spec (`--template` for browser, cli, db, grpc, http, mock, services, ssh; `cli` is the default) |
 | `atago snapshot update` | record or refresh golden files |
-| `atago explain` | describe what a spec does without running it |
+| `atago explain` | describe what a spec does without running it, or what an `ATG` code means (`atago explain ATG2201`) |
 | `atago doc` | generate Markdown from specs, with fixtures and golden files inlined |
 | `atago manifest` | emit a stable JSON summary of specs for tooling |
 | `atago list` | show scenarios, tags, and artifacts |
@@ -129,4 +129,4 @@ The report and manifest outputs have schemas too: [report.schema.json](https://g
 
 `Ctrl-C`/`SIGTERM` stops the run cleanly: in-flight processes, services, and sessions are torn down, partial results are reported, and the run exits `4`.
 
-Errors also carry a diagnostic code such as `ATG2201`, whose first digit is the exit code above — so `ATG2xxx` always exits 2. The codes are searchable and stable across rewordings of the message; [Error codes](/errors/) lists what each one means, what to change, and which families carry codes today. Assertion failures carry none: exit 1 is a result, not an error.
+Errors also carry a diagnostic code such as `ATG2201`, whose first digit is the exit code above — so `ATG2xxx` always exits 2. The codes are searchable and stable across rewordings of the message; [Error codes](/errors/) lists what each one means, what to change, and which families carry codes today. Assertion failures carry none: exit 1 is a result, not an error. `atago explain ATG2201` prints the same entry without a browser, and the JSON report carries the code as a `code` field on each failure so a dashboard can group by cause.


### PR DESCRIPTION
## Summary

Codes are only useful where the failure is read, and a CI failure is read in a terminal. `atago explain ATG2201` prints what a code means without a browser, and the JSON report carries the code as a field so a dashboard can group failures by cause. This is the last phase of #454.

Stacked on #463; the diff of interest is the last commit.

## Changes

- `internal/diag/markdown.go` — `Text` renders one entry for a terminal, from the registry the website is generated from.
- `internal/cli/explain.go` — a code where a path would go looks the code up; an unassigned code is refused with the nearest assigned one as a suggestion.
- `internal/report/json.go`, `schema/report.schema.json` — a `code` field on each failure.
- `internal/report/gha.go` — the code goes in the annotation title.
- `test/e2e/atago/error_codes.atago.yaml` — five more scenarios.

## Design Decisions

`explain` takes a code as an operand rather than behind a flag, because `atago explain ATG2201` is what someone types after reading `ATG2201` in a log. The two forms cannot be confused: a spec path never spells `ATG` followed by exactly four digits, and a code is never a file. Mixing paths and a code in one invocation is refused rather than half-handled — there is no sensible output for "explain this spec and also this code".

An unassigned code is an error rather than a shrug, and the suggestion stays inside the same family: `ATG4999` is a mistyped execution code, and pointing it at a spec code would be worse than saying nothing.

`explain` and the website render the same registry, so the terminal and the browser cannot disagree about what a code means — which is the same reason `doc/errors.md` is generated rather than written.

For GitHub Actions the code goes in the annotation title, not the message body. The title is what the annotations list renders; in the body it would only be visible to someone who had already opened the annotation, by which point they can read the message anyway.

Assertion failures carry no code in the reports either, and a scenario asserts that the JSON for a failing spec has no `code` field at all. A code on exit 1 would invite consumers to branch on one where they should be reading the diff.

The last scenario is a regression guard rather than a new code: a wrapped error must report one code, not two. The service readiness path reported its own code in front of the timeout's before #463 fixed it, so one failure carried two codes and neither was the whole answer.
