### PR TITLE
fix(e2e): probe for the binary, not for a version flag that might not exist

### DIFF
--- a/doc/e2e/gitea.md
+++ b/doc/e2e/gitea.md
@@ -20,7 +20,7 @@ just a JSON API that claims a repository exists.
 
 Source: `test/e2e/thirdparty/gitea/gitea.atago.yaml`
 ### Scenario: the binary reports its version
-_only when `gitea --version` succeeds_
+_only when `command -v gitea` succeeds_
 #### When
 ```shell
 gitea --version
@@ -29,7 +29,7 @@ gitea --version
 - exit code is `0`
 - stdout matches `/gitea version [0-9]+\.[0-9]+\.[0-9]+/`
 ### Scenario: the server boots from an authored app.ini and reports healthy
-_only when `gitea --version` succeeds_
+_only when `command -v gitea` succeeds_
 #### Given
 - Background service `gitea` is started: `gitea web --config app.ini`.
 - Fixture file `app.ini` is created.
@@ -70,7 +70,7 @@ ROOT = data/repos
   - HTTP status is `200`
   - body at `$.version` matches `/^[0-9]+\.[0-9]+\.[0-9]+/`
 ### Scenario: admin CLI, REST API, and a real git clone interoperate
-_only when `gitea --version` succeeds_
+_only when `command -v gitea` succeeds_
 #### Given
 - Background service `gitea` is started: `gitea web --config app.ini`.
 - Fixture file `app.ini` is created.

--- a/doc/e2e/gotify.md
+++ b/doc/e2e/gotify.md
@@ -23,7 +23,7 @@ bytes that came back.
 
 Source: `test/e2e/thirdparty/gotify/gotify.atago.yaml`
 ### Scenario: the server reports health and version
-_only when `gotify --version` succeeds_
+_only when `command -v gotify` succeeds_
 #### Given
 - Background service `gotify` is started: `gotify`.
 - Fixture file `data/.keep` is created.
@@ -40,7 +40,7 @@ _only when `gotify --version` succeeds_
   - HTTP status is `200`
   - body at `$.version` matches `/^[0-9]+\.[0-9]+\.[0-9]+/`
 ### Scenario: an application pushes and the admin reads it back
-_only when `gotify --version` succeeds_
+_only when `command -v gotify` succeeds_
 #### Given
 - Background service `gotify` is started: `gotify`.
 - Fixture file `data/.keep` is created.
@@ -66,7 +66,7 @@ _only when `gotify --version` succeeds_
   - body at `$.messages` has length 1
   - body at `$.messages[0].priority` equals `5`
 ### Scenario: the app icon round-trips through a multipart upload
-_only when `gotify --version` succeeds_
+_only when `command -v gotify` succeeds_
 #### Given
 - Background service `gotify` is started: `gotify`.
 - Fixture file `data/.keep` is created.

--- a/doc/e2e/grafana.md
+++ b/doc/e2e/grafana.md
@@ -20,7 +20,7 @@ accepted alongside it.
 
 Source: `test/e2e/thirdparty/grafana/grafana.atago.yaml`
 ### Scenario: the server boots and reports health and build info
-_only when `grafana --version` succeeds_
+_only when `command -v grafana` succeeds_
 #### Given
 - Background service `grafana` is started: `grafana server --homepath "$GF_PATHS_HOME"`.
 #### When
@@ -42,7 +42,7 @@ The 302 itself is the behavior under test, so the request is made with
 perfectly healthy login page and can no longer tell whether Grafana
 redirected at all.
 
-_only when `grafana --version` succeeds_
+_only when `command -v grafana` succeeds_
 #### Given
 - Background service `grafana` is started: `grafana server --homepath "$GF_PATHS_HOME"`.
 #### When
@@ -58,7 +58,7 @@ _only when `grafana --version` succeeds_
 - after `HTTP GET /api/search`:
   - HTTP status is `401`
 ### Scenario: a dashboard and datasource lifecycle over the REST API
-_only when `grafana --version` succeeds_
+_only when `command -v grafana` succeeds_
 #### Given
 - Background service `grafana` is started: `grafana server --homepath "$GF_PATHS_HOME"`.
 #### When

--- a/doc/e2e/ntfy.md
+++ b/doc/e2e/ntfy.md
@@ -24,7 +24,7 @@ access through the admin CLI, the same publish succeeds.
 
 Source: `test/e2e/thirdparty/ntfy/ntfy.atago.yaml`
 ### Scenario: the binary reports its version
-_only when `ntfy --version` succeeds_
+_only when `command -v ntfy` succeeds_
 #### When
 ```shell
 ntfy --version
