### PR TITLE
fix(pty): render the right margin and combining marks the way a terminal does

### DIFF
--- a/doc/e2e/atago.md
+++ b/doc/e2e/atago.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-81 suites · 625 scenarios
+81 suites · 627 scenarios
 ## Contents
 - [atago self-hosting / cross-platform no-shell argv tokenization (#154)](#atago-self-hosting--cross-platform-no-shell-argv-tokenization-154) — 4 scenarios
   - [a single-quoted JSON argument survives tokenization](#scenario-a-single-quoted-json-argument-survives-tokenization)
@@ -465,7 +465,7 @@
   - [explain names the manifest that applied](#scenario-explain-names-the-manifest-that-applied)
   - [a manifest pointing at a missing fixtures dir fails to load](#scenario-a-manifest-pointing-at-a-missing-fixtures-dir-fails-to-load)
   - [an unknown manifest key is rejected](#scenario-an-unknown-manifest-key-is-rejected)
-- [atago self-hosting / pty](#atago-self-hosting--pty) — 17 scenarios
+- [atago self-hosting / pty](#atago-self-hosting--pty) — 19 scenarios
   - [a pty step sees a terminal where a run step sees a pipe](#scenario-a-pty-step-sees-a-terminal-where-a-run-step-sees-a-pipe)
   - [a never-matching expect fails with the pattern in the block](#scenario-a-never-matching-expect-fails-with-the-pattern-in-the-block)
   - [named keys transmit their documented bytes and ctrl-c aborts](#scenario-named-keys-transmit-their-documented-bytes-and-ctrl-c-aborts)
@@ -477,7 +477,9 @@
   - [screen attrs check colors and styling, not only text](#scenario-screen-attrs-check-colors-and-styling-not-only-text)
   - [an unknown key name is a load-time error listing the vocabulary](#scenario-an-unknown-key-name-is-a-load-time-error-listing-the-vocabulary)
   - [screen asserts see the final frame where the transcript sees history](#scenario-screen-asserts-see-the-final-frame-where-the-transcript-sees-history)
-  - [a wide character at the right margin does not autowrap yet](#scenario-a-wide-character-at-the-right-margin-does-not-autowrap-yet)
+  - [a wide character at the right margin autowraps](#scenario-a-wide-character-at-the-right-margin-autowraps)
+  - [a wide character that no longer fits wraps instead of vanishing](#scenario-a-wide-character-that-no-longer-fits-wraps-instead-of-vanishing)
+  - [screen preserves a decomposed grapheme's combining mark](#scenario-screen-preserves-a-decomposed-graphemes-combining-mark)
   - [a screen snapshot round-trips through update and compare](#scenario-a-screen-snapshot-round-trips-through-update-and-compare)
   - [a screen assert without a pty step is a load-time error](#scenario-a-screen-assert-without-a-pty-step-is-a-load-time-error)
   - [a send referencing an undefined variable is an execution error, not typed literally](#scenario-a-send-referencing-an-undefined-variable-is-an-execution-error-not-typed-literally)
@@ -9432,8 +9434,8 @@ _skipped on Windows_
 - rendered screen line `1` equals an exact value
 - rendered screen does not contain `loading`
 - stdout contains `loading`
-### Scenario: a wide character at the right margin does not autowrap yet
-_skipped on Windows · expected to FAIL (known bug): the emulator drops or clobbers a character that must autowrap after a wide one fills the last column_
+### Scenario: a wide character at the right margin autowraps
+_skipped on Windows_
 #### When
 ```shell
 # interactive (pty): printf '日本X'; sleep 0.2
@@ -9441,6 +9443,24 @@ _skipped on Windows · expected to FAIL (known bug): the emulator drops or clobb
 #### Then
 - rendered screen line `1` equals an exact value
 - rendered screen line `2` equals an exact value
+### Scenario: a wide character that no longer fits wraps instead of vanishing
+_skipped on Windows_
+#### When
+```shell
+# interactive (pty): printf '日本語'; sleep 0.2
+```
+#### Then
+- rendered screen line `1` equals an exact value
+- rendered screen line `2` equals an exact value
+### Scenario: screen preserves a decomposed grapheme's combining mark
+_skipped on Windows_
+#### When
+```shell
+# interactive (pty): printf '\303\251 e\314\201'; sleep 0.2
+```
+#### Then
+- rendered screen line `1` equals an exact value
+- rendered screen contains `é`
 ### Scenario: a screen snapshot round-trips through update and compare
 _skipped on Windows_
 #### Given

--- a/internal/runner/ptyrun/screen.go
+++ b/internal/runner/ptyrun/screen.go
@@ -35,16 +35,9 @@ type screenResize struct {
 // and overwriting one half of a wide cell blanks it the way a terminal does
 // (#432).
 //
-// One edge remains upstream, and it is wider than "a dropped character": once a
-// wide character has filled the last column, AUTOWRAP is not armed, so whatever
-// comes next is written inside that row instead of on the following one. A wide
-// character that no longer fits is dropped (`日本語` in five columns renders
-// `日本`), and a narrow one overwrites the second half of the wide character
-// already there, blanking its first half — `日本X` in four columns renders
-// `日 X`, where a terminal shows `日本` and puts `X` on the next line. The
-// self-hosted suite carries this as an expect_fail scenario, so the day the
-// emulator learns to wrap it turns XPASS and this note comes out. TUIs position
-// with cursor addressing and explicit newlines, which render correctly.
+// Two edges of that emulator's grapheme handling are corrected on the way in
+// rather than lived with — the right margin after a wide character (#503) and a
+// combining mark on an ASCII base (#505). screenWriter explains both.
 //
 // For a session that changed size while it ran (#379), the transcript is
 // replayed in pieces, resizing the emulator at each recorded boundary, so every
@@ -115,16 +108,19 @@ func renderScreenCells(transcript []byte, p *spec.PTY, resizes []screenResize) (
 	}
 	sanitized, cuts := sanitizeTranscriptMarks(transcript, marks)
 
+	// One writer across every piece: it carries the escape-sequence decoder's
+	// state and the terminal modes, which a resize must not reset.
+	w := newScreenWriter(term)
 	at := 0
 	for i, r := range resizes {
 		cut := min(max(cuts[i], at), len(sanitized))
-		writeTranscript(term, sanitized[at:cut])
+		w.write(sanitized[at:cut])
 		// Resize takes width (cols) first; getting that backwards silently
 		// transposes every frame after a resize.
 		term.Resize(r.cols, r.rows)
 		at = cut
 	}
-	writeTranscript(term, sanitized[at:])
+	w.write(sanitized[at:])
 
 	// Read the grid out of the emulator once and build both views from it. The
 	// emulator's own String() is not consulted: two independent reads of the same
@@ -206,20 +202,6 @@ func colorToIndex(c color.Color) uint32 {
 	default:
 		return uint32(ansi.Convert256(c))
 	}
-}
-
-// writeTranscript feeds the transcript to the emulator, containing any panic
-// from its escape parser. The transcript is arbitrary bytes chosen by the
-// program under test, and a crash there must not take down the whole atago
-// process mid-suite. The shapes that make an emulator loop for minutes on an
-// enormous CSI count are defused up front by sanitizeTranscript, which preserves
-// the rest of the frame; this recover is the backstop for whatever shape the
-// fuzzer has not met yet. On panic the screen state built so far still renders,
-// so the assertion compares against everything drawn before the malformed
-// sequence.
-func writeTranscript(term *vt.Emulator, transcript []byte) {
-	defer func() { _ = recover() }()
-	_, _ = term.Write(transcript)
 }
 
 // maxCSIParamDigits bounds a CSI numeric parameter before the transcript

--- a/internal/runner/ptyrun/screen.go
+++ b/internal/runner/ptyrun/screen.go
@@ -108,19 +108,19 @@ func renderScreenCells(transcript []byte, p *spec.PTY, resizes []screenResize) (
 	}
 	sanitized, cuts := sanitizeTranscriptMarks(transcript, marks)
 
-	// One writer across every piece: it carries the escape-sequence decoder's
-	// state and the terminal modes, which a resize must not reset.
-	w := newScreenWriter(term)
-	at := 0
+	// The transcript is written in ONE pass with the resizes handed to the
+	// writer as offsets, rather than sliced into pieces here: the writer applies
+	// each one at a boundary between whole units, so a resize offset that lands
+	// inside a grapheme cluster cannot separate a base character from the
+	// combining mark that belongs to it.
+	breaks := make([]screenBreak, 0, len(resizes))
+	prevCut := 0
 	for i, r := range resizes {
-		cut := min(max(cuts[i], at), len(sanitized))
-		w.write(sanitized[at:cut])
-		// Resize takes width (cols) first; getting that backwards silently
-		// transposes every frame after a resize.
-		term.Resize(r.cols, r.rows)
-		at = cut
+		cut := min(max(cuts[i], prevCut), len(sanitized))
+		breaks = append(breaks, screenBreak{at: cut, cols: r.cols, rows: r.rows})
+		prevCut = cut
 	}
-	w.write(sanitized[at:])
+	newScreenWriter(term).write(sanitized, breaks)
 
 	// Read the grid out of the emulator once and build both views from it. The
 	// emulator's own String() is not consulted: two independent reads of the same

--- a/internal/runner/ptyrun/screen_test.go
+++ b/internal/runner/ptyrun/screen_test.go
@@ -266,6 +266,41 @@ func TestRenderScreen_PreservesCombiningMarks(t *testing.T) {
 	}
 }
 
+// TestRenderScreen_PendingWrapCancelledByCursorMove is a regression for the
+// wrap atago arms on the emulator's behalf (#503): a terminal cancels a pending
+// wrap the moment the cursor moves, so a move away and back must leave the wrap
+// cancelled rather than looking untouched. Comparing only the final cursor
+// position cannot tell the two apart, and injecting a wrap here would push a
+// character onto a row the terminal never put it on.
+func TestRenderScreen_PendingWrapCancelledByCursorMove(t *testing.T) {
+	t.Parallel()
+	// `日本` fills a four-column row. BS then CUF returns the cursor to the
+	// column it started from, with the wrap cancelled, so `X` is written in the
+	// row — overwriting the second half of `本`, which blanks its first half.
+	got := RenderScreen([]byte("日本\b\x1b[CX"), &spec.PTY{Rows: 5, Cols: 4})
+	if got != "日 X" {
+		t.Errorf("RenderScreen(%q) = %q, want %q (a cursor move cancels the pending wrap)",
+			"日本\\b\\x1b[CX", got, "日 X")
+	}
+}
+
+// TestRenderScreenResized_SplitGraphemeCluster is a regression for #505 under a
+// mid-session resize (#379): the recorded resize offset is a byte position in
+// the transcript and can fall anywhere, including between a base character and
+// the combining mark that belongs to it. The resize must be applied at a
+// boundary between whole units, or the base is committed to the screen without
+// its mark and the mark arrives with nothing to attach to.
+func TestRenderScreenResized_SplitGraphemeCluster(t *testing.T) {
+	t.Parallel()
+	const transcript = "e\u0301X"
+	// Offset 1 sits between the base "e" and its two-byte combining mark.
+	got := renderScreenResized([]byte(transcript), &spec.PTY{Rows: 5, Cols: 10},
+		[]screenResize{{offset: 1, rows: 5, cols: 20}})
+	if got != "e\u0301X" {
+		t.Errorf("resize inside a grapheme cluster = %q, want %q", got, "e\u0301X")
+	}
+}
+
 // TestRenderScreen_TrailingNormalization proves per-line trailing whitespace
 // and trailing blank rows are stripped so snapshots stay stable.
 func TestRenderScreen_TrailingNormalization(t *testing.T) {

--- a/internal/runner/ptyrun/screen_test.go
+++ b/internal/runner/ptyrun/screen_test.go
@@ -269,13 +269,13 @@ func TestRenderScreen_PreservesCombiningMarks(t *testing.T) {
 // TestRenderScreen_PendingWrapCancelledByCursorMove is a regression for the
 // wrap atago arms on the emulator's behalf (#503): a terminal cancels a pending
 // wrap the moment the cursor moves, so a move away and back must leave the wrap
-// cancelled rather than looking untouched. Comparing only the final cursor
+// canceled rather than looking untouched. Comparing only the final cursor
 // position cannot tell the two apart, and injecting a wrap here would push a
 // character onto a row the terminal never put it on.
 func TestRenderScreen_PendingWrapCancelledByCursorMove(t *testing.T) {
 	t.Parallel()
 	// `日本` fills a four-column row. BS then CUF returns the cursor to the
-	// column it started from, with the wrap cancelled, so `X` is written in the
+	// column it started from, with the wrap canceled, so `X` is written in the
 	// row — overwriting the second half of `本`, which blanks its first half.
 	got := RenderScreen([]byte("日本\b\x1b[CX"), &spec.PTY{Rows: 5, Cols: 4})
 	if got != "日 X" {

--- a/internal/runner/ptyrun/screen_test.go
+++ b/internal/runner/ptyrun/screen_test.go
@@ -129,6 +129,143 @@ func TestRenderScreen_PreservesGraphemeClusters(t *testing.T) {
 	}
 }
 
+// TestRenderScreen_WideCharacterAutowrap is the #503 regression. A real
+// terminal arms pending wrap once a wide character has filled the last columns,
+// so the next character starts the following row, and it wraps a wide character
+// that no longer fits rather than dropping it. The emulator arms pending wrap
+// only from the LAST column, which a wide character reaches from the
+// second-to-last — so `X` overwrote the second half of `本` (blanking its first
+// half) and `語` fell off the end entirely.
+func TestRenderScreen_WideCharacterAutowrap(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		transcript string
+		rows, cols int
+		want       string
+	}{
+		{
+			name:       "a character after a wide one filled the row starts the next row",
+			transcript: "日本X",
+			rows:       5, cols: 4,
+			want: "日本\nX",
+		},
+		{
+			name:       "a wide character that no longer fits wraps instead of vanishing",
+			transcript: "日本語",
+			rows:       5, cols: 5,
+			want: "日本\n語",
+		},
+		{
+			name:       "a wide character after a narrow one filled the row wraps too",
+			transcript: "abcd日",
+			rows:       5, cols: 4,
+			want: "abcd\n日",
+		},
+		{
+			// The wrap must not fire twice: `日本` fills row 1 exactly, and the
+			// program's own newline is what moves to row 2.
+			name:       "an explicit newline after a filled row does not skip one",
+			transcript: "日本\r\nX",
+			rows:       5, cols: 4,
+			want: "日本\nX",
+		},
+		{
+			// Cursor addressing cancels a pending wrap, the way a terminal does.
+			name:       "cursor addressing after a filled row cancels the pending wrap",
+			transcript: "日本\x1b[1;1HX",
+			rows:       5, cols: 4,
+			want: "X 本",
+		},
+		{
+			// With autowrap off (DECAWM reset) a terminal keeps overwriting the
+			// last column instead of wrapping, so the correction must stay out.
+			name:       "autowrap off keeps the emulator's overwrite behavior",
+			transcript: "\x1b[?7l日本X",
+			rows:       5, cols: 4,
+			want: "日 X",
+		},
+		{
+			// Narrow autowrap was never broken; it must keep working alongside.
+			name:       "narrow characters still wrap at the last column",
+			transcript: "abcdX",
+			rows:       5, cols: 4,
+			want: "abcd\nX",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := RenderScreen([]byte(tt.transcript), &spec.PTY{Rows: tt.rows, Cols: tt.cols})
+			if got != tt.want {
+				t.Errorf("RenderScreen(%q) = %q, want %q", tt.transcript, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRenderScreen_PreservesCombiningMarks is the #505 regression: a decomposed
+// grapheme (an ASCII base plus a combining mark) must render as the program
+// wrote it. The emulator commits an ASCII character to the screen the moment it
+// arrives, so the mark that follows can never join it and was dropped — a
+// `screen:` assertion saw `e` where the program wrote `e´`.
+func TestRenderScreen_PreservesCombiningMarks(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		transcript string
+		rows, cols int
+		want       string
+	}{
+		{
+			name:       "a decomposed accent keeps its mark",
+			transcript: "e\u0301",
+			rows:       3, cols: 10,
+			want: "e\u0301",
+		},
+		{
+			name:       "the mark does not swallow the character after it",
+			transcript: "e\u0301X",
+			rows:       3, cols: 10,
+			want: "e\u0301X",
+		},
+		{
+			name:       "two marks on one base are both kept",
+			transcript: "e\u0301\u0308",
+			rows:       3, cols: 10,
+			want: "e\u0301\u0308",
+		},
+		{
+			name:       "a mark on the last column still lands on its base",
+			transcript: "abce\u0301",
+			rows:       3, cols: 4,
+			want: "abce\u0301",
+		},
+		{
+			// A precomposed accent and a non-ASCII base were never affected.
+			name:       "a precomposed accent is unchanged",
+			transcript: "\u00e9",
+			rows:       3, cols: 10,
+			want: "\u00e9",
+		},
+		{
+			name:       "a wide base keeps its mark",
+			transcript: "\u304b\u3099",
+			rows:       3, cols: 10,
+			want: "\u304b\u3099",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := RenderScreen([]byte(tt.transcript), &spec.PTY{Rows: tt.rows, Cols: tt.cols})
+			if got != tt.want {
+				t.Errorf("RenderScreen(%q) = %q, want %q", tt.transcript, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestRenderScreen_TrailingNormalization proves per-line trailing whitespace
 // and trailing blank rows are stripped so snapshots stay stable.
 func TestRenderScreen_TrailingNormalization(t *testing.T) {

--- a/internal/runner/ptyrun/screenwrite.go
+++ b/internal/runner/ptyrun/screenwrite.go
@@ -164,7 +164,7 @@ func (w *screenWriter) control(seq []byte) {
 // keep the wrap that was armed before it.
 const cursorMovingFinals = "ABCDEFGHIZdeafr`"
 
-// movesCursor reports whether this unit repositions the cursor, cancelling a
+// movesCursor reports whether this unit repositions the cursor, canceling a
 // pending wrap.
 func (w *screenWriter) movesCursor(seq []byte) bool {
 	if len(seq) == 1 {

--- a/internal/runner/ptyrun/screenwrite.go
+++ b/internal/runner/ptyrun/screenwrite.go
@@ -1,6 +1,7 @@
 package ptyrun
 
 import (
+	"strings"
 	"unicode/utf8"
 
 	uv "github.com/charmbracelet/ultraviolet"
@@ -64,8 +65,19 @@ func newScreenWriter(term *vt.Emulator) *screenWriter {
 	return &screenWriter{term: term, parser: ansi.NewParser(), autowrap: true}
 }
 
-// write feeds one piece of the transcript to the emulator, containing any panic
-// from its escape parser. The transcript is arbitrary bytes chosen by the
+// screenBreak is a mid-session resize (#379) anchored at its byte offset in the
+// sanitized transcript.
+type screenBreak struct {
+	at         int
+	cols, rows int
+}
+
+// write feeds the transcript to the emulator, applying each resize when the
+// scan reaches its offset — always at a boundary between whole units, so a
+// resize can never land inside an escape sequence or split a base character
+// from the combining mark that belongs to it.
+//
+// It contains any panic from the emulator's escape parser. The transcript is arbitrary bytes chosen by the
 // program under test, and a crash there must not take down the whole atago
 // process mid-suite. The shapes that make an emulator loop for minutes on an
 // enormous CSI count are defused up front by sanitizeTranscript, which preserves
@@ -73,10 +85,20 @@ func newScreenWriter(term *vt.Emulator) *screenWriter {
 // fuzzer has not met yet. On panic the screen state built so far still renders,
 // so the assertion compares against everything drawn before the malformed
 // sequence.
-func (w *screenWriter) write(transcript []byte) {
+func (w *screenWriter) write(transcript []byte, breaks []screenBreak) {
 	defer func() { _ = recover() }()
 	defer w.flush()
+	at := 0
 	for len(transcript) > 0 {
+		for len(breaks) > 0 && at >= breaks[0].at {
+			// The emulator must see everything drawn at the old size before it
+			// changes, so the batch goes in first. Resize takes width (cols)
+			// first; getting that backwards silently transposes every frame
+			// after a resize.
+			w.flush()
+			w.term.Resize(breaks[0].cols, breaks[0].rows)
+			breaks = breaks[1:]
+		}
 		seq, width, n, next := ansi.DecodeSequence(transcript, w.state, w.parser)
 		if n <= 0 {
 			// The decoder consumed nothing (an input shape it cannot advance
@@ -84,13 +106,13 @@ func (w *screenWriter) write(transcript []byte) {
 			// stops early is a wrong screen, and a render that does not move is
 			// a hung suite.
 			w.batch = append(w.batch, transcript[0])
-			transcript = transcript[1:]
+			transcript, at = transcript[1:], at+1
 			continue
 		}
 		w.state = next
 		if width <= 0 {
 			w.control(seq)
-			transcript = transcript[n:]
+			transcript, at = transcript[n:], at+n
 			continue
 		}
 		// The decoder returns an ASCII character on its own, splitting the very
@@ -109,7 +131,13 @@ func (w *screenWriter) write(transcript []byte) {
 			}
 		}
 		w.printable(cluster, clusterWidth)
-		transcript = transcript[n:]
+		transcript, at = transcript[n:], at+n
+	}
+	// A resize recorded at (or past) the end of the transcript still has to
+	// reach the emulator: the rendered grid is read at whatever size it leaves.
+	for _, b := range breaks {
+		w.flush()
+		w.term.Resize(b.cols, b.rows)
 	}
 }
 
@@ -117,7 +145,44 @@ func (w *screenWriter) write(transcript []byte) {
 // only the ones that change whether the corrections apply at all.
 func (w *screenWriter) control(seq []byte) {
 	w.trackAutoWrap(seq)
+	if w.movesCursor(seq) {
+		// A terminal cancels a pending wrap the moment the cursor moves. Where
+		// the cursor ENDS UP cannot tell that apart from never having moved —
+		// a move away and back looks identical — so the cancel is decided from
+		// the sequence itself, and the position check that follows it is only
+		// a backstop for a move this list does not name.
+		w.pending = false
+	}
 	w.batch = append(w.batch, seq...)
+}
+
+// cursorMovingFinals are the CSI final bytes that reposition the cursor:
+// CUU/CUD/CUF/CUB/CNL/CPL/CHA/CUP (A-H), CHT/CBT (I, Z), VPA/VPR (d, e), HPA/HPR
+// (`, a), HVP (f), and DECSTBM (r), which homes the cursor with the margins it
+// sets. Sequences that only paint (SGR), set a mode, or report state are
+// deliberately absent: a TUI that colors its output between two characters must
+// keep the wrap that was armed before it.
+const cursorMovingFinals = "ABCDEFGHIZdeafr`"
+
+// movesCursor reports whether this unit repositions the cursor, cancelling a
+// pending wrap.
+func (w *screenWriter) movesCursor(seq []byte) bool {
+	if len(seq) == 1 {
+		switch seq[0] {
+		case ansi.BS, ansi.HT, ansi.LF, ansi.VT, ansi.FF, ansi.CR:
+			return true
+		}
+		return false
+	}
+	if len(seq) == 2 && seq[0] == ansi.ESC {
+		switch seq[1] {
+		case 'D', 'E', 'M', '7', '8', 'c': // IND, NEL, RI, DECSC/DECRC, RIS
+			return true
+		}
+		return false
+	}
+	cmd := ansi.Cmd(w.parser.Command())
+	return cmd.Prefix() == 0 && strings.IndexByte(cursorMovingFinals, cmd.Final()) >= 0
 }
 
 // trackAutoWrap follows DECAWM (CSI ? 7 h / l) and the full reset that restores

--- a/internal/runner/ptyrun/screenwrite.go
+++ b/internal/runner/ptyrun/screenwrite.go
@@ -1,0 +1,248 @@
+package ptyrun
+
+import (
+	"unicode/utf8"
+
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/charmbracelet/x/vt"
+)
+
+// crlf is the wrap atago injects on the emulator's behalf: CR returns to column
+// 0 and LF indexes down (scrolling at the bottom margin, honoring the scroll
+// region), which is exactly what a terminal's autowrap does. Going through the
+// emulator's own control codes rather than absolute cursor addressing keeps
+// scroll regions and origin mode behaving as the program set them, and both
+// codes clear the emulator's pending-wrap state, so the wrap can never fire
+// twice.
+var crlf = []byte("\r\n")
+
+// screenWriter feeds a sanitized transcript to the terminal emulator, repairing
+// the two places where the emulator's grapheme handling differs from a real
+// terminal. Both are upstream (github.com/charmbracelet/x/vt), still present in
+// its latest revision, and both are corrected here rather than lived with,
+// because each one silently changes what a `screen:` assertion compares against:
+//
+//   - Pending wrap is armed only from the LAST column (#503). A wide character
+//     reaches the right margin from the second-to-last one, so after `日本` fills
+//     a four-column row the emulator leaves wrap disarmed: the next character is
+//     written INSIDE the row, overwriting the second half of `本` and blanking
+//     its first half, and a wide character that no longer fits is dropped
+//     entirely. This writer arms the wrap itself for a wide character that
+//     reaches the margin, and wraps one that does not fit.
+//
+//   - An ASCII character is committed to the screen the moment it arrives
+//     (#505), so a combining mark that follows can never join it and is dropped:
+//     a program that writes a decomposed `é` renders `e`. This writer keeps the
+//     whole grapheme cluster and puts it back into the cell the base landed in.
+//     A non-ASCII base (`か` + dakuten) and a ZWJ emoji sequence go through the
+//     emulator's grapheme buffer and were never affected.
+//
+// The transcript is decoded with the same library the emulator parses it with
+// (x/ansi), so the units this writer sees are the units the emulator will see.
+// Everything that needs no correction is batched and handed over untouched, so
+// ordinary output reaches the emulator exactly as before.
+type screenWriter struct {
+	term   *vt.Emulator
+	parser *ansi.Parser
+	// state is the decoder's escape-sequence state, carried across writes
+	// because a resize splits one transcript into several (#379).
+	state byte
+	// autowrap tracks DECAWM. With autowrap off a terminal keeps overwriting
+	// the last column instead of wrapping, so every correction below is off too.
+	autowrap bool
+	// pending is the wrap the emulator failed to arm after a wide character
+	// filled the row, and pendingAt where the cursor stood when it was armed:
+	// anything that moves the cursor before the next character cancels the
+	// wrap, exactly as a terminal cancels its own.
+	pending   bool
+	pendingAt uv.Position
+	batch     []byte
+}
+
+func newScreenWriter(term *vt.Emulator) *screenWriter {
+	return &screenWriter{term: term, parser: ansi.NewParser(), autowrap: true}
+}
+
+// write feeds one piece of the transcript to the emulator, containing any panic
+// from its escape parser. The transcript is arbitrary bytes chosen by the
+// program under test, and a crash there must not take down the whole atago
+// process mid-suite. The shapes that make an emulator loop for minutes on an
+// enormous CSI count are defused up front by sanitizeTranscript, which preserves
+// the rest of the frame; this recover is the backstop for whatever shape the
+// fuzzer has not met yet. On panic the screen state built so far still renders,
+// so the assertion compares against everything drawn before the malformed
+// sequence.
+func (w *screenWriter) write(transcript []byte) {
+	defer func() { _ = recover() }()
+	defer w.flush()
+	for len(transcript) > 0 {
+		seq, width, n, next := ansi.DecodeSequence(transcript, w.state, w.parser)
+		if n <= 0 {
+			// The decoder consumed nothing (an input shape it cannot advance
+			// over). Hand the byte to the emulator and move on: a render that
+			// stops early is a wrong screen, and a render that does not move is
+			// a hung suite.
+			w.batch = append(w.batch, transcript[0])
+			transcript = transcript[1:]
+			continue
+		}
+		w.state = next
+		if width <= 0 {
+			w.control(seq)
+			transcript = transcript[n:]
+			continue
+		}
+		// The decoder returns an ASCII character on its own, splitting the very
+		// cluster whose tail the emulator then drops. Re-read it as a cluster so
+		// a combining mark stays with its base.
+		//
+		// Only a cluster that is valid UTF-8 is taken: the grapheme segmenter
+		// will happily carry a stray continuation byte along with the character
+		// before it, and the emulator DROPS invalid UTF-8 rather than printing
+		// it — so keeping such a "cluster" would put bytes on the screen that
+		// the terminal never showed (found by FuzzRenderScreen).
+		cluster, clusterWidth := seq, width
+		if len(seq) == 1 && isASCIIPrintable(seq[0]) {
+			if c, cw := ansi.FirstGraphemeCluster(transcript, ansi.GraphemeWidth); len(c) > len(seq) && utf8.Valid(c) {
+				cluster, clusterWidth, n = c, cw, len(c)
+			}
+		}
+		w.printable(cluster, clusterWidth)
+		transcript = transcript[n:]
+	}
+}
+
+// control passes an escape sequence or control byte through untouched, noting
+// only the ones that change whether the corrections apply at all.
+func (w *screenWriter) control(seq []byte) {
+	w.trackAutoWrap(seq)
+	w.batch = append(w.batch, seq...)
+}
+
+// trackAutoWrap follows DECAWM (CSI ? 7 h / l) and the full reset that restores
+// it. The emulator keeps this mode privately, so the one place that can know it
+// is the stream both of them read.
+func (w *screenWriter) trackAutoWrap(seq []byte) {
+	if len(seq) == 2 && seq[0] == ansi.ESC && seq[1] == 'c' {
+		w.autowrap = true // RIS restores every mode to its default
+		return
+	}
+	cmd := ansi.Cmd(w.parser.Command())
+	final := cmd.Final()
+	if cmd.Prefix() != '?' || (final != 'h' && final != 'l') {
+		return
+	}
+	for _, p := range w.parser.Params() {
+		if p.Param(0) == 7 {
+			w.autowrap = final == 'h'
+		}
+	}
+}
+
+// printable writes one grapheme cluster, correcting the right margin around it.
+func (w *screenWriter) printable(cluster []byte, width int) {
+	repair := needsMarkRepair(cluster)
+	if repair {
+		// An ASCII base is one column, and the base is all that reaches the
+		// emulator below — so the margin arithmetic follows the base, whatever
+		// width the segmenter reports for the cluster as a whole.
+		width = 1
+	}
+	wide := w.autowrap && width > 1
+	if !repair && !w.pending && !wide {
+		// Nothing to correct around this character: batch it and let the
+		// emulator lay it out exactly as it does today.
+		w.batch = append(w.batch, cluster...)
+		return
+	}
+	// Everything below reads the emulator's cursor, so the batch has to be in
+	// it first.
+	w.flush()
+	if w.pending {
+		// A sequence that moved the cursor since the wrap was armed cancels it,
+		// the way a terminal cancels its own pending wrap.
+		if w.term.CursorPosition() == w.pendingAt {
+			w.writeNow(crlf)
+		}
+		w.pending = false
+	}
+	pos := w.term.CursorPosition()
+	cols := w.term.Width()
+	if wide && pos.X+width > cols {
+		// A wide character that no longer fits: a terminal starts it on the
+		// next row, where the emulator drops it.
+		w.writeNow(crlf)
+		pos = w.term.CursorPosition()
+	}
+	if repair {
+		// Only the base reaches the emulator. The marks it would drop anyway
+		// are not inert on the way out: a mark arriving while pending wrap is
+		// armed makes the emulator index — moving the cursor to the next row,
+		// and scrolling the screen when the base sat on the last one — for a
+		// grapheme that a terminal does not move the cursor for at all.
+		w.writeNow(cluster[:1])
+		w.repairCell(cluster, width)
+	} else {
+		w.writeNow(cluster)
+	}
+	if wide && pos.X+width >= cols {
+		w.pending = true
+		w.pendingAt = w.term.CursorPosition()
+	}
+}
+
+// repairCell puts the whole cluster into the cell the base just landed in.
+//
+// The cell is found from the cursor AFTER the write rather than from where the
+// write started, so a base that wrapped to the next row (scrolling the screen
+// with it) is still found: the cursor sits just past the base, or still on it
+// when the base filled the last column. The base character has to actually be
+// there — a cluster the emulator placed some other way is left alone rather
+// than overwritten with content that would not belong to it.
+func (w *screenWriter) repairCell(cluster []byte, width int) {
+	baseChar := string(cluster[:1]) // an ASCII base is one byte; see needsMarkRepair
+	at := w.term.CursorPosition()
+	for _, x := range []int{at.X - width, at.X} {
+		if x < 0 {
+			continue
+		}
+		c := w.term.CellAt(x, at.Y)
+		if c == nil || c.Content != baseChar {
+			continue
+		}
+		fixed := *c
+		fixed.Content = string(cluster)
+		w.term.SetCell(x, at.Y, &fixed)
+		return
+	}
+}
+
+// needsMarkRepair reports whether the emulator will drop part of this cluster:
+// it commits an ASCII base to the screen before the rest of the cluster has
+// arrived, so any cluster longer than its ASCII base loses the remainder.
+func needsMarkRepair(cluster []byte) bool {
+	return len(cluster) > 1 && isASCIIPrintable(cluster[0])
+}
+
+// isASCIIPrintable reports whether b takes the emulator's (and the decoder's)
+// single-character fast path.
+func isASCIIPrintable(b byte) bool {
+	return b >= 0x20 && b < 0x7f
+}
+
+// flush hands the batched units to the emulator. Units are only ever appended
+// whole, so a flush never splits an escape sequence or a grapheme cluster —
+// which matters, because the emulator resolves its grapheme buffer at the end
+// of every write.
+func (w *screenWriter) flush() {
+	if len(w.batch) == 0 {
+		return
+	}
+	w.writeNow(w.batch)
+	w.batch = w.batch[:0]
+}
+
+func (w *screenWriter) writeNow(b []byte) {
+	_, _ = w.term.Write(b)
+}

--- a/internal/runner/ptyrun/testdata/fuzz/FuzzRenderScreen/3b54a5f27d67bea4
+++ b/internal/runner/ptyrun/testdata/fuzz/FuzzRenderScreen/3b54a5f27d67bea4
@@ -1,0 +1,4 @@
+go test fuzz v1
+[]byte("0\xc2")
+int(24)
+int(42)

--- a/test/e2e/atago/pty.atago.yaml
+++ b/test/e2e/atago/pty.atago.yaml
@@ -518,17 +518,14 @@ scenarios:
           stdout:
             contains: loading
 
-  # A known limitation of the terminal emulator atago renders `screen:` with,
-  # kept in CI rather than in a comment nobody re-checks: once a wide character
-  # has filled the last column, autowrap is not armed, so `X` overwrites the
-  # second half of `本` instead of landing on the next line. A terminal shows
-  # `日本` and then `X` on row 2. The day the emulator learns to wrap, this turns
-  # XPASS and the run goes red, which is what gets the limitation retired.
-  - name: a wide character at the right margin does not autowrap yet
+  # #503: a wide character reaches the right margin from the second-to-last
+  # column, and the emulator arms pending wrap only from the last one — so `X`
+  # used to overwrite the second half of `本` (blanking its first half) instead
+  # of starting row 2, and a wide character that no longer fits was dropped.
+  # atago arms the wrap itself; these are what a terminal shows.
+  - name: a wide character at the right margin autowraps
     skip:
       os: windows
-    expect_fail:
-      reason: "the emulator drops or clobbers a character that must autowrap after a wide one fills the last column"
     steps:
       - pty:
           shell: true
@@ -543,6 +540,48 @@ scenarios:
           screen:
             line: 2
             equals: "X"
+
+  - name: a wide character that no longer fits wraps instead of vanishing
+    skip:
+      os: windows
+    steps:
+      - pty:
+          shell: true
+          command: "printf '日本語'; sleep 0.2"
+          rows: 5
+          cols: 5
+      - assert:
+          screen:
+            line: 1
+            equals: "日本"
+      - assert:
+          screen:
+            line: 2
+            equals: "語"
+
+  # #505: the emulator commits an ASCII character to the screen the moment it
+  # arrives, so a combining mark that follows could never join it and was
+  # dropped — `screen:` saw `e` where the program wrote a decomposed `é`. The
+  # expected text is written with an explicit \u escape on both sides of the
+  # comparison, because a screen assertion compares the bytes the program wrote:
+  # a decomposed grapheme and its precomposed spelling look identical and are
+  # not the same text.
+  - name: screen preserves a decomposed grapheme's combining mark
+    skip:
+      os: windows
+    steps:
+      - pty:
+          shell: true
+          command: "printf '\\303\\251 e\\314\\201'; sleep 0.2"
+          rows: 5
+          cols: 10
+      - assert:
+          screen:
+            line: 1
+            equals: "\u00e9 e\u0301"
+      - assert:
+          screen:
+            contains: "e\u0301"
 
   - name: a screen snapshot round-trips through update and compare
     skip:


### PR DESCRIPTION
## What

Two flaws in the terminal emulator `screen:` is rendered through (`github.com/charmbracelet/x/vt`) changed what an assertion compares against. Both are still present in its latest revision (`v0.0.0-20260816001655`, checked against the emulator directly), so both are corrected on atago's side of the boundary.

**Right margin after a wide character (#503).** Pending wrap is armed only from the LAST column (`atPhantom = awm && x >= width-1`), and a wide character reaches the right margin from the second-to-last one. So after `日本` filled a four-column row the wrap stayed disarmed: `X` was written *inside* the row, overwriting the second half of `本` and blanking its first half (`日 X`), and a wide character that no longer fit was dropped entirely (`日本語` in five columns rendered `日本`).

**Combining marks (#505).** An ASCII character takes the emulator's single-character fast path and is committed to the screen the moment it arrives, so a combining mark that follows can never join it and is dropped — a program writing a decomposed `é` rendered `e`. A non-ASCII base (`か` + dakuten) and a ZWJ emoji sequence go through the emulator's grapheme buffer and were never affected, which is why #437 looked complete.

Fixes #503. Fixes #505.

## How

`screenWriter` sits between the sanitized transcript and the emulator. It decodes the transcript with **the same library the emulator parses it with** (`x/ansi`), so the units it sees are the units the emulator will see, and it hands everything that needs no correction over in batches — ordinary output reaches the emulator exactly as before.

- A wide character that reaches the margin arms the wrap; one that no longer fits is wrapped rather than dropped. The wrap is injected as CR+LF, so scroll regions, origin mode, and scrolling at the bottom margin all behave as the program set them, and both codes clear the emulator's own pending-wrap state so a wrap can never fire twice. A cursor move between the armed wrap and the next character cancels it, the way a terminal cancels its own.
- DECAWM is tracked (`CSI ? 7 h/l`, and the RIS that restores it): with autowrap off a terminal keeps overwriting the last column, so every correction switches off with it.
- A cluster whose base is ASCII is re-read as a whole grapheme cluster, and after the base is written its cell content is replaced with the full cluster. Only the base is handed to the emulator — a mark arriving while pending wrap is armed makes it index a row (and scroll the screen when the base sat on the last one) for a grapheme that moves the cursor nowhere.

A cluster that is not valid UTF-8 is left alone: the segmenter will carry a stray continuation byte along with the character before it, and the emulator drops invalid UTF-8 rather than printing it. `FuzzRenderScreen` found that within a second of the first version; its input is committed as a seed.

## Tests

- `TestRenderScreen_WideCharacterAutowrap`: the two broken cases plus what must NOT change — an explicit newline after a filled row does not skip one, cursor addressing cancels the pending wrap, `DECAWM` off keeps the overwrite behavior, narrow autowrap still wraps.
- `TestRenderScreen_PreservesCombiningMarks`: one mark, two marks, a mark at the last column, a mark followed by another character, and the precomposed / wide-base spellings that were already right.
- `test/e2e/atago/pty.atago.yaml`: the wide-character scenario was an `expect_fail` carried since #480 — it is now an ordinary passing scenario, joined by the "no longer fits" case and a decomposed-grapheme one. The expected text uses explicit `\u` escapes on both sides, because a screen assertion compares the bytes the program wrote and a decomposed grapheme is not the same text as its precomposed spelling.
- `FuzzRenderScreen`: 5 minutes, ~3.1M execs, no failures.
- Rendering a 1.4 MB ASCII transcript costs ~10% more, a 2 MB CJK one ~3%; the emulator itself dominates both.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal rendering for wide characters at line boundaries and during overflow wrapping.
  - Preserved combining marks and decomposed characters correctly in displayed text.
  - Fixed cursor, newline, and autowrap behavior for more accurate screen output.
  - Improved rendering consistency across resized terminal transcript segments.

- **Tests**
  - Added coverage for wide-character wrapping, combining marks, and related terminal edge cases.

- **Documentation**
  - Updated behavior-spec documentation to reflect the expanded terminal rendering coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->