### PR TITLE
fix(schema): report and manifest schemas describe what the writers emit

### DIFF
--- a/internal/manifest/schema_parity_test.go
+++ b/internal/manifest/schema_parity_test.go
@@ -1,0 +1,22 @@
+package manifest
+
+import (
+	"os"
+	"testing"
+
+	"github.com/nao1215/atago/internal/schematest"
+)
+
+// TestManifestSchema_StructParity is the drift guard the manifest schema lacked
+// (#496): its example-conformance check could only catch a missing property
+// once the committed example happened to carry one, so project_path,
+// fixtures_dir, expect_fail, and deterministic all shipped unschemad.
+func TestManifestSchema_StructParity(t *testing.T) {
+	t.Parallel()
+	const schemaPath = "../../schema/manifest.schema.json"
+	data, err := os.ReadFile(schemaPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", schemaPath, err)
+	}
+	schematest.CheckParity(t, schemaPath, data, Document{})
+}

--- a/internal/report/schema_parity_test.go
+++ b/internal/report/schema_parity_test.go
@@ -1,0 +1,23 @@
+package report
+
+import (
+	"os"
+	"testing"
+
+	"github.com/nao1215/atago/internal/schematest"
+)
+
+// TestReportSchema_StructParity is the drift guard the report schema lacked
+// (#496). The schema's only check was that a committed example validates, and
+// that example carries neither a load failure, nor a suite-setup failure, nor an
+// expect_fail scenario — so three fields shipped in this writer while the schema
+// kept rejecting any real report that used them.
+func TestReportSchema_StructParity(t *testing.T) {
+	t.Parallel()
+	const schemaPath = "../../schema/report.schema.json"
+	data, err := os.ReadFile(schemaPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", schemaPath, err)
+	}
+	schematest.CheckParity(t, schemaPath, data, jsonDocument{})
+}