@@ -33,7 +33,7 @@ ntfy --version
 - exit code is `0`
 - stdout matches `/ntfy version [0-9]+\.[0-9]+\.[0-9]+/`
 ### Scenario: a published notification comes back through the JSON poll feed
-_only when `ntfy --version` succeeds_
+_only when `command -v ntfy` succeeds_
 #### Given
 - Background service `ntfy` is started: `ntfy serve --listen-http 127.0.0.1:18180 --base-url http://127.0.0.1:18180 --cache-file data/cache.db`.
 - Fixture file `data/.keep` is created.
@@ -60,7 +60,7 @@ _only when `ntfy --version` succeeds_
   - HTTP status is `200`
   - body is empty
 ### Scenario: the bundled CLI publishes against the same server
-_only when `ntfy --version` succeeds_
+_only when `command -v ntfy` succeeds_
 #### Given
 - Background service `ntfy` is started: `ntfy serve --listen-http 127.0.0.1:18181 --base-url http://127.0.0.1:18181 --cache-file data/cache.db`.
 - Fixture file `data/.keep` is created.
@@ -79,7 +79,7 @@ ntfy publish http://127.0.0.1:18181/atago-deploys "deploy two"
   - HTTP status is `200`
   - body contains `deploy one`, `deploy two`
 ### Scenario: deny-all access control locks a topic until a user is granted
-_only when `ntfy --version` succeeds_
+_only when `command -v ntfy` succeeds_
 #### Given
 - Background service `ntfy` is started: `ntfy serve --listen-http 127.0.0.1:18182 --base-url http://127.0.0.1:18182 --cache-file data/cache.db --auth-file data/auth.db --auth-default-access deny-all`.
 - Fixture file `data/.keep` is created.

--- a/doc/e2e/prometheus.md
+++ b/doc/e2e/prometheus.md
@@ -24,7 +24,7 @@ all had to work for the sample to be there.
 
 Source: `test/e2e/thirdparty/prometheus/prometheus.atago.yaml`
 ### Scenario: promtool accepts a valid config and rejects a broken one
-_only when `promtool --version` succeeds_
+_only when `command -v promtool && command -v prometheus` succeeds_
 #### Given
 - Fixture file `prometheus.yml` is created.
 - Fixture file `broken.yml` is created.
@@ -56,7 +56,7 @@ promtool check config broken.yml
   - exit code is not `0`
   - stderr contains `not a valid duration string`
 ### Scenario: promtool unit-tests an alerting rule
-_only when `promtool --version` succeeds_
+_only when `command -v promtool && command -v prometheus` succeeds_
 #### Given
 - Fixture file `rules.yml` is created.
 - Fixture file `rules_test.yml` is created.
@@ -110,7 +110,7 @@ promtool test rules rules_test.yml
   - exit code is `0`
   - stdout contains `SUCCESS`
 ### Scenario: the server boots from an authored config and answers the query API
-_only when `promtool --version` succeeds_
+_only when `command -v promtool && command -v prometheus` succeeds_
 #### Given
 - Background service `prometheus` is started: `prometheus --config.file=prometheus.yml --storage.tsdb.path=data --web.listen-address=127.0.0.1:18130`.
 - Fixture file `prometheus.yml` is created.
@@ -143,7 +143,7 @@ scrape_configs: []
   - HTTP status is `200`
   - body at `$.data.result[0].value[1]` equals `42`
 ### Scenario: a self-scrape is ingested and queryable as up == 1
