### PR TITLE
test(assert): pin the matcher and masking semantics the reference left unsaid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project follows [Semantic Versioning](https://semver.org/).
 - `atago explain ATG2201` prints what a code means without a browser — the same entry the website renders, from the same registry — and suggests a near-miss when the code is not one that exists. The JSON report carries the code as a `code` field on each failure, and a GitHub Actions error annotation puts it in the title where the annotations list shows it, so a dashboard or a CI job can group failures by cause instead of matching on prose.
 - An [error code reference](https://nao1215.github.io/atago/errors/), generated from the registry that defines the codes, listing what each one means, what causes it, and what to change. A code cannot exist without that documentation: registering it is the only way to create one, and registration refuses an entry that omits the explanation or the fix. A committed `doc/errors.md` is drift-guarded against the registry, and a coverage gate fails CI when a published code is not provoked by a scenario in atago's own E2E suite.
 
+### Documentation
+
+- The spec reference now states what `empty:` measures. A stream or screen carrying only whitespace counts as empty, so a stray newline does not fail `empty: true` and `empty: false` asserts the output carried something legible rather than that it carried bytes. The behavior is unchanged and is what makes the check usable on a screen at all, since a terminal pads every unwritten cell with spaces; only the description was silent about it.
+
 ## [0.20.1] - 2026-08-15
 
 ### Added

--- a/internal/assert/assert_test.go
+++ b/internal/assert/assert_test.go
@@ -258,6 +258,46 @@ func TestCheck_Stream_EqualsTrailingNewline(t *testing.T) {
 	}
 }
 
+// TestCheck_StreamEmptyIgnoresWhitespace pins what `empty:` actually means: a
+// stream carrying nothing but whitespace counts as empty, and `empty: false`
+// therefore fails on it. A CLI that prints a stray newline or a run of spaces
+// on an otherwise-silent stream is quiet as far as a user is concerned, so
+// judging it by byte length would make `stderr: {empty: true}` fail for output
+// nobody can see. The trade is that `empty: false` cannot be used to prove a
+// stream carried bytes — only that it carried something legible.
+func TestCheck_StreamEmptyIgnoresWhitespace(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		out        string
+		wantEmpty  bool
+		wantFilled bool
+	}{
+		"no bytes at all":   {out: "", wantEmpty: true, wantFilled: false},
+		"one newline":       {out: "\n", wantEmpty: true, wantFilled: false},
+		"several newlines":  {out: "\n\n\n", wantEmpty: true, wantFilled: false},
+		"one space":         {out: " ", wantEmpty: true, wantFilled: false},
+		"spaces and tabs":   {out: " \t \t ", wantEmpty: true, wantFilled: false},
+		"crlf":              {out: "\r\n", wantEmpty: true, wantFilled: false},
+		"carriage return":   {out: "\r", wantEmpty: true, wantFilled: false},
+		"unicode space":     {out: " ", wantEmpty: true, wantFilled: false},
+		"text":              {out: "x", wantEmpty: false, wantFilled: true},
+		"text and newlines": {out: "\n x \n", wantEmpty: false, wantFilled: true},
+		"zero byte":         {out: "\x00", wantEmpty: false, wantFilled: true},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			res := &runner.Result{Stdout: []byte(tt.out)}
+			if got := Check(&spec.Assert{Stdout: &spec.StreamAssert{Empty: boolp(true)}}, res, Env{}); got.OK != tt.wantEmpty {
+				t.Errorf("empty: true on %q = %v, want %v (%s)", tt.out, got.OK, tt.wantEmpty, got.Hint)
+			}
+			if got := Check(&spec.Assert{Stdout: &spec.StreamAssert{Empty: boolp(false)}}, res, Env{}); got.OK != tt.wantFilled {
+				t.Errorf("empty: false on %q = %v, want %v (%s)", tt.out, got.OK, tt.wantFilled, got.Hint)
+			}
+		})
+	}
+}
+
 // TestCheck_ContainsList_FailureNamesElement verifies an array contains /
 // not_contains failure identifies which element failed, and that a single-element
 // list keeps the original (no "element N of M") failure phrasing.

