### PR TITLE
ci: stop leaving cross-platform and third-party regressions to the nightly

### DIFF
--- a/.github/workflows/e2e-cross.yml
+++ b/.github/workflows/e2e-cross.yml
@@ -10,11 +10,18 @@ name: CrossPlatformE2E
 # Linux and macOS are POSIX and run the FULL self-hosted suite. Windows runs an
 # explicit, portable SUBSET — the atago-invoking-atago specs that use no
 # POSIX-only external commands — so the Windows story is intentional rather than
-# accidental. It is scheduled and on-demand (not a push gate) so the required
-# push checks stay fast and deterministic while cross-platform drift is still
-# caught continuously.
+# accidental.
+#
+# It gates pull requests as well as running on a schedule. Every failure this
+# workflow has recorded was macOS-only and real — a behavior difference the
+# Ubuntu legs cannot see — so it is signal rather than noise, and a run takes
+# about a minute and a half. Leaving it to the nightly meant a macOS regression
+# lived on main until the next morning, which is how one shipped.
 on:
   workflow_dispatch:
+  pull_request:
+  push:
+    branches: [main]
   schedule:
     # 05:00 UTC daily, before the dogfood matrix.
     - cron: "0 5 * * *"

--- a/.github/workflows/thirdparty.yml
+++ b/.github/workflows/thirdparty.yml
@@ -11,8 +11,17 @@ name: ThirdParty
 # pinned deliberately: `go install` legs pin a module version (integrity still
 # comes from the Go checksum database), and raw binary-download legs pin a
 # version + SHA256 because a CDN download has no implicit integrity check.
+#
+# It also runs on every push to main, so a regression in the pty/TUI engine is
+# found minutes after it lands rather than at the next nightly. It deliberately
+# does NOT gate pull requests: one run in five fails for reasons that have
+# nothing to do with the change under review — a CDN hiccup installing one of
+# 44 programs, or a real terminal UI missing its budget on a loaded runner — and
+# a gate that cries wolf at that rate teaches people to merge past it.
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
   schedule:
     # 06:30 UTC daily, after the dogfood matrix.
     - cron: "30 6 * * *"


### PR DESCRIPTION
## Summary

Two regressions reached main this week because the workflows that catch them only ran on a schedule: a macOS-only pty failure, and a pty change that broke 19 of the 160 yazi scenarios. Both were found by triggering the workflows by hand, one at a time, which is not a process.

## Changes

- `.github/workflows/e2e-cross.yml` — also runs on pull requests and on pushes to main.
- `.github/workflows/thirdparty.yml` — also runs on pushes to main.

## Design Decisions

The two workflows get different treatment because their failures mean different things, and the numbers say so. Over the last 40 runs of each:

| Workflow | Failure rate | What failed |
|---|---|---|
| CrossPlatformE2E | 10% | macOS, every time |
| ThirdParty | 20.5% | yazi and lazygit mostly — real terminal UIs on a loaded runner |
| Fuzz | 12.5% | a different target each time |
| Dogfood | 0% | — |

CrossPlatformE2E gates pull requests. Every failure it has recorded was macOS-only and real: a behavior difference the Ubuntu legs cannot see. That is signal, and the run takes about a minute and a half.

ThirdParty runs on merge and deliberately does not gate pull requests. One run in five fails for reasons that have nothing to do with the change under review — a CDN hiccup installing one of 44 programs, or a TUI missing its budget under load. A gate that cries wolf at that rate teaches people to merge past it, and then it protects nothing. Running it on merge closes the gap that actually hurt: a pty regression is now found minutes after it lands rather than at the next nightly.

Fuzz and Dogfood stay scheduled. A fuzz failure is a new finding rather than a regression of the change at hand, so blocking on it would be blocking the wrong person; Dogfood has not failed in 40 runs and depends on other repositories' releases, where a red run says something about them rather than about atago.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * End-to-end checks now run automatically for pull requests and changes pushed to the main branch.
  * Third-party integration checks now run automatically when changes are pushed to the main branch.
  * Scheduled and manual test runs remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->