### PR TITLE
refactor(http): raise the one PolicyError every runner already shares

### DIFF
--- a/internal/engine/http.go
+++ b/internal/engine/http.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"context"
-	"errors"
 	"net/url"
 	"time"
 
@@ -53,11 +52,10 @@ func (e *Engine) runHTTP(ctx context.Context, h *spec.HTTP, st *store.Store, rc 
 	cfg.Workdir = workdir
 	res, err := httprunner.New(cfg).Do(ctx, h)
 	if err != nil {
-		var pe *httprunner.PolicyError
-		if errors.As(err, &pe) {
-			return nil, true, err
-		}
-		return nil, false, err
+		// One detector for every runner: the http runner raises the same
+		// security.PolicyError the grpc and ssh paths do, so isPolicyViolation
+		// is what decides exit 6 for all of them.
+		return nil, isPolicyViolation(err), err
 	}
 	return res, false, nil
 }

--- a/internal/runner/http/http.go
+++ b/internal/runner/http/http.go
@@ -26,18 +26,6 @@ import (
 	"github.com/nao1215/atago/internal/spec"
 )
 
-// PolicyError reports that a request targeted a host the spec's
-// `permissions.network.allow` list does not permit. The engine
-// maps it to exit code 6 (security policy violation).
-type PolicyError struct {
-	Host  string
-	Allow []string
-}
-
-func (e *PolicyError) Error() string {
-	return diag.NetworkPolicyDenied.Annotate(fmt.Sprintf("network policy denies host %q (allowed: %s)", e.Host, strings.Join(e.Allow, ", ")))
-}
-
 // Config is the resolved configuration for an HTTP runner, derived from a named
 // `runners:` entry and the spec's network policy.
 type Config struct {
@@ -183,17 +171,13 @@ func (r *Runner) resolveURL(path string) (*url.URL, error) {
 	return u, nil
 }
 
-// checkPolicy enforces the network allowlist when one is configured.
+// checkPolicy enforces the network allowlist when one is configured. The rule
+// itself lives in security.CheckHost, which the gRPC and SSH runners also call:
+// one allowlist declared in one place has to mean one thing, and two copies of
+// the comparison would be free to drift into disagreeing about what "the same
+// host" is.
 func (r *Runner) checkPolicy(u *url.URL) error {
-	if len(r.allow) == 0 {
-		return nil
-	}
-	for _, a := range r.allow {
-		if a == u.Hostname() || a == u.Host {
-			return nil
-		}
-	}
-	return &PolicyError{Host: u.Hostname(), Allow: r.allow}
+	return security.CheckHost(r.allow, u.Host)
 }
 
 func isAbsURL(p string) bool {

--- a/internal/runner/http/http_test.go
+++ b/internal/runner/http/http_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nao1215/atago/internal/security"
 	"github.com/nao1215/atago/internal/spec"
 )
 
@@ -199,9 +200,9 @@ func TestRunner_Do_NetworkPolicyDenies(t *testing.T) {
 	if err == nil {
 		t.Fatal("Do() error = nil, want PolicyError")
 	}
-	var pe *PolicyError
+	var pe *security.PolicyError
 	if !errors.As(err, &pe) {
-		t.Fatalf("error = %T (%v), want *PolicyError", err, err)
+		t.Fatalf("error = %T (%v), want *security.PolicyError", err, err)
 	}
 }
 
@@ -249,9 +250,9 @@ func TestRunner_Do_RedirectToDeniedHostBlocked(t *testing.T) {
 	if err == nil {
 		t.Fatal("Do() error = nil, want the redirect to a denied host to be blocked")
 	}
-	var pe *PolicyError
+	var pe *security.PolicyError
 	if !errors.As(err, &pe) {
-		t.Fatalf("error = %T (%v), want *PolicyError", err, err)
+		t.Fatalf("error = %T (%v), want *security.PolicyError", err, err)
 	}
 	if reachedDenied {
 		t.Error("the denied host was reached: the network policy was bypassed via redirect")


### PR DESCRIPTION
## Summary

`internal/runner/http` declared its own `PolicyError` with the same two fields and the same `Error()` as the one in `internal/security`, plus its own copy of the allowlist comparison. The gRPC and SSH runners were already using `security.CheckHost` for both. This removes the duplicate.

No behavior change: the comparison `security.CheckHost` performs is the one the http runner performed, on the same `host:port` value, and the message is byte-identical.

## Changes

- `internal/runner/http/http.go` — `PolicyError` deleted; `checkPolicy` delegates to `security.CheckHost`.
- `internal/engine/http.go` — the http result is classified by the `isPolicyViolation` helper the grpc and ssh paths already used.
- `internal/runner/http/http_test.go` — asserts on `*security.PolicyError`.

## Design Decisions

Two copies of one rule is one rule that can drift, and the cost was not hypothetical here: adding the diagnostic code to the message meant patching the identical `Error()` twice, in two packages, in the same change. The allowlist comparison was the more dangerous half — one copy compared against `u.Hostname()` and `u.Host`, the other split `host:port` and compared both parts, and nothing would have caught them disagreeing about what counts as the same host.

The engine had the same duplication one level up: an `errors.As` against the http type in `http.go` and an `isPolicyViolation` helper in `mask.go` doing the same thing for grpc and ssh. One detector now decides exit 6 for every runner, which is what the exit-code contract actually promises.

Net 17 lines removed.