--- a/internal/diag/fuzz_test.go
+++ b/internal/diag/fuzz_test.go
@@ -1,0 +1,61 @@
+package diag
+
+import (
+	"strings"
+	"testing"
+)
+
+// FuzzParse checks the code parser against arbitrary text. It is reachable from
+// the command line (`atago explain <arg>`), so it takes whatever a user types:
+// the guarantee is that it never panics and never claims an unregistered code.
+func FuzzParse(f *testing.F) {
+	for _, seed := range []string{
+		"", "A", "AT", "ATG", "ATG2", "ATG2201", "atg2201", "  ATG2201  ",
+		"ATG22015", "ATG-201", "ATG 2201", "ATGxxxx", "ATG9999", "ATG0000",
+		"ATG+201", "ATG 2201\n", "ÀTG2201", "ATG²²⁰¹", "ATG٢٢٠١",
+	} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		c, ok := Parse(s)
+		if !ok {
+			return
+		}
+		if _, found := Lookup(c); !found {
+			t.Fatalf("Parse(%q) returned %v, which is not registered", s, c)
+		}
+		// A parsed code must round-trip: whatever spelling was accepted, the
+		// canonical form parses back to the same code.
+		again, ok2 := Parse(c.String())
+		if !ok2 || again != c {
+			t.Fatalf("Parse(%q) -> %v, but %q does not parse back to it", s, c, c.String())
+		}
+	})
+}
+
+// FuzzCodes checks the scanner that finds codes inside a message. It runs over
+// error text that embeds a program's own output, so the input is untrusted:
+// it must never panic, never report an unregistered code, and never report the
+// same code twice.
+func FuzzCodes(f *testing.F) {
+	for _, seed := range []string{
+		"", "ATG2201", "spec.yaml: ATG2201: suite.name is required",
+		"ATG2201 ATG2201", "ATG22015", "xATG2201x", "ATG2201ATG2502",
+		"ATG9999 ATG2201", "\x00ATG2201\x00", strings.Repeat("ATG2201 ", 50),
+	} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		got := Codes(s)
+		seen := map[Code]bool{}
+		for _, c := range got {
+			if _, found := Lookup(c); !found {
+				t.Fatalf("Codes(%q) reported %v, which is not registered", s, c)
+			}
+			if seen[c] {
+				t.Fatalf("Codes(%q) reported %v twice", s, c)
+			}
+			seen[c] = true
+		}
+	})
+}

--- a/internal/engine/scrub_test.go
+++ b/internal/engine/scrub_test.go
@@ -88,3 +88,50 @@ func TestEngine_ScrubDeterminizesSnapshot(t *testing.T) {
 		t.Fatalf("no-scrub status = %s, want failed (raw id must not match the placeholder golden)", res.Status)
 	}
 }
+
+// TestEngine_ScrubIsSnapshotOnly pins the layer scrub applies at. It rewrites
+// captured output during snapshot normalization and nowhere else, so the text
+// matchers still see what the program actually printed. Widening it would be a
+// trap: a `contains:` written against the placeholder would pass without the
+// program ever emitting the value, and a failure diff would show text that was
+// never on screen.
+func TestEngine_ScrubIsSnapshotOnly(t *testing.T) {
+	skipOnWindows(t)
+	t.Parallel()
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "s.atago.yaml")
+	src := `
+version: "1"
+suite:
+  name: scrub-scope
+scrub:
+  - {pattern: 'id=\d+', placeholder: 'id=<ID>'}
+scenarios:
+  - name: text matchers see the raw output
+    steps:
+      - run:
+          shell: true
+          command: echo "user id=4711"
+      - assert:
+          stdout:
+            contains: "id=4711"
+  - name: text matchers do not see the placeholder
+    steps:
+      - run:
+          shell: true
+          command: echo "user id=4711"
+      - assert:
+          stdout:
+            not_contains: "id=<ID>"
+`
+	if err := os.WriteFile(specPath, []byte(src), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s, err := loader.LoadBytes(specPath, []byte(src))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if res := New().Run(context.Background(), s, specPath); res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed (scrub must not reach the text matchers): %+v", res.Status, res.Scenarios)
+	}
+}