--- a/internal/schematest/schematest.go
+++ b/internal/schematest/schematest.go
@@ -1,0 +1,150 @@
+// Package schematest compares a JSON writer's Go structs against the JSON
+// Schema published for that writer's output.
+//
+// atago ships schema/report.schema.json and schema/manifest.schema.json for
+// editors and CI consumers to validate against, and both set
+// "additionalProperties": false at every level. Nothing linked them to the
+// structs that produce the documents, so every field added to a writer after
+// the schema was written made the schema reject real output — and the only
+// guard, a conformance check over a committed example, stayed green because the
+// example never exercised the new field (#496).
+//
+// CheckParity closes that gap by deriving the key inventory from both sides and
+// comparing the whole set in both directions, so the next added field fails at
+// the source rather than when an example happens to include it.
+package schematest
+
+import (
+	"encoding/json"
+	"maps"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// CheckParity asserts that the JSON Schema in schemaJSON describes exactly the
+// fields document's type emits: every `json:` tag has a schema property, and
+// every schema property has a field. document is a zero value of the writer's
+// top-level document type, and schemaPath only names the schema in failure
+// messages (the caller reads it, so the path stays where the test can see it).
+//
+// It walks the two trees together, following $ref into $defs and items into
+// array element types, and reports each mismatch with the JSON path it found.
+// A type is walked once: the schema models a Go type as one definition, so a
+// second visit would only repeat the same comparison.
+func CheckParity(t *testing.T, schemaPath string, schemaJSON []byte, document any) {
+	t.Helper()
+	var root map[string]any
+	if err := json.Unmarshal(schemaJSON, &root); err != nil {
+		t.Fatalf("parse %s: %v", schemaPath, err)
+	}
+	w := &walker{t: t, schemaPath: schemaPath, root: root, seen: map[reflect.Type]bool{}}
+	w.walk(root, reflect.TypeOf(document), "")
+}
+
+type walker struct {
+	t          *testing.T
+	schemaPath string
+	root       map[string]any
+	seen       map[reflect.Type]bool
+}
+
+// walk compares one schema node against one Go type, recursing into struct
+// fields and array elements.
+func (w *walker) walk(node map[string]any, typ reflect.Type, path string) {
+	for typ.Kind() == reflect.Pointer {
+		typ = typ.Elem()
+	}
+	node = w.resolve(node)
+	if node == nil {
+		return
+	}
+	switch typ.Kind() {
+	case reflect.Slice, reflect.Array:
+		items, _ := node["items"].(map[string]any)
+		if items == nil {
+			w.t.Errorf("%s: %s is an array in Go but the schema declares no items", w.schemaPath, path)
+			return
+		}
+		w.walk(items, typ.Elem(), path+"[]")
+	case reflect.Struct:
+		w.walkStruct(node, typ, path)
+	default:
+		// A scalar or a map: the schema constrains it with type /
+		// additionalProperties, which carries no key inventory to compare.
+	}
+}
+
+func (w *walker) walkStruct(node map[string]any, typ reflect.Type, path string) {
+	if w.seen[typ] {
+		return
+	}
+	w.seen[typ] = true
+	props, _ := node["properties"].(map[string]any)
+	fields := jsonFields(typ)
+	for _, name := range slices.Sorted(maps.Keys(fields)) {
+		if _, ok := props[name]; !ok {
+			w.t.Errorf("%s: %s emits %q, which the schema does not declare — a real document carrying it fails validation (additionalProperties: false)",
+				w.schemaPath, joinPath(path, name), name)
+		}
+	}
+	for _, name := range slices.Sorted(maps.Keys(props)) {
+		if _, ok := fields[name]; !ok {
+			w.t.Errorf("%s: the schema declares %s, which %s never emits — drop it or the writer field that went with it",
+				w.schemaPath, joinPath(path, name), typ)
+		}
+	}
+	for name, field := range fields {
+		prop, _ := props[name].(map[string]any)
+		if prop == nil {
+			continue
+		}
+		w.walk(prop, field.Type, joinPath(path, name))
+	}
+}
+
+// resolve follows a $ref to the definition it names, so a walk never has to
+// know whether a node is written inline or shared.
+func (w *walker) resolve(node map[string]any) map[string]any {
+	ref, ok := node["$ref"].(string)
+	if !ok {
+		return node
+	}
+	name, found := strings.CutPrefix(ref, "#/$defs/")
+	if !found {
+		w.t.Errorf("%s: unsupported $ref %q (only #/$defs/<name> is walked)", w.schemaPath, ref)
+		return nil
+	}
+	defs, _ := w.root["$defs"].(map[string]any)
+	def, _ := defs[name].(map[string]any)
+	if def == nil {
+		w.t.Errorf("%s: $ref %q names no definition", w.schemaPath, ref)
+		return nil
+	}
+	return def
+}
+
+// jsonFields returns the struct's serialized fields by their JSON name.
+func jsonFields(typ reflect.Type) map[string]reflect.StructField {
+	out := make(map[string]reflect.StructField, typ.NumField())
+	for i := range typ.NumField() {
+		f := typ.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+		name, _, _ := strings.Cut(f.Tag.Get("json"), ",")
+		if name == "" || name == "-" {
+			continue
+		}
+		out[name] = f
+	}
+	return out
+}
+
+func joinPath(path, name string) string {
+	if path == "" {
+		return name
+	}
+	return path + "." + name
+}

--- a/schema/manifest.schema.json
+++ b/schema/manifest.schema.json
@@ -23,6 +23,44 @@
     }
   },
   "$defs": {
+    "expectFail": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "reason"
+      ],
+      "properties": {
+        "reason": {
+          "description": "Why the scenario is expected to fail.",
+          "type": "string"
+        },
+        "issue": {
+          "description": "The issue tracking the known bug, when the spec names one.",
+          "type": "string"
+        }
+      }
+    },
+    "deterministic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "runs",
+        "compare"
+      ],
+      "properties": {
+        "runs": {
+          "description": "How many times the command is executed.",
+          "type": "integer"
+        },
+        "compare": {
+          "description": "The streams compared across runs (stdout, stderr, exit_code).",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "spec": {
       "type": "object",
       "additionalProperties": false,
@@ -39,6 +77,14 @@
         },
         "suite": {
           "description": "Suite name declared by the spec.",
+          "type": "string"
+        },
+        "project_path": {
+          "description": "Directory manifest (atago.project.yaml) that applied to this spec (#392); omitted when none did, so tooling can tell a spec carrying hidden configuration from one that does not.",
+          "type": "string"
+        },
+        "fixtures_dir": {
+          "description": "Committed fixture tree the project manifest pointed at (#394); omitted when none applied.",
           "type": "string"
         },
         "suite_timeout": {
@@ -200,6 +246,10 @@
         },
         "skip": {
           "$ref": "#/$defs/condition"
+        },
+        "expect_fail": {
+          "description": "The known bug the scenario declared with `expect_fail:` (#395): the scenario is expected to fail, and a passing run is reported as an unexpected pass.",
+          "$ref": "#/$defs/expectFail"
         },
         "services": {
           "type": "array",
@@ -378,6 +428,10 @@
         },
         "retry": {
           "$ref": "#/$defs/retry"
+        },
+        "deterministic": {
+          "description": "The step's same-input-same-output claim (#398), so a reviewer sees that the command is run more than once and what is compared.",
+          "$ref": "#/$defs/deterministic"
         },
         "source": {
           "$ref": "#/$defs/source"

--- a/schema/report.schema.json
+++ b/schema/report.schema.json
@@ -15,6 +15,11 @@
       "description": "One entry per suite run, regardless of how many suites were requested.",
       "type": "array",
       "items": {"$ref": "#/$defs/report"}
+    },
+    "load_failures": {
+      "description": "Spec files the run could not read (#120). They ran no scenario, so they appear in no suite above; omitted when there are none.",
+      "type": "array",
+      "items": {"$ref": "#/$defs/load_failure"}
     }
   },
   "$defs": {
@@ -41,6 +46,16 @@
           "description": "Flat list of failures across all scenarios; empty on success.",
           "type": "array",
           "items": {"$ref": "#/$defs/failure"}
+        },
+        "setup_failures": {
+          "description": "suite.setup steps that failed (#7). A setup failure also errors every scenario; omitted when setup was clean or absent.",
+          "type": "array",
+          "items": {"$ref": "#/$defs/failure"}
+        },
+        "teardown_failures": {
+          "description": "suite.teardown steps that failed (#7). Teardown outcomes never change the suite status, but incomplete cleanup stays visible; omitted when clean or absent.",
+          "type": "array",
+          "items": {"$ref": "#/$defs/failure"}
         }
       }
     },
