### PR TITLE
test(report): decide every run-level fact for every format, from one catalog

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -176,6 +176,24 @@ func runCmd(label string, args []string, stdout, stderr io.Writer) int {
 	return finishRun(ctx, opts, suiteResults, loadErrs, progress, elapsed)
 }
 
+// formatAlternatives renders the report formats as the "console|json|…" list
+// the flag help and usage line show. Derived from report.AllFormats — the list
+// used to be spelled here by hand and a format added to the report package
+// would have been invisible in --help.
+func formatAlternatives() string {
+	return strings.Join(report.FormatNames(), "|")
+}
+
+// formatProse renders the report formats as the "console, json, …, or tap"
+// prose the unknown-format diagnostic uses, from the same list.
+func formatProse() string {
+	names := report.FormatNames()
+	if len(names) == 1 {
+		return names[0]
+	}
+	return strings.Join(names[:len(names)-1], ", ") + ", or " + names[len(names)-1]
+}
+
 // parseRunFlags parses and validates `atago run`'s flags into a runOptions. The
 // bool return is true when parsing already decided the outcome (a --help, a bad
 // flag, an unknown --report, no matching spec files, or a failed bounds check),
@@ -184,7 +202,7 @@ func runCmd(label string, args []string, stdout, stderr io.Writer) int {
 func parseRunFlags(label string, args []string, stdout, stderr io.Writer) (*runOptions, int, bool) {
 	fs := flag.NewFlagSet(label, flag.ContinueOnError)
 	fs.SetOutput(stderr)
-	reportFmt := fs.String("report", "console", "report format: console|json|junit|gha|tap")
+	reportFmt := fs.String("report", "console", "report format: "+formatAlternatives())
 	updateSnapshots := fs.Bool("update-snapshots", false, "create or overwrite snapshot files instead of comparing")
 	ci := fs.Bool("ci", false, "CI-safe defaults: deterministic, no color (sets NO_COLOR), secret masking")
 	parallel := fs.Int("parallel", runtime.NumCPU(), "number of scenarios to run concurrently; scenarios are isolated, each in its own temp dir")
@@ -204,7 +222,7 @@ func parseRunFlags(label string, args []string, stdout, stderr io.Writer) (*runO
 	allowXPass := fs.Bool("allow-xpass", false, "exit 0 when an expect_fail scenario passed (XPASS); by default a fixed known bug fails the run so the spec gets promoted")
 	verbose := fs.Bool("verbose", false, "trace every scenario as it finishes: commands, exit codes, captured output, and per-assertion verdicts — for passing scenarios too")
 	fs.Usage = func() {
-		fmt.Fprint(fs.Output(), "Usage: atago run [--report console|json|junit|gha|tap] [--update-snapshots] [--parallel N] [--fail-fast] [--filter S] [--tag T] [--skip-tag T] [--rerun-failed] [--repeat N] [--retry-failed N] [--allow-flaky] [--allow-xpass] [--profile NAME] [--artifacts-dir DIR] [--verbose] [--ci] <path | dir>...\n  (directories are searched recursively)\n")
+		fmt.Fprint(fs.Output(), "Usage: atago run [--report "+formatAlternatives()+"] [--update-snapshots] [--parallel N] [--fail-fast] [--filter S] [--tag T] [--skip-tag T] [--rerun-failed] [--repeat N] [--retry-failed N] [--allow-flaky] [--allow-xpass] [--profile NAME] [--artifacts-dir DIR] [--verbose] [--ci] <path | dir>...\n  (directories are searched recursively)\n")
 		fs.PrintDefaults()
 	}
 	operands, err := parseFlagsAnywhere(fs, args)
@@ -223,7 +241,7 @@ func parseRunFlags(label string, args []string, stdout, stderr io.Writer) (*runO
 
 	format := report.Format(*reportFmt)
 	if !format.Valid() {
-		fmt.Fprintf(stderr, "%s: %s\n", label, diag.BadOptionValue.Annotate(fmt.Sprintf("unknown --report %q (want console, json, junit, gha, or tap)", *reportFmt)))
+		fmt.Fprintf(stderr, "%s: %s\n", label, diag.BadOptionValue.Annotate(fmt.Sprintf("unknown --report %q (want %s)", *reportFmt, formatProse())))
 		return nil, ExitConfig, true
 	}
 

--- a/internal/report/factmatrix_test.go
+++ b/internal/report/factmatrix_test.go
@@ -1,0 +1,380 @@
+package report
+
+import (
+	"bytes"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nao1215/atago/internal/assert"
+	"github.com/nao1215/atago/internal/engine"
+	"github.com/nao1215/atago/internal/spec"
+)
+
+// This file is the run-level twin of the spec package's Decides tests: a
+// catalog of every fact a run can carry — a verdict class, a teardown failure,
+// a rewritten golden, a load failure, the evidence paths — with an explicit
+// decision for every report format: either a substring proving the format
+// carries it, or the recorded reason it deliberately does not. The recurring
+// bug this closes off is the partially wired fact: a load failure reached only
+// the console (#120/#479), a failed teardown only console and json (#511), the
+// artifact and service-log paths the same pair (#528), and the snapshot
+// rewrite count left no trace anywhere (#532/#542) — four rounds of the same
+// defect, each fixed by hand-wiring one fact into the formats it missed. A
+// fact added to this catalog is red for every format nobody decided about.
+//
+// Two reflection guards anchor the catalog to real structs so it cannot rot:
+// every renderOptions field and every engine.Counts field must be claimed by a
+// catalog entry (or exempted with a reason), so a new run-level option or a
+// new verdict class fails these tests until someone decides how each format
+// reports it.
+
+// factProof is one format's decision about one fact.
+type factProof struct {
+	// contains proves the fact is present in the rendered output.
+	contains string
+	// absent, when set alongside contains, additionally proves an output the
+	// fact must NOT produce (an allow-flag removing a synthesized entry).
+	absent string
+	// exempt records why this format deliberately omits the fact. Exactly one
+	// of contains/exempt must be set.
+	exempt string
+}
+
+// reportFact is one run-level fact: the fixture that carries it and the
+// decision per format.
+type reportFact struct {
+	results []*engine.SuiteResult
+	opts    []Option
+	proofs  map[Format]factProof
+	// countAnchor / optionAnchor tie the fact to the struct field whose
+	// existence forces it to be cataloged (see the reflection guards).
+	countAnchor  string
+	optionAnchor []string
+}
+
+// suiteOf wraps scenarios into the single-suite fixture the matrix renders.
+func suiteOf(scs ...engine.ScenarioResult) []*engine.SuiteResult {
+	return []*engine.SuiteResult{{
+		Suite:     "matrix",
+		SpecPath:  "matrix.atago.yaml",
+		Status:    engine.StatusPassed,
+		Scenarios: scs,
+	}}
+}
+
+// failingCheck builds the failed-assertion evidence the failure facts share.
+func failingCheck() *assert.CheckResult {
+	return &assert.CheckResult{
+		Desc:          "assert stdout contains \"never\"",
+		Expected:      "EXPECTED-MARKER",
+		Actual:        "ACTUAL-MARKER",
+		Hint:          "HINT-MARKER",
+		ArtifactFiles: []assert.ArtifactFile{{Role: "actual", Path: "art/PATH-MARKER.txt"}},
+	}
+}
+
+func factCatalog() map[string]reportFact {
+	passed := suiteOf(engine.ScenarioResult{Name: "greets", Status: engine.StatusPassed,
+		Steps: []engine.StepResult{{Kind: spec.StepAssert, Checks: []*assert.CheckResult{{OK: true, Desc: "assert exit_code is 0"}}}}})
+	failed := suiteOf(engine.ScenarioResult{Name: "greets", Status: engine.StatusFailed,
+		ServiceLogs: []engine.ServiceLog{{Name: "svc", Path: "logs/SVCLOG-MARKER.log"}},
+		Steps:       []engine.StepResult{{Kind: spec.StepAssert, Checks: []*assert.CheckResult{failingCheck()}}}})
+	failed[0].Status = engine.StatusFailed
+	errored := suiteOf(engine.ScenarioResult{Name: "greets", Status: engine.StatusError,
+		Steps: []engine.StepResult{{Kind: spec.StepRun, ErrMsg: "ERRMSG-MARKER"}}})
+	errored[0].Status = engine.StatusError
+	skipped := suiteOf(engine.ScenarioResult{Name: "greets", Status: engine.StatusSkipped, SkipReason: "SKIPREASON-MARKER"})
+	flaky := suiteOf(engine.ScenarioResult{Name: "greets", Status: engine.StatusFlaky, Attempts: 2,
+		Steps: []engine.StepResult{{Kind: spec.StepAssert, Checks: []*assert.CheckResult{{OK: true, Desc: "assert exit_code is 0"}}}}})
+	xfail := suiteOf(engine.ScenarioResult{Name: "greets", Status: engine.StatusXFail,
+		ExpectFail: &spec.ExpectFail{Reason: "XFREASON-MARKER"}})
+	xpass := suiteOf(engine.ScenarioResult{Name: "greets", Status: engine.StatusXPass,
+		ExpectFail: &spec.ExpectFail{Reason: "XFREASON-MARKER"}})
+	scenarioTeardown := suiteOf(engine.ScenarioResult{Name: "greets", Status: engine.StatusPassed,
+		Teardown: []engine.StepResult{{Kind: spec.StepAssert, Checks: []*assert.CheckResult{{Desc: "TDDESC-MARKER"}}}}})
+	suiteTeardown := suiteOf(engine.ScenarioResult{Name: "greets", Status: engine.StatusPassed})
+	suiteTeardown[0].Teardown = []engine.StepResult{{Kind: spec.StepAssert, Checks: []*assert.CheckResult{{Desc: "SUITETD-MARKER"}}}}
+
+	return map[string]reportFact{
+		"passed scenario": {
+			results: passed, countAnchor: "Passed",
+			proofs: map[Format]factProof{
+				FormatConsole: {contains: "1 passed"},
+				FormatJSON:    {contains: `"status": "passed"`},
+				FormatJUnit:   {contains: `failures="0"`},
+				FormatTAP:     {contains: "ok 1 - "},
+				FormatGHA:     {contains: "1 passed"},
+			},
+		},
+		"failed scenario": {
+			results: failed, countAnchor: "Failed",
+			proofs: map[Format]factProof{
+				FormatConsole: {contains: "FAILED:"},
+				FormatJSON:    {contains: `"status": "failed"`},
+				FormatJUnit:   {contains: "<failure"},
+				FormatTAP:     {contains: "not ok 1 - "},
+				FormatGHA:     {contains: "::error"},
+			},
+		},
+		"errored scenario": {
+			results: errored, countAnchor: "Errored",
+			proofs: map[Format]factProof{
+				FormatConsole: {contains: "ERRMSG-MARKER"},
+				FormatJSON:    {contains: `"status": "error"`},
+				FormatJUnit:   {contains: "<error"},
+				FormatTAP:     {contains: "not ok 1 - "},
+				FormatGHA:     {contains: "::error"},
+			},
+		},
+		"skipped scenario with its reason": {
+			results: skipped, countAnchor: "Skipped",
+			proofs: map[Format]factProof{
+				FormatConsole: {contains: "1 skipped"},
+				FormatJSON:    {contains: `"skip_reason": "SKIPREASON-MARKER"`},
+				FormatJUnit:   {contains: "<skipped"},
+				FormatTAP:     {contains: "# SKIP SKIPREASON-MARKER"},
+				FormatGHA:     {contains: "1 skipped"},
+			},
+		},
+		"flaky scenario with its instability": {
+			results: flaky, countAnchor: "Flaky",
+			proofs: map[Format]factProof{
+				FormatConsole: {contains: "1 flaky"},
+				FormatJSON:    {contains: `"status": "flaky"`},
+				FormatJUnit:   {contains: "flakyFailure"},
+				FormatTAP:     {contains: "flaky: passed after 2 attempts"},
+				FormatGHA:     {contains: "flaky: passed after 2 attempts"},
+			},
+		},
+		"expected failure with its reason": {
+			results: xfail, countAnchor: "XFail",
+			proofs: map[Format]factProof{
+				FormatConsole: {contains: "XFAIL:"},
+				FormatJSON:    {contains: `"status": "xfail"`},
+				FormatJUnit:   {contains: "xfail: XFREASON-MARKER"},
+				FormatTAP:     {contains: "# TODO XFREASON-MARKER"},
+				FormatGHA:     {contains: "xfail: XFREASON-MARKER"},
+			},
+		},
+		"unexpectedly passing known bug": {
+			results: xpass, countAnchor: "XPass",
+			proofs: map[Format]factProof{
+				FormatConsole: {contains: "XPASS:"},
+				FormatJSON:    {contains: `"status": "xpass"`},
+				FormatJUnit:   {contains: "xpass: the known bug is fixed"},
+				FormatTAP:     {contains: "xpass: the known bug is fixed"},
+				FormatGHA:     {contains: "xpass: the known bug is fixed"},
+			},
+		},
+		"failure evidence (hint, expected/actual)": {
+			results: failed,
+			proofs: map[Format]factProof{
+				FormatConsole: {contains: "HINT-MARKER"},
+				FormatJSON:    {contains: `"hint": "HINT-MARKER"`},
+				FormatJUnit:   {contains: "Hint: HINT-MARKER"},
+				FormatTAP:     {contains: "HINT-MARKER"},
+				FormatGHA:     {contains: "HINT-MARKER"},
+			},
+		},
+		"artifact sidecar paths": {
+			results: failed,
+			proofs: map[Format]factProof{
+				FormatConsole: {contains: "art/PATH-MARKER.txt"},
+				FormatJSON:    {contains: `"artifacts"`},
+				FormatJUnit:   {contains: "Artifact (actual): art/PATH-MARKER.txt"},
+				FormatTAP:     {contains: "Artifact (actual): art/PATH-MARKER.txt"},
+				FormatGHA:     {contains: "Artifact (actual): art/PATH-MARKER.txt"},
+			},
+		},
+		"preserved service log paths": {
+			results: failed,
+			proofs: map[Format]factProof{
+				FormatConsole: {contains: "logs/SVCLOG-MARKER.log"},
+				FormatJSON:    {contains: `"service_logs"`},
+				FormatJUnit:   {contains: "Service log (svc): logs/SVCLOG-MARKER.log"},
+				FormatTAP:     {contains: "Service log (svc): logs/SVCLOG-MARKER.log"},
+				FormatGHA:     {contains: "Service log (svc): logs/SVCLOG-MARKER.log"},
+			},
+		},
+		"scenario teardown failure": {
+			results: scenarioTeardown,
+			proofs: map[Format]factProof{
+				FormatConsole: {contains: "TEARDOWN FAILED:"},
+				FormatJSON:    {contains: `"teardown_failures"`},
+				FormatJUnit:   {contains: "teardown failed (the verdict is decided by the steps alone):"},
+				FormatTAP:     {contains: "# teardown failed: TDDESC-MARKER"},
+				FormatGHA:     {contains: "teardown failed: TDDESC-MARKER"},
+			},
+		},
+		"suite teardown failure": {
+			results: suiteTeardown,
+			proofs: map[Format]factProof{
+				FormatConsole: {contains: "SUITE TEARDOWN FAILED:"},
+				FormatJSON:    {contains: "SUITETD-MARKER"},
+				FormatJUnit:   {contains: "suite teardown failed (teardown outcomes never change the suite status):"},
+				FormatTAP:     {contains: "# suite teardown failed: SUITETD-MARKER"},
+				FormatGHA:     {contains: "suite teardown failed: SUITETD-MARKER"},
+			},
+		},
+		"spec that failed to load": {
+			results: passed, optionAnchor: []string{"loadFailures"},
+			opts: []Option{WithLoadFailures(LoadFailure{SpecPath: "bad.atago.yaml", Message: "LOADMSG-MARKER"})},
+			proofs: map[Format]factProof{
+				FormatConsole: {contains: "failed to load"},
+				FormatJSON:    {contains: `"load_failures"`},
+				FormatJUnit:   {contains: "spec failed to load"},
+				FormatTAP:     {contains: "spec failed to load"},
+				FormatGHA:     {contains: "spec failed to load"},
+			},
+		},
+		"rewritten snapshot goldens": {
+			results: passed, optionAnchor: []string{"snapshotsUpdated"},
+			opts: []Option{WithSnapshotsUpdated(3)},
+			proofs: map[Format]factProof{
+				FormatConsole: {contains: "3 snapshots updated"},
+				FormatJSON:    {contains: `"snapshots_updated": 3`},
+				FormatJUnit:   {exempt: "deliberate (#542): surefire's schema has no run-level annotation slot, and hanging the count on an arbitrary testsuite would misattribute it"},
+				FormatTAP:     {contains: "# 3 snapshots updated"},
+				FormatGHA:     {contains: "3 snapshots updated"},
+			},
+		},
+		"run wall-clock time": {
+			results: passed, optionAnchor: []string{"elapsed", "hasElapsed"},
+			opts: []Option{WithElapsed(2 * time.Second)},
+			proofs: map[Format]factProof{
+				FormatConsole: {contains: "(2s)"},
+				FormatJSON:    {exempt: "the machine formats carry per-suite durations from the results; the run's wall clock is the console summary's nicety"},
+				FormatJUnit:   {exempt: "same: testsuite time attributes come from the per-suite durations"},
+				FormatTAP:     {exempt: "TAP carries points and diagnostics, not a run duration"},
+				FormatGHA:     {exempt: "the Actions UI shows the job's own duration; the summary line repeats the counts only"},
+			},
+		},
+		"accepted flakiness (--allow-flaky)": {
+			results: flaky, optionAnchor: []string{"allowFlaky"},
+			opts: []Option{WithAllowFlaky(true)},
+			proofs: map[Format]factProof{
+				FormatConsole: {contains: "PASSED"},
+				FormatJSON:    {exempt: "the per-scenario classification is identical either way; the flag moves only the exit code and the console verdict word"},
+				FormatJUnit:   {exempt: "same: a flaky scenario is a flakyFailure with or without the flag"},
+				FormatTAP:     {exempt: "same: the point is ok with the instability in its diagnostic either way"},
+				FormatGHA:     {exempt: "same: the annotation stays a warning either way"},
+			},
+		},
+		"accepted xpass (--allow-xpass)": {
+			results: xpass, optionAnchor: []string{"allowXPass"},
+			opts: []Option{WithAllowXPass(true)},
+			proofs: map[Format]factProof{
+				FormatConsole: {contains: "PASSED"},
+				FormatJSON:    {contains: `"failures": []`},
+				FormatJUnit:   {contains: "flakyFailure", absent: "<failure"},
+				FormatTAP:     {exempt: "an ok TODO point already encodes unexpected-success; TAP has no verdict the flag could soften"},
+				FormatGHA:     {contains: "::warning", absent: "::error"},
+			},
+		},
+	}
+}
+
+// TestReportFacts_DecideEveryFormat renders each cataloged fact in every
+// format and holds the decision: the proving substring is present (and the
+// forbidden one absent), or the exemption carries a reason. A fact with no
+// decision for some format — what every historical instance of this bug family
+// was — fails with the question to answer.
+func TestReportFacts_DecideEveryFormat(t *testing.T) {
+	t.Parallel()
+	for name, fact := range factCatalog() {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			for _, f := range AllFormats() {
+				proof, ok := fact.proofs[f]
+				if !ok {
+					t.Errorf("format %q: no decision for fact %q; add a proving substring or an exemption with its reason", f, name)
+					continue
+				}
+				if (proof.contains == "") == (proof.exempt == "") {
+					t.Errorf("format %q: fact %q must set exactly one of contains/exempt", f, name)
+					continue
+				}
+				if proof.exempt != "" {
+					continue
+				}
+				var b bytes.Buffer
+				if err := Render(&b, f, fact.results, fact.opts...); err != nil {
+					t.Fatalf("format %q: render: %v", f, err)
+				}
+				out := b.String()
+				if !strings.Contains(out, proof.contains) {
+					t.Errorf("format %q does not carry fact %q: want substring %q in:\n%s", f, name, proof.contains, out)
+				}
+				if proof.absent != "" && strings.Contains(out, proof.absent) {
+					t.Errorf("format %q: fact %q forbids substring %q, present in:\n%s", f, name, proof.absent, out)
+				}
+			}
+		})
+	}
+}
+
+// TestReportFacts_CoverEveryCount anchors the catalog to engine.Counts: every
+// verdict class the run tallies must be a cataloged fact, so a new status —
+// the next StatusFlaky — cannot ship without deciding how each format reports
+// it.
+func TestReportFacts_CoverEveryCount(t *testing.T) {
+	t.Parallel()
+	anchored := map[string]bool{}
+	for _, fact := range factCatalog() {
+		if fact.countAnchor != "" {
+			anchored[fact.countAnchor] = true
+		}
+	}
+	rt := reflect.TypeOf(engine.Counts{})
+	for i := range rt.NumField() {
+		name := rt.Field(i).Name
+		if !anchored[name] {
+			t.Errorf("engine.Counts.%s has no cataloged fact; add one so every format decides how to report that verdict class", name)
+		}
+	}
+}
+
+// TestReportFacts_CoverEveryRenderOption anchors the catalog to renderOptions:
+// every run-level input Render accepts must be claimed by a cataloged fact, so
+// a new WithX option — the next snapshotsUpdated — cannot ship without
+// deciding how each format reports what it carries.
+func TestReportFacts_CoverEveryRenderOption(t *testing.T) {
+	t.Parallel()
+	anchored := map[string]bool{}
+	for _, fact := range factCatalog() {
+		for _, f := range fact.optionAnchor {
+			anchored[f] = true
+		}
+	}
+	rt := reflect.TypeOf(renderOptions{})
+	for i := range rt.NumField() {
+		name := rt.Field(i).Name
+		if !anchored[name] {
+			t.Errorf("renderOptions.%s has no cataloged fact; add one (or extend an existing fact's optionAnchor) so every format decides how to report it", name)
+		}
+	}
+}
+
+// TestAllFormats_RenderKnowsEveryFormat pins the format list to the Render
+// dispatch from both sides: every listed format renders, and a format outside
+// the list is refused — the list and the switch used to be two hand copies.
+func TestAllFormats_RenderKnowsEveryFormat(t *testing.T) {
+	t.Parallel()
+	for _, f := range AllFormats() {
+		var b bytes.Buffer
+		if err := Render(&b, f, nil); err != nil {
+			t.Errorf("format %q is listed but Render refuses it: %v", f, err)
+		}
+		if !f.Valid() {
+			t.Errorf("format %q is listed but Valid() rejects it", f)
+		}
+	}
+	if err := Render(&bytes.Buffer{}, Format("nope"), nil); err == nil {
+		t.Error("an unlisted format was rendered")
+	}
+	if Format("nope").Valid() {
+		t.Error("an unlisted format is Valid()")
+	}
+}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -3,6 +3,7 @@
 package report
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/nao1215/atago/internal/engine"
@@ -121,13 +122,29 @@ const (
 	FormatTAP Format = "tap"
 )
 
-// Valid reports whether f is a known report format. Render is the single entry
-// point that dispatches on Format to the per-format build/write helpers.
-func (f Format) Valid() bool {
-	switch f {
-	case FormatConsole, FormatJSON, FormatJUnit, FormatGHA, FormatTAP:
-		return true
-	default:
-		return false
+// AllFormats returns every report format, in the order user-facing lists show
+// them. It is the one list: Valid derives from it, the CLI's flag help, usage
+// line, and unknown-format error render it, and the fact-matrix test iterates
+// it — the same list used to be spelled in four places (two switches and two
+// help strings), which is one place per opportunity to forget a new format.
+func AllFormats() []Format {
+	return []Format{FormatConsole, FormatJSON, FormatJUnit, FormatGHA, FormatTAP}
+}
+
+// FormatNames returns AllFormats as plain strings, for the CLI surfaces that
+// join them into help text.
+func FormatNames() []string {
+	all := AllFormats()
+	out := make([]string, len(all))
+	for i, f := range all {
+		out[i] = string(f)
 	}
+	return out
+}
+
+// Valid reports whether f is a known report format, against the one list.
+// Render is the single entry point that dispatches on Format to the per-format
+// build/write helpers.
+func (f Format) Valid() bool {
+	return slices.Contains(AllFormats(), f)
 }


### PR DESCRIPTION
## What

A Decides-style matrix for the report layer: every run-level fact, crossed with every format, each cell holding either the substring that proves the format carries the fact or the recorded reason it deliberately does not — plus reflection anchors that force the NEXT fact to be decided, and a single source for the format list itself.

## Why

The report layer's most-recurring defect is the partially wired fact. A spec that failed to load reached only the console while every machine format rendered a green document (#120/#479); a failed teardown reached console and json while junit, tap, and gha stayed silent (#511); the artifact sidecar and service-log paths reached the same pair while the three formats CI actually reads reproduced the diff text naming no file (#528); and a run that rewrote its goldens left no trace anywhere (#532/#542). Four rounds of one defect, each fixed by hand-wiring one fact into the formats it had missed — and nothing forcing the next fact to be wired everywhere, which is how each round happened after the one before it.

The cross-format tests that exist (`format_parity_test.go`, the per-fix regressions) each pin one fact. What was missing is the registry: a place where a new fact MUST appear and where "which formats carry it" is a question the test refuses to leave unanswered.

## How

`factmatrix_test.go` catalogs sixteen facts — the seven verdict classes (passed/failed/errored/skipped/flaky/xfail/xpass, each with its evidence: the skip reason, the flake wording, the expect_fail reason), the failure evidence (hint, expected/actual), the artifact and service-log paths, scenario and suite teardown failures, load failures, the snapshot rewrite count, the wall clock, and the two allow flags (with forbidden-substring proofs where the flag's effect is removing an output). `TestReportFacts_DecideEveryFormat` renders each fact in every format and holds the decision; a missing cell fails with the question to answer.

Two guards anchor the catalog to real structs so it cannot rot silently: `TestReportFacts_CoverEveryCount` (reflection over `engine.Counts` — a new verdict class must be cataloged) and `TestReportFacts_CoverEveryRenderOption` (reflection over `renderOptions` — a new `WithX` option must be cataloged). This mirrors the anchoring the spec package's Decides tests use for step kinds.

The format list was the same bug one level up, spelled in four places: the `Valid` switch, the `Render` dispatch, and the CLI's flag help and unknown-format diagnostic. `report.AllFormats` is now the one list — `Valid` derives from it, the CLI builds `console|json|junit|gha|tap` and the "want console, json, junit, gha, or tap" prose from it (byte-identical to the old hand copies, pinned by the existing CLI tests), and `TestAllFormats_RenderKnowsEveryFormat` pins the list to the dispatch from both sides.

## Verification

The matrix passes against today's formats with no production behavior change: the four historical fixes left no open gap, so this PR is the fence, not another patch. The only production edits are the derived format strings (identical output) and the `AllFormats`/`FormatNames` accessors. `make test` (0 failures), `make lint` (0 issues), `make e2e` (677 scenarios: 673 passed, 4 skipped), `make docs`/`make site` drift guards green.

With this, the walk-forgetting prevention set is complete across its four layers: step kinds and phases (#552), expansion fields (#553), the assert Env construction (#551), and now the run-level facts × formats — each with a forcing test that turns "nobody decided" into a red build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated command-line help and usage information to list all currently supported report formats automatically.
  * Improved unknown-format messages with accurate, up-to-date format names.
  * Standardized report-format validation across supported output formats.

* **Quality**
  * Expanded coverage to verify report details—including verdicts, failures, artifacts, logs, timing, snapshots, and flaky results—across all supported formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->