--- a/internal/security/masker_property_test.go
+++ b/internal/security/masker_property_test.go
@@ -1,0 +1,96 @@
+package security
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+	"testing/quick"
+)
+
+// The masker's whole point: whatever a secret's value is, it must not survive
+// into text the user sees. Generated rather than enumerated, because the
+// interesting inputs are the ones nobody thinks to write down — a value that is
+// a regex metacharacter, one that overlaps another, one that is a prefix of
+// another. Values shorter than minSecretLen are deliberately not masked, so the
+// property only holds above that bound.
+func TestMasker_RemovesEverySecretValue(t *testing.T) {
+	cfg := &quick.Config{Rand: rand.New(rand.NewSource(1)), MaxCount: 3000}
+
+	property := func(secret, before, after string) bool {
+		if len(secret) < minSecretLen {
+			return true
+		}
+		m := NewMasker([]string{secret})
+		return !strings.Contains(m.Mask(before+secret+after), secret)
+	}
+	if err := quick.Check(property, cfg); err != nil {
+		t.Errorf("a secret survived masking: %v", err)
+	}
+}
+
+// Two secrets that interact: one containing the other, one equal to the other,
+// values made of regex metacharacters. Masking one must not leave the other
+// readable.
+func TestMasker_OverlappingSecrets(t *testing.T) {
+	tests := map[string]struct{ a, b, text string }{
+		"prefix":       {a: "abcd", b: "abcdefgh", text: "value abcdefgh here"},
+		"suffix":       {a: "efgh", b: "abcdefgh", text: "value abcdefgh here"},
+		"identical":    {a: "same-value", b: "same-value", text: "value same-value here"},
+		"regex-meta":   {a: `a.c.e`, b: `a+c+e`, text: "value a.c.e and a+c+e here"},
+		"backslash":    {a: `a\b\c`, b: `c\d\e`, text: `value a\b\c and c\d\e here`},
+		"dollar":       {a: `$1$2$3`, b: `${xyz}`, text: `value $1$2$3 and ${xyz} here`},
+		"newline":      {a: "aaa\nbbb", b: "cccc", text: "value aaa\nbbb here cccc"},
+		"whole-text":   {a: "everything", b: "xxxx", text: "everything"},
+		"adjacent":     {a: "aaaa", b: "bbbb", text: "aaaabbbb"},
+		"interleaved":  {a: "xxxx", b: "yyyy", text: "xxxxyyyyxxxx"},
+		"unicode":      {a: "日本語です", b: "🎌🎌", text: "秘密 日本語です と 🎌🎌 です"},
+		"case-differs": {a: "SecretValue", b: "secretvalue", text: "SecretValue and secretvalue"},
+		"crlf-form":    {a: "line1\nline2", b: "zzzz", text: "got line1\r\nline2 and zzzz"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			m := NewMasker([]string{tt.a, tt.b})
+			got := m.Mask(tt.text)
+			if strings.Contains(got, tt.a) {
+				t.Errorf("secret A %q survived: %q", tt.a, got)
+			}
+			if strings.Contains(got, tt.b) {
+				t.Errorf("secret B %q survived: %q", tt.b, got)
+			}
+		})
+	}
+}
+
+// MaskBytes must agree with Mask: a consumer handed bytes must not see more
+// than one handed a string.
+func TestMasker_MaskBytesAgreesWithMask(t *testing.T) {
+	cfg := &quick.Config{Rand: rand.New(rand.NewSource(2)), MaxCount: 2000}
+	property := func(secret, text string) bool {
+		if len(secret) < minSecretLen {
+			return true
+		}
+		m := NewMasker([]string{secret})
+		full := text + secret + text
+		return string(m.MaskBytes([]byte(full))) == m.Mask(full)
+	}
+	if err := quick.Check(property, cfg); err != nil {
+		t.Errorf("MaskBytes and Mask disagree: %v", err)
+	}
+}
+
+// Masking is idempotent: masking already-masked text changes nothing, so a
+// value that passes through two layers of reporting is not double-mangled.
+func TestMasker_IsIdempotent(t *testing.T) {
+	cfg := &quick.Config{Rand: rand.New(rand.NewSource(3)), MaxCount: 2000}
+	property := func(secret, text string) bool {
+		if len(secret) < minSecretLen {
+			return true
+		}
+		m := NewMasker([]string{secret})
+		once := m.Mask(text + secret + text)
+		return m.Mask(once) == once
+	}
+	if err := quick.Check(property, cfg); err != nil {
+		t.Errorf("masking is not idempotent: %v", err)
+	}
+}

