### PR TITLE
ci(thirdparty): fail a leg that installed its program and then ran nothing

### DIFF
--- a/.github/workflows/thirdparty.yml
+++ b/.github/workflows/thirdparty.yml
@@ -342,4 +342,15 @@ jobs:
         # nothing but load: the TUI suites timed out waiting for a screen that
         # arrives promptly on a quiet machine. A regression still fails both
         # attempts; only a flake is absorbed, and the report names it.
-        run: ./dist/atago run --retry-failed 1 --allow-flaky "${{ matrix.program.dir }}"
+        run: |
+          set -o pipefail
+          ./dist/atago run --retry-failed 1 --allow-flaky "${{ matrix.program.dir }}" | tee run.log
+          # This leg installed the program, so a suite that ran nothing means
+          # the gate's `only:` probe is wrong. That failure is silent — the job
+          # stays green while testing nothing — and it lands on a scheduled
+          # workflow nobody watches, so it has to be caught here rather than
+          # noticed.
+          if grep -qE '^[A-Z]+ +[0-9]+ scenarios?: 0 passed' run.log; then
+            echo "::error::every scenario was skipped after installing ${{ matrix.program.name }}; the suite's only: probe does not match the installed binary"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Each leg of the third-party matrix installs one program and runs the one suite that drives it. A suite that skipped every scenario there means the gate's `only:` probe does not match the installed binary — and that failure is silent, leaving the job green while testing nothing, on a workflow that runs by schedule rather than on a pull request.

## Changes

- `.github/workflows/thirdparty.yml` — the run step tees its output and fails the leg when the summary reports nothing ran.

## Design Decisions

The suites were gated one commit ago and six of their probes could not be verified against the real binary, because those programs are not installed on the machine the gates were written on. I verified them by hand in a manual run of this workflow — all six executed rather than skipped — but verifying once is not the same as it being caught, and the next probe added has the same exposure.

The check reads the summary line rather than a JSON report so the console output a human reads on failure is unchanged. A genuinely failing run also trips it, which costs nothing: that job is already red, and the extra annotation names the one thing that is not wrong with it.