### PR TITLE
fix(e2e): keep the echo scenario's program alive so it runs on macOS

### DIFF
--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -9110,7 +9110,7 @@ scenarios:
   - name: the program never produced this
     steps:
       - pty:
-          command: "sh -c 'echo ready; exit 0'"
+          command: "sh -c 'echo ready; sleep 30'"
           timeout: 4s
           session:
             - expect: "ready"

--- a/test/e2e/atago/pty.atago.yaml
+++ b/test/e2e/atago/pty.atago.yaml
@@ -560,11 +560,15 @@ scenarios:
               - "$${no_such_var}"
 
   # An expect that matches only the terminal's echo of the send before it has
-  # asserted that atago can type, not that the program answered — and it passes
-  # whether the program is listening, busy, or already dead. The inner spec
-  # sends text to a program that has already exited, so the echo is the only
-  # possible source; it must fail rather than report a green scenario that
-  # tested nothing.
+  # asserted that atago can type, not that the program answered. The inner
+  # program stays alive and silent after its greeting, so the echo is the only
+  # possible source of the text; the expect must run out its budget rather than
+  # report a green scenario that tested nothing.
+  #
+  # The program sleeps rather than exiting, which is what makes this portable: a
+  # write to a terminal whose child has gone is EIO on macOS and accepted on
+  # Linux, so a dead program would test the platform's pty semantics instead of
+  # the rule under test here.
   - name: an expect does not match the echo of its own send
     skip:
       os: windows
@@ -579,7 +583,7 @@ scenarios:
               - name: the program never produced this
                 steps:
                   - pty:
-                      command: "sh -c 'echo ready; exit 0'"
+                      command: "sh -c 'echo ready; sleep 30'"
                       timeout: 4s
                       session:
                         - expect: "ready"


### PR DESCRIPTION
## Summary

The scenario added with the echo fix failed the macOS leg of CrossPlatformE2E on main. It sent to a program that had already exited, and a write to a terminal whose child has gone is EIO on macOS and accepted on Linux — so the send itself errored there, the run exited 4 instead of 1, and the scenario was testing the platform's pty semantics rather than the rule.

## Changes

- `test/e2e/atago/pty.atago.yaml` — the inner program sleeps instead of exiting.

## Design Decisions

A dead program was never necessary to the point being made. What the scenario needs is a program that cannot have produced the text, and one that is alive and silent after its greeting does that just as well while behaving the same on both platforms. The echo remains the only possible source, so the expect still has to run out its budget.

Worth noting for #465's history: macOS already refuses to drive a terminal whose program has gone, which is the narrower fix that issue listed as an option. This change does not adopt it — it just stops depending on the difference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PTY interaction testing to prevent echoed input from being mistaken for program output.
  * Ensured test processes remain active and silent after displaying their initial greeting.

* **Documentation**
  * Updated the related test documentation to reflect the revised command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->