### PR TITLE
refactor(engine): build every assert Env in one place and drop the write-only snapshot flag

### DIFF
--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -38,11 +38,6 @@ type CheckResult struct {
 	Expected string
 	Actual   string
 	Hint     string
-	// SnapshotUpdated reports that this check WROTE its snapshot instead of
-	// comparing against it (`--update-snapshots`). Rewriting the committed
-	// goldens is the one passing outcome a reviewer has to be told about, so
-	// the reports can count it rather than reading it out of the description.
-	SnapshotUpdated bool
 
 	// ArtifactKind, ArtifactActual, and ArtifactExpected carry the full,
 	// untruncated payloads a failed text assertion compared, for durable export

--- a/internal/assert/snapshot.go
+++ b/internal/assert/snapshot.go
@@ -138,10 +138,10 @@ func checkSnapshot(desc, label, snapPath string, data []byte, env Env) *CheckRes
 		if err := snapshot.Update(env.SpecDir, path, data, opt); err != nil {
 			return &CheckResult{Desc: desc, Hint: fmt.Sprintf("could not write snapshot %q: %v", snapPath, err)}
 		}
+		// The run-level tally of rewrites lives in the recorder (markWritten
+		// above); the check itself only says so in its label.
 		env.SnapshotWrites.markWritten(path)
-		updated := pass(desc + " (updated)")
-		updated.SnapshotUpdated = true
-		return updated
+		return pass(desc + " (updated)")
 	}
 
 	// Under --update-snapshots a frozen golden's hints must not send the reader

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -474,6 +474,25 @@ type runConfig struct {
 	keepSnapshots bool
 }
 
+// assertEnv builds the assertion context every checking site shares: the step
+// loop, the run/http retry `until` polls, and the suite lifecycle. It is the
+// one place the run-scoped fields are wired, because hand-built Envs are how
+// they go missing — the snapshot-freeze flag and the clash writer were each
+// added to some of the four sites and had to be chased into the rest. A site
+// with extra context (mock records) sets it on the returned value.
+func (e *Engine) assertEnv(rc runConfig, workdir, specDir string) assert.Env {
+	return assert.Env{
+		Workdir:         workdir,
+		SpecDir:         specDir,
+		UpdateSnapshots: e.UpdateSnapshots,
+		SnapshotWrites:  e.snapshotWrites,
+		Writer:          rc.snapshotWriter,
+		KeepSnapshots:   rc.keepSnapshots,
+		Secrets:         rc.masker.MaskBytes,
+		Scrub:           rc.scrubber.Apply,
+	}
+}
+
 // absPath makes a path absolute for use as a spec variable, falling back to the
 // original when the working directory cannot be read.
 //

