### PR TITLE
fix(defaults): a runner's cwd is more specific than a suite-wide default

### DIFF
--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-81 suites · 621 scenarios
+81 suites · 622 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -85,13 +85,14 @@
 - [atago self-hosting / db runner](#atago-self-hosting--db-runner) — 2 scenarios
   - [query workflow (create, insert, select, row assert, value binding) passes](#scenario-query-workflow-create-insert-select-row-assert-value-binding-passes)
   - [a query against an undeclared runner fails validation (exit 2)](#scenario-a-query-against-an-undeclared-runner-fails-validation-exit-2)
-- [atago self-hosting / top-level defaults](#atago-self-hosting--top-level-defaults) — 9 scenarios
+- [atago self-hosting / top-level defaults](#atago-self-hosting--top-level-defaults) — 10 scenarios
   - [defaults.run.shell applies to every run step without repeating it](#scenario-defaultsrunshell-applies-to-every-run-step-without-repeating-it)
   - [defaults.scenario.env is merged and an explicit scenario env wins](#scenario-defaultsscenarioenv-is-merged-and-an-explicit-scenario-env-wins)
   - [defaults.run.sandbox_home governs a run step and a pty step alike (POSIX)](#scenario-defaultsrunsandbox_home-governs-a-run-step-and-a-pty-step-alike-posix)
   - [an unsupported defaults field is a load-time error (exit 2)](#scenario-an-unsupported-defaults-field-is-a-load-time-error-exit-2)
   - [defaults.run.env merges per key and a step env wins the collisions](#scenario-defaultsrunenv-merges-per-key-and-a-step-env-wins-the-collisions)
   - [a step opts out of defaults.run.shell with an explicit shell false](#scenario-a-step-opts-out-of-defaultsrunshell-with-an-explicit-shell-false)
+  - [a runner's cwd beats defaults.run.cwd](#scenario-a-runners-cwd-beats-defaultsruncwd)
   - [defaults.scenario.only gates every scenario that states no gate](#scenario-defaultsscenarioonly-gates-every-scenario-that-states-no-gate)
   - [a scenario's own gate replaces the default rather than combining](#scenario-a-scenarios-own-gate-replaces-the-default-rather-than-combining)
   - [defaults.scenario.skip excludes every scenario that states no skip](#scenario-defaultsscenarioskip-excludes-every-scenario-that-states-no-skip)
@@ -2316,6 +2317,41 @@ ${atago} run optout.atago.yaml
 #### Then
 - exit code is `0`
 - stdout contains `PASSED`
+### Scenario: a runner's cwd beats defaults.run.cwd
+#### Given
+- Fixture file `cwd.atago.yaml` is created.
+#### Inputs
+_Fixture `cwd.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: cwdprec
+defaults:
+  run:
+    shell: true
+    cwd: from-defaults
+runners:
+  located:
+    type: cmd
+    cwd: from-runner
+scenarios:
+  - name: the step lands in the runner's directory
+    steps:
+      - fixture: {file: from-defaults/keep, content: keep}
+      - fixture: {file: from-runner/keep, content: keep}
+      - run: {runner: located, command: "echo here > made.txt"}
+      - assert: {exit_code: 0}
+      - assert: {file: {path: from-runner/made.txt, exists: true}}
+      - assert: {file: {path: from-defaults/made.txt, exists: false}}
+… (truncated, 14 more lines)
+```
+#### When
+```shell
+${atago} run cwd.atago.yaml
+```
+#### Then
+- exit code is `0`
+- stdout contains `3 passed`
 ### Scenario: defaults.scenario.only gates every scenario that states no gate
 #### Given
 - Fixture file `gated.atago.yaml` is created.

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -191,6 +191,57 @@ scenarios:
 	}
 }
 
+// TestEngine_CwdPrecedence pins the documented step > runner > defaults.run
+// order for cwd (#498): a runner names a directory more specifically than a
+// suite-wide default does, so the runner's cwd must beat defaults.run.cwd
+// instead of being erased by it.
+func TestEngine_CwdPrecedence(t *testing.T) {
+	t.Parallel()
+	res := runSpec(t, `
+version: "1"
+suite:
+  name: s
+defaults:
+  run: {shell: true, cwd: from-defaults}
+runners:
+  located:
+    type: cmd
+    cwd: from-runner
+  bare:
+    type: cmd
+scenarios:
+  - name: runner cwd beats defaults.run.cwd
+    steps:
+      - fixture: {file: from-defaults/who.txt, content: defaults}
+      - fixture: {file: from-runner/who.txt, content: runner}
+      - fixture: {file: from-step/who.txt, content: step}
+      - run: {runner: located, command: `+catCmd()+` who.txt}
+      - assert: {exit_code: 0, stdout: {contains: runner}}
+  - name: step cwd beats both
+    steps:
+      - fixture: {file: from-defaults/who.txt, content: defaults}
+      - fixture: {file: from-runner/who.txt, content: runner}
+      - fixture: {file: from-step/who.txt, content: step}
+      - run: {runner: located, cwd: from-step, command: `+catCmd()+` who.txt}
+      - assert: {exit_code: 0, stdout: {contains: step}}
+  - name: defaults apply when no runner names a cwd
+    steps:
+      - fixture: {file: from-defaults/who.txt, content: defaults}
+      - fixture: {file: from-runner/who.txt, content: runner}
+      - run: {command: `+catCmd()+` who.txt}
+      - assert: {exit_code: 0, stdout: {contains: defaults}}
+  - name: defaults apply when the named runner declares no cwd
+    steps:
+      - fixture: {file: from-defaults/who.txt, content: defaults}
+      - fixture: {file: from-runner/who.txt, content: runner}
+      - run: {runner: bare, command: `+catCmd()+` who.txt}
+      - assert: {exit_code: 0, stdout: {contains: defaults}}
+`)
+	if res.Status != StatusPassed {
+		t.Fatalf("status = %s, want passed: %+v", res.Status, res.Scenarios)
+	}
+}
+
 // TestEngine_EnvInterpolation proves ${env:NAME} resolves from the host
 // environment (t.Setenv forbids t.Parallel): a set variable flows into a
 // command, and an unset one on a shell-less run errors naming the variable

--- a/internal/loader/defaults.go
+++ b/internal/loader/defaults.go
@@ -79,6 +79,19 @@ func mergeStringMap(def, own map[string]string) map[string]string {
 	return out
 }
 
+// runnerHasCwd reports whether name references a declared command runner that
+// carries its own cwd — the one runner knob defaults.run also owns, and so the
+// one place where a load-time fill could hide a more specific value (#498).
+// Only cmd runners run local commands; any other type on a run step is an error
+// the engine reports, and none of them relocate a working directory.
+func runnerHasCwd(name string, runners map[string]spec.Runner) bool {
+	if name == "" {
+		return false
+	}
+	rdef, ok := runners[name]
+	return ok && rdef.Cwd != "" && (rdef.Type == "cmd" || rdef.Type == "")
+}
+
 // mergeRunDefaults layers def beneath an authored run step. Command and Retry are
 // intentionally not merged (they are per-step; the validator rejects them on
 // defaults.run so a stray value is never silently ignored).
@@ -98,7 +111,12 @@ func mergeRunDefaults(def, r *spec.Run, runners map[string]spec.Runner) {
 	if r.Shell == nil {
 		r.Shell = def.Shell
 	}
-	if r.Cwd == "" {
+	// A runner names a directory more specifically than a suite-wide default
+	// does, so a step whose cmd runner declares its own cwd must not take
+	// defaults.run.cwd: the engine layers the runner's value beneath the step's
+	// at exec time, and a string-fill here would leave that layering nothing to
+	// do, inverting the documented step > runner > defaults.run order (#498).
+	if r.Cwd == "" && !runnerHasCwd(r.Runner, runners) {
 		r.Cwd = def.Cwd
 	}
 	// Timeout is deliberately NOT merged here: the engine resolves the full

--- a/internal/loader/defaults_test.go
+++ b/internal/loader/defaults_test.go
@@ -111,6 +111,47 @@ scenarios:
 	}
 }
 
+// TestApplyDefaults_RunnerCwdBeatsDefaults is a regression for #498: a step
+// naming a cmd runner that declares its own cwd must be left cwd-less by the
+// merge, so the engine's runner layering still supplies it. Filling
+// defaults.run.cwd here would erase the runner value and invert the documented
+// step > runner > defaults.run precedence.
+func TestApplyDefaults_RunnerCwdBeatsDefaults(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: sample
+runners:
+  located:
+    type: cmd
+    cwd: from-runner
+  bare:
+    type: cmd
+defaults:
+  run:
+    cwd: from-defaults
+scenarios:
+  - name: cwd precedence
+    steps:
+      - run: {runner: located, command: echo hi}
+      - run: {runner: located, cwd: from-step, command: echo hi}
+      - run: {runner: bare, command: echo hi}
+      - run: {command: echo hi}
+`
+	s, err := LoadBytes("sample.atago.yaml", []byte(src))
+	if err != nil {
+		t.Fatalf("LoadBytes() error = %v", err)
+	}
+	steps := s.Scenarios[0].Steps
+	want := []string{"", "from-step", "from-defaults", "from-defaults"}
+	for i, w := range want {
+		if got := steps[i].Run.Cwd; got != w {
+			t.Errorf("step %d cwd = %q, want %q", i, got, w)
+		}
+	}
+}
+
 // TestApplyDefaults_ExplicitShellFalseWins proves an authored `shell: false`
 // beats a defaulted `shell: true` — the documented "an explicitly authored
 // value always wins" rule holds for booleans too (Shell is a *bool so unset

--- a/schema/atago.schema.json
+++ b/schema/atago.schema.json
@@ -170,7 +170,7 @@
             },
             "cwd": {
               "type": "string",
-              "description": "Default working directory for every run step."
+              "description": "Default working directory for every run step. Precedence: step > runner > defaults.run."
             },
             "timeout": {
               "type": "string",
@@ -306,7 +306,7 @@
             },
             "cwd": {
               "type": "string",
-              "description": "Working directory for commands run through this runner, relative to the scenario workdir."
+              "description": "Working directory for commands run through this runner, relative to the scenario workdir. Beaten by a step's own `cwd`, and beats `defaults.run.cwd`."
             },
             "timeout": {
               "type": "string",

--- a/test/e2e/atago/defaults.atago.yaml
+++ b/test/e2e/atago/defaults.atago.yaml
@@ -194,6 +194,55 @@ scenarios:
           stdout:
             contains: PASSED
 
+  # #498: a runner names a working directory more specifically than a
+  # suite-wide default does, so a step that names the runner must land in the
+  # runner's directory. Filling defaults.run.cwd into the step at load time made
+  # the runner's cwd dead whenever a default existed, inverting the documented
+  # step > runner > defaults.run order.
+  - name: a runner's cwd beats defaults.run.cwd
+    steps:
+      - fixture:
+          file: cwd.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: cwdprec
+            defaults:
+              run:
+                shell: true
+                cwd: from-defaults
+            runners:
+              located:
+                type: cmd
+                cwd: from-runner
+            scenarios:
+              - name: the step lands in the runner's directory
+                steps:
+                  - fixture: {file: from-defaults/keep, content: keep}
+                  - fixture: {file: from-runner/keep, content: keep}
+                  - run: {runner: located, command: "echo here > made.txt"}
+                  - assert: {exit_code: 0}
+                  - assert: {file: {path: from-runner/made.txt, exists: true}}
+                  - assert: {file: {path: from-defaults/made.txt, exists: false}}
+              - name: a step's own cwd still beats both
+                steps:
+                  - fixture: {file: from-defaults/keep, content: keep}
+                  - fixture: {file: from-runner/keep, content: keep}
+                  - fixture: {file: from-step/keep, content: keep}
+                  - run: {runner: located, cwd: from-step, command: "echo here > made.txt"}
+                  - assert: {exit_code: 0}
+                  - assert: {file: {path: from-step/made.txt, exists: true}}
+              - name: defaults still apply when no runner names a cwd
+                steps:
+                  - fixture: {file: from-defaults/keep, content: keep}
+                  - run: {command: "echo here > made.txt"}
+                  - assert: {exit_code: 0}
+                  - assert: {file: {path: from-defaults/made.txt, exists: true}}
+      - run: {command: "${atago} run cwd.atago.yaml"}
+      - assert:
+          exit_code: 0
+          stdout: {contains: "3 passed"}
+
   # A probe-first suite's gate belongs to the file, not to each scenario in it.
   # Repeating `only:` per scenario is how a suite ends up with some scenarios
   # gated and some not — and the ungated ones then error on a machine without


### PR DESCRIPTION
## What

For a run step that names a `cmd` runner, `defaults.run.cwd` beat the runner's own `cwd`, so the runner value was dead whenever a default existed. The documented order — stated for timeouts in the schema and in the engine's resolver — is `step > runner > defaults.run > suite`, and a runner names a directory more specifically than a suite-wide default does.

The loader string-filled `defaults.run.cwd` into every run step at load time, so by exec time the engine's `if run.Cwd == "" { run.Cwd = rdef.Cwd }` layering never saw an authored-empty step and never applied the runner's value. The comment right below that fill, explaining why `timeout` is deliberately NOT merged there, describes this exact failure mode.

Fixes #498.

## How

`mergeRunDefaults` now skips the `cwd` fill when the step names a `cmd` runner that declares its own `cwd`, leaving the engine to layer the runner value in — with the use-time `${name}` expansion it already applies. Everything else keeps working as before: a step's own `cwd` still wins, and a step naming no runner (or a runner without a `cwd`) still takes the default.

Resolving it this way rather than threading `defaults.run.cwd` through to the engine keeps the load-time validation and the unresolved-`${...}` guard seeing the same merged value they see today, so no diagnostic changes shape or location.

The two schema descriptions that document `cwd` now state the precedence, the way the `timeout` description already does.

## Tests

- `TestApplyDefaults_RunnerCwdBeatsDefaults` (loader): the four-way table — runner cwd, step cwd, no runner, runner without cwd.
- `TestEngine_CwdPrecedence` (engine): the same four cases run real commands and prove which directory they landed in. The first scenario fails on `main`.
- `test/e2e/atago/defaults.atago.yaml`: a self-hosted suite running the real binary over an inner spec that combines `defaults.run.cwd` with a runner `cwd`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected working-directory precedence for commands.
  * Runner-specific directories now override default directories, while step-specific directories remain highest priority.
  * Default directories continue to apply when no runner or step directory is specified.

* **Documentation**
  * Clarified working-directory precedence in the configuration schema and behavior documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->