-_only when `promtool --version` succeeds_
+_only when `command -v promtool && command -v prometheus` succeeds_
 #### Given
 - Background service `prometheus` is started: `prometheus --config.file=prometheus.yml --storage.tsdb.path=data --web.listen-address=127.0.0.1:18131`.
 - Fixture file `prometheus.yml` is created.

--- a/doc/e2e/transfersh.md
+++ b/doc/e2e/transfersh.md
@@ -22,7 +22,7 @@ how a file arrives from a web form rather than from `curl`.
 
 Source: `test/e2e/thirdparty/transfersh/transfersh.atago.yaml`
 ### Scenario: the binary reports its version
-_only when `transfer.sh --help` succeeds_
+_only when `command -v transfer.sh` succeeds_
 #### When
 ```shell
 transfer.sh version
@@ -31,7 +31,7 @@ transfer.sh version
 - exit code is `0`
 - stdout contains `transfer.sh`
 ### Scenario: a binary upload round-trips byte-for-byte
-_only when `transfer.sh --help` succeeds_
+_only when `command -v transfer.sh` succeeds_
 #### Given
 - Background service `transfersh` is started: `transfer.sh --provider local --basedir storage --temp-path tmp --listener 127.0.0.1:18210`.
 - Fixture file `storage/.keep` is created.
@@ -56,7 +56,7 @@ cmp pixel.png downloaded.png
 #### Generated artifacts
 - `downloaded.png`
 ### Scenario: a browser-style multipart upload is accepted too
-_only when `transfer.sh --help` succeeds_
+_only when `command -v transfer.sh` succeeds_
 #### Given
 - Background service `transfersh` is started: `transfer.sh --provider local --basedir storage --temp-path tmp --listener 127.0.0.1:18211`.
 - Fixture file `storage/.keep` is created.

--- a/test/e2e/thirdparty/gitea/gitea.atago.yaml
+++ b/test/e2e/thirdparty/gitea/gitea.atago.yaml
@@ -37,8 +37,14 @@ defaults:
     # Every scenario here drives gitea. Without the program there is nothing to
     # test, so the suite skips rather than erroring: a missing tool is not a
     # result. The gate is declared once so no scenario can be left out of it.
+    #
+    # The probe asks whether the binary is on PATH rather than running it. A
+    # probe that gets the version flag wrong would skip the whole suite and
+    # leave CI green while testing nothing, which is the one failure mode a
+    # gate must not have — and this workflow runs on a schedule, so nobody
+    # would see it happen on a pull request.
     only:
-      command: gitea --version
+      command: command -v gitea
     env:
       GITEA_WORK_DIR: ${workdir}/work
 

--- a/test/e2e/thirdparty/gotify/gotify.atago.yaml
+++ b/test/e2e/thirdparty/gotify/gotify.atago.yaml
@@ -46,8 +46,14 @@ defaults:
     # Every scenario here drives gotify. Without the program there is nothing to
     # test, so the suite skips rather than erroring: a missing tool is not a
     # result. The gate is declared once so no scenario can be left out of it.
+    #
+    # The probe asks whether the binary is on PATH rather than running it. A
+    # probe that gets the version flag wrong would skip the whole suite and
+    # leave CI green while testing nothing, which is the one failure mode a
+    # gate must not have — and this workflow runs on a schedule, so nobody
+    # would see it happen on a pull request.
     only:
-      command: gotify --version
+      command: command -v gotify
     env:
       GOTIFY_SERVER_LISTENADDR: 127.0.0.1
       GOTIFY_DATABASE_DIALECT: sqlite3

--- a/test/e2e/thirdparty/grafana/grafana.atago.yaml
+++ b/test/e2e/thirdparty/grafana/grafana.atago.yaml
@@ -45,8 +45,14 @@ defaults:
     # Every scenario here drives grafana. Without the program there is nothing to
     # test, so the suite skips rather than erroring: a missing tool is not a
     # result. The gate is declared once so no scenario can be left out of it.
+    #
+    # The probe asks whether the binary is on PATH rather than running it. A
+    # probe that gets the version flag wrong would skip the whole suite and
+    # leave CI green while testing nothing, which is the one failure mode a
+    # gate must not have — and this workflow runs on a schedule, so nobody
+    # would see it happen on a pull request.
     only:
-      command: grafana --version
+      command: command -v grafana
     env:
       GF_PATHS_DATA: ${workdir}/data
       GF_PATHS_LOGS: ${workdir}/logs

--- a/test/e2e/thirdparty/ntfy/ntfy.atago.yaml
+++ b/test/e2e/thirdparty/ntfy/ntfy.atago.yaml
@@ -45,8 +45,14 @@ defaults:
     # Every scenario here drives ntfy. Without the program there is nothing to
     # test, so the suite skips rather than erroring: a missing tool is not a
     # result. The gate is declared once so no scenario can be left out of it.
+    #
+    # The probe asks whether the binary is on PATH rather than running it. A
+    # probe that gets the version flag wrong would skip the whole suite and
+    # leave CI green while testing nothing, which is the one failure mode a
+    # gate must not have — and this workflow runs on a schedule, so nobody
+    # would see it happen on a pull request.
     only:
-      command: ntfy --version
+      command: command -v ntfy
 
 scenarios:
   - name: the binary reports its version

--- a/test/e2e/thirdparty/prometheus/prometheus.atago.yaml
+++ b/test/e2e/thirdparty/prometheus/prometheus.atago.yaml
@@ -41,8 +41,14 @@ defaults:
     # Every scenario here drives promtool. Without the program there is nothing to
     # test, so the suite skips rather than erroring: a missing tool is not a
     # result. The gate is declared once so no scenario can be left out of it.
+    #
+    # The probe asks whether the binary is on PATH rather than running it. A
+    # probe that gets the version flag wrong would skip the whole suite and
+    # leave CI green while testing nothing, which is the one failure mode a
+    # gate must not have — and this workflow runs on a schedule, so nobody
+    # would see it happen on a pull request.
     only:
-      command: promtool --version
+      command: command -v promtool && command -v prometheus
 
 scenarios:
   - name: promtool accepts a valid config and rejects a broken one

--- a/test/e2e/thirdparty/transfersh/transfersh.atago.yaml
+++ b/test/e2e/thirdparty/transfersh/transfersh.atago.yaml
@@ -39,8 +39,14 @@ defaults:
     # Every scenario here drives transfer.sh. Without the program there is nothing to
     # test, so the suite skips rather than erroring: a missing tool is not a
     # result. The gate is declared once so no scenario can be left out of it.
+    #
+    # The probe asks whether the binary is on PATH rather than running it. A
+    # probe that gets the version flag wrong would skip the whole suite and
+    # leave CI green while testing nothing, which is the one failure mode a
+    # gate must not have — and this workflow runs on a schedule, so nobody
+    # would see it happen on a pull request.
     only:
-      command: transfer.sh --help
+      command: command -v transfer.sh
 
 scenarios:
   - name: the binary reports its version


### PR DESCRIPTION
## Summary

Six of the gates added with the third-party sweep ran the tool to prove it was there, and the version flag was a guess for each: those binaries are not installed on the machine the sweep was written on, and `thirdparty.yml` runs on a schedule rather than on a pull request, so nothing would have checked the guess before a nightly run.

## Changes

- `test/e2e/thirdparty/{gitea,gotify,grafana,ntfy,prometheus,transfersh}` — probe with `command -v`, and say why in the comment.

## Design Decisions

A wrong probe has the one failure mode a gate must not have. It does not fail: it skips the whole suite and leaves CI green while testing nothing, on a workflow nobody watches. Asking whether the binary is on PATH cannot do that — at worst the suite runs and fails loudly, which is a result someone acts on.

The probes kept as `--version` were each run against the real binary. The six changed are the ones that could not be, and `command -v` is what the ssh-keygen, sops and ecspresso suites already use, so this is the existing convention rather than a new one.

The comment in each file now says this, because the reasoning is not visible from the line: `command -v gitea` looks like a weaker check than `gitea --version` until you know which way the failure falls.