@@ -58,6 +73,10 @@
         "skip_reason": {
           "description": "Present only for skipped scenarios.",
           "type": "string"
+        },
+        "expect_fail": {
+          "description": "The known bug the scenario declared with `expect_fail:` (#395). Present on xfail and xpass scenarios, so a dashboard can link the issue instead of re-reading the spec.",
+          "$ref": "#/$defs/expect_fail"
         },
         "attempts": {
           "description": "Execution count under --retry-failed (#29); status \"flaky\" means a re-run recovered.",
@@ -78,6 +97,24 @@
           "type": "array",
           "items": {"$ref": "#/$defs/service_log"}
         }
+      }
+    },
+    "load_failure": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["spec_path", "error"],
+      "properties": {
+        "spec_path": {"type": "string"},
+        "error": {"type": "string"}
+      }
+    },
+    "expect_fail": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reason"],
+      "properties": {
+        "reason": {"description": "Why the scenario is expected to fail.", "type": "string"},
+        "issue": {"description": "The issue tracking the known bug, when the spec names one.", "type": "string"}
       }
     },
     "service_log": {

--- a/schema_test.go
+++ b/schema_test.go
@@ -1,15 +1,20 @@
 package main
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/goccy/go-yaml"
 	"github.com/santhosh-tekuri/jsonschema/v6"
 
+	"github.com/nao1215/atago/internal/engine"
 	"github.com/nao1215/atago/internal/loader"
 	"github.com/nao1215/atago/internal/manifest"
+	"github.com/nao1215/atago/internal/report"
 	"github.com/nao1215/atago/internal/spec"
 )
 