--- a/internal/engine/http.go
+++ b/internal/engine/http.go
@@ -27,8 +27,7 @@ func (e *Engine) runHTTPStep(ctx context.Context, h *spec.HTTP, st *store.Store,
 	// The policy-violation flag only matters alongside an error, so the shared
 	// poll loop carries it inside the closure.
 	secViolation := false
-	env := assert.Env{Workdir: workdir, SpecDir: specDir, UpdateSnapshots: e.UpdateSnapshots, SnapshotWrites: e.snapshotWrites, Writer: rc.snapshotWriter, KeepSnapshots: rc.keepSnapshots, Secrets: rc.masker.MaskBytes, Scrub: rc.scrubber.Apply}
-	last, checks, err := pollUntil(ctx, h.Retry, st, env, func(ctx context.Context) (*runner.Result, error) {
+	last, checks, err := pollUntil(ctx, h.Retry, st, e.assertEnv(rc, workdir, specDir), func(ctx context.Context) (*runner.Result, error) {
 		r, sv, rerr := e.runHTTP(ctx, h, st, rc, workdir)
 		secViolation = sv
 		return r, rerr

--- a/internal/engine/stepexec.go
+++ b/internal/engine/stepexec.go
@@ -237,17 +237,9 @@ func (x *scenarioRun) execStep(ctx context.Context, steps []spec.Step, i int, st
 	case spec.StepRun:
 		return x.execRunStep(ctx, steps, i, step, beforeAttempt)
 	case spec.StepAssert:
-		crs := assert.CheckAll(expandAssert(x.st, step.Assert), x.current, assert.Env{
-			Workdir:         x.workdir,
-			SpecDir:         x.specDir,
-			UpdateSnapshots: x.e.UpdateSnapshots,
-			SnapshotWrites:  x.e.snapshotWrites,
-			Writer:          x.rc.snapshotWriter,
-			KeepSnapshots:   x.rc.keepSnapshots,
-			Secrets:         x.masker.MaskBytes,
-			Scrub:           x.rc.scrubber.Apply,
-			MockRecords:     x.mockRecords,
-		})
+		env := x.e.assertEnv(x.rc, x.workdir, x.specDir)
+		env.MockRecords = x.mockRecords
+		crs := assert.CheckAll(expandAssert(x.st, step.Assert), x.current, env)
 		x.e.recordChecks(x.masker, crs, x.artifactScope(), i)
 		sr.Checks = crs
 		if !assert.AllOK(crs) {
@@ -499,8 +491,7 @@ func (e *Engine) runStep(ctx context.Context, run *spec.Run, st *store.Store, wo
 		}
 		return r, nil, nil
 	}
-	env := assert.Env{Workdir: workdir, SpecDir: specDir, UpdateSnapshots: e.UpdateSnapshots, SnapshotWrites: e.snapshotWrites, Writer: rc.snapshotWriter, KeepSnapshots: rc.keepSnapshots, Secrets: rc.masker.MaskBytes, Scrub: rc.scrubber.Apply}
-	return pollUntil(ctx, run.Retry, st, env, exec, beforeAttempt)
+	return pollUntil(ctx, run.Retry, st, e.assertEnv(rc, workdir, specDir), exec, beforeAttempt)
 }
 
 // resolveRunTarget decides whether a run step executes remotely and settles

--- a/internal/engine/suite.go
+++ b/internal/engine/suite.go
@@ -109,6 +109,12 @@ func (e *Engine) newSuiteRuntime(s *spec.Spec, specDir, fixturesDir string) (*su
 // The returned bool reports whether every step succeeded.
 func (e *Engine) runSuiteSteps(ctx context.Context, steps []spec.Step, rt *suiteRuntime, rc runConfig, stopOnFailure bool, label string) ([]StepResult, bool) {
 	var out []StepResult
+	// rc is this block's own copy. A suite block is its own snapshot writer —
+	// it belongs to no scenario, and naming the two blocks separately keeps a
+	// clash between them naming both sides — set the same way runScenario names
+	// a scenario, so every Env built below it (asserts and `until` polls alike)
+	// carries it.
+	rc.snapshotWriter = rc.specPath + " / " + label
 	x := &suiteStepper{e: e, rt: rt, rc: rc, label: label}
 	ok := true
 
@@ -210,26 +216,16 @@ func (x *suiteStepper) execRun(ctx context.Context, step *spec.Step, i int, sr *
 
 // execAssert checks one suite-level assert against the latest run result.
 func (x *suiteStepper) execAssert(step *spec.Step, i int, sr *StepResult) bool {
-	crs := assert.CheckAll(expandAssert(x.rt.st, step.Assert), x.current, assert.Env{
-		Workdir:         x.rt.dir,
-		SpecDir:         x.rc.specDir,
-		UpdateSnapshots: x.e.UpdateSnapshots,
-		SnapshotWrites:  x.e.snapshotWrites,
-		// A suite block is its own writer: it belongs to no scenario, and the two
-		// blocks are separate so a clash between them still names both sides.
-		Writer:        x.rc.specPath + " / " + x.label,
-		KeepSnapshots: x.rc.keepSnapshots,
-		Secrets:       x.rc.masker.MaskBytes,
-		Scrub:         x.rc.scrubber.Apply,
-		MockRecords: func(name string) ([]mockrunner.Record, bool) {
-			for _, m := range x.rt.mocks {
-				if m.Name() == name {
-					return m.Records(), true
-				}
+	env := x.e.assertEnv(x.rc, x.rt.dir, x.rc.specDir)
+	env.MockRecords = func(name string) ([]mockrunner.Record, bool) {
+		for _, m := range x.rt.mocks {
+			if m.Name() == name {
+				return m.Records(), true
 			}
-			return nil, false
-		},
-	})
+		}
+		return nil, false
+	}
+	crs := assert.CheckAll(expandAssert(x.rt.st, step.Assert), x.current, env)
 	x.e.recordChecks(x.rc.masker, crs, suiteArtifactScope(x.rc, x.label), i)
 	sr.Checks = crs
 	return !assert.AllOK(crs)

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -815,7 +815,7 @@ func TestSnapshotUpdates_AreReported(t *testing.T) {
 			Name:   "greets",
 			Status: engine.StatusPassed,
 			Steps: []engine.StepResult{{Kind: "assert", Checks: []*assert.CheckResult{
-				{OK: true, Desc: "assert stdout snapshot (updated)", SnapshotUpdated: true},
+				{OK: true, Desc: "assert stdout snapshot (updated)"},
 				{OK: true, Desc: "assert exit_code is 0"},
 			}}},
 		}},


### PR DESCRIPTION
## What

Every assert `Env` the engine builds now comes from one constructor, `Engine.assertEnv`, and the write-only `CheckResult.SnapshotUpdated` field is removed.

## Why

The assertion context was hand-built at four sites — the step loop, the run and http `until` polls, and the suite lifecycle — and hand-built Envs are exactly how run-scoped fields go missing. It happened twice in two days: the snapshot-freeze flag (#549) and the clash writer (#550) were each added to some of the four sites and then had to be chased into the rest, and both issues' fix cautions had to enumerate the construction sites by hand. A single constructor turns "add the field everywhere" into "add the field".

`CheckResult.SnapshotUpdated` became dead weight when #550 moved the rewrite tally onto the write recorder: after that, the field was set on every updated check and read by nothing in the codebase — no report, no json tag, nothing. The "(updated)" label on the check already says what happened.

## How

`assertEnv(rc, workdir, specDir)` wires Workdir/SpecDir plus the run-scoped fields (UpdateSnapshots, SnapshotWrites, Writer, KeepSnapshots, Secrets, Scrub); the two sites with mock records set `MockRecords` on the returned value. The suite lifecycle now names its snapshot writer on its own copy of the run config in `runSuiteSteps`, the same way `runScenario` names a scenario's, instead of overriding the field inside its assert site — which also carries the writer into the `until` polls a suite-level `run:` performs, where it was previously empty. That is the one behavior delta, and it is the corrective direction: a clash detected inside a suite-level poll now names the suite block instead of nobody.

Net -0 lines (43 insertions, 43 deletions), four struct literals collapsed to one constructor plus two one-field additions.

## Verification

`make test` (0 failures), `make lint` (0 issues), and `make e2e` (676 scenarios: 672 passed, 4 skipped) are green locally; no spec/doc surface changed, so the drift guards are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snapshot update tracking so results are reported consistently at the run level.
  * Preserved snapshot update reporting while removing outdated per-check status details.

* **Refactor**
  * Centralized assertion environment setup across HTTP steps, retries, and suite execution.
  * Maintained existing polling, mocking, snapshot, secret-masking, and scrubbing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->