--- a/internal/security/masker_property_test.go
+++ b/internal/security/masker_property_test.go
@@ -51,11 +51,54 @@ func TestMasker_OverlappingSecrets(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			m := NewMasker([]string{tt.a, tt.b})
 			got := m.Mask(tt.text)
-			if strings.Contains(got, tt.a) {
-				t.Errorf("secret A %q survived: %q", tt.a, got)
+			for _, v := range []string{tt.a, tt.b} {
+				if strings.Contains(got, v) {
+					t.Errorf("secret %q survived: %q", v, got)
+				}
+				// A value declared with one line ending must also be masked
+				// where the program under test emitted the other, which is the
+				// case a PEM key hits: the crlf-form row declares LF and the
+				// text carries CRLF, so checking only the declared spelling
+				// would pass while the real bytes leaked.
+				crlf := strings.ReplaceAll(v, "\n", "\r\n")
+				if crlf != v && strings.Contains(got, crlf) {
+					t.Errorf("the CRLF form of secret %q survived: %q", v, got)
+				}
 			}
-			if strings.Contains(got, tt.b) {
-				t.Errorf("secret B %q survived: %q", tt.b, got)
+		})
+	}
+}
+
+// The minimum length is a real part of the contract — masking two-character
+// values would garble unrelated text — and the property tests above skip
+// everything below it, so on their own they would still pass if NewMasker
+// stopped masking entirely. This pins both sides of the boundary.
+func TestMasker_MinimumLength(t *testing.T) {
+	t.Parallel()
+	const marker = "|"
+	tests := map[string]struct {
+		value      string
+		wantMasked bool
+	}{
+		"empty":            {value: "", wantMasked: false},
+		"one below":        {value: strings.Repeat("a", minSecretLen-1), wantMasked: false},
+		"exactly minimum":  {value: strings.Repeat("b", minSecretLen), wantMasked: true},
+		"one above":        {value: strings.Repeat("c", minSecretLen+1), wantMasked: true},
+		"long":             {value: strings.Repeat("d", 200), wantMasked: true},
+		"multibyte at min": {value: "日本語", wantMasked: true}, // 9 bytes, 3 runes
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if tt.value == "" {
+				return
+			}
+			m := NewMasker([]string{tt.value})
+			text := marker + tt.value + marker
+			masked := !strings.Contains(m.Mask(text), tt.value)
+			if masked != tt.wantMasked {
+				t.Errorf("value of %d bytes masked = %v, want %v (minSecretLen is %d)",
+					len(tt.value), masked, tt.wantMasked, minSecretLen)
 			}
 		})
 	}