@@ -582,6 +587,121 @@ func TestReportExample_Conforms(t *testing.T) {
 	s := compileSchema(t, "schema/report.schema.json")
 	if err := s.Validate(readJSONAny(t, "schema/examples/report.example.json")); err != nil {
 		t.Errorf("report example does not conform to schema:\n%v", err)
+	}
+}
+
+// TestManifest_ExpectFailAndDeterministicConform builds a manifest for a spec
+// carrying the two features the committed example never exercises — a
+// scenario's `expect_fail:` and a step's `deterministic:` — and validates the
+// real output against the manifest schema. Both shipped in the writer without a
+// schema property, so a manifest that used them failed the schema atago
+// publishes for it (#496).
+func TestManifest_ExpectFailAndDeterministicConform(t *testing.T) {
+	src := `
+version: "1"
+suite:
+  name: known-bugs
+scenarios:
+  - name: a known bug
+    expect_fail:
+      reason: still broken
+      issue: "https://github.com/nao1215/atago/issues/496"
+    steps:
+      - run:
+          shell: true
+          command: "exit 1"
+          deterministic:
+            runs: 3
+            compare: [stdout, exit_code]
+      - assert: {exit_code: 0}
+`
+	s, err := loader.LoadBytes("xf.atago.yaml", []byte(src))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	doc := manifest.Build([]manifest.Input{{Spec: s, Path: "xf.atago.yaml"}})
+	blob, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	var v any
+	if err := json.Unmarshal(blob, &v); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+	// The manifest must actually carry both fields, or the conformance check
+	// below would pass over a document that never exercised them.
+	sc := doc.Specs[0].Scenarios[0]
+	if sc.ExpectFail == nil {
+		t.Fatal("manifest scenario carries no expect_fail")
+	}
+	if sc.Steps[0].Deterministic == nil {
+		t.Fatal("manifest step carries no deterministic")
+	}
+	if err := compileSchema(t, "schema/manifest.schema.json").Validate(v); err != nil {
+		t.Errorf("expect_fail/deterministic manifest does not conform to schema:\n%v", err)
+	}
+}
+
+// TestReport_FeatureFieldsConform renders a real `--report json` document for
+// the three features the committed example never exercises — a spec that failed
+// to load, a suite whose setup failed, and a scenario declaring `expect_fail:` —
+// and validates it against the report schema. Each shipped in the writer without
+// a schema property, so any report using them failed the schema atago publishes
+// for editors and CI consumers (#496).
+func TestReport_FeatureFieldsConform(t *testing.T) {
+	specs := map[string]string{
+		"xf.atago.yaml": `
+version: "1"
+suite:
+  name: known-bug
+scenarios:
+  - name: a known bug
+    expect_fail:
+      reason: still broken
+      issue: "https://github.com/nao1215/atago/issues/496"
+    steps:
+      - run: {shell: true, command: "exit 1"}
+      - assert: {exit_code: 0}
+`,
+		"setup.atago.yaml": `
+version: "1"
+suite:
+  name: broken-setup
+  setup:
+    - run: {shell: true, command: "exit 1"}
+    - assert: {exit_code: 0}
+scenarios:
+  - name: never runs
+    steps:
+      - run: {shell: true, command: "echo hi"}
+`,
+	}
+	var results []*engine.SuiteResult
+	for _, path := range []string{"xf.atago.yaml", "setup.atago.yaml"} {
+		sp, err := loader.LoadBytes(path, []byte(specs[path]))
+		if err != nil {
+			t.Fatalf("load %s: %v", path, err)
+		}
+		results = append(results, engine.New().Run(context.Background(), sp, path))
+	}
+	var buf bytes.Buffer
+	if err := report.Render(&buf, report.FormatJSON, results,
+		report.WithLoadFailures(report.LoadFailure{SpecPath: "broken.atago.yaml", Message: "yaml: line 3: mapping values are not allowed"})); err != nil {
+		t.Fatalf("render json report: %v", err)
+	}
+	// Every field under test must really be in the document, or conformance
+	// would be asserted over a report that exercised none of them.
+	for _, want := range []string{`"load_failures"`, `"setup_failures"`, `"expect_fail"`} {
+		if !strings.Contains(buf.String(), want) {
+			t.Fatalf("rendered report carries no %s:\n%s", want, buf.String())
+		}
+	}
+	var v any
+	if err := json.Unmarshal(buf.Bytes(), &v); err != nil {
+		t.Fatalf("unmarshal report: %v", err)
+	}
+	if err := compileSchema(t, "schema/report.schema.json").Validate(v); err != nil {
+		t.Errorf("report does not conform to schema:\n%v", err)
 	}
 }
 


### PR DESCRIPTION
## What

`schema/report.schema.json` and `schema/manifest.schema.json` both set `"additionalProperties": false` at every level, and both writers emit fields the schemas never declared. A real report that exercises `expect_fail:`, a spec load failure, or a suite-setup failure — and a manifest carrying `project_path`, `fixtures_dir`, `expect_fail`, or `deterministic` — failed validation against the very schema atago publishes for editors and CI consumers.

Each schema's only drift guard validated a committed example, and that example exercises none of those features, so every field added after the example was written landed in the writer alone and the guard stayed green.

Fixes #496.

## How

Both schemas now declare the missing properties, typed from the writer structs:

- report: `load_failures` (top level, with a `load_failure` definition), `setup_failures` and `teardown_failures` on a suite, `expect_fail` on a scenario (with an `expect_fail` definition).
- manifest: `project_path` and `fixtures_dir` on a spec, `expect_fail` on a scenario, `deterministic` on a step, with definitions for the latter two.

The suite-level `teardown_failures` was not in the issue's list — the parity walk below found it.

`internal/schematest` holds the guard that prevents the recurrence: it walks the writer's document type and the schema together, following `$ref` into `$defs` and `items` into element types, and reports any `json:` tag with no schema property and any schema property with no field. `TestReportSchema_StructParity` and `TestManifestSchema_StructParity` run it over `report.jsonDocument` and `manifest.Document`, so the next field added to a writer fails at the source instead of waiting for an example to happen to include it.

## Tests

- The two parity tests above. On `main` they report exactly the eight missing properties.
- `TestManifest_ExpectFailAndDeterministicConform` and `TestReport_FeatureFieldsConform` validate **real** output — a manifest built from a spec using `expect_fail:` and `deterministic:`, and a rendered `--report json` carrying a load failure, a suite-setup failure, and an xfail scenario — against the published schemas. Both assert the fields are actually present before validating, so neither can pass over a document that exercised none of them. Both fail on `main` with `additional properties … not allowed`.
- The issue's two reproduce commands now validate cleanly under `jsonschema`.
