### PR TITLE
fix(e2e): stop asserting a send count the recorder is free to coalesce

### DIFF
--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -9402,7 +9402,6 @@ ${atago} run silent.atago.yaml
 #### Then
 - exit code is `0`
 - file `silent.atago.yaml` does not contain `- expect:`
-- file `silent.atago.yaml` contains `no expect before`
 - exit code is `0`
 - stdout contains `1 passed`
 ### Scenario: record --pty of a no-input command yields a session-less spec that replays green

--- a/test/e2e/atago/record.atago.yaml
+++ b/test/e2e/atago/record.atago.yaml
@@ -247,19 +247,21 @@ scenarios:
                 contains: "x"
                 stable_for: 40ms
             - send: "y\n"
-            - expect: "2 send"
+            # The recorder's closing line, which does not name a send count:
+            # waiting on the count would race the same coalescing.
+            - expect: "wrote silent.atago.yaml"
       - assert:
           exit_code: 0
+      # No expect at all, whether the recorder saw the two lines as one input
+      # burst or two: it coalesces consecutive input, and which it captured
+      # depends on when its reader goroutine ran. The header warning that names
+      # an anchorless send therefore appears only in the two-burst case, and is
+      # pinned by a unit test instead of by this race.
       - assert:
           file:
             path: silent.atago.yaml
             not_contains:
               - "- expect:"
-      - assert:
-          file:
-            path: silent.atago.yaml
-            contains:
-              - "no expect before"
       # The round-trip: replaying the generated spec passes.
       - run:
           command: ${atago} run silent.atago.yaml


### PR DESCRIPTION
## Summary

The `record --pty of a silent program` scenario asserted that the recorder saw two sends: it waited on the summary line's send count and then required the header warning that names an anchorless send. Both hold only when the recorder captured the two typed lines as two input bursts, and `AppendInput` coalesces consecutive input — which of the two it captured depends on when its reader goroutine ran against the one draining the terminal. It failed the Coverage job on a loaded runner, where both lines landed in one burst and the generated spec carried a single `send: "x\ny\n"`.

## Changes

- `test/e2e/atago/record.atago.yaml`: the outer session waits on `wrote silent.atago.yaml`, which carries no count, and the send-count-dependent file assertion is gone. What the scenario is for — the recorder anchoring no expect on the echo — is asserted as before, and holds either way.
- `doc/e2e/atago.md` regenerated.

## Design Decisions

The header warning keeps its coverage in `TestGeneratePTY_WarnsUnanchoredSends`, which builds the two-burst recording directly instead of racing for it. An E2E scenario is the wrong place to pin a detail that depends on goroutine scheduling.

Verified both interleavings rather than only the one this machine produces: driving the recorder with `x\ry\r` as a single write reproduces the coalesced capture, and the generated spec has no `expect:` and replays green there too.
