### PR TITLE
test(pty): keep the wide-character autowrap limit in CI, not in a comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Documentation
 
+- The wide-character limit of the `screen:` renderer is stated accurately and pinned by an expect_fail scenario in atago's own suite. Once a wide character has filled the last column the emulator does not arm autowrap, and the note called that "a dropped character" — it is more than that: `日本語` in five columns renders `日本`, and `日本X` in four renders `日 X`, where a terminal shows `日本` with `X` on the next row. Keeping the case in CI as an expected failure means the day the emulator learns to wrap, the scenario turns XPASS, the run goes red, and the limitation is retired instead of outliving its comment.
 - The spec reference now states what `empty:` measures. A stream or screen carrying only whitespace counts as empty, so a stray newline does not fail `empty: true` and `empty: false` asserts the output carried something legible rather than that it carried bytes. The behavior is unchanged and is what makes the check usable on a screen at all, since a terminal pads every unwritten cell with spaces; only the description was silent about it.
 
 ## [0.20.1] - 2026-08-15

--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-81 suites · 612 scenarios
+81 suites · 613 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -454,7 +454,7 @@
   - [explain names the manifest that applied](#scenario-explain-names-the-manifest-that-applied)
   - [a manifest pointing at a missing fixtures dir fails to load](#scenario-a-manifest-pointing-at-a-missing-fixtures-dir-fails-to-load)
   - [an unknown manifest key is rejected](#scenario-an-unknown-manifest-key-is-rejected)
-- [atago self-hosting / pty](#atago-self-hosting--pty) — 16 scenarios
+- [atago self-hosting / pty](#atago-self-hosting--pty) — 17 scenarios
   - [a pty step sees a terminal where a run step sees a pipe](#scenario-a-pty-step-sees-a-terminal-where-a-run-step-sees-a-pipe)
   - [a never-matching expect fails with the pattern in the block](#scenario-a-never-matching-expect-fails-with-the-pattern-in-the-block)
   - [named keys transmit their documented bytes and ctrl-c aborts](#scenario-named-keys-transmit-their-documented-bytes-and-ctrl-c-aborts)
@@ -466,6 +466,7 @@
   - [screen attrs check colors and styling, not only text](#scenario-screen-attrs-check-colors-and-styling-not-only-text)
   - [an unknown key name is a load-time error listing the vocabulary](#scenario-an-unknown-key-name-is-a-load-time-error-listing-the-vocabulary)
   - [screen asserts see the final frame where the transcript sees history](#scenario-screen-asserts-see-the-final-frame-where-the-transcript-sees-history)
+  - [a wide character at the right margin does not autowrap yet](#scenario-a-wide-character-at-the-right-margin-does-not-autowrap-yet)
   - [a screen snapshot round-trips through update and compare](#scenario-a-screen-snapshot-round-trips-through-update-and-compare)
   - [a screen assert without a pty step is a load-time error](#scenario-a-screen-assert-without-a-pty-step-is-a-load-time-error)
   - [a send referencing an undefined variable is an execution error, not typed literally](#scenario-a-send-referencing-an-undefined-variable-is-an-execution-error-not-typed-literally)
@@ -9019,6 +9020,15 @@ _skipped on Windows_
 - rendered screen line `1` equals an exact value
 - rendered screen does not contain `loading`
 - stdout contains `loading`
+### Scenario: a wide character at the right margin does not autowrap yet
+_skipped on Windows · expected to FAIL (known bug): the emulator drops or clobbers a character that must autowrap after a wide one fills the last column_
+#### When
+```shell
+# interactive (pty): printf '日本X'; sleep 0.2
+```
+#### Then
+- rendered screen line `1` equals an exact value
+- rendered screen line `2` equals an exact value
 ### Scenario: a screen snapshot round-trips through update and compare
 _skipped on Windows_
 #### Given

--- a/internal/runner/ptyrun/screen.go
+++ b/internal/runner/ptyrun/screen.go
@@ -33,10 +33,18 @@ type screenResize struct {
 // emulator does; a program that positions a label just past a Japanese string
 // with `\x1b[row;colH` lands it where the terminal put it, not two columns early,
 // and overwriting one half of a wide cell blanks it the way a terminal does
-// (#432). One edge remains upstream: a wide character that must AUTOWRAP at the
-// right margin (no explicit newline, the char straddling the last column) is
-// dropped rather than carried to the next line. TUIs position with cursor
-// addressing and explicit newlines, which render correctly.
+// (#432).
+//
+// One edge remains upstream, and it is wider than "a dropped character": once a
+// wide character has filled the last column, AUTOWRAP is not armed, so whatever
+// comes next is written inside that row instead of on the following one. A wide
+// character that no longer fits is dropped (`日本語` in five columns renders
+// `日本`), and a narrow one overwrites the second half of the wide character
+// already there, blanking its first half — `日本X` in four columns renders
+// `日 X`, where a terminal shows `日本` and puts `X` on the next line. The
+// self-hosted suite carries this as an expect_fail scenario, so the day the
+// emulator learns to wrap it turns XPASS and this note comes out. TUIs position
+// with cursor addressing and explicit newlines, which render correctly.
 //
 // For a session that changed size while it ran (#379), the transcript is
 // replayed in pieces, resizing the emulator at each recorded boundary, so every

--- a/test/e2e/atago/pty.atago.yaml
+++ b/test/e2e/atago/pty.atago.yaml
@@ -472,6 +472,32 @@ scenarios:
           stdout:
             contains: loading
 
+  # A known limitation of the terminal emulator atago renders `screen:` with,
+  # kept in CI rather than in a comment nobody re-checks: once a wide character
+  # has filled the last column, autowrap is not armed, so `X` overwrites the
+  # second half of `本` instead of landing on the next line. A terminal shows
+  # `日本` and then `X` on row 2. The day the emulator learns to wrap, this turns
+  # XPASS and the run goes red, which is what gets the limitation retired.
+  - name: a wide character at the right margin does not autowrap yet
+    skip:
+      os: windows
+    expect_fail:
+      reason: "the emulator drops or clobbers a character that must autowrap after a wide one fills the last column"
+    steps:
+      - pty:
+          shell: true
+          command: "printf '日本X'; sleep 0.2"
+          rows: 5
+          cols: 4
+      - assert:
+          screen:
+            line: 1
+            equals: "日本"
+      - assert:
+          screen:
+            line: 2
+            equals: "X"
+
   - name: a screen snapshot round-trips through update and compare
     skip:
       os: windows


### PR DESCRIPTION
## Summary

Probing the `screen:` renderer at the column boundary turned up a wide-character case the code comment described, and two shapes it did not. Once a wide character has filled the last column the emulator does not arm autowrap, so what comes next stays inside that row: `日本語` in five columns renders `日本` (the third character dropped, which the comment covered), and `日本X` in four renders `日 X` — `X` overwrites the second half of `本`, blanking its first, where a terminal shows `日本` and puts `X` on the next row. That second shape is not a dropped character, it is content in a position the terminal never put it, and the comment promised otherwise.

The limitation is upstream, in the terminal emulator `screen:` renders through. Upgrading to the newest `charmbracelet/x/vt` (built today) changes nothing, so there is no fix to take.

## Changes

- `test/e2e/atago/pty.atago.yaml`: an `expect_fail:` scenario asserting what a terminal does. It is XFAIL today, so the suite stays green and the case executes on every commit.
- `internal/runner/ptyrun/screen.go`: the comment now describes both shapes with the renders they produce, and points at the scenario.
- `CHANGELOG.md` under Documentation.

## Design Decisions

This is what `expect_fail:` is for, so it is used rather than a comment or a skipped test. A comment describing a dependency's behavior goes stale the moment the dependency moves and nobody re-checks it; a scenario in CI turns XPASS the day the emulator learns to wrap, which turns the run red and gets the limitation retired. That is the same argument atago makes to its own users for keeping a known bug in the suite.

Nothing is reported upstream: filing against a third-party repository is out of bounds for this project.

The rest of the boundary probe came back clean and is not in the diff — cursor addressing, narrow-character wrap, carriage-return overwrite, erase-to-end-of-line, clear-screen, scrolling past the last row, tab stops, backspace, the alternate screen and its restore, a one-by-one terminal, and trailing-space stripping all render as a terminal does.

## Limitations

The scenario is skipped on Windows, like every pty scenario in this suite.
