### PR TITLE
fix(pty): an expect no longer matches the echo of its own send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project follows [Semantic Versioning](https://semver.org/).
 - `atago explain ATG2201` prints what a code means without a browser — the same entry the website renders, from the same registry — and suggests a near-miss when the code is not one that exists. The JSON report carries the code as a `code` field on each failure, and a GitHub Actions error annotation puts it in the title where the annotations list shows it, so a dashboard or a CI job can group failures by cause instead of matching on prose.
 - An [error code reference](https://nao1215.github.io/atago/errors/), generated from the registry that defines the codes, listing what each one means, what causes it, and what to change. A code cannot exist without that documentation: registering it is the only way to create one, and registration refuses an entry that omits the explanation or the fix. A committed `doc/errors.md` is drift-guarded against the registry, and a coverage gate fails CI when a published code is not provoked by a scenario in atago's own E2E suite.
 
+### Bug Fixes
+
+- A `pty:` `expect:` no longer matches the terminal's echo of the `send:` before it. Sending a line and expecting a substring of it is the natural way to drive a prompt, and with ECHO on the typed text appears in the transcript, so the expect matched the keystrokes rather than the program's answer — passing whether the program was listening, busy, or already dead. atago refuses assertions that cannot fail while loading a spec (ATG2312); this was the same defect one layer down. Only a match lying entirely inside the echo is discounted, so a program that prints the input back keeps its own copy and the ordinary shape still works.
+
 ### Documentation
 
 - The spec reference now states what `empty:` measures. A stream or screen carrying only whitespace counts as empty, so a stray newline does not fail `empty: true` and `empty: false` asserts the output carried something legible rather than that it carried bytes. The behavior is unchanged and is what makes the check usable on a screen at all, since a terminal pads every unwritten cell with spaces; only the description was silent about it.

--- a/doc/cookbook.md
+++ b/doc/cookbook.md
@@ -2989,6 +2989,16 @@ in the session waits forever for a second occurrence. The session dies at
 `timeout` (default 30s) with the transcript in the failure, so read what the
 terminal actually showed.
 
+A fourth cause looks like the transcript disagreeing with the failure. An
+`expect` does not match the terminal's echo of the `send:` before it, so
+`send: "yes\n"` followed by `expect: "yes"` waits for the program to say it,
+not for your own keystrokes to appear. The echoed line is in the transcript,
+which is why the failure can look wrong at first glance. This is deliberate: an
+expect that matched its own send would pass whether the program was listening,
+busy, or already dead. Assert on something the program produces — its prompt,
+its answer, its next screen. A program that prints the input back, like a REPL
+echoing a command, keeps its own copy, so that still matches.
+
 ### A `screen:` assert sees a blank screen
 
 Most full-screen TUIs use the alternate screen buffer and restore the primary

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-81 suites · 602 scenarios
+81 suites · 604 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -451,7 +451,7 @@
   - [explain names the manifest that applied](#scenario-explain-names-the-manifest-that-applied)
   - [a manifest pointing at a missing fixtures dir fails to load](#scenario-a-manifest-pointing-at-a-missing-fixtures-dir-fails-to-load)
   - [an unknown manifest key is rejected](#scenario-an-unknown-manifest-key-is-rejected)
-- [atago self-hosting / pty](#atago-self-hosting--pty) — 14 scenarios
+- [atago self-hosting / pty](#atago-self-hosting--pty) — 16 scenarios
   - [a pty step sees a terminal where a run step sees a pipe](#scenario-a-pty-step-sees-a-terminal-where-a-run-step-sees-a-pipe)
   - [a never-matching expect fails with the pattern in the block](#scenario-a-never-matching-expect-fails-with-the-pattern-in-the-block)
   - [named keys transmit their documented bytes and ctrl-c aborts](#scenario-named-keys-transmit-their-documented-bytes-and-ctrl-c-aborts)
@@ -466,6 +466,8 @@
   - [a screen snapshot round-trips through update and compare](#scenario-a-screen-snapshot-round-trips-through-update-and-compare)
   - [a screen assert without a pty step is a load-time error](#scenario-a-screen-assert-without-a-pty-step-is-a-load-time-error)
   - [a send referencing an undefined variable is an execution error, not typed literally](#scenario-a-send-referencing-an-undefined-variable-is-an-execution-error-not-typed-literally)
+  - [an expect does not match the echo of its own send](#scenario-an-expect-does-not-match-the-echo-of-its-own-send)
+  - [a program's own copy of the input still satisfies an expect](#scenario-a-programs-own-copy-of-the-input-still-satisfies-an-expect)
 - [atago self-hosting / pty (portable)](#atago-self-hosting--pty-portable) — 9 scenarios
   - [a pty step starts a command, captures its output, and reports exit 0](#scenario-a-pty-step-starts-a-command-captures-its-output-and-reports-exit-0)
   - [a pty step surfaces a command's non-zero exit code](#scenario-a-pty-step-surfaces-a-commands-non-zero-exit-code)
@@ -9003,6 +9005,42 @@ ${atago} run typo.atago.yaml
 #### Then
 - exit code is `4`
 - stdout contains `no variable with that name is defined`, `$${no_such_var}`
+### Scenario: an expect does not match the echo of its own send
+_skipped on Windows_
+#### Given
+- Fixture file `echo.atago.yaml` is created.
+#### Inputs
+_Fixture `echo.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: echo
+scenarios:
+  - name: the program never produced this
+    steps:
+      - pty:
+          command: "sh -c 'echo ready; exit 0'"
+          timeout: 4s
+          session:
+            - expect: "ready"
+            - send: "NEVER-PRODUCED-BY-THE-PROGRAM\n"
+            - expect: "NEVER-PRODUCED-BY-THE-PROGRAM"
+```
+#### When
+```shell
+${atago} run echo.atago.yaml
+```
+#### Then
+- exit code is `1`
+- stdout contains `pty expect /NEVER-PRODUCED-BY-THE-PROGRAM/`, `never appeared in the terminal transcript`
+### Scenario: a program's own copy of the input still satisfies an expect
+_skipped on Windows_
+#### When
+```shell
+# interactive (pty): cat
+```
+#### Then
+- exit code is `0`
 ## atago self-hosting / pty (portable)
 Source: `test/e2e/atago/pty_portable.atago.yaml`
 ### Scenario: a pty step starts a command, captures its output, and reports exit 0

--- a/internal/runner/ptyrun/session.go
+++ b/internal/runner/ptyrun/session.go
@@ -1,6 +1,7 @@
 package ptyrun
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -151,6 +152,95 @@ type sessionDriver struct {
 	// (any shell prompt) waits for its NEXT occurrence instead of matching the
 	// stale earlier one.
 	matchOffset int
+	// echoes records what each send since the last match transmitted, so an
+	// expect can tell the terminal's echo of its own keystrokes apart from the
+	// program's answer.
+	echoes []echoSpan
+}
+
+// echoSpan is one send's echo: the bytes the terminal would write back, and
+// where in the transcript to start looking for them.
+type echoSpan struct {
+	// searchFrom is the transcript length at the moment of the send, so the
+	// echo is looked for at or after it and an identical earlier line cannot be
+	// mistaken for it.
+	searchFrom int
+	// echo is what the line discipline writes back: the sent bytes with each LF
+	// rendered as CRLF, which is what ONLCR does on the way out.
+	echo []byte
+	// at is where the echo was found, or -1 while it has not been.
+	at int
+}
+
+// echoOf is what a terminal writes back when its line discipline echoes the
+// bytes a send transmitted.
+func echoOf(sent []byte) []byte {
+	return bytes.ReplaceAll(sent, []byte("\n"), []byte("\r\n"))
+}
+
+// locateEchoes resolves where each pending send was echoed, given the
+// transcript so far. A span whose echo has not appeared stays unresolved and is
+// retried on the next poll; one that never appears simply never matches, which
+// is what happens when the mode is off (a password prompt, a raw-mode TUI) or
+// when the terminal renders it differently (ECHOCTL writes a control byte as
+// ^A).
+func (d *sessionDriver) locateEchoes(transcript []byte) {
+	for i := range d.echoes {
+		e := &d.echoes[i]
+		if e.at >= 0 || len(e.echo) == 0 || e.searchFrom > len(transcript) {
+			continue
+		}
+		if k := bytes.Index(transcript[e.searchFrom:], e.echo); k >= 0 {
+			e.at = e.searchFrom + k
+		}
+	}
+}
+
+// isEcho reports whether the transcript range [from,to) lies entirely inside
+// the echo of a send this expect has not yet passed.
+//
+// An expect that matches only its own keystrokes has asserted that atago can
+// type, not that the program answered: it passes whether the program is
+// listening, busy, or already dead. atago refuses assertions that cannot fail
+// while loading a spec (ATG2312), and this is the same defect one layer down,
+// reached by the natural way to drive a prompt — send a line, expect a
+// substring of it. The terminal is not lying, since with ECHO on typed input
+// does appear; it is the assertion that means nothing.
+//
+// Only a match wholly inside the echo is rejected. A program that repeats the
+// input itself keeps its copy: cat both echoes through the line discipline and
+// prints the line, and the printed one falls outside the echo span.
+func (d *sessionDriver) isEcho(from, to int) bool {
+	for _, e := range d.echoes {
+		if e.at < 0 {
+			continue
+		}
+		if from >= e.at && to <= e.at+len(e.echo) {
+			return true
+		}
+	}
+	return false
+}
+
+// findReal returns the first match in tail that is not a send's echo, as an
+// offset pair relative to tail, or nil when there is none yet. base is tail's
+// own offset in the transcript, since the echo spans are absolute.
+func (d *sessionDriver) findReal(re *regexp.Regexp, tail []byte, base int) []int {
+	for at := 0; at <= len(tail); {
+		loc := re.FindIndex(tail[at:])
+		if loc == nil {
+			return nil
+		}
+		from, to := at+loc[0], at+loc[1]
+		if !d.isEcho(base+from, base+to) {
+			return []int{from, to}
+		}
+		// Step past this occurrence and keep looking: the program's own copy
+		// may follow the echo. Advancing by one keeps an empty match from
+		// spinning.
+		at = from + 1
+	}
+	return nil
 }
 
 // finish shapes the session's Result after the child has been reaped.
@@ -245,9 +335,10 @@ func (d *sessionDriver) waitExpect(ctx context.Context, re *regexp.Regexp, patte
 	scannedTo := -1 // transcript length at the last scan; -1 forces one
 	for {
 		if n := d.term.curLen(); n != scannedTo {
+			d.locateEchoes(d.term.snapshot())
 			tail, m := d.term.tailFrom(d.matchOffset)
 			scannedTo = m
-			if loc := re.FindIndex(tail); loc != nil {
+			if loc := d.findReal(re, tail, d.matchOffset); loc != nil {
 				d.matchOffset += loc[1]
 				matched = true
 				break
@@ -257,8 +348,9 @@ func (d *sessionDriver) waitExpect(ctx context.Context, re *regexp.Regexp, patte
 		case <-ctx.Done():
 			// One last check: bytes may have landed in the final poll
 			// window before the deadline fired.
+			d.locateEchoes(d.term.snapshot())
 			tail, _ := d.term.tailFrom(d.matchOffset)
-			if loc := re.FindIndex(tail); loc != nil {
+			if loc := d.findReal(re, tail, d.matchOffset); loc != nil {
 				d.matchOffset += loc[1]
 				matched = true
 			}
@@ -419,9 +511,11 @@ func (d *sessionDriver) send(i int, s *spec.PTYSend) *sessionOutcome {
 	// Bytes resolves named keys to their xterm sequences, wraps a paste
 	// in its markers, and keeps the historical rule that an empty
 	// verbatim send transmits EOF (^D).
-	if _, werr := d.term.write(s.Bytes()); werr != nil {
+	sent := s.Bytes()
+	if _, werr := d.term.write(sent); werr != nil {
 		return d.failHard(diag.PTYFailed.Errorf("pty: send: %w", werr))
 	}
+	d.echoes = append(d.echoes, echoSpan{searchFrom: d.term.curLen(), echo: echoOf(sent), at: -1})
 	return nil
 }
 

--- a/internal/runner/ptyrun/session_test.go
+++ b/internal/runner/ptyrun/session_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"syscall"
@@ -609,4 +610,93 @@ func TestDriveSession_MouseRequiresTracking(t *testing.T) {
 			t.Errorf("terminal received %q, want %q", got, want)
 		}
 	})
+}
+
+// TestSessionDriver_EchoIsNotAMatch covers the rule that keeps an expect
+// honest: a match that lies entirely inside the terminal's echo of a preceding
+// send is the scenario reading back its own keystrokes, not the program
+// answering, so it does not count. The program's own copy of the same text
+// does, which is what keeps a `cat`-shaped session working — the line
+// discipline echoes the line and the program prints it again.
+func TestSessionDriver_EchoIsNotAMatch(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		sentAt     int    // transcript length when the send happened
+		sent       string // bytes the send transmitted
+		transcript string // what the terminal produced, in full
+		scanFrom   int    // where this expect starts scanning
+		pattern    string // the expect
+		wantMatch  bool   // whether a real (non-echo) match exists
+	}{
+		"only the echo is present": {
+			sentAt: 7, sent: "ABC\n", transcript: "ready\r\nABC\r\n",
+			scanFrom: 7, pattern: "ABC", wantMatch: false,
+		},
+		"the program repeated the line": {
+			sentAt: 0, sent: "ABC\n", transcript: "ABC\r\nABC\r\n",
+			scanFrom: 0, pattern: "ABC", wantMatch: true,
+		},
+		"the program answered something else": {
+			sentAt: 0, sent: "name\n", transcript: "name\r\nhello-name\r\n",
+			scanFrom: 0, pattern: "hello-", wantMatch: true,
+		},
+		"echo has not arrived yet": {
+			sentAt: 0, sent: "ABC\n", transcript: "",
+			scanFrom: 0, pattern: "ABC", wantMatch: false,
+		},
+		"echo is off, so the text is the program's": {
+			// Nothing in the transcript equals the echo, so no span resolves
+			// and the match stands.
+			sentAt: 0, sent: "secret\n", transcript: "Password: ****\r\n",
+			scanFrom: 0, pattern: `\*\*\*\*`, wantMatch: true,
+		},
+		"a longer match spanning past the echo counts": {
+			sentAt: 0, sent: "AB\n", transcript: "AB\r\nCD\r\n",
+			scanFrom: 0, pattern: `AB\r\nCD`, wantMatch: true,
+		},
+		"an identical earlier line is not the echo": {
+			// The echo is looked for at or after the send, so the earlier
+			// occurrence is the program's and matches.
+			sentAt: 5, sent: "ABC\n", transcript: "ABC\r\nABC\r\n",
+			scanFrom: 0, pattern: "ABC", wantMatch: true,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			d := &sessionDriver{
+				echoes: []echoSpan{{searchFrom: tt.sentAt, echo: echoOf([]byte(tt.sent)), at: -1}},
+			}
+			transcript := []byte(tt.transcript)
+			d.locateEchoes(transcript)
+			re := regexp.MustCompile(tt.pattern)
+			got := d.findReal(re, transcript[tt.scanFrom:], tt.scanFrom) != nil
+			if got != tt.wantMatch {
+				t.Errorf("match = %v, want %v (transcript %q, echo span %+v)", got, tt.wantMatch, tt.transcript, d.echoes[0])
+			}
+		})
+	}
+}
+
+// TestEchoOf pins the one translation the line discipline performs on the way
+// out: ONLCR renders each LF as CRLF, so the bytes a send transmitted are not
+// byte-for-byte what comes back.
+func TestEchoOf(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct{ sent, want string }{
+		"no newline":       {sent: "abc", want: "abc"},
+		"one newline":      {sent: "abc\n", want: "abc\r\n"},
+		"several newlines": {sent: "a\nb\n", want: "a\r\nb\r\n"},
+		"already crlf":     {sent: "a\r\n", want: "a\r\r\n"},
+		"empty":            {sent: "", want: ""},
+		"control byte":     {sent: "\x01", want: "\x01"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := string(echoOf([]byte(tt.sent))); got != tt.want {
+				t.Errorf("echoOf(%q) = %q, want %q", tt.sent, got, tt.want)
+			}
+		})
+	}
 }

--- a/test/e2e/atago/pty.atago.yaml
+++ b/test/e2e/atago/pty.atago.yaml
@@ -558,3 +558,56 @@ scenarios:
             contains:
               - "no variable with that name is defined"
               - "$${no_such_var}"
+
+  # An expect that matches only the terminal's echo of the send before it has
+  # asserted that atago can type, not that the program answered — and it passes
+  # whether the program is listening, busy, or already dead. The inner spec
+  # sends text to a program that has already exited, so the echo is the only
+  # possible source; it must fail rather than report a green scenario that
+  # tested nothing.
+  - name: an expect does not match the echo of its own send
+    skip:
+      os: windows
+    steps:
+      - fixture:
+          file: echo.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: echo
+            scenarios:
+              - name: the program never produced this
+                steps:
+                  - pty:
+                      command: "sh -c 'echo ready; exit 0'"
+                      timeout: 4s
+                      session:
+                        - expect: "ready"
+                        - send: "NEVER-PRODUCED-BY-THE-PROGRAM\n"
+                        - expect: "NEVER-PRODUCED-BY-THE-PROGRAM"
+      - run:
+          command: ${atago} run echo.atago.yaml
+      - assert:
+          exit_code: 1
+          stdout:
+            contains:
+              - "pty expect /NEVER-PRODUCED-BY-THE-PROGRAM/"
+              - "never appeared in the terminal transcript"
+
+  # The other side of the same rule: a program that prints the line back keeps
+  # its own copy, so the ordinary shape — type a line, expect the answer — still
+  # works. `cat` produces the text twice (the line discipline echoes it and cat
+  # prints it); only the echo is discounted.
+  - name: a program's own copy of the input still satisfies an expect
+    skip:
+      os: windows
+    steps:
+      - pty:
+          command: cat
+          timeout: 15s
+          session:
+            - send: "ROUNDTRIP\n"
+            - expect: "ROUNDTRIP"
+            - send: ""
+      - assert:
+          exit_code: 0


### PR DESCRIPTION
## Summary

A `pty:` session could pass without the program under test doing anything. Sending a line and expecting a substring of it is the natural way to drive a prompt, and with ECHO on the typed text lands in the transcript — so the expect matched the keystrokes rather than the answer, and it passed whether the program was listening, busy, or already dead.

Closes #465.

## Reproduction, before this change

```yaml
- pty:
    command: "sh -c 'echo ready; exit 0'"
    session:
      - expect: "ready"
      - send: "NEVER-PRODUCED-BY-THE-PROGRAM\n"
      - expect: "NEVER-PRODUCED-BY-THE-PROGRAM"
```

```
PASSED  1 scenario: 1 passed, 0 failed, 0 errored, 0 skipped
```

The program exits before the send. The only source of the matched text is the line discipline echoing it back.

## Changes

- `internal/runner/ptyrun/session.go` — each send records what it transmitted and where the transcript stood; an expect discounts a match lying entirely inside where that echo landed.
- `internal/runner/ptyrun/session_test.go` — the rule and the CRLF translation, tested at the layer that has no pty in it.
- `test/e2e/atago/pty.atago.yaml` — the reproduction now fails, and a `cat` round-trip still passes, both against a real terminal.
- `doc/cookbook.md` — the pty troubleshooting section explains why the transcript can look like it disagrees with the failure.

## Design Decisions

This is the defect atago already refuses one layer up. A spec cannot write `contains: ""` — that is ATG2312 — because an assertion that cannot fail is worse than no assertion: it reports success and is counted as coverage. The same thing was reachable inside a pty session by accident, through the most natural shape there is.

Only a match lying wholly inside the echo is discounted, which is what keeps the ordinary case working. `cat` produces the text twice — the line discipline echoes the line and `cat` prints it — and the printed copy falls outside the echo span, so the expect still matches it. A REPL that prints the command back is the same shape.

Where the echo never appears, nothing is discounted and those sessions are untouched: a password prompt with ECHO off, a raw-mode TUI, or a control byte the terminal renders as `^A` rather than as the byte sent. The span simply never resolves.

The echo is searched for at or after the send rather than anywhere in the transcript, so an identical line the program printed earlier is not mistaken for it — that earlier line is the program's and still matches.

The alternative was to detect the ECHO termios flag and skip accordingly. That was rejected: ConPTY exposes no echo state, so it would have made a core matcher behave differently on Windows than on POSIX, for a rule that should read the same everywhere. Comparing against the bytes actually sent needs no platform support and fails safe — when it cannot tell, it discounts nothing.

## Verification

The full self-hosted suite is green, and so are the third-party TUI suites that drive real terminals (fzf, htop, gum). The one failure in that run is lazygit asserting a released version string against a locally-built binary, which is unrelated to this change.