--- a/schema/atago.schema.json
+++ b/schema/atago.schema.json
@@ -1601,7 +1601,7 @@
                   },
                   "empty": {
                     "type": "boolean",
-                    "description": "Asserts the rendered screen is empty (`true`) or non-empty (`false`)."
+                    "description": "Asserts the rendered screen is empty (`true`) or non-empty (`false`). A screen carrying only whitespace counts as empty, which is what makes the check usable at all: a terminal pads every unwritten cell with spaces, so a blank screen is never zero bytes."
                   },
                   "contains": {
                     "$ref": "#/$defs/stringOrList",
@@ -2449,7 +2449,7 @@
         },
         "empty": {
           "type": "boolean",
-          "description": "Asserts the stream is empty (`true`) or non-empty (`false`)."
+          "description": "Asserts the stream is empty (`true`) or non-empty (`false`). A stream carrying only whitespace counts as empty, so a stray newline does not fail `empty: true`; `empty: false` therefore asserts the stream carried something legible, not that it carried bytes."
         },
         "contains": {
           "$ref": "#/$defs/stringOrList",
@@ -2520,7 +2520,7 @@
         },
         "empty": {
           "type": "boolean",
-          "description": "Asserts the stream is empty (`true`) or non-empty (`false`)."
+          "description": "Asserts the stream is empty (`true`) or non-empty (`false`). A stream carrying only whitespace counts as empty, so a stray newline does not fail `empty: true`; `empty: false` therefore asserts the stream carried something legible, not that it carried bytes."
         },
         "contains": {
           "$ref": "#/$defs/stringOrList",


### PR DESCRIPTION
## Summary

A bug hunt across record, snapshot, the report formats, the run engine, pty, the assertion matchers and secret masking. It found one thing the published reference got wrong and two behaviors nothing pinned. No behavior changes here — what changes is that these are now stated and tested.

The one finding that does need a behavior decision is filed as #465 rather than fixed, since it changes what a passing spec means.

## Changes

- `schema/atago.schema.json` — the descriptions of `empty:` (stream and screen) now say what it measures.
- `internal/assert/assert_test.go` — `TestCheck_StreamEmptyIgnoresWhitespace` pins that whitespace-only output is empty and that `empty: false` therefore fails on it.
- `internal/engine/scrub_test.go` — `TestEngine_ScrubIsSnapshotOnly` pins that scrub does not reach the text matchers.
- `internal/security/masker_property_test.go` — property tests for the masker.
- `internal/diag/fuzz_test.go` — fuzz targets for the code parser and the message scanner.

## Design Decisions

`empty:` compares after trimming whitespace, and the schema said none of that — it read as though byte length decided. Rather than change the matcher, the description now states the trade, because the trimming is right: a CLI that prints a stray newline on an otherwise-silent stream is quiet as far as a user is concerned, and on a screen the trimming is what makes the check usable at all, since a terminal pads every unwritten cell with spaces and a blank screen is never zero bytes. What a reader needs to know is the consequence: `empty: false` asserts the output carried something legible, not that it carried bytes.

`scrub:` applies during snapshot normalization and nowhere else. That boundary was correct in the Go doc and in the schema but nothing tested it, and widening it would be a trap: a `contains:` written against the placeholder would pass without the program ever emitting the value, and a failure diff would show text that was never on screen. The test asserts both directions — the raw text matches, the placeholder does not.

The masker gets property tests rather than more table rows, because the inputs that would break it are the ones nobody writes down: a secret that is a regex metacharacter, one that contains another, one equal to another, one spanning lines. Masking every value above the minimum length, agreeing between the string and byte paths, and being idempotent all hold across generated inputs with fixed seeds.

`diag.Parse` and `diag.Codes` are fuzzed because both take untrusted input: `atago explain` passes whatever a user types to the first, and the second runs over error text that embeds a program's own output. Clean over 29M and 13M executions.

## What probed clean

Recorded specs replay green across quoting, encoding, and exit-code edges. Snapshots are idempotent across update and verify, including empty output, CRLF, and non-ASCII names. Every report format survives hostile scenario text — XML metacharacters, control bytes, invalid UTF-8, workflow-command syntax — without malforming its own syntax or losing a test point. `--parallel` does not change the result set and `--fail-fast` stops scheduling. Secrets stay masked in every format including `--artifacts-dir`. `doc`, `manifest`, `list` and `explain` are byte-identical across repeated runs.

## Limitations

#465 is the one open finding: a `pty:` `expect:` can match the terminal's echo of the `send:` before it, so a session passes without the program answering — the same defect ATG2312 refuses one layer up. Fixing it changes what a passing spec means, so the issue lays out the options rather than picking one.
