### PR TITLE
feat(spec): state a suite's selection gate once, and gate every third-party suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,14 @@ and this project follows [Semantic Versioning](https://semver.org/).
 - `atago explain ATG2201` prints what a code means without a browser — the same entry the website renders, from the same registry — and suggests a near-miss when the code is not one that exists. The JSON report carries the code as a `code` field on each failure, and a GitHub Actions error annotation puts it in the title where the annotations list shows it, so a dashboard or a CI job can group failures by cause instead of matching on prose.
 - An [error code reference](https://nao1215.github.io/atago/errors/), generated from the registry that defines the codes, listing what each one means, what causes it, and what to change. A code cannot exist without that documentation: registering it is the only way to create one, and registration refuses an entry that omits the explanation or the fix. A committed `doc/errors.md` is drift-guarded against the registry, and a coverage gate fails CI when a published code is not provoked by a scenario in atago's own E2E suite.
 
+### Added
+
+- `defaults.scenario.only` and `defaults.scenario.skip` state a suite's selection gate once instead of on every scenario. A probe-first suite exists only where the program it drives is installed, which is a property of the file rather than of each scenario in it, and repeating the condition is how a suite ends up with some scenarios gated and some not — the ungated ones then error on a machine without the tool instead of skipping. A scenario that states its own condition keeps it; the two are not combined.
+
 ### Bug Fixes
 
+- Twenty-one third-party suites now skip cleanly on a machine without the program they drive, instead of erroring through every scenario. They had no probe gate at all, so `atago run ./test/e2e/thirdparty` reported 17 errors here for tools that simply were not installed.
+- The lazygit suite asserts the shape of the version line rather than the exact release. Pinning the number coupled the scenario to the version the CI workflow installs, so it failed against any other build — a developer's own lazygit, or CI itself the moment the pin moved.
 - A `pty:` `expect:` no longer matches the terminal's echo of the `send:` before it. Sending a line and expecting a substring of it is the natural way to drive a prompt, and with ECHO on the typed text appears in the transcript, so the expect matched the keystrokes rather than the program's answer — passing whether the program was listening, busy, or already dead. atago refuses assertions that cannot fail while loading a spec (ATG2312); this was the same defect one layer down. Only a match lying entirely inside the echo is discounted, so a program that prints the input back keeps its own copy and the ordinary shape still works.
 
 ### Documentation

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-81 suites · 604 scenarios
+81 suites · 607 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -85,13 +85,16 @@
 - [atago self-hosting / db runner](#atago-self-hosting--db-runner) — 2 scenarios
   - [query workflow (create, insert, select, row assert, value binding) passes](#scenario-query-workflow-create-insert-select-row-assert-value-binding-passes)
   - [a query against an undeclared runner fails validation (exit 2)](#scenario-a-query-against-an-undeclared-runner-fails-validation-exit-2)
-- [atago self-hosting / top-level defaults](#atago-self-hosting--top-level-defaults) — 6 scenarios
+- [atago self-hosting / top-level defaults](#atago-self-hosting--top-level-defaults) — 9 scenarios
   - [defaults.run.shell applies to every run step without repeating it](#scenario-defaultsrunshell-applies-to-every-run-step-without-repeating-it)
   - [defaults.scenario.env is merged and an explicit scenario env wins](#scenario-defaultsscenarioenv-is-merged-and-an-explicit-scenario-env-wins)
   - [defaults.run.sandbox_home governs a run step and a pty step alike (POSIX)](#scenario-defaultsrunsandbox_home-governs-a-run-step-and-a-pty-step-alike-posix)
   - [an unsupported defaults field is a load-time error (exit 2)](#scenario-an-unsupported-defaults-field-is-a-load-time-error-exit-2)
   - [defaults.run.env merges per key and a step env wins the collisions](#scenario-defaultsrunenv-merges-per-key-and-a-step-env-wins-the-collisions)
   - [a step opts out of defaults.run.shell with an explicit shell false](#scenario-a-step-opts-out-of-defaultsrunshell-with-an-explicit-shell-false)
+  - [defaults.scenario.only gates every scenario that states no gate](#scenario-defaultsscenarioonly-gates-every-scenario-that-states-no-gate)
+  - [a scenario's own gate replaces the default rather than combining](#scenario-a-scenarios-own-gate-replaces-the-default-rather-than-combining)
+  - [defaults.scenario.skip excludes every scenario that states no skip](#scenario-defaultsscenarioskip-excludes-every-scenario-that-states-no-skip)
 - [atago self-hosting / deterministic runs](#atago-self-hosting--deterministic-runs) — 8 scenarios
   - [a read-only command satisfies the default check](#scenario-a-read-only-command-satisfies-the-default-check)
   - [the asserts and store still describe the first run](#scenario-the-asserts-and-store-still-describe-the-first-run)
@@ -2299,6 +2302,94 @@ ${atago} run optout.atago.yaml
 #### Then
 - exit code is `0`
 - stdout contains `PASSED`
+### Scenario: defaults.scenario.only gates every scenario that states no gate
+#### Given
+- Fixture file `gated.atago.yaml` is created.
+#### Inputs
+_Fixture `gated.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: gated
+defaults:
+  scenario:
+    only:
+      command: definitely-no-such-tool-xyz --version
+scenarios:
+  - name: inherits the file gate
+    steps:
+      - run: {command: "false"}
+      - assert: {exit_code: 0}
+  - name: also inherits it
+    steps:
+      - run: {command: "false"}
+      - assert: {exit_code: 0}
+```
+#### When
+```shell
+${atago} run gated.atago.yaml
+```
+#### Then
+- exit code is `0`
+- stdout contains `2 skipped`
+### Scenario: a scenario's own gate replaces the default rather than combining
+#### Given
+- Fixture file `own.atago.yaml` is created.
+#### Inputs
+_Fixture `own.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: own
+defaults:
+  scenario:
+    only:
+      command: definitely-no-such-tool-xyz --version
+scenarios:
+  - name: states its own gate and runs
+    only:
+      command: "true"
+    steps:
+      - run: {command: "true"}
+      - assert: {exit_code: 0}
+  - name: takes the default and skips
+    steps:
+      - run: {command: "false"}
+      - assert: {exit_code: 0}
+```
+#### When
+```shell
+${atago} run own.atago.yaml
+```
+#### Then
+- exit code is `0`
+- stdout contains `1 passed`, `1 skipped`
+### Scenario: defaults.scenario.skip excludes every scenario that states no skip
+#### Given
+- Fixture file `skipped.atago.yaml` is created.
+#### Inputs
+_Fixture `skipped.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: skipped
+defaults:
+  scenario:
+    skip:
+      command: "true"
+scenarios:
+  - name: inherits the file exclusion
+    steps:
+      - run: {command: "false"}
+      - assert: {exit_code: 0}
+```
+#### When
+```shell
+${atago} run skipped.atago.yaml
+```
+#### Then
+- exit code is `0`
+- stdout contains `1 skipped`
 ## atago self-hosting / deterministic runs
 Source: `test/e2e/atago/deterministic.atago.yaml`
 ### Scenario: a read-only command satisfies the default check

--- a/doc/e2e/caddy.md
+++ b/doc/e2e/caddy.md
@@ -23,6 +23,7 @@ claiming the server came up.
 
 Source: `test/e2e/thirdparty/caddy/caddy.atago.yaml`
 ### Scenario: the standard module set is compiled in
+_only when `caddy version` succeeds_
 #### When
 ```shell
 caddy list-modules
@@ -31,6 +32,7 @@ caddy list-modules
 - exit code is `0`
 - stdout contains `http.handlers.file_server`, `http.handlers.static_response`
 ### Scenario: adapt turns a Caddyfile into canonical JSON
+_only when `caddy version` succeeds_
 #### Given
 - Fixture file `Caddyfile` is created.
 #### Inputs
@@ -47,6 +49,7 @@ caddy adapt --config Caddyfile
 - exit code is `0`
 - stdout at `$.apps.http.servers.srv0.listen[0]` equals `:18080`
 ### Scenario: fmt normalizes a messy Caddyfile in place
+_only when `caddy version` succeeds_
 #### Given
 - Fixture file `Caddyfile` is created.
 #### Inputs
@@ -64,6 +67,7 @@ caddy fmt --overwrite Caddyfile
 - exit code is `0`
 - file `Caddyfile` contains `respond "ok"`
 ### Scenario: validate rejects a broken Caddyfile
+_only when `caddy version` succeeds_
 #### Given
 - Fixture file `Caddyfile` is created.
 #### Inputs
@@ -80,6 +84,7 @@ caddy validate --config Caddyfile --adapter caddyfile
 - exit code is not `0`
 - stderr contains `no_such_directive_xyz`
 ### Scenario: a config-driven server boots from an authored Caddyfile
+_only when `caddy version` succeeds_
 #### Given
 - Background service `caddy` is started: `caddy run --config Caddyfile --adapter caddyfile`.
 - Fixture file `Caddyfile` is created.
@@ -101,6 +106,7 @@ respond "configured response" 200
 - HTTP status is `200`
 - body contains `configured response`
 ### Scenario: the file server serves fixtures over real HTTP
+_only when `caddy version` succeeds_
 #### Given
 - Background service `caddy` is started: `caddy file-server --listen 127.0.0.1:18080 --root site`.
 - Fixture file `site/index.html` is created.

--- a/doc/e2e/coredns.md
+++ b/doc/e2e/coredns.md
@@ -24,6 +24,7 @@ separately.
 
 Source: `test/e2e/thirdparty/coredns/coredns.atago.yaml`
 ### Scenario: the binary reports its version
+_only when `coredns -version` succeeds_
 #### When
 ```shell
 coredns -version
@@ -32,6 +33,7 @@ coredns -version
 - exit code is `0`
 - stdout matches `/CoreDNS-[0-9]+\.[0-9]+\.[0-9]+/`
 ### Scenario: an authored zone is served authoritatively
+_only when `coredns -version` succeeds_
 #### Given
 - Background service `coredns` is started: `coredns -conf Corefile`.
 - Fixture file `Corefile` is created.
@@ -73,6 +75,7 @@ dig @127.0.0.1 -p 18150 alias.example.test A +short
   - exit code is `0`
   - stdout contains `www.example.test.`, `192.0.2.10`
 ### Scenario: missing names and foreign zones get the right RCODEs
+_only when `coredns -version` succeeds_
 #### Given
 - Background service `coredns` is started: `coredns -conf Corefile`.
 - Fixture file `Corefile` is created.
@@ -106,6 +109,7 @@ dig @127.0.0.1 -p 18151 www.example.com A +noall +comments
   - exit code is `0`
   - stdout contains `status: REFUSED`
 ### Scenario: the health plugin answers over HTTP while DNS serves
+_only when `coredns -version` succeeds_
 #### Given
 - Background service `coredns` is started: `coredns -conf Corefile`.
 - Fixture file `Corefile` is created.
@@ -140,6 +144,7 @@ dig @127.0.0.1 -p 18152 www.example.test A +short
   - exit code is `0`
   - stdout contains `192.0.2.10`
 ### Scenario: a broken Corefile is rejected at startup
+_only when `coredns -version` succeeds_
 #### Given
 - Fixture file `Corefile` is created.
 #### Inputs

--- a/doc/e2e/gitea.md
+++ b/doc/e2e/gitea.md
@@ -20,6 +20,7 @@ just a JSON API that claims a repository exists.
 
 Source: `test/e2e/thirdparty/gitea/gitea.atago.yaml`
 ### Scenario: the binary reports its version
+_only when `gitea --version` succeeds_
 #### When
 ```shell
 gitea --version
@@ -28,6 +29,7 @@ gitea --version
 - exit code is `0`
 - stdout matches `/gitea version [0-9]+\.[0-9]+\.[0-9]+/`
 ### Scenario: the server boots from an authored app.ini and reports healthy
+_only when `gitea --version` succeeds_
 #### Given
 - Background service `gitea` is started: `gitea web --config app.ini`.
 - Fixture file `app.ini` is created.
@@ -68,6 +70,7 @@ ROOT = data/repos
   - HTTP status is `200`
   - body at `$.version` matches `/^[0-9]+\.[0-9]+\.[0-9]+/`
 ### Scenario: admin CLI, REST API, and a real git clone interoperate
+_only when `gitea --version` succeeds_
 #### Given
 - Background service `gitea` is started: `gitea web --config app.ini`.
 - Fixture file `app.ini` is created.

--- a/doc/e2e/gotify.md
+++ b/doc/e2e/gotify.md
@@ -23,6 +23,7 @@ bytes that came back.
 
 Source: `test/e2e/thirdparty/gotify/gotify.atago.yaml`
 ### Scenario: the server reports health and version
+_only when `gotify --version` succeeds_
 #### Given
 - Background service `gotify` is started: `gotify`.
 - Fixture file `data/.keep` is created.
@@ -39,6 +40,7 @@ Source: `test/e2e/thirdparty/gotify/gotify.atago.yaml`
   - HTTP status is `200`
   - body at `$.version` matches `/^[0-9]+\.[0-9]+\.[0-9]+/`
 ### Scenario: an application pushes and the admin reads it back
+_only when `gotify --version` succeeds_
 #### Given
 - Background service `gotify` is started: `gotify`.
 - Fixture file `data/.keep` is created.
@@ -64,6 +66,7 @@ Source: `test/e2e/thirdparty/gotify/gotify.atago.yaml`
   - body at `$.messages` has length 1
   - body at `$.messages[0].priority` equals `5`
 ### Scenario: the app icon round-trips through a multipart upload
+_only when `gotify --version` succeeds_
 #### Given
 - Background service `gotify` is started: `gotify`.
 - Fixture file `data/.keep` is created.

--- a/doc/e2e/grafana.md
+++ b/doc/e2e/grafana.md
@@ -20,6 +20,7 @@ accepted alongside it.
 
 Source: `test/e2e/thirdparty/grafana/grafana.atago.yaml`
 ### Scenario: the server boots and reports health and build info
+_only when `grafana --version` succeeds_
 #### Given
 - Background service `grafana` is started: `grafana server --homepath "$GF_PATHS_HOME"`.
 #### When
@@ -41,6 +42,7 @@ The 302 itself is the behavior under test, so the request is made with
 perfectly healthy login page and can no longer tell whether Grafana
 redirected at all.
 
+_only when `grafana --version` succeeds_
 #### Given
 - Background service `grafana` is started: `grafana server --homepath "$GF_PATHS_HOME"`.
 #### When
@@ -56,6 +58,7 @@ redirected at all.
 - after `HTTP GET /api/search`:
   - HTTP status is `401`
 ### Scenario: a dashboard and datasource lifecycle over the REST API
+_only when `grafana --version` succeeds_
 #### Given
 - Background service `grafana` is started: `grafana server --homepath "$GF_PATHS_HOME"`.
 #### When

--- a/doc/e2e/hugo.md
+++ b/doc/e2e/hugo.md
@@ -194,6 +194,7 @@ build-then-serve bootstrap every "run my app and test it" setup needs.
 
 Source: `test/e2e/thirdparty/hugo/hugo_server.atago.yaml`
 ### Scenario: the home page lists the post
+_only when `hugo version` succeeds_
 #### When
 ```shell
 # HTTP GET /
@@ -203,6 +204,7 @@ Source: `test/e2e/thirdparty/hugo/hugo_server.atago.yaml`
 - body contains `HOME`
 - body contains `/posts/hello/`
 ### Scenario: the post page renders its title
+_only when `hugo version` succeeds_
 #### When
 ```shell
 # HTTP GET /posts/hello/
@@ -211,6 +213,7 @@ Source: `test/e2e/thirdparty/hugo/hugo_server.atago.yaml`
 - HTTP status is `200`
 - body contains `<h1>Hello</h1>`
 ### Scenario: an unknown path is a 404
+_only when `hugo version` succeeds_
 #### When
 ```shell
 # HTTP GET /no/such/page/

--- a/doc/e2e/jq.md
+++ b/doc/e2e/jq.md
@@ -30,6 +30,7 @@ pinned here.
 
 Source: `test/e2e/thirdparty/jq/extra.atago.yaml`
 ### Scenario: multibyte unicode passes through unchanged
+_only when `jq --version` succeeds_
 #### Inputs
 _stdin for `jq`:_
 ```text
@@ -43,6 +44,7 @@ jq -c .
 - exit code is `0`
 - stdout equals an exact value
 ### Scenario: jq empty validates JSON — silent success, loud failure
+_only when `jq --version` succeeds_
 #### Inputs
 _stdin for `jq`:_
 ```text
@@ -79,6 +81,7 @@ handle differently — and each of which must not be confused for the others.
 
 Source: `test/e2e/thirdparty/jq/jq.atago.yaml`
 ### Scenario: identity filter echoes the document from stdin
+_only when `jq --version` succeeds_
 #### Inputs
 _stdin for `jq`:_
 ```text
@@ -93,6 +96,7 @@ jq -c .
 - stdout at `$.a` equals `1`
 - stderr is empty
 ### Scenario: sort-keys output is deterministic and exact
+_only when `jq --version` succeeds_
 #### Given
 - Fixture file `input.json` is created.
 #### Inputs
@@ -112,6 +116,7 @@ jq -c --sort-keys .
 - exit code is `0`
 - stdout equals an exact value
 ### Scenario: raw output strips JSON quoting
+_only when `jq --version` succeeds_
 #### Given
 - Fixture file `user.json` is created.
 #### Inputs
@@ -127,6 +132,7 @@ jq -r .name user.json
 - exit code is `0`
 - stdout equals an exact value
 ### Scenario: arguments flow in with --arg
+_only when `jq --version` succeeds_
 #### Inputs
 _stdin for `jq`:_
 ```text
@@ -140,6 +146,7 @@ jq -c --arg who atago '{greeting: ("hello " + $who)}'
 - exit code is `0`
 - stdout at `$.greeting` equals `hello atago`
 ### Scenario: reduce aggregates an array
+_only when `jq --version` succeeds_
 #### Given
 - Fixture file `nums.json` is created.
 #### Inputs
@@ -155,6 +162,7 @@ jq 'reduce .[] as $n (0; . + $n)' nums.json
 - exit code is `0`
 - stdout equals an exact value
 ### Scenario: -e exits 1 when the result is false
+_only when `jq --version` succeeds_
 #### Inputs
 _stdin for `jq`:_
 ```text
@@ -167,6 +175,7 @@ jq -e '.missing'
 #### Then
 - exit code is `1`
 ### Scenario: a program that does not compile exits 3 with a diagnostic on stderr
+_only when `jq --version` succeeds_
 #### Inputs
 _stdin for `jq`:_
 ```text
@@ -181,6 +190,7 @@ jq '.foo['
 - stdout is empty
 - stderr contains `error`
 ### Scenario: invalid JSON input fails loudly and keeps stdout clean
+_only when `jq --version` succeeds_
 #### Inputs
 _stdin for `jq`:_
 ```text
@@ -194,6 +204,7 @@ jq .
 - exit code is not `0`
 - stderr contains `parse error`
 ### Scenario: streaming several documents produces one result per document
+_only when `jq --version` succeeds_
 #### Inputs
 _stdin for `jq`:_
 ```text

--- a/doc/e2e/lazygit.md
+++ b/doc/e2e/lazygit.md
@@ -3,7 +3,7 @@
 1 suite · 21 scenarios
 ## Contents
 - [lazygit (third-party git TUI)](#lazygit-third-party-git-tui) — 21 scenarios
-  - [version prints the pinned release](#scenario-version-prints-the-pinned-release)
+  - [version prints a semantic version](#scenario-version-prints-a-semantic-version)
   - [opening a dirty repository shows unstaged changes and quits cleanly](#scenario-opening-a-dirty-repository-shows-unstaged-changes-and-quits-cleanly)
   - [opening from a nested repository path rejects the subdirectory as invalid](#scenario-opening-from-a-nested-repository-path-rejects-the-subdirectory-as-invalid)
   - [space stages the selected unstaged file](#scenario-space-stages-the-selected-unstaged-file)
@@ -36,7 +36,7 @@ reading git state afterwards. A TUI test that only looked at the screen
 would pass on a version that draws a commit it never made.
 
 Source: `test/e2e/thirdparty/lazygit/lazygit.atago.yaml`
-### Scenario: version prints the pinned release
+### Scenario: version prints a semantic version
 _only when `lazygit --version` succeeds_
 #### When
 ```shell
@@ -44,7 +44,7 @@ lazygit --version
 ```
 #### Then
 - exit code is `0`
-- stdout contains `version=0.63.1`
+- stdout contains `os=`, matches `/version=[0-9]+\.[0-9]+\.[0-9]+/`
 ### Scenario: opening a dirty repository shows unstaged changes and quits cleanly
 _only when `lazygit --version` succeeds · skipped on Windows_
 #### Given

--- a/doc/e2e/mailpit.md
+++ b/doc/e2e/mailpit.md
@@ -22,6 +22,7 @@ it.
 
 Source: `test/e2e/thirdparty/mailpit/mailpit.atago.yaml`
 ### Scenario: the binary reports its version
+_only when `mailpit version` succeeds_
 #### When
 ```shell
 mailpit version --no-release-check
@@ -30,6 +31,7 @@ mailpit version --no-release-check
 - exit code is `0`
 - stdout contains `mailpit`
 ### Scenario: a message sent over real SMTP is captured and readable via the API
+_only when `mailpit version` succeeds_
 #### Given
 - Background service `mailpit` is started: `mailpit --smtp 127.0.0.1:18170 --listen 127.0.0.1:18171 --database data.db`.
 - Fixture file `mail.txt` is created.
@@ -60,6 +62,7 @@ curl -s --url smtp://127.0.0.1:18170 --mail-from alice@example.test --mail-rcpt 
   - HTTP status is `200`
   - body at `$.Text` matches `/deploy pipeline completed successfully/`
 ### Scenario: full-text search finds exactly the matching message
+_only when `mailpit version` succeeds_
 #### Given
 - Background service `mailpit` is started: `mailpit --smtp 127.0.0.1:18172 --listen 127.0.0.1:18173 --database data.db`.
 - Fixture file `mail1.txt` is created.
@@ -94,6 +97,7 @@ curl -s --url smtp://127.0.0.1:18172 --mail-from ci@example.test --mail-rcpt tea
   - body at `$.messages_count` equals `1`
   - body at `$.messages[0].Subject` equals `nightly build report`
 ### Scenario: a MIME attachment survives delivery intact
+_only when `mailpit version` succeeds_
 #### Given
 - Background service `mailpit` is started: `mailpit --smtp 127.0.0.1:18174 --listen 127.0.0.1:18175 --database data.db`.
 - Fixture file `mail.txt` is created.
@@ -131,6 +135,7 @@ curl -s --url smtp://127.0.0.1:18174 --mail-from reports@example.test --mail-rcp
   - body at `$.Attachments` has length 1
   - body at `$.Attachments[0].FileName` equals `data.csv`
 ### Scenario: deleting all messages empties the mailbox
+_only when `mailpit version` succeeds_
 #### Given
 - Background service `mailpit` is started: `mailpit --smtp 127.0.0.1:18176 --listen 127.0.0.1:18177 --database data.db`.
 - Fixture file `mail.txt` is created.

--- a/doc/e2e/minio.md
+++ b/doc/e2e/minio.md
@@ -23,6 +23,7 @@ arrive in a form the client can understand.
 
 Source: `test/e2e/thirdparty/minio/minio.atago.yaml`
 ### Scenario: the server reports itself alive over the health API
+_only when `minio --version` succeeds_
 #### Given
 - Background service `minio` is started: `minio server data --address 127.0.0.1:18120`.
 #### When
@@ -36,6 +37,7 @@ Source: `test/e2e/thirdparty/minio/minio.atago.yaml`
 - after `HTTP GET /minio/health/ready`:
   - HTTP status is `200`
 ### Scenario: anonymous S3 access is denied with a proper S3 XML error
+_only when `minio --version` succeeds_
 #### Given
 - Background service `minio` is started: `minio server data --address 127.0.0.1:18121`.
 #### When
@@ -46,6 +48,7 @@ Source: `test/e2e/thirdparty/minio/minio.atago.yaml`
 - HTTP status is `403`
 - body contains `<Code>AccessDenied</Code>`
 ### Scenario: a full object lifecycle through the mc client
+_only when `minio --version` succeeds_
 #### Given
 - Background service `minio` is started: `minio server data --address 127.0.0.1:18122`.
 - Fixture file `upload.txt` is created.
@@ -90,6 +93,7 @@ mc ls lifecycle/atago-bucket
   - exit code is `0`
   - stdout is empty
 ### Scenario: bucket versioning can be enabled and reported
+_only when `minio --version` succeeds_
 #### Given
 - Background service `minio` is started: `minio server data --address 127.0.0.1:18123`.
 #### When
@@ -107,6 +111,7 @@ mc version info --json versioned/versioned
   - exit code is `0`
   - stdout at `$.versioning.status` equals `Enabled`
 ### Scenario: an anonymous download policy publishes a bucket read-only
+_only when `minio --version` succeeds_
 #### Given
 - Background service `minio` is started: `minio server data --address 127.0.0.1:18124`.
 - Fixture file `page.txt` is created.

--- a/doc/e2e/nats.md
+++ b/doc/e2e/nats.md
@@ -24,6 +24,7 @@ endpoint is checked over HTTP alongside.
 
 Source: `test/e2e/thirdparty/nats/nats.atago.yaml`
 ### Scenario: the binary reports its version
+_only when `nats-server --version` succeeds_
 #### When
 ```shell
 nats-server --version
@@ -32,6 +33,7 @@ nats-server --version
 - exit code is `0`
 - stdout matches `/nats-server: v[0-9]+\.[0-9]+\.[0-9]+/`
 ### Scenario: the monitoring endpoint reports a healthy JetStream server
+_only when `nats-server --version` succeeds_
 #### Given
 - Background service `nats-server` is started: `nats-server -js -sd store -a 127.0.0.1 -p 18160 -m 18161`.
 #### When
@@ -48,6 +50,7 @@ nats-server --version
   - body at `$.version` matches `/^[0-9]+\.[0-9]+\.[0-9]+/`
   - body at `$.port` equals `18160`
 ### Scenario: request/reply round-trips through the broker
+_only when `nats-server --version` succeeds_
 #### Given
 - Background service `nats-server` is started: `nats-server -a 127.0.0.1 -p 18162`.
 - Background service `responder` is started: `nats -s nats://127.0.0.1:18162 reply help.please "OK I CAN HELP"`.
@@ -59,6 +62,7 @@ nats -s nats://127.0.0.1:18162 request help.please "help me"
 - exit code is `0`
 - stdout contains `OK I CAN HELP`
 ### Scenario: a JetStream stream persists, counts, and purges messages
+_only when `nats-server --version` succeeds_
 #### Given
 - Background service `nats-server` is started: `nats-server -js -sd store -a 127.0.0.1 -p 18163`.
 #### When
@@ -88,6 +92,7 @@ nats -s nats://127.0.0.1:18163 stream info ORDERS --json
   - exit code is `0`
   - stdout at `$.state.messages` equals `0`
 ### Scenario: the JetStream KV bucket stores and serves configuration
+_only when `nats-server --version` succeeds_
 #### Given
 - Background service `nats-server` is started: `nats-server -js -sd store -a 127.0.0.1 -p 18164`.
 #### When

--- a/doc/e2e/ntfy.md
+++ b/doc/e2e/ntfy.md
@@ -24,6 +24,7 @@ access through the admin CLI, the same publish succeeds.
 
 Source: `test/e2e/thirdparty/ntfy/ntfy.atago.yaml`
 ### Scenario: the binary reports its version
+_only when `ntfy --version` succeeds_
 #### When
 ```shell
 ntfy --version
@@ -32,6 +33,7 @@ ntfy --version
 - exit code is `0`
 - stdout matches `/ntfy version [0-9]+\.[0-9]+\.[0-9]+/`
 ### Scenario: a published notification comes back through the JSON poll feed
+_only when `ntfy --version` succeeds_
 #### Given
 - Background service `ntfy` is started: `ntfy serve --listen-http 127.0.0.1:18180 --base-url http://127.0.0.1:18180 --cache-file data/cache.db`.
 - Fixture file `data/.keep` is created.
@@ -58,6 +60,7 @@ ntfy --version
   - HTTP status is `200`
   - body is empty
 ### Scenario: the bundled CLI publishes against the same server
+_only when `ntfy --version` succeeds_
 #### Given
 - Background service `ntfy` is started: `ntfy serve --listen-http 127.0.0.1:18181 --base-url http://127.0.0.1:18181 --cache-file data/cache.db`.
 - Fixture file `data/.keep` is created.
@@ -76,6 +79,7 @@ ntfy publish http://127.0.0.1:18181/atago-deploys "deploy two"
   - HTTP status is `200`
   - body contains `deploy one`, `deploy two`
 ### Scenario: deny-all access control locks a topic until a user is granted
+_only when `ntfy --version` succeeds_
 #### Given
 - Background service `ntfy` is started: `ntfy serve --listen-http 127.0.0.1:18182 --base-url http://127.0.0.1:18182 --cache-file data/cache.db --auth-file data/auth.db --auth-default-access deny-all`.
 - Fixture file `data/.keep` is created.

--- a/doc/e2e/openssl.md
+++ b/doc/e2e/openssl.md
@@ -64,6 +64,7 @@ checked to carry the subject that was requested.
 
 Source: `test/e2e/thirdparty/openssl/openssl.atago.yaml`
 ### Scenario: sha256 digest of a fixed input is exact and stable
+_only when `openssl version` succeeds_
 #### Given
 - Fixture file `msg.txt` is created.
 #### Inputs
@@ -79,6 +80,7 @@ openssl dgst -sha256 -r msg.txt
 - exit code is `0`
 - stdout contains `6e459fed18ddb06d57c8e9f0d000c302c7e01389926db6e89884bfbe91a2a5df`
 ### Scenario: base64 encode and decode round-trip via stdin
+_only when `openssl version` succeeds_
 #### Inputs
 _stdin for `openssl`:_
 ```text
@@ -99,6 +101,7 @@ openssl base64 -d
   - exit code is `0`
   - stdout contains `round-trip me`
 ### Scenario: rand -hex emits exactly the requested entropy
+_only when `openssl version` succeeds_
 #### When
 ```shell
 openssl rand -hex 16
@@ -107,6 +110,7 @@ openssl rand -hex 16
 - exit code is `0`
 - stdout matches `/^[0-9a-f]{32}\n?$/`
 ### Scenario: a generated private key is valid and yields its public half
+_only when `openssl version` succeeds_
 #### When
 ```shell
 openssl genpkey -algorithm ed25519 -out key.pem
@@ -124,6 +128,7 @@ openssl pkey -in key.pem -pubout -out pub.pem
   - exit code is `0`
   - file `pub.pem` contains `BEGIN PUBLIC KEY`
 ### Scenario: symmetric encryption round-trips and a wrong password fails loudly
+_only when `openssl version` succeeds_
 #### Given
 - Fixture file `secret.txt` is created.
 #### Inputs
@@ -151,6 +156,7 @@ openssl enc -d -aes-256-cbc -pbkdf2 -pass pass:wrong-password -in secret.enc -ou
 #### Generated artifacts
 - `secret.enc`
 ### Scenario: a self-signed certificate carries the requested subject
+_only when `openssl version` succeeds_
 #### When
 ```shell
 openssl req -x509 -newkey ed25519 -keyout ca.key -out ca.crt -nodes -days 1 -subj /CN=atago-test
@@ -167,6 +173,7 @@ openssl verify -CAfile ca.crt ca.crt
   - exit code is `0`
   - stdout contains `OK`
 ### Scenario: signing with the private key verifies with the public key
+_only when `openssl version` succeeds_
 #### Given
 - Fixture file `payload.txt` is created.
 - Fixture file `payload.txt` is created.

--- a/doc/e2e/prometheus.md
+++ b/doc/e2e/prometheus.md
@@ -24,6 +24,7 @@ all had to work for the sample to be there.
 
 Source: `test/e2e/thirdparty/prometheus/prometheus.atago.yaml`
 ### Scenario: promtool accepts a valid config and rejects a broken one
+_only when `promtool --version` succeeds_
 #### Given
 - Fixture file `prometheus.yml` is created.
 - Fixture file `broken.yml` is created.
@@ -55,6 +56,7 @@ promtool check config broken.yml
   - exit code is not `0`
   - stderr contains `not a valid duration string`
 ### Scenario: promtool unit-tests an alerting rule
+_only when `promtool --version` succeeds_
 #### Given
 - Fixture file `rules.yml` is created.
 - Fixture file `rules_test.yml` is created.
@@ -108,6 +110,7 @@ promtool test rules rules_test.yml
   - exit code is `0`
   - stdout contains `SUCCESS`
 ### Scenario: the server boots from an authored config and answers the query API
+_only when `promtool --version` succeeds_
 #### Given
 - Background service `prometheus` is started: `prometheus --config.file=prometheus.yml --storage.tsdb.path=data --web.listen-address=127.0.0.1:18130`.
 - Fixture file `prometheus.yml` is created.
@@ -140,6 +143,7 @@ scrape_configs: []
   - HTTP status is `200`
   - body at `$.data.result[0].value[1]` equals `42`
 ### Scenario: a self-scrape is ingested and queryable as up == 1
+_only when `promtool --version` succeeds_
 #### Given
 - Background service `prometheus` is started: `prometheus --config.file=prometheus.yml --storage.tsdb.path=data --web.listen-address=127.0.0.1:18131`.
 - Fixture file `prometheus.yml` is created.

--- a/doc/e2e/pushgateway.md
+++ b/doc/e2e/pushgateway.md
@@ -21,6 +21,7 @@ samples, in the format a Prometheus scrape would consume.
 
 Source: `test/e2e/thirdparty/pushgateway/pushgateway.atago.yaml`
 ### Scenario: a pushed metric appears on the scrape endpoint
+_only when `pushgateway --version` succeeds_
 #### Given
 - Background service `pushgateway` is started: `pushgateway --web.listen-address=127.0.0.1:18092`.
 #### When
@@ -36,6 +37,7 @@ Source: `test/e2e/thirdparty/pushgateway/pushgateway.atago.yaml`
   - body contains `job="atago_e2e"`
   - body matches `/atago_e2e_metric\{[^}]*job="atago_e2e"[^}]*\} 3.14/`
 ### Scenario: deleting a job group removes its metrics
+_only when `pushgateway --version` succeeds_
 #### Given
 - Background service `pushgateway` is started: `pushgateway --web.listen-address=127.0.0.1:18093`.
 #### When
@@ -53,6 +55,7 @@ Source: `test/e2e/thirdparty/pushgateway/pushgateway.atago.yaml`
   - HTTP status is `200`
   - body does not contain `ephemeral_metric`
 ### Scenario: a malformed exposition body is rejected and never ingested
+_only when `pushgateway --version` succeeds_
 #### Given
 - Background service `pushgateway` is started: `pushgateway --web.listen-address=127.0.0.1:18099`.
 #### When
@@ -68,6 +71,7 @@ Source: `test/e2e/thirdparty/pushgateway/pushgateway.atago.yaml`
   - HTTP status is `200`
   - body does not contain `job="badjob"`
 ### Scenario: POST merges into a group while PUT replaces it
+_only when `pushgateway --version` succeeds_
 #### Given
 - Background service `pushgateway` is started: `pushgateway --web.listen-address=127.0.0.1:18100`.
 #### When
@@ -93,6 +97,7 @@ Source: `test/e2e/thirdparty/pushgateway/pushgateway.atago.yaml`
   - body contains `metric_c`
   - body does not contain `metric_a`, `metric_b`
 ### Scenario: a grouping label decorates every metric in the group
+_only when `pushgateway --version` succeeds_
 #### Given
 - Background service `pushgateway` is started: `pushgateway --web.listen-address=127.0.0.1:18101`.
 #### When

--- a/doc/e2e/rclone.md
+++ b/doc/e2e/rclone.md
@@ -27,6 +27,7 @@ local backend, which keeps every scenario hermetic.
 
 Source: `test/e2e/thirdparty/rclone/rclone.atago.yaml`
 ### Scenario: version prints a semantic version
+_only when `rclone version` succeeds_
 #### When
 ```shell
 rclone version
@@ -35,6 +36,7 @@ rclone version
 - exit code is `0`
 - stdout matches `/rclone v[0-9]+\.[0-9]+\.[0-9]+/`
 ### Scenario: copy replicates a tree and check certifies the replica
+_only when `rclone version` succeeds_
 #### Given
 - Fixture file `rclone.conf` is created.
 - Fixture file `src/hello.txt` is created.
@@ -63,6 +65,7 @@ rclone check src dst
   - exit code is `0`
   - stderr contains `0 differences found`
 ### Scenario: check fails loudly once the replica is corrupted
+_only when `rclone version` succeeds_
 #### Given
 - Fixture file `rclone.conf` is created.
 - Fixture file `src/hello.txt` is created.
@@ -86,6 +89,7 @@ rclone check src dst
   - exit code is not `0`
   - stderr contains `1 differences found`
 ### Scenario: lsjson emits a machine-readable listing
+_only when `rclone version` succeeds_
 #### Given
 - Fixture file `rclone.conf` is created.
 - Fixture file `src/hello.txt` is created.
@@ -116,6 +120,7 @@ rclone size --json src
   - exit code is `0`
   - stdout at `$.count` equals `2`
 ### Scenario: sync makes the destination mirror the source, deletions included
+_only when `rclone version` succeeds_
 #### Given
 - Fixture file `rclone.conf` is created.
 - Fixture file `src/keep.txt` is created.
@@ -137,6 +142,7 @@ rclone sync src dst
 - exit code is `0`
 - dir `dst` contains `keep.txt`, does not contain `extraneous.txt`
 ### Scenario: obscure and reveal round-trip a secret
+_only when `rclone version` succeeds_
 #### Given
 - Fixture file `rclone.conf` is created.
 #### When
@@ -152,6 +158,7 @@ rclone reveal ${obscured}
   - exit code is `0`
   - stdout equals an exact value
 ### Scenario: serve http publishes the tree over real HTTP
+_only when `rclone version` succeeds_
 #### Given
 - Background service `rclone-http` is started: `rclone serve http src --addr 127.0.0.1:18110`.
 - Fixture file `rclone.conf` is created.

--- a/doc/e2e/restic.md
+++ b/doc/e2e/restic.md
@@ -28,6 +28,7 @@ restore.
 
 Source: `test/e2e/thirdparty/restic/restic.atago.yaml`
 ### Scenario: version prints a semantic version
+_only when `restic version` succeeds_
 #### When
 ```shell
 restic version
@@ -36,6 +37,7 @@ restic version
 - exit code is `0`
 - stdout matches `/restic [0-9]+\.[0-9]+\.[0-9]+/`
 ### Scenario: init creates an encrypted repository on disk
+_only when `restic version` succeeds_
 #### When
 ```shell
 restic init
@@ -45,6 +47,7 @@ restic init
 - stdout contains `created restic repository`
 - dir `repo` exists, contains `config`, contains `keys`, contains `snapshots`
 ### Scenario: backup, list as JSON, and restore round-trip user data
+_only when `restic version` succeeds_
 #### Given
 - Fixture file `data/hello.txt` is created.
 - Fixture file `data/sub/notes.md` is created.
@@ -79,6 +82,7 @@ restic restore ${snap} --target restored
   - file `restored/data/hello.txt` contains `hello from atago`
   - file `restored/data/sub/notes.md` contains `# notes kept safe`
 ### Scenario: diff names exactly the file added between two snapshots
+_only when `restic version` succeeds_
 #### Given
 - Fixture file `data/base.txt` is created.
 - Fixture file `data/added-later.txt` is created.
@@ -110,6 +114,7 @@ restic diff ${first} ${second}
   - stdout contains `+    /data/added-later.txt`
   - stdout does not contain `/data/base.txt`
 ### Scenario: check reports a healthy repository as error-free
+_only when `restic version` succeeds_
 #### Given
 - Fixture file `data/precious.txt` is created.
 #### Inputs
@@ -128,6 +133,7 @@ restic check
   - exit code is `0`
   - stdout contains `no errors were found`
 ### Scenario: forget --keep-last 1 --prune drops the older snapshot
+_only when `restic version` succeeds_
 #### Given
 - Fixture file `data/gen.txt` is created.
 - Fixture file `data/gen.txt` is created.
@@ -156,6 +162,7 @@ restic snapshots --json
   - exit code is `0`
   - stdout at `$` has length 1
 ### Scenario: the wrong password cannot unlock the repository
+_only when `restic version` succeeds_
 #### Given
 - Environment variables are set: RESTIC_PASSWORD.
 #### When

--- a/doc/e2e/sqlite3.md
+++ b/doc/e2e/sqlite3.md
@@ -30,6 +30,7 @@ notices until a restore.
 
 Source: `test/e2e/thirdparty/sqlite3/changes.atago.yaml`
 ### Scenario: default rollback-journal mode creates exactly the db file
+_only when `sqlite3 --version` succeeds_
 #### When
 ```shell
 sqlite3 t.db "create table x(a); insert into x values(1)"
@@ -38,6 +39,7 @@ sqlite3 t.db "create table x(a); insert into x values(1)"
 - exit code is `0`
 - the step changed exactly created `t.db`, modified nothing, deleted nothing
 ### Scenario: WAL mode leaves no -wal/-shm behind after a clean close
+_only when `sqlite3 --version` succeeds_
 #### When
 ```shell
 sqlite3 t.db "PRAGMA journal_mode=WAL; create table x(a); insert into x values(1)"
@@ -61,6 +63,7 @@ database rather than a pipe.
 
 Source: `test/e2e/thirdparty/sqlite3/sqlite3.atago.yaml`
 ### Scenario: one-shot SQL creates, inserts, and counts in a single invocation
+_only when `sqlite3 --version` succeeds_
 #### When
 ```shell
 sqlite3 app.db "CREATE TABLE u(id INTEGER, name TEXT); INSERT INTO u VALUES(1,'alice'),(2,'bob'); SELECT count(*) FROM u;"
@@ -72,6 +75,7 @@ sqlite3 app.db "CREATE TABLE u(id INTEGER, name TEXT); INSERT INTO u VALUES(1,'a
 #### Generated artifacts
 - `app.db`
 ### Scenario: the database file is durable across invocations
+_only when `sqlite3 --version` succeeds_
 #### When
 ```shell
 sqlite3 app.db "CREATE TABLE kv(k TEXT, v TEXT); INSERT INTO kv VALUES('answer','42');"
@@ -82,6 +86,7 @@ sqlite3 app.db "SELECT v FROM kv WHERE k='answer';"
   - exit code is `0`
   - stdout equals an exact value
 ### Scenario: -json output mode is valid JSON with typed values
+_only when `sqlite3 --version` succeeds_
 #### When
 ```shell
 sqlite3 app.db "CREATE TABLE u(id INTEGER, name TEXT); INSERT INTO u VALUES(1,'alice');"
@@ -93,6 +98,7 @@ sqlite3 -json app.db "SELECT * FROM u;"
   - stdout at `$[0].id` equals `1`
   - stdout at `$[0].name` equals `alice`
 ### Scenario: -csv output mode emits plain rows
+_only when `sqlite3 --version` succeeds_
 #### When
 ```shell
 sqlite3 app.db "CREATE TABLE u(id INTEGER, name TEXT); INSERT INTO u VALUES(1,'alice'),(2,'bob');"
@@ -104,6 +110,7 @@ sqlite3 -csv app.db "SELECT * FROM u ORDER BY id;"
   - stdout line `1` equals an exact value
   - stdout line `2` equals an exact value
 ### Scenario: .dump emits SQL that rebuilds an identical database
+_only when `sqlite3 --version` succeeds_
 #### When
 ```shell
 sqlite3 app.db "CREATE TABLE u(id INTEGER, name TEXT); INSERT INTO u VALUES(1,'alice');"
@@ -121,6 +128,7 @@ sqlite3 copy.db "SELECT name FROM u WHERE id=1;"
 #### Generated artifacts
 - `dump.sql`
 ### Scenario: .import loads a CSV fixture into a table
+_only when `sqlite3 --version` succeeds_
 #### Given
 - Fixture file `people.csv` is created.
 #### Inputs
@@ -142,6 +150,7 @@ sqlite3 app.db "SELECT count(*) FROM people;"
   - exit code is `0`
   - stdout equals an exact value
 ### Scenario: bad SQL exits 1 with the error position on stderr
+_only when `sqlite3 --version` succeeds_
 #### When
 ```shell
 sqlite3 app.db "SELEC broken;"
@@ -151,6 +160,7 @@ sqlite3 app.db "SELEC broken;"
 - stdout is empty
 - stderr contains `syntax error`
 ### Scenario: querying a missing table names it in the diagnostics
+_only when `sqlite3 --version` succeeds_
 #### When
 ```shell
 sqlite3 app.db "SELECT * FROM no_such_table;"

--- a/doc/e2e/transfersh.md
+++ b/doc/e2e/transfersh.md
@@ -22,6 +22,7 @@ how a file arrives from a web form rather than from `curl`.
 
 Source: `test/e2e/thirdparty/transfersh/transfersh.atago.yaml`
 ### Scenario: the binary reports its version
+_only when `transfer.sh --help` succeeds_
 #### When
 ```shell
 transfer.sh version
@@ -30,6 +31,7 @@ transfer.sh version
 - exit code is `0`
 - stdout contains `transfer.sh`
 ### Scenario: a binary upload round-trips byte-for-byte
+_only when `transfer.sh --help` succeeds_
 #### Given
 - Background service `transfersh` is started: `transfer.sh --provider local --basedir storage --temp-path tmp --listener 127.0.0.1:18210`.
 - Fixture file `storage/.keep` is created.
@@ -54,6 +56,7 @@ cmp pixel.png downloaded.png
 #### Generated artifacts
 - `downloaded.png`
 ### Scenario: a browser-style multipart upload is accepted too
+_only when `transfer.sh --help` succeeds_
 #### Given
 - Background service `transfersh` is started: `transfer.sh --provider local --basedir storage --temp-path tmp --listener 127.0.0.1:18211`.
 - Fixture file `storage/.keep` is created.

--- a/doc/e2e/webhook.md
+++ b/doc/e2e/webhook.md
@@ -25,6 +25,7 @@ non-zero surfaces as a 500 instead of being reported as success.
 
 Source: `test/e2e/thirdparty/webhook/webhook.atago.yaml`
 ### Scenario: a post runs the command, returns its output, and writes its file
+_only when `webhook -version` succeeds_
 #### Given
 - Background service `webhook` is started: `webhook -hooks hooks.json -ip 127.0.0.1 -port 18094`.
 - Fixture file `handler.sh` is created.
@@ -63,6 +64,7 @@ _Fixture `hooks.json`:_
 - after `HTTP POST /hooks/nope`:
   - HTTP status is `404`
 ### Scenario: a trigger-rule gates execution and blocks it when unsatisfied
+_only when `webhook -version` succeeds_
 #### Given
 - Background service `webhook` is started: `webhook -hooks hooks.json -ip 127.0.0.1 -port 18095`.
 - Fixture file `handler.sh` is created.
@@ -106,6 +108,7 @@ _Fixture `hooks.json`:_
   - HTTP status is `200`
   - file `ran.txt` contains `executed`
 ### Scenario: an HMAC signature is verified against an independent oracle
+_only when `webhook -version` succeeds_
 #### Given
 - Background service `webhook` is started: `webhook -hooks hooks.json -ip 127.0.0.1 -port 18096`.
 - Fixture file `handler.sh` is created.
@@ -149,6 +152,7 @@ _Fixture `hooks.json`:_
   - HTTP status is `200`
   - file `ran.txt` contains `signed`
 ### Scenario: the http-methods allowlist rejects the wrong verb
+_only when `webhook -version` succeeds_
 #### Given
 - Background service `webhook` is started: `webhook -hooks hooks.json -ip 127.0.0.1 -port 18097`.
 - Fixture file `handler.sh` is created.
@@ -178,6 +182,7 @@ _Fixture `hooks.json`:_
 #### Then
 - HTTP status is `405`
 ### Scenario: a command that exits non-zero surfaces as a 500
+_only when `webhook -version` succeeds_
 #### Given
 - Background service `webhook` is started: `webhook -hooks hooks.json -ip 127.0.0.1 -port 18098`.
 - Fixture file `handler.sh` is created.

--- a/internal/loader/defaults.go
+++ b/internal/loader/defaults.go
@@ -25,6 +25,16 @@ func applyDefaults(s *spec.Spec) {
 		sc := &s.Scenarios[i]
 		if d.Scenario != nil {
 			sc.Env = mergeStringMap(d.Scenario.Env, sc.Env)
+			// A gate is taken whole rather than merged: a scenario that states
+			// its own condition means that one, and silently ANDing a
+			// file-level condition onto it would make the scenario's own line
+			// no longer describe when it runs.
+			if sc.Only == nil {
+				sc.Only = d.Scenario.Only
+			}
+			if sc.Skip == nil {
+				sc.Skip = d.Scenario.Skip
+			}
 		}
 		if d.Service != nil {
 			for j := range sc.Services {

--- a/internal/loader/defaults_test.go
+++ b/internal/loader/defaults_test.go
@@ -1232,3 +1232,72 @@ scenarios:
 		t.Errorf("run.shell = true, want unchanged false without defaults")
 	}
 }
+
+// TestApplyDefaults_ScenarioGate covers the file-level selection gate. A
+// probe-first suite states "these scenarios exist only where the tool is
+// installed" once, and a scenario that states its own condition keeps it: the
+// two are not combined, because a scenario's own `only:` line has to keep
+// describing when that scenario runs.
+func TestApplyDefaults_ScenarioGate(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: gate
+defaults:
+  scenario:
+    only:
+      command: mytool --version
+    skip:
+      os: windows
+scenarios:
+  - name: takes both defaults
+    steps:
+      - run: {command: "true"}
+  - name: states its own only
+    only:
+      env: MYTOOL_HOME
+    steps:
+      - run: {command: "true"}
+  - name: states its own skip
+    skip:
+      os: darwin
+    steps:
+      - run: {command: "true"}
+`
+	s, err := LoadBytes("gate.atago.yaml", []byte(src))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	tests := []struct {
+		idx      int
+		wantOnly string
+		wantSkip string
+	}{
+		{idx: 0, wantOnly: "mytool --version", wantSkip: "windows"},
+		{idx: 1, wantOnly: "", wantSkip: "windows"},
+		{idx: 2, wantOnly: "mytool --version", wantSkip: "darwin"},
+	}
+	for _, tt := range tests {
+		sc := s.Scenarios[tt.idx]
+		gotOnly := ""
+		if sc.Only != nil {
+			gotOnly = sc.Only.Command
+		}
+		if gotOnly != tt.wantOnly {
+			t.Errorf("scenario %q only.command = %q, want %q", sc.Name, gotOnly, tt.wantOnly)
+		}
+		gotSkip := ""
+		if sc.Skip != nil {
+			gotSkip = sc.Skip.OS
+		}
+		if gotSkip != tt.wantSkip {
+			t.Errorf("scenario %q skip.os = %q, want %q", sc.Name, gotSkip, tt.wantSkip)
+		}
+	}
+	// The scenario that stated its own only: keeps it whole, rather than
+	// inheriting the default's command alongside its own env.
+	if s.Scenarios[1].Only == nil || s.Scenarios[1].Only.Env != "MYTOOL_HOME" {
+		t.Errorf("scenario 1 lost its own only: %+v", s.Scenarios[1].Only)
+	}
+}

--- a/internal/loader/validate.go
+++ b/internal/loader/validate.go
@@ -235,6 +235,13 @@ func validateDefaults(add addFunc, d *spec.Defaults) {
 		nonNegativeDuration(add, "defaults.run.timeout", r.Timeout, "30s")
 		validateHermeticEnv(add, "defaults.run", r.ClearEnv, r.PassEnv)
 	}
+	if scn := d.Scenario; scn != nil {
+		// The gates are validated here as well as on each scenario, so a
+		// malformed default fails even when every scenario states its own and
+		// the default is therefore never applied.
+		validateCondition(add, "defaults.scenario", "only", scn.Only)
+		validateCondition(add, "defaults.scenario", "skip", scn.Skip)
+	}
 	if sv := d.Service; sv != nil {
 		if sv.Name != "" {
 			add(diag.KeyNotHere, "defaults.service.name is not supported (each service names itself)")

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -71,11 +71,23 @@ type Defaults struct {
 	Service  *Service          `yaml:"service,omitempty"`
 }
 
-// ScenarioDefaults holds the scenario-level default fragments. Only `env` is
-// supported — the highest-value duplication — and it shallow-merges beneath each
-// scenario's own `env`.
+// ScenarioDefaults holds the scenario-level default fragments: the env every
+// scenario shares, and the gate every scenario is selected by.
+//
+// Env shallow-merges beneath each scenario's own `env`. Only and Skip are taken
+// whole by a scenario that does not state its own, which is what a probe-first
+// suite needs: "these scenarios exist only where the tool is installed" is a
+// property of the file, not of each scenario in it, and repeating it on every
+// scenario is how a suite ends up with some scenarios gated and some not — the
+// ungated ones then error on a machine without the tool instead of skipping.
 type ScenarioDefaults struct {
 	Env map[string]string `yaml:"env,omitempty"`
+	// Only is the default selection gate: a scenario without its own `only:`
+	// runs only when this condition holds.
+	Only *Condition `yaml:"only,omitempty"`
+	// Skip is the default exclusion gate: a scenario without its own `skip:` is
+	// skipped when this condition holds.
+	Skip *Condition `yaml:"skip,omitempty"`
 }
 
 // Suite groups scenarios under a name.

--- a/schema/atago.schema.json
+++ b/schema/atago.schema.json
@@ -203,7 +203,7 @@
         },
         "scenario": {
           "type": "object",
-          "description": "Scenario-level defaults. Only `env` is supported; it shallow-merges beneath each scenario's own env.",
+          "description": "Scenario-level defaults: the env every scenario shares, and the gate every scenario is selected by.",
           "additionalProperties": false,
           "properties": {
             "env": {
@@ -212,6 +212,14 @@
                 "type": "string"
               },
               "description": "Env map shallow-merged beneath every scenario's own `env`."
+            },
+            "only": {
+              "$ref": "#/$defs/condition",
+              "description": "Default selection gate: a scenario without its own `only:` runs only when this holds. Declaring a probe-first suite's gate once — `only: {command: mytool --version}` — is what keeps some scenarios in the file from being left ungated, which is how a suite ends up erroring on a machine without the tool instead of skipping. A scenario that states its own `only:` uses that one instead; the two are not combined."
+            },
+            "skip": {
+              "$ref": "#/$defs/condition",
+              "description": "Default exclusion gate: a scenario without its own `skip:` is skipped when this holds. A scenario that states its own `skip:` uses that one instead; the two are not combined."
             }
           }
         },

--- a/test/e2e/atago/defaults.atago.yaml
+++ b/test/e2e/atago/defaults.atago.yaml
@@ -193,3 +193,92 @@ scenarios:
           exit_code: 0
           stdout:
             contains: PASSED
+
+  # A probe-first suite's gate belongs to the file, not to each scenario in it.
+  # Repeating `only:` per scenario is how a suite ends up with some scenarios
+  # gated and some not — and the ungated ones then error on a machine without
+  # the tool instead of skipping, which is noise rather than a result.
+  - name: defaults.scenario.only gates every scenario that states no gate
+    steps:
+      - fixture:
+          file: gated.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: gated
+            defaults:
+              scenario:
+                only:
+                  command: definitely-no-such-tool-xyz --version
+            scenarios:
+              - name: inherits the file gate
+                steps:
+                  - run: {command: "false"}
+                  - assert: {exit_code: 0}
+              - name: also inherits it
+                steps:
+                  - run: {command: "false"}
+                  - assert: {exit_code: 0}
+      - run: {command: "${atago} run gated.atago.yaml"}
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "2 skipped"
+
+  # A scenario that states its own gate means that one. Silently ANDing the
+  # file-level condition onto it would make the scenario's own line stop
+  # describing when it runs.
+  - name: a scenario's own gate replaces the default rather than combining
+    steps:
+      - fixture:
+          file: own.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: own
+            defaults:
+              scenario:
+                only:
+                  command: definitely-no-such-tool-xyz --version
+            scenarios:
+              - name: states its own gate and runs
+                only:
+                  command: "true"
+                steps:
+                  - run: {command: "true"}
+                  - assert: {exit_code: 0}
+              - name: takes the default and skips
+                steps:
+                  - run: {command: "false"}
+                  - assert: {exit_code: 0}
+      - run: {command: "${atago} run own.atago.yaml"}
+      - assert:
+          exit_code: 0
+          stdout:
+            contains:
+              - "1 passed"
+              - "1 skipped"
+
+  # The same for skip, so a file-wide platform exclusion is stated once.
+  - name: defaults.scenario.skip excludes every scenario that states no skip
+    steps:
+      - fixture:
+          file: skipped.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: skipped
+            defaults:
+              scenario:
+                skip:
+                  command: "true"
+            scenarios:
+              - name: inherits the file exclusion
+                steps:
+                  - run: {command: "false"}
+                  - assert: {exit_code: 0}
+      - run: {command: "${atago} run skipped.atago.yaml"}
+      - assert:
+          exit_code: 0
+          stdout:
+            contains: "1 skipped"

--- a/test/e2e/thirdparty/caddy/caddy.atago.yaml
+++ b/test/e2e/thirdparty/caddy/caddy.atago.yaml
@@ -30,6 +30,14 @@ runners:
     base_url: http://127.0.0.1:18081
     timeout: 10s
 
+defaults:
+  scenario:
+    # Every scenario here drives caddy. Without the program there is nothing to
+    # test, so the suite skips rather than erroring: a missing tool is not a
+    # result. The gate is declared once so no scenario can be left out of it.
+    only:
+      command: caddy version
+
 scenarios:
   - name: the standard module set is compiled in
     steps:

--- a/test/e2e/thirdparty/coredns/coredns.atago.yaml
+++ b/test/e2e/thirdparty/coredns/coredns.atago.yaml
@@ -31,6 +31,14 @@ runners:
     base_url: http://127.0.0.1:18153
     timeout: 10s
 
+defaults:
+  scenario:
+    # Every scenario here drives coredns. Without the program there is nothing to
+    # test, so the suite skips rather than erroring: a missing tool is not a
+    # result. The gate is declared once so no scenario can be left out of it.
+    only:
+      command: coredns -version
+
 scenarios:
   - name: the binary reports its version
     steps:

--- a/test/e2e/thirdparty/gitea/gitea.atago.yaml
+++ b/test/e2e/thirdparty/gitea/gitea.atago.yaml
@@ -34,6 +34,11 @@ runners:
 
 defaults:
   scenario:
+    # Every scenario here drives gitea. Without the program there is nothing to
+    # test, so the suite skips rather than erroring: a missing tool is not a
+    # result. The gate is declared once so no scenario can be left out of it.
+    only:
+      command: gitea --version
     env:
       GITEA_WORK_DIR: ${workdir}/work
 

--- a/test/e2e/thirdparty/gotify/gotify.atago.yaml
+++ b/test/e2e/thirdparty/gotify/gotify.atago.yaml
@@ -43,6 +43,11 @@ runners:
 
 defaults:
   scenario:
+    # Every scenario here drives gotify. Without the program there is nothing to
+    # test, so the suite skips rather than erroring: a missing tool is not a
+    # result. The gate is declared once so no scenario can be left out of it.
+    only:
+      command: gotify --version
     env:
       GOTIFY_SERVER_LISTENADDR: 127.0.0.1
       GOTIFY_DATABASE_DIALECT: sqlite3

--- a/test/e2e/thirdparty/grafana/grafana.atago.yaml
+++ b/test/e2e/thirdparty/grafana/grafana.atago.yaml
@@ -42,6 +42,11 @@ runners:
 
 defaults:
   scenario:
+    # Every scenario here drives grafana. Without the program there is nothing to
+    # test, so the suite skips rather than erroring: a missing tool is not a
+    # result. The gate is declared once so no scenario can be left out of it.
+    only:
+      command: grafana --version
     env:
       GF_PATHS_DATA: ${workdir}/data
       GF_PATHS_LOGS: ${workdir}/logs

--- a/test/e2e/thirdparty/hugo/hugo_server.atago.yaml
+++ b/test/e2e/thirdparty/hugo/hugo_server.atago.yaml
@@ -47,6 +47,14 @@ runners:
     base_url: http://127.0.0.1:14140
     timeout: 10s
 
+defaults:
+  scenario:
+    # Every scenario here drives hugo. Without the program there is nothing to
+    # test, so the suite skips rather than erroring: a missing tool is not a
+    # result. The gate is declared once so no scenario can be left out of it.
+    only:
+      command: hugo version
+
 scenarios:
   - name: the home page lists the post
     steps:

--- a/test/e2e/thirdparty/jq/extra.atago.yaml
+++ b/test/e2e/thirdparty/jq/extra.atago.yaml
@@ -14,6 +14,14 @@ suite:
     malformed input. That combination (silent on success, non-zero on garbage)
     is what makes it usable as a JSON check in a script, and both halves are
     pinned here.
+defaults:
+  scenario:
+    # Every scenario here drives jq. Without the program there is nothing to
+    # test, so the suite skips rather than erroring: a missing tool is not a
+    # result. The gate is declared once so no scenario can be left out of it.
+    only:
+      command: jq --version
+
 scenarios:
   - name: multibyte unicode passes through unchanged
     steps:

--- a/test/e2e/thirdparty/jq/jq.atago.yaml
+++ b/test/e2e/thirdparty/jq/jq.atago.yaml
@@ -14,6 +14,14 @@ suite:
     handle differently — and each of which must not be confused for the others.
 
 # The unicode and `jq empty` contracts live in extra.atago.yaml.
+defaults:
+  scenario:
+    # Every scenario here drives jq. Without the program there is nothing to
+    # test, so the suite skips rather than erroring: a missing tool is not a
+    # result. The gate is declared once so no scenario can be left out of it.
+    only:
+      command: jq --version
+
 scenarios:
   - name: identity filter echoes the document from stdin
     steps:

--- a/test/e2e/thirdparty/lazygit/lazygit.atago.yaml
+++ b/test/e2e/thirdparty/lazygit/lazygit.atago.yaml
@@ -20,7 +20,7 @@ suite:
 # only holds onto whatever the previous scenario left running, so the number is
 # staying where it was until that is understood.
 scenarios:
-  - name: version prints the pinned release
+  - name: version prints a semantic version
     only:
       command: lazygit --version
     steps:
@@ -29,7 +29,14 @@ scenarios:
       - assert:
           exit_code: 0
           stdout:
-            contains: version=0.63.1
+            # The shape, not the number. Pinning the exact release coupled this
+            # scenario to the version thirdparty.yml installs, so it failed
+            # against any other build — a developer's own lazygit, or CI itself
+            # the moment the pin moved. What is worth asserting is that lazygit
+            # reports a version at all, in the field-tagged form the rest of
+            # this suite reads.
+            matches: 'version=[0-9]+\.[0-9]+\.[0-9]+'
+            contains: "os="
 
   - name: opening a dirty repository shows unstaged changes and quits cleanly
     only:

--- a/test/e2e/thirdparty/mailpit/mailpit.atago.yaml
+++ b/test/e2e/thirdparty/mailpit/mailpit.atago.yaml
@@ -40,6 +40,14 @@ runners:
     base_url: http://127.0.0.1:18177
     timeout: 10s
 
+defaults:
+  scenario:
+    # Every scenario here drives mailpit. Without the program there is nothing to
+    # test, so the suite skips rather than erroring: a missing tool is not a
+    # result. The gate is declared once so no scenario can be left out of it.
+    only:
+      command: mailpit version
+
 scenarios:
   - name: the binary reports its version
     steps:

--- a/test/e2e/thirdparty/minio/minio.atago.yaml
+++ b/test/e2e/thirdparty/minio/minio.atago.yaml
@@ -40,6 +40,11 @@ runners:
 
 defaults:
   scenario:
+    # Every scenario here drives minio. Without the program there is nothing to
+    # test, so the suite skips rather than erroring: a missing tool is not a
+    # result. The gate is declared once so no scenario can be left out of it.
+    only:
+      command: minio --version
     env:
       MINIO_ROOT_USER: atago
       MINIO_ROOT_PASSWORD: atago-secret-key

--- a/test/e2e/thirdparty/nats/nats.atago.yaml
+++ b/test/e2e/thirdparty/nats/nats.atago.yaml
@@ -30,6 +30,14 @@ runners:
     base_url: http://127.0.0.1:18161
     timeout: 10s
 
+defaults:
+  scenario:
+    # Every scenario here drives nats-server. Without the program there is nothing to
+    # test, so the suite skips rather than erroring: a missing tool is not a
+    # result. The gate is declared once so no scenario can be left out of it.
+    only:
+      command: nats-server --version
+
 scenarios:
   - name: the binary reports its version
     steps:

--- a/test/e2e/thirdparty/ntfy/ntfy.atago.yaml
+++ b/test/e2e/thirdparty/ntfy/ntfy.atago.yaml
@@ -40,6 +40,14 @@ runners:
     base_url: http://127.0.0.1:18182
     timeout: 10s
 
+defaults:
+  scenario:
+    # Every scenario here drives ntfy. Without the program there is nothing to
+    # test, so the suite skips rather than erroring: a missing tool is not a
+    # result. The gate is declared once so no scenario can be left out of it.
+    only:
+      command: ntfy --version
+
 scenarios:
   - name: the binary reports its version
     steps:

--- a/test/e2e/thirdparty/openssl/openssl.atago.yaml
+++ b/test/e2e/thirdparty/openssl/openssl.atago.yaml
@@ -17,6 +17,14 @@ suite:
     password must fail loudly, because a crypto tool that silently emits garbage
     on a bad key is worse than one that crashes. A self-signed certificate is
     checked to carry the subject that was requested.
+defaults:
+  scenario:
+    # Every scenario here drives openssl. Without the program there is nothing to
+    # test, so the suite skips rather than erroring: a missing tool is not a
+    # result. The gate is declared once so no scenario can be left out of it.
+    only:
+      command: openssl version
+
 scenarios:
   - name: sha256 digest of a fixed input is exact and stable
     steps:

--- a/test/e2e/thirdparty/prometheus/prometheus.atago.yaml
+++ b/test/e2e/thirdparty/prometheus/prometheus.atago.yaml
@@ -36,6 +36,14 @@ runners:
     base_url: http://127.0.0.1:18131
     timeout: 10s
 
+defaults:
+  scenario:
+    # Every scenario here drives promtool. Without the program there is nothing to
+    # test, so the suite skips rather than erroring: a missing tool is not a
+    # result. The gate is declared once so no scenario can be left out of it.
+    only:
+      command: promtool --version
+
 scenarios:
   - name: promtool accepts a valid config and rejects a broken one
     steps:

--- a/test/e2e/thirdparty/pushgateway/pushgateway.atago.yaml
+++ b/test/e2e/thirdparty/pushgateway/pushgateway.atago.yaml
@@ -43,6 +43,14 @@ runners:
     base_url: http://127.0.0.1:18101
     timeout: 10s
 
+defaults:
+  scenario:
+    # Every scenario here drives pushgateway. Without the program there is nothing to
+    # test, so the suite skips rather than erroring: a missing tool is not a
+    # result. The gate is declared once so no scenario can be left out of it.
+    only:
+      command: pushgateway --version
+
 scenarios:
   - name: a pushed metric appears on the scrape endpoint
     services:

--- a/test/e2e/thirdparty/rclone/rclone.atago.yaml
+++ b/test/e2e/thirdparty/rclone/rclone.atago.yaml
@@ -33,6 +33,11 @@ runners:
 # empty one so assertions never race that NOTICE line.
 defaults:
   scenario:
+    # Every scenario here drives rclone. Without the program there is nothing to
+    # test, so the suite skips rather than erroring: a missing tool is not a
+    # result. The gate is declared once so no scenario can be left out of it.
+    only:
+      command: rclone version
     env:
       RCLONE_CONFIG: rclone.conf
 

--- a/test/e2e/thirdparty/restic/restic.atago.yaml
+++ b/test/e2e/thirdparty/restic/restic.atago.yaml
@@ -24,6 +24,11 @@ suite:
 
 defaults:
   scenario:
+    # Every scenario here drives restic. Without the program there is nothing to
+    # test, so the suite skips rather than erroring: a missing tool is not a
+    # result. The gate is declared once so no scenario can be left out of it.
+    only:
+      command: restic version
     env:
       RESTIC_PASSWORD: atago-e2e-pass
       RESTIC_REPOSITORY: repo

--- a/test/e2e/thirdparty/sqlite3/changes.atago.yaml
+++ b/test/e2e/thirdparty/sqlite3/changes.atago.yaml
@@ -15,6 +15,14 @@ suite:
     That is a stronger statement than "the write worked", and it is what makes a
     leftover journal file a detectable regression rather than something nobody
     notices until a restore.
+defaults:
+  scenario:
+    # Every scenario here drives sqlite3. Without the program there is nothing to
+    # test, so the suite skips rather than erroring: a missing tool is not a
+    # result. The gate is declared once so no scenario can be left out of it.
+    only:
+      command: sqlite3 --version
+
 scenarios:
   - name: default rollback-journal mode creates exactly the db file
     steps:

--- a/test/e2e/thirdparty/sqlite3/sqlite3.atago.yaml
+++ b/test/e2e/thirdparty/sqlite3/sqlite3.atago.yaml
@@ -15,6 +15,14 @@ suite:
     Durability gets its own attention: data written by one invocation must still
     be there for the next one, which is the whole reason to use a file-backed
     database rather than a pipe.
+defaults:
+  scenario:
+    # Every scenario here drives sqlite3. Without the program there is nothing to
+    # test, so the suite skips rather than erroring: a missing tool is not a
+    # result. The gate is declared once so no scenario can be left out of it.
+    only:
+      command: sqlite3 --version
+
 scenarios:
   - name: one-shot SQL creates, inserts, and counts in a single invocation
     steps:

--- a/test/e2e/thirdparty/transfersh/transfersh.atago.yaml
+++ b/test/e2e/thirdparty/transfersh/transfersh.atago.yaml
@@ -34,6 +34,14 @@ runners:
     base_url: http://127.0.0.1:18211
     timeout: 15s
 
+defaults:
+  scenario:
+    # Every scenario here drives transfer.sh. Without the program there is nothing to
+    # test, so the suite skips rather than erroring: a missing tool is not a
+    # result. The gate is declared once so no scenario can be left out of it.
+    only:
+      command: transfer.sh --help
+
 scenarios:
   - name: the binary reports its version
     steps:

--- a/test/e2e/thirdparty/webhook/webhook.atago.yaml
+++ b/test/e2e/thirdparty/webhook/webhook.atago.yaml
@@ -49,6 +49,14 @@ runners:
     base_url: http://127.0.0.1:18098
     timeout: 10s
 
+defaults:
+  scenario:
+    # Every scenario here drives webhook. Without the program there is nothing to
+    # test, so the suite skips rather than erroring: a missing tool is not a
+    # result. The gate is declared once so no scenario can be left out of it.
+    only:
+      command: webhook -version
+
 scenarios:
   - name: a post runs the command, returns its output, and writes its file
     services:

--- a/website/data/spec_keys.json
+++ b/website/data/spec_keys.json
@@ -70,6 +70,8 @@
   "defaults.run.timeout": "v0.1.0",
   "defaults.scenario": "v0.1.0",
   "defaults.scenario.env": "v0.1.0",
+  "defaults.scenario.only": "unreleased",
+  "defaults.scenario.skip": "unreleased",
   "defaults.service": "v0.1.0",
   "defaults.service.clear_env": "v0.3.0",
   "defaults.service.cwd": "v0.1.0",


### PR DESCRIPTION
## Summary

Running the third-party tree on a machine without every program reported 17 errors for tools that were simply not installed, plus one failure from a pinned version string. Neither is a result — both are noise that makes a red run mean nothing.

Twenty-one of the suites carried no probe gate at all. The convention is a per-scenario `only: {command: ...}`, and repeating it on every scenario is how a file ends up with some scenarios gated and some not.

## Changes

- `internal/spec/spec.go`, `internal/loader/defaults.go`, `internal/loader/validate.go` — `defaults.scenario` takes `only` and `skip`.
- `schema/atago.schema.json`, `website/data/spec_keys.json` — the two new keys.
- `test/e2e/thirdparty/**` — twenty-one suites gated on the program they drive; lazygit asserts the version's shape.
- `test/e2e/atago/defaults.atago.yaml`, `internal/loader/defaults_test.go` — the gate, the override, and the skip side.

## Design Decisions

The gate belongs to the file. "These scenarios exist only where the tool is installed" is a property of the suite, not of each scenario in it, and stating it once is what stops a scenario from being left out — which is exactly how these twenty-one suites came to error rather than skip.

A scenario that states its own condition keeps it whole; the default is not ANDed onto it. Combining them would be defensible in the abstract, but it would mean a scenario's own `only:` line no longer describes when that scenario runs, and a reader would have to hold two places in their head to answer the question. Taking the nearer one is also what `defaults.scenario.env` already does for a key the scenario sets itself.

Both gates are validated in `defaults` as well as on each scenario, so a malformed default fails even when every scenario states its own and the default is therefore never applied.

The lazygit scenario asserted `version=0.63.1`, the release the CI workflow installs. That coupled it to the pin: it failed against any other build, and would have failed in CI itself the moment the pin moved, in a file nobody would think to edit alongside the workflow. What is worth asserting is that lazygit reports a semantic version at all, in the field-tagged form the rest of the suite reads.

## Verification

The whole third-party tree is clean here: 373 passed, 199 skipped, nothing failed or errored. Before this change the same run was 372 passed, 1 failed, 17 errored. The self-hosted suite and the unit tests are green, and `make docs` and `make site` are regenerated.
