### PR TITLE
fix(db): hold every host a libpq dsn names to the network policy

### DIFF
--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-81 suites · 621 scenarios
+81 suites · 623 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -82,9 +82,11 @@
   - [an unsatisfiable size range is a load error](#scenario-an-unsatisfiable-size-range-is-a-load-error)
   - [a size bound refuses to stat through a planted symlink](#scenario-a-size-bound-refuses-to-stat-through-a-planted-symlink)
   - [a size bound next to exists false is a load error](#scenario-a-size-bound-next-to-exists-false-is-a-load-error)
-- [atago self-hosting / db runner](#atago-self-hosting--db-runner) — 2 scenarios
+- [atago self-hosting / db runner](#atago-self-hosting--db-runner) — 4 scenarios
   - [query workflow (create, insert, select, row assert, value binding) passes](#scenario-query-workflow-create-insert-select-row-assert-value-binding-passes)
   - [a query against an undeclared runner fails validation (exit 2)](#scenario-a-query-against-an-undeclared-runner-fails-validation-exit-2)
+  - [a hostaddr dsn is held to the network policy (exit 6)](#scenario-a-hostaddr-dsn-is-held-to-the-network-policy-exit-6)
+  - [a quoted host is compared to the allowlist without its quotes](#scenario-a-quoted-host-is-compared-to-the-allowlist-without-its-quotes)
 - [atago self-hosting / top-level defaults](#atago-self-hosting--top-level-defaults) — 9 scenarios
   - [defaults.run.shell applies to every run step without repeating it](#scenario-defaultsrunshell-applies-to-every-run-step-without-repeating-it)
   - [defaults.scenario.env is merged and an explicit scenario env wins](#scenario-defaultsscenarioenv-is-merged-and-an-explicit-scenario-env-wins)
@@ -2130,6 +2132,70 @@ ${atago} run norunner.atago.yaml
 #### Then
 - exit code is `2`
 - stderr contains `is not declared`
+### Scenario: a hostaddr dsn is held to the network policy (exit 6)
+#### Given
+- Fixture file `hostaddr.atago.yaml` is created.
+#### Inputs
+_Fixture `hostaddr.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: inner-hostaddr
+  timeout: 10s
+permissions:
+  network:
+    allow: ["db.allowed.example"]
+runners:
+  store:
+    type: db
+    driver: postgres
+    dsn: "hostaddr=127.0.0.1 port=1 user=u dbname=app sslmode=disable"
+scenarios:
+  - name: reaches an address the policy never named
+    steps:
+      - query:
+          runner: store
+          sql: "SELECT 1"
+```
+#### When
+```shell
+${atago} run hostaddr.atago.yaml
+```
+#### Then
+- exit code is `6`
+- stdout contains `network policy denies host "127.0.0.1"`
+### Scenario: a quoted host is compared to the allowlist without its quotes
+#### Given
+- Fixture file `quoted.atago.yaml` is created.
+#### Inputs
+_Fixture `quoted.atago.yaml`:_
+```text
+version: "1"
+suite:
+  name: inner-quoted
+  timeout: 10s
+permissions:
+  network:
+    allow: ["127.0.0.1"]
+runners:
+  store:
+    type: db
+    driver: postgres
+    dsn: "host='127.0.0.1' port=1 user=u dbname=app sslmode=disable"
+scenarios:
+  - name: the allowlisted host connects (and fails as a connection)
+    steps:
+      - query:
+          runner: store
+          sql: "SELECT 1"
+```
+#### When
+```shell
+${atago} run quoted.atago.yaml
+```
+#### Then
+- exit code is `4`
+- stdout does not contain `network policy denies`
 ## atago self-hosting / top-level defaults
 Source: `test/e2e/atago/defaults.atago.yaml`
 ### Scenario: defaults.run.shell applies to every run step without repeating it

--- a/internal/engine/db.go
+++ b/internal/engine/db.go
@@ -36,8 +36,11 @@ func dbConn(name string, st *store.Store, rc runConfig, conns map[string]*dbrunn
 		// confined to permissions.network.allow just like HTTP, grpc, and ssh.
 		// Before the pool, because database/sql connects lazily — a check after
 		// it would run once the denied host had already been dialed.
-		if cfg.Host != "" {
-			if err := security.CheckHost(rc.allow, cfg.Host); err != nil {
+		// Every peer the dsn names is checked, not just the first: a libpq dsn
+		// can name a failover list, or a host beside the hostaddr the driver
+		// actually dials, and an unchecked one is a hole (#497).
+		for _, host := range cfg.Hosts {
+			if err := security.CheckHost(rc.allow, host); err != nil {
 				return nil, err
 			}
 		}

--- a/internal/engine/db_test.go
+++ b/internal/engine/db_test.go
@@ -166,6 +166,16 @@ func TestEngine_DBNetworkPolicyViolation(t *testing.T) {
 		{"mysql url", "mysql://u:p@denied.example:3306/app"},
 		{"mysql native", "u:p@tcp(denied.example:3306)/app"},
 		{"postgres keyword dsn", "host=denied.example port=5432 user=u dbname=app sslmode=disable"},
+		// #497: hostaddr is the address lib/pq dials, so a dsn that names only
+		// it must be denied like any other peer instead of slipping through as
+		// a dsn that names no host.
+		{"postgres hostaddr dsn", "hostaddr=127.0.0.1 port=1 user=u dbname=app sslmode=disable"},
+		// #497: a host beside a hostaddr is not a way to launder the address —
+		// lib/pq dials the hostaddr and keeps the host only as a name.
+		{"postgres allowed host with denied hostaddr", "host=db.allowed.example hostaddr=127.0.0.1 port=1 user=u sslmode=disable"},
+		// #497: a failover list must have every entry checked, not only the
+		// first one the driver would try.
+		{"postgres host failover list", "host=db.allowed.example,denied.example port=5432 user=u sslmode=disable"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -246,5 +256,45 @@ scenarios:
 	}
 	if res.SecurityViolation {
 		t.Error("SecurityViolation = true for a sqlite dsn, which contacts no host")
+	}
+}
+
+// TestEngine_DBNetworkPolicyAllowsQuotedHost is a regression for #497: libpq
+// lets a value be single-quoted, and the quotes belong to the dsn syntax rather
+// than to the host. Keeping them made the check compare "'db.allowed.example'"
+// against the allowlist and deny a host the policy names — so the spec failed
+// with a policy violation instead of the connection error it should have
+// reached.
+func TestEngine_DBNetworkPolicyAllowsQuotedHost(t *testing.T) {
+	t.Parallel()
+	src := `
+version: "1"
+suite:
+  name: db
+permissions:
+  network:
+    allow:
+      - db.allowed.example
+runners:
+  store:
+    type: db
+    driver: postgres
+    dsn: "host='db.allowed.example' port=5432 user=u dbname=app sslmode=disable"
+scenarios:
+  - name: quoted allowed host
+    steps:
+      - query:
+          runner: store
+          sql: "SELECT 1"
+`
+	res := runSpec(t, src)
+	if res.SecurityViolation {
+		t.Errorf("SecurityViolation = true for a quoted allowlisted host: %q",
+			res.Scenarios[0].Steps[0].ErrMsg)
+	}
+	// The connection itself is expected to fail (the host does not resolve);
+	// what matters is that it failed as a connection, not as a policy denial.
+	if got := res.Scenarios[0].Steps[0].ErrMsg; strings.Contains(got, "network policy denies") {
+		t.Errorf("err = %q, want no policy denial for an allowlisted host", got)
 	}
 }

--- a/internal/runner/db/db.go
+++ b/internal/runner/db/db.go
@@ -13,8 +13,10 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/nao1215/atago/internal/diag"
 	"github.com/nao1215/atago/internal/runner"
@@ -33,13 +35,16 @@ type Config struct {
 	DataSource string
 	// Timeout bounds a single query; zero means no timeout.
 	Timeout time.Duration
-	// Host is the "host" or "host:port" the DSN dials, so the engine can hold a
-	// db connection to permissions.network.allow the way it already holds an
-	// http, grpc, or ssh one. It is empty when the DSN names no network peer —
-	// a sqlite file, a unix socket — and when the DSN leaves the peer implicit,
-	// because the host to check is the one the spec names, not one inferred
-	// from a driver's defaults.
-	Host string
+	// Hosts are the "host" or "host:port" peers the DSN may dial, so the engine
+	// can hold a db connection to permissions.network.allow the way it already
+	// holds an http, grpc, or ssh one. It is empty when the DSN names no network
+	// peer — a sqlite file, a unix socket — and when the DSN leaves the peer
+	// implicit, because the hosts to check are the ones the spec names, not ones
+	// inferred from a driver's defaults. It holds more than one entry when the
+	// DSN names more than one peer (a libpq failover list, or a host paired with
+	// a hostaddr): each is somewhere the driver may connect, so all of them must
+	// clear the policy (#497).
+	Hosts []string
 }
 
 // Resolve derives a Config from a runner's optional driver and its dsn. When
@@ -58,64 +63,184 @@ func Resolve(driver, dsn string) (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
-	return Config{Driver: drv, DataSource: ds, Host: dsnHost(drv, dsn)}, nil
+	return Config{Driver: drv, DataSource: ds, Hosts: dsnHosts(drv, dsn)}, nil
 }
 
-// dsnHost returns the network peer a DSN dials, as "host" or "host:port", or ""
-// when it dials none.
+// dsnHosts returns every network peer a DSN may dial, each as "host" or
+// "host:port". It returns none when the DSN dials none.
 //
 // It reads the DSN the spec wrote rather than asking the driver, because the
 // answer is needed BEFORE opening: database/sql connects lazily, so by the time
 // a driver could report its peer the connection to the denied host has already
-// been made. Only an explicitly named host is returned — a sqlite path, a unix
-// socket, and a form that leaves the peer to the driver's default all yield ""
-// — so the check never denies a spec over a host the spec does not name.
-func dsnHost(driver, dsn string) string {
+// been made. Only explicitly named hosts are returned — a sqlite path, a unix
+// socket, and a form that leaves the peer to the driver's default all yield
+// nothing — so the check never denies a spec over a host the spec does not name.
+func dsnHosts(driver, dsn string) []string {
 	switch driver {
 	case "sqlite":
-		return "" // a file path, not a peer
+		return nil // a file path, not a peer
 	case "postgres":
 		if u, err := url.Parse(dsn); err == nil && u.Host != "" {
-			return u.Host
+			return []string{u.Host}
 		}
-		return keywordDSNHost(dsn)
+		return keywordDSNHosts(dsn)
 	case "mysql":
 		if strings.HasPrefix(dsn, "mysql://") {
-			if u, err := url.Parse(dsn); err == nil {
-				return u.Host
+			if u, err := url.Parse(dsn); err == nil && u.Host != "" {
+				return []string{u.Host}
 			}
-			return ""
+			return nil
 		}
-		return nativeMySQLHost(dsn)
+		return nonEmpty(nativeMySQLHost(dsn))
+	default:
+		return nil
+	}
+}
+
+// nonEmpty wraps a single host in a slice, or returns none for an empty one.
+func nonEmpty(host string) []string {
+	if host == "" {
+		return nil
+	}
+	return []string{host}
+}
+
+// keywordDSNHosts pulls every peer out of a libpq keyword/value DSN
+// ("host=db.example port=5432 user=u").
+//
+// Both `host` and `hostaddr` are read: they are alternative spellings of the
+// same peer, and when a DSN carries both, lib/pq dials the hostaddr and keeps
+// the host only as a name for authentication — so reading just one of them
+// leaves an address the policy never saw (#497). Each may also be a
+// comma-separated failover list, whose entries the driver tries in turn, with
+// `port` either a matching list or one port shared by all. An entry beginning
+// with '/' is a unix socket directory, which reaches no network.
+func keywordDSNHosts(dsn string) []string {
+	opts := keywordDSNOptions(dsn)
+	ports := splitDSNList(opts["port"])
+	var out []string
+	for _, key := range []string{"host", "hostaddr"} {
+		for i, host := range splitDSNList(opts[key]) {
+			if host == "" || strings.HasPrefix(host, "/") {
+				continue
+			}
+			if port := portAt(ports, i); port != "" {
+				host = net.JoinHostPort(host, port)
+			}
+			if !slices.Contains(out, host) {
+				out = append(out, host)
+			}
+		}
+	}
+	return out
+}
+
+// splitDSNList splits a libpq comma-separated value (a host or port failover
+// list) into its entries. An empty value is no entries rather than one empty.
+func splitDSNList(v string) []string {
+	if v == "" {
+		return nil
+	}
+	return strings.Split(v, ",")
+}
+
+// portAt returns the port libpq pairs with the i-th host: a single port applies
+// to every host, otherwise the ports line up with the hosts by position.
+func portAt(ports []string, i int) string {
+	switch {
+	case len(ports) == 1:
+		return ports[0]
+	case i < len(ports):
+		return ports[i]
 	default:
 		return ""
 	}
 }
 
-// keywordDSNHost pulls the host (and port) out of a libpq keyword/value DSN
-// ("host=db.example port=5432 user=u"). A host beginning with '/' is a unix
-// socket directory, which reaches no network.
-func keywordDSNHost(dsn string) string {
-	host, port := "", ""
-	for _, field := range strings.Fields(dsn) {
-		k, v, ok := strings.Cut(field, "=")
+// keywordDSNOptions tokenises a libpq keyword/value connection string into its
+// keyword/value pairs, lowercasing the keywords.
+//
+// It follows libpq's own syntax rather than splitting on whitespace: whitespace
+// may surround the '=', a value may be single-quoted (so that it can contain
+// spaces), and a backslash escapes the next character inside or outside the
+// quotes. Splitting on spaces instead both kept the quotes as part of the value
+// — denying a host the policy allowed — and mis-split the fields around a
+// legitimately quoted space (#497).
+//
+// A malformed tail is ignored: the driver reports a bad DSN far better than a
+// host extractor could, and the keywords already read are still worth checking.
+func keywordDSNOptions(dsn string) map[string]string {
+	opts := make(map[string]string)
+	s := &dsnScanner{r: []rune(dsn)}
+	for {
+		key, ok := s.keyword()
 		if !ok {
-			continue
+			return opts
 		}
-		switch strings.ToLower(k) {
-		case "host":
-			host = v
-		case "port":
-			port = v
+		value := s.value()
+		if key != "" {
+			opts[key] = value
 		}
 	}
-	if host == "" || strings.HasPrefix(host, "/") {
-		return ""
+}
+
+// dsnScanner walks a libpq keyword/value connection string token by token.
+type dsnScanner struct {
+	r []rune
+	i int
+}
+
+func (s *dsnScanner) skipSpace() {
+	for s.i < len(s.r) && unicode.IsSpace(s.r[s.i]) {
+		s.i++
 	}
-	if port != "" {
-		return net.JoinHostPort(host, port)
+}
+
+// keyword reads the next keyword and consumes the '=' that follows it. It
+// reports false at the end of the string, and for a keyword carrying no value —
+// which libpq rejects outright, so there is nothing further worth reading.
+func (s *dsnScanner) keyword() (string, bool) {
+	s.skipSpace()
+	start := s.i
+	for s.i < len(s.r) && s.r[s.i] != '=' && !unicode.IsSpace(s.r[s.i]) {
+		s.i++
 	}
-	return host
+	key := strings.ToLower(string(s.r[start:s.i]))
+	s.skipSpace()
+	if s.i >= len(s.r) || s.r[s.i] != '=' {
+		return "", false
+	}
+	s.i++
+	return key, true
+}
+
+// value reads the value after an '=': single-quoted, where a space is literal
+// and the value ends at the closing quote, or bare, where it ends at the next
+// space. A backslash escapes the next character in either form.
+func (s *dsnScanner) value() string {
+	s.skipSpace()
+	quoted := s.i < len(s.r) && s.r[s.i] == '\''
+	if quoted {
+		s.i++
+	}
+	var b strings.Builder
+	for s.i < len(s.r) {
+		c := s.r[s.i]
+		if quoted && c == '\'' {
+			s.i++ // the closing quote
+			break
+		}
+		if !quoted && unicode.IsSpace(c) {
+			break
+		}
+		if c == '\\' && s.i+1 < len(s.r) {
+			s.i++
+			c = s.r[s.i]
+		}
+		b.WriteRune(c)
+		s.i++
+	}
+	return b.String()
 }
 
 // nativeMySQLHost pulls the address out of a go-sql-driver native DSN

--- a/internal/runner/db/db_test.go
+++ b/internal/runner/db/db_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -328,37 +329,56 @@ func TestSkipQuotedEdges(t *testing.T) {
 	}
 }
 
-// TestDSNHost pins what the network allowlist is handed for each DSN form. The
+// TestDSNHosts pins what the network allowlist is handed for each DSN form. The
 // empty results matter as much as the rest: a DSN that names no peer must not
 // be denied, or a sqlite spec would stop running the moment a spec declared a
 // network policy.
-func TestDSNHost(t *testing.T) {
+func TestDSNHosts(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
-		name, driver, dsn, want string
+		name, driver, dsn string
+		want              []string
 	}{
-		{"sqlite scheme", "sqlite", "sqlite:./a.db", ""},
-		{"sqlite bare path", "sqlite", "/abs/path.db", ""},
-		{"sqlite memory", "sqlite", ":memory:", ""},
-		{"postgres url", "postgres", "postgres://u:p@db.example:5432/app", "db.example:5432"},
-		{"postgres url no port", "postgres", "postgres://u@db.example/app", "db.example"},
-		{"postgresql scheme", "postgres", "postgresql://u@db.example/app", "db.example"},
-		{"postgres keywords", "postgres", "host=db.example port=5432 user=u", "db.example:5432"},
-		{"postgres keywords no port", "postgres", "user=u host=db.example dbname=app", "db.example"},
-		{"postgres unix socket", "postgres", "host=/var/run/postgresql user=u", ""},
-		{"postgres keywords no host", "postgres", "user=u dbname=app", ""},
-		{"mysql url", "mysql", "mysql://u:p@db.example:3306/app", "db.example:3306"},
-		{"mysql native tcp", "mysql", "u:p@tcp(db.example:3306)/app", "db.example:3306"},
-		{"mysql native tcp uppercase", "mysql", "u:p@TCP(db.example:3306)/app", "db.example:3306"},
-		{"mysql native unix", "mysql", "u:p@unix(/tmp/mysql.sock)/app", ""},
-		{"mysql native no protocol", "mysql", "/app", ""},
-		{"mysql native password with at", "mysql", "u:p@ss@tcp(db.example:3306)/app", "db.example:3306"},
+		{"sqlite scheme", "sqlite", "sqlite:./a.db", nil},
+		{"sqlite bare path", "sqlite", "/abs/path.db", nil},
+		{"sqlite memory", "sqlite", ":memory:", nil},
+		{"postgres url", "postgres", "postgres://u:p@db.example:5432/app", []string{"db.example:5432"}},
+		{"postgres url no port", "postgres", "postgres://u@db.example/app", []string{"db.example"}},
+		{"postgresql scheme", "postgres", "postgresql://u@db.example/app", []string{"db.example"}},
+		{"postgres keywords", "postgres", "host=db.example port=5432 user=u", []string{"db.example:5432"}},
+		{"postgres keywords no port", "postgres", "user=u host=db.example dbname=app", []string{"db.example"}},
+		{"postgres unix socket", "postgres", "host=/var/run/postgresql user=u", nil},
+		{"postgres keywords no host", "postgres", "user=u dbname=app", nil},
+		// #497: hostaddr is an alternative spelling of the peer, and lib/pq
+		// dials it in preference to host when both are given — so neither key
+		// may be left unchecked.
+		{"pg hostaddr only", "postgres", "hostaddr=127.0.0.1 port=5432 user=u", []string{"127.0.0.1:5432"}},
+		{"pg host and hostaddr both checked", "postgres", "host=db.example hostaddr=127.0.0.1 user=u", []string{"db.example", "127.0.0.1"}},
+		// #497: libpq quoting. The quotes belong to the syntax, not to the
+		// host, and a quoted value may hold the spaces that used to mis-split
+		// the fields.
+		{"pg quoted host", "postgres", "host='db.example' port=5432 user=u", []string{"db.example:5432"}},
+		{"pg quoted spaced password keeps host", "postgres", "password='a b' host=db.example user=u", []string{"db.example"}},
+		{"pg escaped quote in value keeps host", "postgres", `password='a\'b' host=db.example user=u`, []string{"db.example"}},
+		{"pg spaces around equals", "postgres", "host = db.example port = 5432", []string{"db.example:5432"}},
+		// #497: libpq accepts a failover list; every entry is a peer the driver
+		// may reach, and a shared port applies to all of them.
+		{"pg host list", "postgres", "host=a.example,b.example port=5432 user=u", []string{"a.example:5432", "b.example:5432"}},
+		{"pg host list with per-host ports", "postgres", "host=a.example,b.example port=5432,5433", []string{"a.example:5432", "b.example:5433"}},
+		{"pg host list drops the socket entry", "postgres", "host=a.example,/var/run/postgresql", []string{"a.example"}},
+		{"mysql url", "mysql", "mysql://u:p@db.example:3306/app", []string{"db.example:3306"}},
+		{"mysql native tcp", "mysql", "u:p@tcp(db.example:3306)/app", []string{"db.example:3306"}},
+		{"mysql native tcp uppercase", "mysql", "u:p@TCP(db.example:3306)/app", []string{"db.example:3306"}},
+		{"mysql native unix", "mysql", "u:p@unix(/tmp/mysql.sock)/app", nil},
+		{"mysql native no protocol", "mysql", "/app", nil},
+		{"mysql native password with at", "mysql", "u:p@ss@tcp(db.example:3306)/app", []string{"db.example:3306"}},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
-			if got := dsnHost(c.driver, c.dsn); got != c.want {
-				t.Errorf("dsnHost(%q, %q) = %q, want %q", c.driver, c.dsn, got, c.want)
+			got := dsnHosts(c.driver, c.dsn)
+			if !slices.Equal(got, c.want) {
+				t.Errorf("dsnHosts(%q, %q) = %v, want %v", c.driver, c.dsn, got, c.want)
 			}
 		})
 	}
@@ -372,14 +392,14 @@ func TestResolve_CarriesHost(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
-	if cfg.Host != "db.example:5432" {
-		t.Errorf("Config.Host = %q, want db.example:5432", cfg.Host)
+	if !slices.Equal(cfg.Hosts, []string{"db.example:5432"}) {
+		t.Errorf("Config.Hosts = %v, want [db.example:5432]", cfg.Hosts)
 	}
 	local, err := Resolve("", "sqlite:./a.db")
 	if err != nil {
 		t.Fatalf("Resolve(sqlite): %v", err)
 	}
-	if local.Host != "" {
-		t.Errorf("Config.Host = %q for a sqlite dsn, want empty", local.Host)
+	if len(local.Hosts) != 0 {
+		t.Errorf("Config.Hosts = %v for a sqlite dsn, want none", local.Hosts)
 	}
 }

--- a/test/e2e/atago/db.atago.yaml
+++ b/test/e2e/atago/db.atago.yaml
@@ -83,3 +83,71 @@ scenarios:
           exit_code: 2
           stderr:
             contains: is not declared
+
+  # #497: a libpq keyword dsn can name its peer as `hostaddr` instead of
+  # `host`. Reading only `host` left that address unchecked, so a spec could
+  # reach a database the network policy was written to keep it away from —
+  # the connection error proved the dial had already happened.
+  - name: a hostaddr dsn is held to the network policy (exit 6)
+    steps:
+      - fixture:
+          file: hostaddr.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: inner-hostaddr
+              timeout: 10s
+            permissions:
+              network:
+                allow: ["db.allowed.example"]
+            runners:
+              store:
+                type: db
+                driver: postgres
+                dsn: "hostaddr=127.0.0.1 port=1 user=u dbname=app sslmode=disable"
+            scenarios:
+              - name: reaches an address the policy never named
+                steps:
+                  - query:
+                      runner: store
+                      sql: "SELECT 1"
+      - run:
+          command: ${atago} run hostaddr.atago.yaml
+      - assert:
+          exit_code: 6
+          stdout:
+            contains: 'network policy denies host "127.0.0.1"'
+
+  # #497: libpq lets a value be single-quoted, and the quotes belong to the dsn
+  # syntax rather than to the host. Keeping them denied a host the policy names.
+  - name: a quoted host is compared to the allowlist without its quotes
+    steps:
+      - fixture:
+          file: quoted.atago.yaml
+          content: |
+            version: "1"
+            suite:
+              name: inner-quoted
+              timeout: 10s
+            permissions:
+              network:
+                allow: ["127.0.0.1"]
+            runners:
+              store:
+                type: db
+                driver: postgres
+                dsn: "host='127.0.0.1' port=1 user=u dbname=app sslmode=disable"
+            scenarios:
+              - name: the allowlisted host connects (and fails as a connection)
+                steps:
+                  - query:
+                      runner: store
+                      sql: "SELECT 1"
+      - run:
+          command: ${atago} run quoted.atago.yaml
+      - assert:
+          # The connection is refused (nothing listens on port 1), which is a
+          # runner error rather than a policy violation: exit 4, not exit 6.
+          exit_code: 4
+          stdout:
+            not_contains: network policy denies


### PR DESCRIPTION
## What

`db` runner egress is held to `permissions.network.allow` by extracting the host from the dsn, and the extractor read a libpq keyword/value dsn with `strings.Fields` + `strings.Cut`. That is not how libpq parses one, and three failures followed — one of them a bypass:

1. **Security**: `hostaddr=` is libpq's numeric-address spelling of the peer. Only `host=` was read, so `hostaddr=127.0.0.1 port=1 …` produced no host, skipped the check, and dialed an address the policy never named (`connection refused` is proof the dial happened).
2. A single-quoted `host='db.example'` kept its quotes, so the policy was compared against `'db.example'` and denied a host the allowlist names.
3. A quoted value holding a space (`password='a b'`) shifted every field boundary after it.

Fixes #497.

## How

The keyword dsn is tokenised the way libpq documents — whitespace may surround the `=`, a value may be single-quoted so it can hold spaces, and a backslash escapes the next character — instead of being split on spaces.

Every peer the dsn names is then checked, rather than the first one found:

- `host` **and** `hostaddr`. lib/pq (v1.12.3, whose `Config` documents the rule) dials the **hostaddr** when a dsn carries both, keeping `host` only as a name for authentication — so treating `host` as the answer and stopping would leave the address that actually gets dialed unchecked. Both are network identities the spec named, and both must clear the policy.
- each entry of a comma-separated failover list, paired with the port libpq would use for it (one shared port, or a matching list).

`Config.Host string` became `Config.Hosts []string` and the engine loops over it. Everything that named no peer before still names none: sqlite, unix sockets, and a dsn that leaves the peer to the driver's default are unchanged, so no spec starts being denied for a host it does not write.

## Tests

- `TestDSNHosts` (db): the issue's table plus quoting, escapes, spaces around `=`, and failover lists.
- `TestEngine_DBNetworkPolicyViolation` (engine): `hostaddr`-only, an allowed `host` beside a denied `hostaddr`, and a failover list with one denied entry — all must be ATG6001 rather than a dial. The first two fail on `main` with `ATG4203: … connect: connection refused`.
- `TestEngine_DBNetworkPolicyAllowsQuotedHost`: a quoted allowlisted host must not be denied. Fails on `main` with `denies host "'db.allowed.example'"`.
- `test/e2e/atago/db.atago.yaml`: both halves through the real binary — the `hostaddr` dsn exits 6, and the quoted allowlisted host exits 4 (a connection error, not a policy violation).
