### PR TITLE
fix(thirdparty): probe mailpit with --no-release-check so a GitHub rate limit cannot skip the suite

### DIFF
--- a/doc/e2e/mailpit.md
+++ b/doc/e2e/mailpit.md
@@ -22,7 +22,7 @@ it.
 
 Source: `test/e2e/thirdparty/mailpit/mailpit.atago.yaml`
 ### Scenario: the binary reports its version
-_only when `mailpit version` succeeds_
+_only when `mailpit version --no-release-check` succeeds_
 #### When
 ```shell
 mailpit version --no-release-check
@@ -31,7 +31,7 @@ mailpit version --no-release-check
 - exit code is `0`
 - stdout contains `mailpit`
 ### Scenario: a message sent over real SMTP is captured and readable via the API
-_only when `mailpit version` succeeds_
+_only when `mailpit version --no-release-check` succeeds_
 #### Given
 - Background service `mailpit` is started: `mailpit --smtp 127.0.0.1:18170 --listen 127.0.0.1:18171 --database data.db`.
 - Fixture file `mail.txt` is created.
@@ -62,7 +62,7 @@ curl -s --url smtp://127.0.0.1:18170 --mail-from alice@example.test --mail-rcpt 
   - HTTP status is `200`
   - body at `$.Text` matches `/deploy pipeline completed successfully/`
 ### Scenario: full-text search finds exactly the matching message
-_only when `mailpit version` succeeds_
+_only when `mailpit version --no-release-check` succeeds_
 #### Given
 - Background service `mailpit` is started: `mailpit --smtp 127.0.0.1:18172 --listen 127.0.0.1:18173 --database data.db`.
 - Fixture file `mail1.txt` is created.
@@ -97,7 +97,7 @@ curl -s --url smtp://127.0.0.1:18172 --mail-from ci@example.test --mail-rcpt tea
   - body at `$.messages_count` equals `1`
   - body at `$.messages[0].Subject` equals `nightly build report`
 ### Scenario: a MIME attachment survives delivery intact
-_only when `mailpit version` succeeds_
+_only when `mailpit version --no-release-check` succeeds_
 #### Given
 - Background service `mailpit` is started: `mailpit --smtp 127.0.0.1:18174 --listen 127.0.0.1:18175 --database data.db`.
 - Fixture file `mail.txt` is created.
@@ -135,7 +135,7 @@ curl -s --url smtp://127.0.0.1:18174 --mail-from reports@example.test --mail-rcp
   - body at `$.Attachments` has length 1
   - body at `$.Attachments[0].FileName` equals `data.csv`
 ### Scenario: deleting all messages empties the mailbox
-_only when `mailpit version` succeeds_
+_only when `mailpit version --no-release-check` succeeds_
 #### Given
 - Background service `mailpit` is started: `mailpit --smtp 127.0.0.1:18176 --listen 127.0.0.1:18177 --database data.db`.
 - Fixture file `mail.txt` is created.

--- a/test/e2e/thirdparty/mailpit/mailpit.atago.yaml
+++ b/test/e2e/thirdparty/mailpit/mailpit.atago.yaml
@@ -45,8 +45,12 @@ defaults:
     # Every scenario here drives mailpit. Without the program there is nothing to
     # test, so the suite skips rather than erroring: a missing tool is not a
     # result. The gate is declared once so no scenario can be left out of it.
+    # --no-release-check matters here just as it does in the version scenario
+    # below: without it the probe asks GitHub for the latest release and exits 1
+    # when that call fails, so an unauthenticated rate limit on a shared CI
+    # runner would skip the whole suite with mailpit installed and working.
     only:
-      command: mailpit version
+      command: mailpit version --no-release-check
 
 scenarios:
   - name: the binary reports its version


### PR DESCRIPTION
## Summary

The `thirdparty (mailpit)` job went red on the last two main pushes (runs 31985705923 and 31986223615): the suite reported `0 passed, 0 failed, 0 errored, 5 skipped` right after installing mailpit, and the install-then-ran-nothing guard from #477 correctly failed the job. The root cause is the suite-wide selection gate that #469 introduced as plain `mailpit version`: that command asks the GitHub releases API for the latest release and exits 1 when the call fails, so an unauthenticated rate limit on a shared CI runner failed the probe even though mailpit was installed and working, and every scenario skipped. The install step itself was fine — the pinned `go install github.com/axllent/mailpit@v1.30.4` completed normally in the failing run's log.

## Changes

- `test/e2e/thirdparty/mailpit/mailpit.atago.yaml`: the `defaults.scenario.only` probe is now `mailpit version --no-release-check`, the same command the version scenario in this file already uses for exactly this reason, with a comment explaining why the flag matters on the gate too. The probe now stays offline, which also makes it consistent with the `127.0.0.1`-only network permission the suite declares. The guard from #477 is untouched.
- `doc/e2e/mailpit.md`: regenerated via `make docs`.

## Tests

- Reproduced the failure mode locally against the pinned v1.30.4: with the release check unable to reach api.github.com, `mailpit version` exits 1 while `mailpit version --no-release-check` exits 0.
- `./dist/atago run --retry-failed 1 --allow-flaky ./test/e2e/thirdparty/mailpit` passes 5/5 locally with mailpit v1.30.4 on PATH.
- `make docs` and `make site` are green with no further drift; `make test` and `make lint` pass.
