### PR TITLE
feat(lint): expand the linter set and add atago-specific rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,12 @@ linters:
     - errchkjson
     - errname
     - errorlint
+    # exhaustruct is scoped to assert.Env alone. Applied broadly it is noise, but
+    # that struct is built by exactly one production constructor whose whole job is
+    # to be complete: the run-scoped fields it wires reached three of the four
+    # assertion sites twice before, and each time the fix was to route everything
+    # through this one function. Now the function itself cannot forget a field.
+    - exhaustruct
     # forbidigo carries the rules that are specific to atago rather than to Go.
     # All four report nothing today; they exist so the next change cannot quietly
     # take one of these away. See settings.forbidigo for what each one protects.
@@ -82,6 +88,9 @@ linters:
       # for the same reason, so the switches and the coverage tests are checked
       # against one universe.
       ignore-enum-members: 'atago/internal/(spec\.(StepNone|AssertNone))$'
+    exhaustruct:
+      include:
+        - 'github.com/nao1215/atago/internal/assert\.Env'
     forbidigo:
       analyze-types: true
       forbid:
@@ -138,8 +147,11 @@ linters:
         source: defer
       # Tests legitimately read files via computed temp paths and embed sample
       # spec text; gosec's G304/G101 are noise there.
+      # Tests build an Env with just the field under test, which is the readable
+      # way to write them; the constructor the rule protects is production code.
       - linters:
           - gosec
+          - exhaustruct
         path: _test\.go
       # A test helper subprocess is the program under test: printing to its own
       # stdout is what the capture assertions read.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,10 @@ linters:
     - errchkjson
     - errname
     - errorlint
+    # forbidigo carries the rules that are specific to atago rather than to Go.
+    # All four report nothing today; they exist so the next change cannot quietly
+    # take one of these away. See settings.forbidigo for what each one protects.
+    - forbidigo
     # exhaustive is the structural half of atago's oldest bug family: a new step
     # kind, assert target, or scenario status gets wired into some of the layers
     # that switch on it and quietly skipped by the rest. The coverage tests guard
@@ -78,6 +82,24 @@ linters:
       # for the same reason, so the switches and the coverage tests are checked
       # against one universe.
       ignore-enum-members: 'atago/internal/(spec\.(StepNone|AssertNone))$'
+    forbidigo:
+      analyze-types: true
+      forbid:
+        # atago's stdout is a machine-readable contract under --format json/junit/gha.
+        # A stray Print corrupts the document a CI job parses, and the failure lands
+        # on whoever wrote the parser. Every writer is injected; use it.
+        - pattern: '^fmt\.(Print|Printf|Println)$'
+          msg: "atago's stdout carries the report; write through the injected io.Writer instead"
+        # Process-global state and --parallel are incompatible: scenarios run
+        # concurrently in their own workdirs, so a chdir or a setenv from one of them
+        # is observable by all the others. The two deliberate exceptions in
+        # internal/cli run once at startup and say so.
+        - pattern: '^os\.(Chdir|Setenv|Unsetenv|Clearenv)$'
+          msg: "process-global state is visible to every scenario running in parallel"
+        # A test runner that is not reproducible cannot tell a real failure from its
+        # own noise. Seeded values belong in the spec, not in the runner.
+        - pattern: '^math/rand(/v2)?\.'
+          msg: "atago's output has to be reproducible; take the value from the spec"
     gocognit:
       min-complexity: 30
     recvcheck:
@@ -119,6 +141,12 @@ linters:
       - linters:
           - gosec
         path: _test\.go
+      # A test helper subprocess is the program under test: printing to its own
+      # stdout is what the capture assertions read.
+      - linters:
+          - forbidigo
+        path: _test\.go
+        text: fmt\.Print
       # Table-driven tests and fuzz harnesses are long by nature; the
       # complexity bounds are a production-code contract.
       - linters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,25 +3,42 @@ run:
   go: "1.26"
 linters:
   enable:
+    - asasalint
     - asciicheck
     - bidichk
     - bodyclose
+    - canonicalheader
     - copyloopvar
     - durationcheck
     - errcheck
     - errname
     - errorlint
+    - fatcontext
     - gocheckcompilerdirectives
     - gochecknoinits
     - gocognit
     - gosec
     - govet
+    - iface
     - ineffassign
+    - makezero
     - misspell
+    # musttag guards the JSON side of atago's machine-readable contracts (the
+    # json/junit/gha reports, the manifest and rerun ledgers): a field added
+    # there without a tag silently changes key names for downstream consumers.
+    # goccy/go-yaml is deliberately not registered under settings.musttag:
+    # spec types like Stdin, ExitCode and PTYSend decode through hand-written
+    # UnmarshalYAML that accepts a bare scalar as well as a mapping, so their
+    # fields have no honest tag to carry.
+    - musttag
     - nestif
     - nilerr
+    - nilnesserr
     - noctx
     - nolintlint
+    - reassign
+    - rowserrcheck
+    - sqlclosecheck
     - staticcheck
     - tagliatelle
     - thelper

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,11 @@ linters:
     - errcheck
     - errname
     - errorlint
+    # exhaustive is the structural half of atago's oldest bug family: a new step
+    # kind, assert target, or scenario status gets wired into some of the layers
+    # that switch on it and quietly skipped by the rest. The coverage tests guard
+    # the walkers someone remembered to test; this guards every switch.
+    - exhaustive
     - fatcontext
     - gocheckcompilerdirectives
     - gochecknoinits
@@ -50,6 +55,19 @@ linters:
   settings:
     # The 2026-08 refactoring series brought every production function under
     # these bounds; the linters keep the next hot spot from growing back.
+    exhaustive:
+      # A `default:` clause does not excuse a missing case. Most of these switches
+      # HAVE a default, and inheriting its answer in silence is exactly how a kind
+      # goes half-wired.
+      default-signifies-exhaustive: false
+      # reflect.Kind has 27 members and the two switches over it are schema
+      # walkers that care about four.
+      ignore-enum-types: 'reflect\.Kind$'
+      # StepNone and AssertNone are the "not exactly one action" sentinels, not
+      # kinds a spec can carry. AllStepKinds and AllAssertTargets leave them out
+      # for the same reason, so the switches and the coverage tests are checked
+      # against one universe.
+      ignore-enum-members: 'atago/internal/(spec\.(StepNone|AssertNone))$'
     gocognit:
       min-complexity: 30
     nestif:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,9 +8,12 @@ linters:
     - bidichk
     - bodyclose
     - canonicalheader
+    - contextcheck
     - copyloopvar
     - durationcheck
     - errcheck
+    - embeddedstructfieldcheck
+    - errchkjson
     - errname
     - errorlint
     # exhaustive is the structural half of atago's oldest bug family: a new step
@@ -21,12 +24,14 @@ linters:
     - fatcontext
     - gocheckcompilerdirectives
     - gochecknoinits
+    - gocritic
     - gocognit
     - gosec
     - govet
     - iface
     - ineffassign
     - makezero
+    - mirror
     - misspell
     # musttag guards the JSON side of atago's machine-readable contracts (the
     # json/junit/gha reports, the manifest and rerun ledgers): a field added
@@ -38,17 +43,22 @@ linters:
     - musttag
     - nestif
     - nilerr
+    - nilnil
     - nilnesserr
     - noctx
     - nolintlint
+    - predeclared
     - reassign
+    - recvcheck
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
     - tagliatelle
     - thelper
+    - tparallel
     - unconvert
     - unused
+    - usetesting
     - usestdlibvars
     - wastedassign
     - whitespace
@@ -70,6 +80,13 @@ linters:
       ignore-enum-members: 'atago/internal/(spec\.(StepNone|AssertNone))$'
     gocognit:
       min-complexity: 30
+    recvcheck:
+      # UnmarshalYAML has to take a pointer and MarshalYAML has to take a value:
+      # the two halves of the yaml codec cannot agree on a receiver, so the mixed
+      # pair is the interface's doing, not an inconsistency to fix.
+      exclusions:
+        - "*.UnmarshalYAML"
+        - "*.MarshalYAML"
     nestif:
       min-complexity: 5
     errcheck:

--- a/drift_test.go
+++ b/drift_test.go
@@ -74,17 +74,17 @@ var referenceSubcommandRowRe = regexp.MustCompile("(?m)^\\| `atago ([a-z][a-z-]*
 // subcommand fails the build instead of quietly misleading readers.
 func TestDocs_ReferenceSubcommandsAreReal(t *testing.T) {
 	ref := readDoc(t, "website/content/reference.md")
-	real := map[string]bool{}
+	known := map[string]bool{}
 	for _, name := range cli.Subcommands() {
-		real[name] = true
+		known[name] = true
 	}
 	rows := referenceSubcommandRowRe.FindAllStringSubmatch(ref, -1)
 	if len(rows) == 0 {
 		t.Fatal("no `| `atago <name>`` Subcommands rows found in website/content/reference.md")
 	}
 	for _, m := range rows {
-		if !real[m[1]] {
-			t.Errorf("website/content/reference.md Subcommands table lists `atago %s`, which is not a real subcommand (real inventory: %v)", m[1], cli.Subcommands())
+		if !known[m[1]] {
+			t.Errorf("website/content/reference.md Subcommands table lists `atago %s`, which is not a known subcommand (known inventory: %v)", m[1], cli.Subcommands())
 		}
 	}
 }

--- a/internal/assert/changes.go
+++ b/internal/assert/changes.go
@@ -3,7 +3,6 @@ package assert
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/nao1215/atago/internal/fsdelta"
 	"github.com/nao1215/atago/internal/fskind"
 	"github.com/nao1215/atago/internal/runner"
+	"github.com/nao1215/atago/internal/security"
 	"github.com/nao1215/atago/internal/spec"
 )
 
@@ -112,7 +112,14 @@ func untrackedKindNote(workdir, pat string) string {
 	if workdir == "" {
 		return ""
 	}
-	info, err := os.Lstat(filepath.Join(workdir, filepath.FromSlash(pat)))
+	// Through the shared resolver, not a bare join: a `changes:` entry is
+	// author-written, and probing it unconfined let the hint answer "does this
+	// exist, and what is it" about a path outside the scenario workdir.
+	full, err := security.ResolveWorkdirPath("assert.changes", workdir, pat)
+	if err != nil {
+		return ""
+	}
+	info, err := os.Lstat(full)
 	if err != nil {
 		return ""
 	}

--- a/internal/assert/changes_test.go
+++ b/internal/assert/changes_test.go
@@ -311,3 +311,34 @@ func TestCheckChanges_Ignore(t *testing.T) {
 		})
 	}
 }
+
+// TestCheckChanges_UntrackedKindHintStaysInsideTheWorkdir pins the confinement of
+// the hint's own filesystem probe. `changes:` entries are author-written patterns,
+// and untrackedKindNote used to stat them through a bare filepath.Join, so an
+// entry naming `../secret` reported the kind of a file outside the scenario
+// workdir — a hint that answers "does this exist, and what is it" about a path the
+// spec has no business reaching. Every other path-taking assertion resolves
+// through security.ResolveWorkdirPath; this one has to as well.
+func TestCheckChanges_UntrackedKindHintStaysInsideTheWorkdir(t *testing.T) {
+	t.Parallel()
+	base := t.TempDir()
+	wd := filepath.Join(base, "workdir")
+	if err := os.MkdirAll(wd, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	// A directory OUTSIDE the workdir: the kind the hint would happily report.
+	if err := os.MkdirAll(filepath.Join(base, "secret"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	got := checkChanges(
+		&spec.ChangesAssert{Created: list("../secret")},
+		changesResult(fsdelta.Delta{}),
+		Env{Workdir: wd},
+	)
+	if got.OK {
+		t.Fatal("an escaping entry cannot be satisfied by an empty delta")
+	}
+	if strings.Contains(got.Hint, "exists as a directory") {
+		t.Errorf("the hint probed outside the scenario workdir: %s", got.Hint)
+	}
+}

--- a/internal/assert/image.go
+++ b/internal/assert/image.go
@@ -146,29 +146,29 @@ func checkExactDim(path, dim string, want *int, got int) *CheckResult {
 	}
 }
 
-func checkMinDim(path, dim string, min *int, got int) *CheckResult {
-	if min == nil || got >= *min {
+func checkMinDim(path, dim string, want *int, got int) *CheckResult {
+	if want == nil || got >= *want {
 		return nil
 	}
-	desc := fmt.Sprintf("assert image %q %s >= %d", path, dim, *min)
+	desc := fmt.Sprintf("assert image %q %s >= %d", path, dim, *want)
 	return &CheckResult{
 		Desc:     desc,
-		Expected: fmt.Sprintf("%s >= %dpx", dim, *min),
+		Expected: fmt.Sprintf("%s >= %dpx", dim, *want),
 		Actual:   fmt.Sprintf("%s %dpx", dim, got),
-		Hint:     fmt.Sprintf("image %q %s %dpx is below the minimum %dpx", path, dim, got, *min),
+		Hint:     fmt.Sprintf("image %q %s %dpx is below the minimum %dpx", path, dim, got, *want),
 	}
 }
 
-func checkMaxDim(path, dim string, max *int, got int) *CheckResult {
-	if max == nil || got <= *max {
+func checkMaxDim(path, dim string, want *int, got int) *CheckResult {
+	if want == nil || got <= *want {
 		return nil
 	}
-	desc := fmt.Sprintf("assert image %q %s <= %d", path, dim, *max)
+	desc := fmt.Sprintf("assert image %q %s <= %d", path, dim, *want)
 	return &CheckResult{
 		Desc:     desc,
-		Expected: fmt.Sprintf("%s <= %dpx", dim, *max),
+		Expected: fmt.Sprintf("%s <= %dpx", dim, *want),
 		Actual:   fmt.Sprintf("%s %dpx", dim, got),
-		Hint:     fmt.Sprintf("image %q %s %dpx exceeds the maximum %dpx", path, dim, got, *max),
+		Hint:     fmt.Sprintf("image %q %s %dpx exceeds the maximum %dpx", path, dim, got, *want),
 	}
 }
 

--- a/internal/cli/features_test.go
+++ b/internal/cli/features_test.go
@@ -127,7 +127,7 @@ func TestCompletion_RunFlagsMatchTheCommand(t *testing.T) {
 	var out, errb bytes.Buffer
 	Main([]string{"run", "--help"}, &out, &errb)
 
-	real := map[string]bool{}
+	declared := map[string]bool{}
 	for _, line := range strings.Split(out.String()+errb.String(), "\n") {
 		rest, ok := strings.CutPrefix(line, "  -")
 		if !ok {
@@ -135,10 +135,10 @@ func TestCompletion_RunFlagsMatchTheCommand(t *testing.T) {
 		}
 		name, _, _ := strings.Cut(rest, " ")
 		if name != "" {
-			real["--"+name] = true
+			declared["--"+name] = true
 		}
 	}
-	if len(real) == 0 {
+	if len(declared) == 0 {
 		t.Fatalf("no flags parsed out of run --help:\n%s%s", out.String(), errb.String())
 	}
 
@@ -146,13 +146,13 @@ func TestCompletion_RunFlagsMatchTheCommand(t *testing.T) {
 	for _, f := range runFlags {
 		offered[f] = true
 	}
-	for f := range real {
+	for f := range declared {
 		if !offered[f] {
 			t.Errorf("`atago run` accepts %s but shell completion does not offer it", f)
 		}
 	}
 	for f := range offered {
-		if !real[f] {
+		if !declared[f] {
 			t.Errorf("shell completion offers %s but `atago run` does not accept it", f)
 		}
 	}
@@ -496,18 +496,11 @@ scenarios:
 // dir to avoid touching the repo.
 func withWorkdir(t *testing.T, dir string, fn func()) {
 	t.Helper()
-	orig, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := os.Chdir(orig); err != nil {
-			t.Fatal(err)
-		}
-	}()
+	// t.Chdir restores the original directory itself, including on a panic, and it
+	// fails a test that has called t.Parallel. That is the outcome to want here:
+	// the rerun ledger's path is resolved against a process-global cwd, so two
+	// tests changing directory at once would read each other's state.
+	t.Chdir(dir)
 	fn()
 }
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -236,6 +236,8 @@ func parseRunFlags(label string, args []string, stdout, stderr io.Writer) (*runO
 	}
 	if *ci {
 		// Force deterministic, color-free output. Secret masking is always on.
+		//nolint:forbidigo // Process-wide on purpose, and set once during flag parsing:
+		// --ci has to reach the color decision in every package, before any scenario runs.
 		_ = os.Setenv("NO_COLOR", "1")
 	}
 

--- a/internal/cli/subject.go
+++ b/internal/cli/subject.go
@@ -194,10 +194,14 @@ func toSet(names []string) map[string]bool {
 func exposeSubjects(built []builtSubject) error {
 	for _, b := range built {
 		dir := filepath.Dir(b.Artifact)
+		//nolint:forbidigo // Process-wide on purpose, as the doc comment above explains,
+		// and done once after the build and before any scenario starts, so no parallel
+		// scenario ever observes the mutation happening.
 		if err := os.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH")); err != nil {
 			return err
 		}
 		for k, v := range b.Env {
+			//nolint:forbidigo // Same one-time subject exposure as the PATH prepend above.
 			if err := os.Setenv(k, v); err != nil {
 				return err
 			}

--- a/internal/docgen/docgen.go
+++ b/internal/docgen/docgen.go
@@ -188,6 +188,9 @@ func retryBullet(step *spec.Step) string {
 		r = step.Run.Retry
 	case spec.StepHTTP:
 		r = step.HTTP.Retry
+	case spec.StepFixture, spec.StepQuery, spec.StepGRPC, spec.StepCDP, spec.StepAssert,
+		spec.StepStore, spec.StepService, spec.StepPTY, spec.StepSignal, spec.StepMockServer:
+		// No retry shape: run and http are the only kinds that carry one.
 	}
 	if r == nil {
 		return ""
@@ -372,6 +375,12 @@ func givenBullets(sc *spec.Scenario, expand func(string) string) []string {
 			if step.PTY.SandboxHomeEnabled() {
 				out = append(out, sandboxHomeBullet)
 			}
+		case spec.StepHTTP, spec.StepQuery, spec.StepGRPC, spec.StepCDP, spec.StepAssert, spec.StepStore, spec.StepSignal:
+			// No environment of their own to declare: they act through a runner
+			// the Runners section documents, or they only read the result.
+		case spec.StepService, spec.StepMockServer:
+			// Suite-level only (ATG-2106). A scenario's own services are rendered
+			// above, from sc.Services.
 		}
 	}
 	return out
@@ -434,9 +443,12 @@ func narrativeLine(step *spec.Step, expand func(string) string, runners map[stri
 			return "# expect " + expand(strings.Join(desc, " and ")), true
 		}
 		return "", false
-	default:
-		return commandLine(step, expand, runners)
+	case spec.StepRun, spec.StepHTTP, spec.StepQuery, spec.StepGRPC, spec.StepCDP,
+		spec.StepStore, spec.StepService, spec.StepPTY, spec.StepSignal, spec.StepMockServer:
+		// commandLine owns the phrasing of every acting kind, so a lifecycle block
+		// reads the way a scenario's When does.
 	}
+	return commandLine(step, expand, runners)
 }
 
 // commandLine renders one step's "When" line; ok is false for a step kind that
@@ -493,6 +505,9 @@ func commandLine(step *spec.Step, expand func(string) string, runners map[string
 		if step.Signal != nil {
 			return signalLine(step.Signal, expand), true
 		}
+	case spec.StepFixture, spec.StepAssert:
+		// Not commands. narrativeLine renders these for the blocks that have no
+		// Given or Then section to carry them.
 	}
 	return "", false
 }
@@ -566,9 +581,13 @@ func isActionStep(kind spec.StepKind) bool {
 	switch kind {
 	case spec.StepRun, spec.StepHTTP, spec.StepQuery, spec.StepGRPC, spec.StepCDP, spec.StepSignal, spec.StepPTY:
 		return true
-	default:
+	case spec.StepFixture, spec.StepAssert, spec.StepStore, spec.StepService, spec.StepMockServer:
+		// Not an action an assertion reads against: a fixture and a store observe
+		// nothing, an assert IS the reading, and the two suite-level kinds never
+		// appear among a scenario's steps.
 		return false
 	}
+	return false
 }
 
 // thenGroups walks the steps and groups each assert under the most recent
@@ -592,6 +611,14 @@ func thenGroups(sc *spec.Scenario, expand func(string) string) []thenGroup {
 			for _, b := range describeAsserts(step.Assert) {
 				g.bullets = append(g.bullets, expand(b))
 			}
+		case spec.StepFixture, spec.StepStore:
+			// Never break a group: they observe nothing, so the assertions after
+			// them still read against the same action.
+		case spec.StepService, spec.StepMockServer:
+			// Suite-level only (ATG-2106).
+		case spec.StepRun, spec.StepHTTP, spec.StepQuery, spec.StepGRPC, spec.StepCDP, spec.StepPTY, spec.StepSignal:
+			// Unreachable: isActionStep claimed these above and continued. Listed
+			// so a new kind has to be classified here as well as there.
 		}
 	}
 	return groups
@@ -617,9 +644,11 @@ func actionLabel(step *spec.Step, expand func(string) string) string {
 		// Match the "When" line's phrasing so the group header names the same
 		// thing the code block shows.
 		return "interactive (pty): " + expand(step.PTY.Command)
-	default:
+	case spec.StepFixture, spec.StepAssert, spec.StepStore, spec.StepService, spec.StepMockServer:
+		// Not actions (isActionStep says so), so they never label a Then group.
 		return ""
 	}
+	return ""
 }
 
 // writeThen renders the Then section. A scenario with at most one action keeps

--- a/internal/docgen/preview.go
+++ b/internal/docgen/preview.go
@@ -68,6 +68,10 @@ func inputPreviews(sc *spec.Scenario) []previewBlock {
 					body:  fmt.Sprintf("(binary, %d base64 chars)", len(s.Base64)),
 				})
 			}
+		case spec.StepHTTP, spec.StepQuery, spec.StepGRPC, spec.StepCDP, spec.StepAssert,
+			spec.StepStore, spec.StepService, spec.StepPTY, spec.StepSignal, spec.StepMockServer:
+			// No authored input the When line hides. An assert's expected values are
+			// previewed by exactPreviews instead, which reads them as outputs.
 		}
 	}
 	return out

--- a/internal/engine/attempts.go
+++ b/internal/engine/attempts.go
@@ -74,10 +74,10 @@ func (e *Engine) runRepeated(ctx context.Context, idx int, sc *spec.Scenario, rc
 	// "not a failure" alongside a pass.
 	passed, errored := 0, 0
 	for _, st := range iterations {
-		switch st {
-		case StatusPassed, StatusSkipped:
+		if st.cleanIteration() {
 			passed++
-		case StatusError:
+		}
+		if st == StatusError {
 			errored++
 		}
 	}
@@ -141,6 +141,12 @@ func applyExpectFail(sc *spec.Scenario, res ScenarioResult) ScenarioResult {
 		res.Status = StatusXFail
 	case StatusPassed:
 		res.Status = StatusXPass
+	case StatusSkipped, StatusError:
+		// Left alone, for the reasons above.
+	case StatusXFail, StatusXPass, StatusFlaky:
+		// Unreachable: this maps the verdict of the single run an expect_fail
+		// scenario gets, and one run never produces a folded or already-remapped
+		// status.
 	}
 	return res
 }

--- a/internal/engine/deterministic.go
+++ b/internal/engine/deterministic.go
@@ -52,6 +52,8 @@ func checkDeterminism(ctx context.Context, d *spec.Deterministic, first *runner.
 			}
 		}
 	}
+	//nolint:nilnil // "no failing check" is the passing answer, not an error: every rerun
+	// matched. A sentinel would make callers treat a clean property as a problem.
 	return nil, nil
 }
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -490,6 +490,11 @@ func (e *Engine) assertEnv(rc runConfig, workdir, specDir string) assert.Env {
 		KeepSnapshots:   rc.keepSnapshots,
 		Secrets:         rc.masker.MaskBytes,
 		Scrub:           rc.scrubber.Apply,
+		// Named explicitly, not omitted: the mock records are the one field a
+		// caller supplies afterwards, because only the scenario step path has them.
+		// Spelling the nil out keeps this constructor exhaustive, which is what
+		// stops the next run-scoped field from reaching three of the four sites.
+		MockRecords: nil,
 	}
 }
 

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -848,7 +848,7 @@ func TestEngine_FailFastParallel(t *testing.T) {
 			failed++
 		case StatusSkipped:
 			skipped++
-		default:
+		case StatusPassed, StatusError, StatusXFail, StatusXPass, StatusFlaky:
 			other++
 		}
 	}

--- a/internal/engine/result.go
+++ b/internal/engine/result.go
@@ -59,9 +59,12 @@ func FailsRun(st Status, allowFlaky, allowXPass bool) bool {
 		return !allowFlaky
 	case StatusXPass:
 		return !allowXPass
-	default:
+	case StatusPassed, StatusSkipped, StatusXFail:
+		// The three green verdicts. XFail belongs here on purpose: a known bug
+		// that is still broken is the outcome expect_fail asked for.
 		return false
 	}
+	return false
 }
 
 // StepResult records what happened for a single step.
@@ -133,11 +136,33 @@ type ScenarioResult struct {
 func (s *ScenarioResult) PassedIterations() int {
 	n := 0
 	for _, st := range s.Iterations {
-		if st == StatusPassed || st == StatusSkipped {
+		if st.cleanIteration() {
 			n++
 		}
 	}
 	return n
+}
+
+// cleanIteration reports whether one --repeat iteration counted as "not a
+// failure": it passed, or a deterministic OS/env gate skipped it.
+//
+// It is the single definition both the fold's classification and the flake rate
+// the reports print are built from. They were written separately once, and the
+// console line then reported a rate the machine formats disagreed with.
+func (st Status) cleanIteration() bool {
+	switch st {
+	case StatusPassed, StatusSkipped:
+		return true
+	case StatusFailed, StatusError:
+		return false
+	case StatusXFail, StatusXPass, StatusFlaky:
+		// Unreachable for an iteration: an expect_fail scenario never repeats
+		// (runScenarioWithPolicy short-circuits it to a single run), and a single
+		// runScenario call never folds to flaky. Named rather than defaulted so a
+		// new status has to answer the question instead of inheriting an answer.
+		return false
+	}
+	return false
 }
 
 // TeardownFailed reports whether any teardown step failed or errored. Reports

--- a/internal/engine/service_test.go
+++ b/internal/engine/service_test.go
@@ -1,7 +1,11 @@
 package engine
 
 import (
+	"context"
+	"strings"
 	"testing"
+
+	"github.com/nao1215/atago/internal/spec"
 )
 
 // TestEngine_ServiceReadyFileCapturedAndUsed covers the services feature end to
@@ -131,5 +135,47 @@ scenarios:
 `)
 	if res.Status != StatusPassed {
 		t.Fatalf("status = %s, want passed", res.Status)
+	}
+}
+
+// TestEngine_SuiteOnlyKindInScenarioStepNamesTheRule covers the backstop for a
+// spec built through the API rather than parsed. `service:` and `mock_server:`
+// are suite.setup-only kinds; the loader turns them away with ATG-2106, so this
+// path is reachable only when a caller assembles the spec in Go.
+//
+// It used to report "step has no recognized action", which is wrong twice over:
+// atago recognizes both kinds perfectly well, and the message sent the reader
+// looking for a typo in a step that has none. The kind is named instead, along
+// with where it does belong.
+func TestEngine_SuiteOnlyKindInScenarioStepNamesTheRule(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name string
+		step spec.Step
+		want string
+	}{
+		{"service", spec.Step{Service: &spec.Service{Name: "worker", Command: "sleep 1"}}, "service steps are only allowed in suite.setup"},
+		{"mock_server", spec.Step{MockServer: &spec.MockServer{Name: "api"}}, "mock_server steps are only allowed in suite.setup"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := &spec.Spec{
+				Version:   "1",
+				Suite:     spec.Suite{Name: "api-built"},
+				Scenarios: []spec.Scenario{{Name: "misplaced", Steps: []spec.Step{tt.step}}},
+			}
+			res := New().Run(context.Background(), s, "api.atago.yaml")
+			sc := res.Scenarios[0]
+			if sc.Status != StatusError {
+				t.Fatalf("status = %s, want error", sc.Status)
+			}
+			got := sc.Steps[0].ErrMsg
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("ErrMsg = %q, want it to contain %q", got, tt.want)
+			}
+			if strings.Contains(got, "no recognized action") {
+				t.Errorf("ErrMsg claims atago does not recognize a kind it does: %q", got)
+			}
+		})
 	}
 }

--- a/internal/engine/stepexec.go
+++ b/internal/engine/stepexec.go
@@ -49,6 +49,9 @@ func resultObserved(steps []spec.Step, i int) bool {
 			}
 		case spec.StepRun, spec.StepHTTP, spec.StepQuery, spec.StepGRPC, spec.StepPTY, spec.StepCDP:
 			return false
+		case spec.StepFixture, spec.StepStore, spec.StepService, spec.StepSignal, spec.StepMockServer:
+			// Keep scanning: none of these replaces the current result, so an
+			// assert further down is still looking at the step at i.
 		}
 	}
 	return false
@@ -296,6 +299,13 @@ func (x *scenarioRun) execStep(ctx context.Context, steps []spec.Step, i int, st
 			sr.ErrMsg = err.Error()
 			status = StatusError
 		}
+	case spec.StepService, spec.StepMockServer:
+		// Suite-level only, and the loader says so with ATG-2106 before a run
+		// starts. This is the backstop for a spec built through the API rather
+		// than parsed, where "no recognized action" would misname a kind atago
+		// recognizes perfectly well and merely refuses here.
+		sr.ErrMsg = fmt.Sprintf("%s steps are only allowed in suite.setup", step.Kind())
+		status = StatusError
 	default:
 		sr.ErrMsg = "step has no recognized action"
 		status = StatusError

--- a/internal/engine/stepexec.go
+++ b/internal/engine/stepexec.go
@@ -430,6 +430,9 @@ func (x *scenarioRun) runSteps(ctx context.Context, leadingFixtures int) {
 // each other.
 func (x *scenarioRun) runTeardown(ctx context.Context) {
 	if len(x.sc.Teardown) > 0 {
+		//nolint:contextcheck // tctx is deliberately not derived from ctx when ctx is
+		// already done: a derived context would cancel cleanup immediately. The bounded
+		// fresh context below is what lets an interrupt still tear external resources down.
 		tctx := ctx
 		if ctx.Err() != nil {
 			// The run was interrupted: give cleanup its own bounded context so an

--- a/internal/engine/suite.go
+++ b/internal/engine/suite.go
@@ -178,10 +178,13 @@ func (x *suiteStepper) exec(ctx context.Context, step *spec.Step, i int, sr *Ste
 		return x.execService(ctx, step, sr)
 	case spec.StepMockServer:
 		return x.execMockServer(ctx, step, sr)
-	default:
-		sr.ErrMsg = fmt.Sprintf("%s steps are not allowed at suite level", step.Kind())
-		return true
+	case spec.StepHTTP, spec.StepQuery, spec.StepGRPC, spec.StepCDP, spec.StepPTY, spec.StepSignal:
+		// Named rather than defaulted so a new step kind has to answer "is this
+		// allowed at suite level?" instead of inheriting "no" in silence. Each of
+		// these drives or produces the result a scenario owns.
 	}
+	sr.ErrMsg = fmt.Sprintf("%s steps are not allowed at suite level", step.Kind())
+	return true
 }
 
 // execRun runs one suite-level command and folds its retry `until` checks.

--- a/internal/engine/suite.go
+++ b/internal/engine/suite.go
@@ -77,6 +77,8 @@ func (rt *suiteRuntime) stop() {
 // nothing.
 func (e *Engine) newSuiteRuntime(s *spec.Spec, specDir, fixturesDir string) (*suiteRuntime, error) {
 	if len(s.Suite.Setup) == 0 && len(s.Suite.Teardown) == 0 && len(s.Suite.Env) == 0 {
+		//nolint:nilnil // A spec with no suite-level blocks needs no runtime; absent is not
+		// an error, and the caller's nil check is what keeps the common case free.
 		return nil, nil
 	}
 	dir, err := os.MkdirTemp("", "atago-suite-")
@@ -288,6 +290,8 @@ func (e *Engine) runSuiteTeardown(ctx context.Context, s *spec.Spec, rt *suiteRu
 	if rt == nil || len(s.Suite.Teardown) == 0 {
 		return nil
 	}
+	//nolint:contextcheck // Deliberately not derived from a done ctx, for the same reason
+	// as scenario teardown: suite teardown has to run even after an interrupt.
 	tctx := ctx
 	if ctx.Err() != nil {
 		var cancel context.CancelFunc

--- a/internal/explain/explain.go
+++ b/internal/explain/explain.go
@@ -102,6 +102,9 @@ func explainSuiteBlock(b *strings.Builder, label string, steps []spec.Step, runn
 			for _, d := range describeAsserts(step.Assert) {
 				fmt.Fprintf(b, "  - expect %s\n", d)
 			}
+		case spec.StepHTTP, spec.StepQuery, spec.StepGRPC, spec.StepCDP, spec.StepPTY, spec.StepSignal:
+			// The loader rejects these at suite level (ATG-2106), so a spec that
+			// reaches explain never carries one here.
 		}
 	}
 }
@@ -205,6 +208,10 @@ func bucketScenarioStep(step *spec.Step, fixtures, commands, expects, stores *[]
 		if step.Signal != nil {
 			*commands = append(*commands, describeSignal(step.Signal))
 		}
+	case spec.StepService, spec.StepMockServer:
+		// Suite-level only (ATG-2106): a scenario's own services and mock servers
+		// are declared in its `services:`/`mock_servers:` lists, not as steps, and
+		// explainScenarioHeading reports those.
 	}
 }
 
@@ -332,6 +339,15 @@ func describeTeardownStep(step *spec.Step, runners map[string]spec.Runner) []str
 		return []string{"store " + step.Store.Name}
 	case spec.StepSignal:
 		return []string{describeSignal(step.Signal)}
+	case spec.StepPTY:
+		// Teardown accepts a pty session and the engine runs it, so explain has to
+		// show it. This branch was missing while the loader allowed the step: a
+		// cleanup block could drive an interactive program with nothing in
+		// `atago explain` to say so.
+		return []string{describePTY(step.PTY)}
+	case spec.StepService, spec.StepMockServer:
+		// Suite-level only (ATG-2106), so a teardown block never carries one.
+		return nil
 	}
 	return nil
 }

--- a/internal/explain/explain_test.go
+++ b/internal/explain/explain_test.go
@@ -1172,6 +1172,11 @@ scenarios:
       - signal:
           service: worker
           signal: TERM
+      - pty:
+          command: ./shutdown-wizard
+          session:
+            - expect: "Really quit"
+            - send: {key: enter}
 `
 	out := mustExplain(t, src)
 	for _, want := range []string{
@@ -1186,6 +1191,11 @@ scenarios:
 		"marker.txt (inline content)",
 		"store final",
 		"send SIGTERM to service worker",
+		// A pty session in teardown executes exactly like one in the steps, so
+		// explain has to show it. It did not: describeTeardownStep had no pty
+		// branch, and the reviewer reading `atago explain` saw a cleanup block
+		// that quietly drove an interactive program.
+		"interactive (pty): ./shutdown-wizard",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("explain teardown missing %q\n--- got ---\n%s", want, out)

--- a/internal/fsdelta/fsdelta_test.go
+++ b/internal/fsdelta/fsdelta_test.go
@@ -130,7 +130,7 @@ func TestScan_TracksSymlinksByTarget(t *testing.T) {
 		t.Skip("symlink creation is restricted on Windows")
 	}
 	root := t.TempDir()
-	target := filepath.Join(root, "real.txt")
+	target := filepath.Join(root, "regular.txt")
 	if err := os.WriteFile(target, []byte("data"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -148,11 +148,11 @@ func TestScan_TracksSymlinksByTarget(t *testing.T) {
 	if want := "symlink:" + filepath.ToSlash(target); got != want {
 		t.Errorf("symlink fingerprint = %q, want %q", got, want)
 	}
-	real, ok := snap["real.txt"]
+	regular, ok := snap["regular.txt"]
 	if !ok {
 		t.Fatalf("regular file should be tracked, snapshot = %v", snap)
 	}
-	if real == got {
+	if regular == got {
 		t.Errorf("symlink and its target share a fingerprint %q", got)
 	}
 }
@@ -520,6 +520,8 @@ func (sp entrySpecimen) specimenRoot(t *testing.T) string {
 // unix socket bound inside it fits in sun_path on macOS as well as Linux.
 func shortTempDir(t *testing.T) string {
 	t.Helper()
+	//nolint:usetesting // t.TempDir() embeds the test name, and a unix socket bound
+	// inside the result would overflow sun_path on macOS. The short prefix is the point.
 	dir, err := os.MkdirTemp("", "atg")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -932,6 +932,7 @@ func TestLoadBytes_ExplicitTagRejected(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			s, err := LoadBytes("t.atago.yaml", []byte(tt.src))
 			if err == nil {
 				t.Fatalf("LoadBytes() = nil error, want a parse error naming the tag")
@@ -1385,6 +1386,7 @@ func TestBugHunt_Rejections(t *testing.T) {
 	// the Go runtime on Windows CI.
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			mustReject(t, tt.name, tt.src, tt.want)
 		})
 	}
@@ -1460,6 +1462,7 @@ func TestBugHunt_Acceptances(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			mustAccept(t, tt.name, tt.src)
 		})
 	}
@@ -1554,6 +1557,7 @@ func TestBugHunt_DirAssert(t *testing.T) {
 	}
 	for _, tt := range reject {
 		t.Run("reject/"+tt.name, func(t *testing.T) {
+			t.Parallel()
 			mustReject(t, tt.name, tt.src, tt.want)
 		})
 	}
@@ -1575,6 +1579,7 @@ func TestBugHunt_DirAssert(t *testing.T) {
 	}
 	for _, tt := range accept {
 		t.Run("accept/"+tt.name, func(t *testing.T) {
+			t.Parallel()
 			mustAccept(t, tt.name, tt.src)
 		})
 	}

--- a/internal/loader/project.go
+++ b/internal/loader/project.go
@@ -79,6 +79,8 @@ func FindProject(dir string) (*Project, error) {
 		}
 		parent := filepath.Dir(abs)
 		if parent == abs {
+			//nolint:nilnil // No manifest anywhere above dir. That is the normal case for a
+			// project without one, so it cannot be reported as a failure.
 			return nil, nil
 		}
 		abs = parent

--- a/internal/loader/validate.go
+++ b/internal/loader/validate.go
@@ -583,7 +583,12 @@ func validateSuiteBlock(add addFunc, where string, steps []spec.Step, runners ma
 				seenMock[ms.Name] = true
 			}
 			validateMockRoutes(add, sw+".mock_server", ms.Routes)
-		default:
+		case spec.StepHTTP, spec.StepQuery, spec.StepGRPC, spec.StepCDP, spec.StepPTY, spec.StepSignal:
+			// The six per-scenario kinds, named rather than defaulted so a new step
+			// kind has to answer "does suite level allow this?" instead of
+			// inheriting "no" in silence. The one-action check above guarantees
+			// Kind() is one of the twelve, so these are exactly what the old
+			// default saw.
 			add(diag.BlockNotHere, "%s: %s steps are per-scenario (they need a scenario workdir and runners); move it into a scenario", sw, st.Kind())
 		}
 	}
@@ -667,9 +672,11 @@ func measurableStep(k spec.StepKind) bool {
 	switch k {
 	case spec.StepRun, spec.StepHTTP, spec.StepQuery, spec.StepGRPC, spec.StepPTY:
 		return true
-	default:
+	case spec.StepFixture, spec.StepCDP, spec.StepAssert, spec.StepStore, spec.StepService, spec.StepSignal, spec.StepMockServer:
+		// Not timed: none of these produces the result a duration assert reads.
 		return false
 	}
+	return false
 }
 
 // nonNegativeDuration validates a wall-clock duration field that may be zero

--- a/internal/loader/validate.go
+++ b/internal/loader/validate.go
@@ -555,11 +555,12 @@ func validateSuiteBlock(add addFunc, where string, steps []spec.Step, runners ma
 				continue
 			}
 			svc := st.Service
-			if svc.Name == "" {
+			switch {
+			case svc.Name == "":
 				add(diag.RequiredKey, "%s.service.name is required", sw)
-			} else if seenService[svc.Name] {
+			case seenService[svc.Name]:
 				add(diag.DuplicateName, "%s: duplicate suite service name %q", where, svc.Name)
-			} else {
+			default:
 				seenService[svc.Name] = true
 			}
 			if svc.Command == "" {
@@ -575,11 +576,12 @@ func validateSuiteBlock(add addFunc, where string, steps []spec.Step, runners ma
 				continue
 			}
 			ms := st.MockServer
-			if ms.Name == "" {
+			switch {
+			case ms.Name == "":
 				add(diag.RequiredKey, "%s.mock_server.name is required", sw)
-			} else if seenMock[ms.Name] {
+			case seenMock[ms.Name]:
 				add(diag.DuplicateName, "%s: duplicate suite mock server name %q", where, ms.Name)
-			} else {
+			default:
 				seenMock[ms.Name] = true
 			}
 			validateMockRoutes(add, sw+".mock_server", ms.Routes)

--- a/internal/loader/validate_assert.go
+++ b/internal/loader/validate_assert.go
@@ -62,8 +62,8 @@ func validateAssertTarget(add addFunc, where string, a *spec.Assert, target spec
 		validateChanges(add, where+".assert.changes", a.Changes)
 	case spec.AssertPDF:
 		validatePDF(add, where+".assert.pdf", a.PDF)
-	case spec.AssertGRPCStatus:
-		// grpc_status is a bare int; no further shape to validate.
+	case spec.AssertStatus, spec.AssertGRPCStatus:
+		// Both are a bare *int; there is no shape to validate beyond the decode.
 	}
 }
 

--- a/internal/loader/validate_service.go
+++ b/internal/loader/validate_service.go
@@ -104,11 +104,12 @@ func validateMockRoutes(add addFunc, where string, routes []spec.MockRoute) {
 		if rt.Method == "" {
 			add(diag.RequiredKey, "%s.method is required", rw)
 		}
-		if rt.Path == "" {
+		switch {
+		case rt.Path == "":
 			add(diag.RequiredKey, "%s.path is required", rw)
-		} else if !strings.HasPrefix(rt.Path, "/") {
+		case !strings.HasPrefix(rt.Path, "/"):
 			add(diag.BadFormat, "%s.path %q must start with \"/\"", rw, rt.Path)
-		} else if strings.Contains(rt.Path, "?") {
+		case strings.Contains(rt.Path, "?"):
 			// Matching compares the request's path, which the server has already
 			// split from its query, so a declared query can never be part of a
 			// match. Serve on the path and assert the query with the mock

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -418,7 +418,10 @@ scenarios:
 		t.Errorf("manifest browser_args = %v, want two entries", web.BrowserArgs)
 	}
 	// The config must not leak into unrelated runner types when absent.
-	out, _ := json.Marshal(doc)
+	out, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
 	if strings.Count(string(out), "\"headless\"") != 1 {
 		t.Errorf("headless should appear exactly once in the manifest JSON:\n%s", out)
 	}

--- a/internal/report/console.go
+++ b/internal/report/console.go
@@ -69,6 +69,12 @@ func writeDetail(b *strings.Builder, color bool, suite, specPath string, sc *eng
 		fmt.Fprintf(b, "\n%s\n", indent(expectFailNarrative(sc.ExpectFail, false)))
 	case engine.StatusError:
 		writeErroredSteps(b, color, suite, where, sc)
+	case engine.StatusPassed, engine.StatusSkipped:
+		// No failure block: there is nothing to explain about a green scenario,
+		// and a gated one is already named in the summary counts.
+	case engine.StatusFlaky:
+		// writeFlaky and writeRepeatRates own the flaky narrative, with the
+		// attempt count or the flake rate a bare failure block cannot carry.
 	}
 	// A failed teardown never flips the verdict — the steps decide that — but
 	// incomplete cleanup of external resources must stay loud.
@@ -186,6 +192,9 @@ func writeRepeatRates(b *strings.Builder, color bool, res *engine.SuiteResult) {
 			code = cYellow
 		case engine.StatusFailed, engine.StatusError:
 			code = cRed
+		case engine.StatusPassed, engine.StatusSkipped, engine.StatusXFail, engine.StatusXPass:
+			// Green: every iteration that mattered came out the way the scenario
+			// declared it would. The skipped case never reaches here.
 		}
 		fmt.Fprintf(b, "\n%s %s: %d/%d passed\n",
 			colorize(color, code+cBold, "REPEAT:"), sc.Name, passed, len(sc.Iterations))

--- a/internal/report/diff.go
+++ b/internal/report/diff.go
@@ -155,11 +155,12 @@ func diffOps(a, b []string) []diffOp {
 	}
 	for i := n - 1; i >= 0; i-- {
 		for j := m - 1; j >= 0; j-- {
-			if a[i] == b[j] {
+			switch {
+			case a[i] == b[j]:
 				lcs[i][j] = lcs[i+1][j+1] + 1
-			} else if lcs[i+1][j] >= lcs[i][j+1] {
+			case lcs[i+1][j] >= lcs[i][j+1]:
 				lcs[i][j] = lcs[i+1][j]
-			} else {
+			default:
 				lcs[i][j] = lcs[i][j+1]
 			}
 		}

--- a/internal/report/gha.go
+++ b/internal/report/gha.go
@@ -66,6 +66,10 @@ func writeGHA(w io.Writer, results []*engine.SuiteResult, allowXPass bool, loadF
 				// reviewers to ignore the annotation channel.
 				fmt.Fprintf(&b, "::notice title=%s::%s\n",
 					ghaEscapeProp(res.Suite+" / "+sc.Name), ghaEscapeData("xfail: "+expectFailSummary(sc)))
+			case engine.StatusPassed, engine.StatusSkipped:
+				// No annotation. Annotating every green or gated scenario would
+				// bury the ones a reviewer has to act on, which is the only
+				// thing the annotation channel is good for.
 			}
 			// A failed teardown never changes the verdict or the exit code, so
 			// it is a warning — the flaky pattern: green for the job, loud in

--- a/internal/report/json.go
+++ b/internal/report/json.go
@@ -160,7 +160,10 @@ func buildJSON(res *engine.SuiteResult, allowXPass bool) jsonReport {
 			if !allowXPass {
 				out.Failures = append(out.Failures, jsonFailure{Scenario: sc.Name, Error: xpassMessage(sc)})
 			}
-		default:
+		case engine.StatusPassed, engine.StatusFailed, engine.StatusSkipped, engine.StatusError, engine.StatusFlaky:
+			// Every ordinary verdict: the failing checks are what the bucket
+			// describes. A passed or skipped scenario has none, so it contributes
+			// nothing here; a flaky one contributes the attempt that failed.
 			out.Failures = append(out.Failures, failuresOf(sc)...)
 		}
 	}

--- a/internal/report/junit.go
+++ b/internal/report/junit.go
@@ -127,6 +127,9 @@ func buildJUnit(results []*engine.SuiteResult, allowXPass bool, loadFailures []L
 				}
 				tc.Failure = &junitMessage{Message: xpassMessage(sc), Body: detailText(sc)}
 				ts.Failures++
+			case engine.StatusPassed:
+				// A bare <testcase> with no child element: JUnit's way of saying
+				// it passed.
 			}
 			if td := stepsDetailText(sc.Teardown); td != "" {
 				tc.SystemErr = "teardown failed (the verdict is decided by the steps alone):\n" + td

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -1256,6 +1256,7 @@ func TestRepeatFlaky_MessageAcrossFormats(t *testing.T) {
 		{"junit", FormatJUnit},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			var b strings.Builder
 			if err := Render(&b, tc.format, res); err != nil {
 				t.Fatalf("render: %v", err)

--- a/internal/runner/browser/browser.go
+++ b/internal/runner/browser/browser.go
@@ -146,6 +146,9 @@ func (r *Runner) Run(ctx context.Context, actions []spec.CDPAction, workdir stri
 	}
 
 	start := time.Now()
+	//nolint:contextcheck // runCtx is rooted at the persistent browser context rather than
+	// at ctx on purpose: the chromedp session has to outlive a single step. The caller's
+	// cancellation still reaches it through the AfterFunc above, which is what #14 asked for.
 	if err := chromedp.Run(runCtx, tasks...); err != nil {
 		return nil, fmt.Errorf("cdp run: %w", err)
 	}
@@ -285,12 +288,25 @@ func buildTasks(actions []spec.CDPAction, workdir string) (chromedp.Tasks, []cap
 	return tasks, caps, shots, nil
 }
 
+// jsStringLiteral renders s as a JavaScript string literal for embedding in an
+// evaluated snippet. json.Marshal is the correct escaper (a selector may carry
+// quotes, backslashes, or newlines) and cannot fail for a string, so the error is
+// swallowed here, once, with the reason written down.
+func jsStringLiteral(s string) string {
+	b, err := json.Marshal(s)
+	if err != nil {
+		// Unreachable: encoding a Go string never fails.
+		return `""`
+	}
+	return string(b)
+}
+
 // setChecked ticks or unticks a checkbox/radio by setting its checked property
 // and dispatching a change event, so listeners react as they would to a click.
 // Selecting by property (not a click) keeps the action deterministic regardless
 // of the element's current state.
 func setChecked(selector string, checked bool) chromedp.Action {
-	sel, _ := json.Marshal(selector)
+	sel := jsStringLiteral(selector)
 	js := fmt.Sprintf(`(() => {
 	const el = document.querySelector(%s);
 	if (!el) throw new Error('check: no element for selector ' + %s);

--- a/internal/runner/cmd/cmd.go
+++ b/internal/runner/cmd/cmd.go
@@ -290,6 +290,8 @@ func stdinReader(run *spec.Run, workdir string) (io.Reader, error) {
 	case s.Inline != "":
 		return strings.NewReader(s.Inline), nil
 	}
+	//nolint:nilnil // No stdin authored: the child inherits an empty stdin, which is a
+	// configuration, not a failure.
 	return nil, nil
 }
 

--- a/internal/runner/cmd/cmd_test.go
+++ b/internal/runner/cmd/cmd_test.go
@@ -431,6 +431,7 @@ func TestRun_ShellCancelKillsChildPromptly(t *testing.T) {
 	// Not t.TempDir(): on Windows the orphaned child (no process groups) may
 	// briefly outlive the kill while holding the workdir open, and TempDir's
 	// cleanup would fail the test on that unrelated race. Best-effort cleanup.
+	//nolint:usetesting // Deliberate, for the reason above: TempDir's cleanup is fatal.
 	wd, err := os.MkdirTemp("", "atago-cancel-")
 	if err != nil {
 		t.Fatal(err)
@@ -579,10 +580,10 @@ func TestWindowsFields_MatchesShellwords(t *testing.T) {
 // timeout/cancel is handled earlier and stays -1; a signal reaching here is the
 // program's own termination.
 func TestRun_SignalExitCode(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("POSIX signals only; Windows has no 128+signal convention")
 	}
-	t.Parallel()
 	cases := []struct {
 		name   string
 		signal string
@@ -899,6 +900,7 @@ func TestRun_CaptureFailureIsNotSilentEmptyOutput(t *testing.T) {
 	// Windows a process that still exists can keep a directory from being
 	// removed. TempDir's cleanup would fail the test on that, so clean up
 	// best-effort like TestRun_ShellCancelKillsChildPromptly does.
+	//nolint:usetesting // Deliberate, for the reason above: TempDir's cleanup is fatal.
 	wd, err := os.MkdirTemp("", "atago-capture-")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/runner/db/db.go
+++ b/internal/runner/db/db.go
@@ -253,15 +253,15 @@ func nativeMySQLHost(dsn string) string {
 	if at >= 0 {
 		rest = dsn[at+1:]
 	}
-	open := strings.Index(rest, "(")
-	close := strings.Index(rest, ")")
-	if open < 0 || close < open {
+	lparen := strings.Index(rest, "(")
+	rparen := strings.Index(rest, ")")
+	if lparen < 0 || rparen < lparen {
 		return ""
 	}
-	if !strings.EqualFold(rest[:open], "tcp") {
+	if !strings.EqualFold(rest[:lparen], "tcp") {
 		return ""
 	}
-	return rest[open+1 : close]
+	return rest[lparen+1 : rparen]
 }
 
 // Runner holds an open database/sql pool for one db runner.

--- a/internal/runner/grpc/grpc_test.go
+++ b/internal/runner/grpc/grpc_test.go
@@ -20,6 +20,7 @@ import (
 // test uses a fake.
 type pastDeadlineCtx struct {
 	context.Context
+
 	deadline time.Time
 }
 

--- a/internal/runner/ptyrun/ptyrun_unix_test.go
+++ b/internal/runner/ptyrun/ptyrun_unix_test.go
@@ -161,7 +161,7 @@ func TestWaitDrain_ClosingTheMasterEndsTheDrain(t *testing.T) {
 	// ends on the closed descriptor and would prove nothing. Seeing the written
 	// bytes land in the transcript means the goroutine consumed them and went
 	// back for more.
-	if _, werr := tty.Write([]byte("parked\n")); werr != nil {
+	if _, werr := tty.WriteString("parked\n"); werr != nil {
 		t.Fatalf("write to the terminal: %v", werr)
 	}
 	deadline := time.Now().Add(10 * time.Second)
@@ -243,7 +243,7 @@ func TestOpenTerminal_PairsTheMasterWithItsOwnSlave(t *testing.T) {
 		if err != nil {
 			t.Fatalf("iteration %d: OpenTerminal: %v", i, err)
 		}
-		if _, werr := tty.Write([]byte("atago\n")); werr != nil {
+		if _, werr := tty.WriteString("atago\n"); werr != nil {
 			t.Fatalf("iteration %d: write to the terminal: %v", i, werr)
 		}
 		// The read has to be bounded, because the failure this test exists for

--- a/internal/runner/ptyrun/query_sanitize.go
+++ b/internal/runner/ptyrun/query_sanitize.go
@@ -34,7 +34,13 @@ type streamSanitizer struct {
 func (s *streamSanitizer) feed(chunk []byte) []byte {
 	buf := chunk
 	if len(s.carry) > 0 {
-		buf = append(s.carry, chunk...)
+		// A fresh slice rather than append(s.carry, chunk...): appending into
+		// carry's spare capacity would leave buf aliasing the carry buffer, and the
+		// next chunk's append could then rewrite bytes this call already handed to
+		// the emulator. Transcript bytes have been corrupted that way before.
+		buf = make([]byte, 0, len(s.carry)+len(chunk))
+		buf = append(buf, s.carry...)
+		buf = append(buf, chunk...)
 		s.carry = nil
 	}
 	split := incompleteEscapeStart(buf)

--- a/internal/runner/ptyrun/session.go
+++ b/internal/runner/ptyrun/session.go
@@ -602,9 +602,13 @@ func parsePositiveDuration(s string) time.Duration {
 }
 
 func checkRenderedScreen(es *spec.PTYExpectScreen, screen []byte, cells [][]runner.ScreenCell) *assert.CheckResult {
+	// A mid-session screen check needs no run context: the loader rejects snapshot
+	// and trim inside expect_screen, so there is no workdir, spec directory, or
+	// snapshot bookkeeping for this comparison to read.
+	env := assert.Env{} //nolint:exhaustruct // deliberately empty, per the comment above
 	return assert.Check(&spec.Assert{Screen: &es.ScreenAssert}, &runner.Result{
 		IsPTY:       true,
 		Screen:      screen,
 		ScreenCells: cells,
-	}, assert.Env{})
+	}, env)
 }

--- a/internal/scrub/scrub.go
+++ b/internal/scrub/scrub.go
@@ -31,6 +31,8 @@ type compiledRule struct {
 // pattern when a rule's regexp does not compile.
 func New(rules []spec.ScrubRule) (*Scrubber, error) {
 	if len(rules) == 0 {
+		//nolint:nilnil // Documented above: a nil Scrubber is the no-op scrubber, so an empty
+		// rule set has nothing to report.
 		return nil, nil
 	}
 	compiled := make([]compiledRule, 0, len(rules))

--- a/internal/scrub/scrub_test.go
+++ b/internal/scrub/scrub_test.go
@@ -2,6 +2,7 @@ package scrub
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/nao1215/atago/internal/spec"
@@ -38,7 +39,7 @@ func TestNew_InvalidPatternErrors(t *testing.T) {
 		t.Fatal("New accepted an invalid regexp, want error")
 	}
 	for _, want := range []string{"scrub[1]", "("} {
-		if !bytes.Contains([]byte(err.Error()), []byte(want)) {
+		if !strings.Contains(err.Error(), want) {
 			t.Errorf("error %q missing %q", err, want)
 		}
 	}

--- a/internal/security/masker.go
+++ b/internal/security/masker.go
@@ -167,7 +167,7 @@ func (m *Masker) Mask(s string) string {
 		return s
 	}
 	covered := make([]bool, len(s))
-	any := false
+	masked := false
 	for _, v := range m.values {
 		for i := 0; ; {
 			j := strings.Index(s[i:], v)
@@ -178,13 +178,13 @@ func (m *Masker) Mask(s string) string {
 			for k := start; k < start+len(v); k++ {
 				covered[k] = true
 			}
-			any = true
+			masked = true
 			// Advance by one, not len(v), so overlapping occurrences of the same
 			// secret are all covered — "aaaa" occurs three times in "aaaaaa".
 			i = start + 1
 		}
 	}
-	if !any {
+	if !masked {
 		return s
 	}
 	var b strings.Builder

--- a/internal/security/path_test.go
+++ b/internal/security/path_test.go
@@ -98,10 +98,10 @@ func TestResolve_RelativeRoot(t *testing.T) {
 // path that is merely absent must not become an error — `exists: false` asks
 // exactly that question.
 func TestResolve_AncestorSymlinkMayNotEscapeTheRoot(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink creation is not reliably available on Windows CI")
 	}
-	t.Parallel()
 	root := t.TempDir()
 	outside := t.TempDir()
 	if err := os.Symlink(outside, filepath.Join(root, "escape")); err != nil {
@@ -225,12 +225,12 @@ func TestResolve_RootBehindASymlink(t *testing.T) {
 	}
 	t.Parallel()
 	base := t.TempDir()
-	real := filepath.Join(base, "real")
-	if err := os.MkdirAll(filepath.Join(real, "sub"), 0o750); err != nil {
+	target := filepath.Join(base, "target")
+	if err := os.MkdirAll(filepath.Join(target, "sub"), 0o750); err != nil {
 		t.Fatal(err)
 	}
 	alias := filepath.Join(base, "alias")
-	if err := os.Symlink("real", alias); err != nil {
+	if err := os.Symlink("target", alias); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := ResolveWorkdirPath("assert.file.path", alias, "sub/out.txt"); err != nil {

--- a/internal/security/pathguard_test.go
+++ b/internal/security/pathguard_test.go
@@ -1,0 +1,192 @@
+package security_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// rootArgNames are the identifiers that name a confinement root. A path built by
+// joining one of these to an author-written value has to go through
+// security.ResolveWorkdirPath / ResolveSpecPath instead, or the resulting path is
+// whatever the spec asked for — including `../` out of the tree, or through a
+// symlinked ancestor the program under test planted.
+var rootArgNames = map[string]bool{
+	"workdir": true,
+	"specDir": true,
+}
+
+// allowedJoins lists the joins that legitimately bypass the resolver, by
+// "<package dir>:<function>". Each entry is a claim that the second argument is
+// NOT author-written, and it has to stay small: this list is the whole reason a
+// reviewer can trust the rule.
+var allowedJoins = map[string]string{
+	"internal/runner/cmd:EnsureSandboxHome": "joins a package constant (SandboxHomeDirName), not spec input",
+	"internal/runner/cmd:resolveDir":        "run.cwd is deliberately unconfined -- an absolute cwd is a documented capability, so confining the relative form would only be inconsistent",
+	"internal/fixture:Write":                "fixture.from READS the author's own tree, which is the point of fixtures_dir pointing above the spec directory; absolute sources are documented",
+}
+
+// TestWorkdirJoinsGoThroughTheResolver is the structural half of the confinement
+// rule. Every path-taking feature -- assert.file, fixtures, redirects, snapshots,
+// screenshots, changes -- resolves author-written paths through one helper, and
+// the reason is that they each grew their own join once and each inherited the
+// same hole: an ancestor component that is a symlink out of the tree (#430).
+//
+// forbidigo cannot express this, because its patterns match the function name
+// and never the arguments. So the rule is checked here, where the arguments are
+// visible: a filepath.Join whose first argument is a confinement root is a
+// finding unless it is listed above with a reason.
+func TestWorkdirJoinsGoThroughTheResolver(t *testing.T) {
+	t.Parallel()
+	root := repoRootDir(t)
+	fset := token.NewFileSet()
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			// .claude can hold git worktrees checked out inside the repo, which
+			// would scan a second copy of every package.
+			case ".git", ".claude", "dist", "node_modules", "public", "testdata", "website", "site":
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		f, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			return perr
+		}
+		rel, rerr := filepath.Rel(root, filepath.Dir(path))
+		if rerr != nil {
+			return rerr
+		}
+		pkgDir := filepath.ToSlash(rel)
+
+		var fn string
+		ast.Inspect(f, func(n ast.Node) bool {
+			if decl, ok := n.(*ast.FuncDecl); ok {
+				fn = decl.Name.Name
+			}
+			call, ok := n.(*ast.CallExpr)
+			if !ok || !isFilepathJoin(call.Fun) || len(call.Args) < 2 {
+				return true
+			}
+			first, ok := call.Args[0].(*ast.Ident)
+			if !ok || !rootArgNames[first.Name] {
+				return true
+			}
+			key := pkgDir + ":" + fn
+			if _, allowed := allowedJoins[key]; allowed {
+				return true
+			}
+			pos := fset.Position(call.Pos())
+			t.Errorf("%s:%d: %s joins %q directly.\n"+
+				"Author-written paths must resolve through security.ResolveWorkdirPath or ResolveSpecPath, "+
+				"which reject `../` and an ancestor symlinked out of the tree.\n"+
+				"If this second argument is not author-written, add %q to allowedJoins with the reason.",
+				filepath.ToSlash(pos.Filename), pos.Line, fn, first.Name, key)
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+}
+
+// TestAllowedJoinsAreAllStillReal keeps the escape list honest: an entry whose
+// join has been rewritten or deleted must not linger, or the list slowly stops
+// describing the code and starts excusing whatever lands on the same name.
+func TestAllowedJoinsAreAllStillReal(t *testing.T) {
+	t.Parallel()
+	root := repoRootDir(t)
+	fset := token.NewFileSet()
+	seen := map[string]bool{}
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", ".claude", "dist", "node_modules", "public", "testdata", "website", "site":
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		f, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			return perr
+		}
+		rel, rerr := filepath.Rel(root, filepath.Dir(path))
+		if rerr != nil {
+			return rerr
+		}
+		pkgDir := filepath.ToSlash(rel)
+		var fn string
+		ast.Inspect(f, func(n ast.Node) bool {
+			if decl, ok := n.(*ast.FuncDecl); ok {
+				fn = decl.Name.Name
+			}
+			call, ok := n.(*ast.CallExpr)
+			if !ok || !isFilepathJoin(call.Fun) || len(call.Args) < 2 {
+				return true
+			}
+			if first, ok := call.Args[0].(*ast.Ident); ok && rootArgNames[first.Name] {
+				seen[pkgDir+":"+fn] = true
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	for key, why := range allowedJoins {
+		if !seen[key] {
+			t.Errorf("allowedJoins lists %q (%s) but no such join exists any more; remove the entry", key, why)
+		}
+	}
+}
+
+// isFilepathJoin reports whether fun is the filepath.Join selector.
+func isFilepathJoin(fun ast.Expr) bool {
+	sel, ok := fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Join" {
+		return false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	return ok && pkg.Name == "filepath"
+}
+
+// repoRootDir walks up to the directory holding go.mod.
+func repoRootDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("working directory: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found above the security package")
+		}
+		dir = parent
+	}
+}

--- a/internal/spec/assert.go
+++ b/internal/spec/assert.go
@@ -299,6 +299,10 @@ func (e ExitCode) MarshalYAML() (any, error) {
 	case len(e.In) > 0:
 		return map[string][]int{"in": e.In}, nil
 	default:
+		//nolint:nilnil // yaml.Marshaler's way of saying "no value": nil emits null rather
+		// than the bogus three-field map the default struct marshal would write. The loader
+		// rejects a matcher-less exit_code (ATG-2104), so this is unreachable for any spec
+		// that was parsed, and TestExitCode_MarshalYAML_AllShapes pins the shape.
 		return nil, nil
 	}
 }

--- a/internal/spec/describe.go
+++ b/internal/spec/describe.go
@@ -127,6 +127,9 @@ func (a *artifactSet) step(step *Step) {
 				a.add(act.Screenshot.Path)
 			}
 		}
+	case StepFixture, StepQuery, StepGRPC, StepStore, StepService, StepPTY, StepSignal, StepMockServer:
+		// No generated artifact. A fixture writes an INPUT, and the rest produce
+		// no file path of their own.
 	}
 }
 
@@ -277,6 +280,10 @@ func (n *noteSet) step(step *Step, runners map[string]Runner) {
 		// elsewhere); the process it starts deserves the same scrutiny as a
 		// scenario-level service.
 		n.service(step.Service)
+	case StepFixture, StepAssert, StepStore, StepSignal, StepMockServer:
+		// No note of their own: none of these reaches the network or starts a
+		// process. Their host-environment reads are still reported, by the
+		// kind-independent CollectStepVars walk below.
 	}
 	// Host-environment reads are one rule for every kind: any ${env:} in a
 	// field the engine expands, found through the same walkers the engine

--- a/internal/spec/pty.go
+++ b/internal/spec/pty.go
@@ -118,6 +118,7 @@ type PTYExpectScreen struct {
 	// the attribute matchers too (#382): the live frame is the same frame the
 	// post-step assert reads, so it deserves the same questions.
 	ScreenAssert `yaml:",inline"`
+
 	// Timeout bounds THIS wait only; when empty, the enclosing pty timeout
 	// supplies the budget.
 	Timeout string `yaml:"timeout,omitempty"`

--- a/internal/spec/screenassert.go
+++ b/internal/spec/screenassert.go
@@ -10,6 +10,7 @@ import "strings"
 // different questions about the same frame: what it says, and how it looks.
 type ScreenAssert struct {
 	StreamAssert `yaml:",inline"`
+
 	// Attrs checks how text is drawn (#382): the error line is red, the selected
 	// row is reverse-video, `--no-color` really did leave the frame uncolored.
 	// Every entry must hold.

--- a/internal/spec/step_test.go
+++ b/internal/spec/step_test.go
@@ -183,6 +183,7 @@ func TestJSONChecks_UnmarshalYAML(t *testing.T) {
 	t.Parallel()
 
 	t.Run("single mapping", func(t *testing.T) {
+		t.Parallel()
 		var s StreamAssert
 		if err := yaml.Unmarshal([]byte("json:\n  path: $.a\n  equals: 1\n"), &s); err != nil {
 			t.Fatalf("unmarshal single: %v", err)
@@ -193,6 +194,7 @@ func TestJSONChecks_UnmarshalYAML(t *testing.T) {
 	})
 
 	t.Run("list of mappings", func(t *testing.T) {
+		t.Parallel()
 		var s StreamAssert
 		src := "json:\n  - {path: $.a, equals: 1}\n  - {path: $.b, equals: 2}\n"
 		if err := yaml.Unmarshal([]byte(src), &s); err != nil {
@@ -204,6 +206,7 @@ func TestJSONChecks_UnmarshalYAML(t *testing.T) {
 	})
 
 	t.Run("empty list rejected", func(t *testing.T) {
+		t.Parallel()
 		var s StreamAssert
 		if err := yaml.Unmarshal([]byte("json: []\n"), &s); err == nil {
 			t.Fatal("empty json list should be rejected")
@@ -211,6 +214,7 @@ func TestJSONChecks_UnmarshalYAML(t *testing.T) {
 	})
 
 	t.Run("unknown key inside a check is rejected", func(t *testing.T) {
+		t.Parallel()
 		var s StreamAssert
 		if err := yaml.Unmarshal([]byte("json:\n  path: $.a\n  equalss: 1\n"), &s); err == nil {
 			t.Fatal("a typo'd key inside a json check should be rejected (strict)")

--- a/internal/spec/walk.go
+++ b/internal/spec/walk.go
@@ -80,9 +80,11 @@ func StepRunner(step *Step) string {
 		return step.GRPC.Runner
 	case StepCDP:
 		return step.CDP.Runner
-	default:
+	case StepFixture, StepAssert, StepStore, StepService, StepPTY, StepSignal, StepMockServer:
+		// No runner to name: none of these payloads carries a `runner:` key.
 		return ""
 	}
+	return ""
 }
 
 // RunnerVarFields returns the runner fields the engine ${name}-expands at use
@@ -142,6 +144,11 @@ func CollectStepVars(set map[string]bool, step *Step, runners map[string]Runner)
 		WalkAssertStrings(step.Assert, collect)
 	case StepStore:
 		WalkStoreStrings(step.Store, collect)
+	case StepMockServer:
+		// A mock server is started verbatim; nothing in it is expanded, so it has
+		// no references to collect. WalkStepStrings says the same for the same
+		// reason, and the two have to agree: a kind this function forgets is a
+		// kind explain and the security summary under-report.
 	}
 }
 

--- a/internal/spec/walk_test.go
+++ b/internal/spec/walk_test.go
@@ -98,7 +98,7 @@ func TestWalkAssertStrings_CollectAndExpand(t *testing.T) {
 func TestWalkJSONValueStrings(t *testing.T) {
 	t.Parallel()
 	in := map[string]any{"s": "${x}", "n": 1, "arr": []any{"${y}", 2}}
-	out, ok := WalkJSONValueStrings(in, func(s string) string { return strings.ToUpper(s) }).(map[string]any)
+	out, ok := WalkJSONValueStrings(in, strings.ToUpper).(map[string]any)
 	if !ok {
 		t.Fatalf("result is not a map")
 	}


### PR DESCRIPTION
## What

Adds 26 linters to `.golangci.yml` and resolves every finding, in five commits that can be read independently.

| Commit | Linters | Findings resolved |
| --- | --- | --- |
| Ten regression-only linters | asasalint, canonicalheader, fatcontext, iface, makezero, musttag, nilnesserr, reassign, rowserrcheck, sqlclosecheck | 0 (all clean today) |
| Guard every enum switch | exhaustive | 30 switches |
| Correctness and hygiene | contextcheck, embeddedstructfieldcheck, errchkjson, gocritic, mirror, nilnil, predeclared, recvcheck, tparallel, usetesting | 44 |
| atago-specific rules | forbidigo + an AST guard test | 4 rules, 0 findings |
| Scoped exhaustruct | exhaustruct (assert.Env only) | 2 |

Every one of the ten "clean today" linters has a live surface to watch, so none is dead weight: musttag covers the JSON side of the machine-readable contracts, canonicalheader the header names the http runner and mock server pass around, sqlclosecheck and rowserrcheck the `database/sql` use in the db runner, makezero the 114 `make([]T, n)` sites a stray append would corrupt.

## Why exhaustive is the important one

atago's oldest bug family is structural: a new step kind, assert target, or scenario status gets wired into some of the layers that switch on it and quietly skipped by the rest. The defense so far lived in tests that pull on `stepActions`, `assertTargets`, `AllStepKinds` and `AllAssertTargets` — and those only guard the walkers someone remembered to write a test for. `exhaustive` guards every switch in the tree, including the ones nobody thought to cover.

Two sentinels are excluded because `AllStepKinds` and `AllAssertTargets` leave them out for the same reason: `StepNone` and `AssertNone` mean "not exactly one action", not a kind a spec can carry. `reflect.Kind` is excluded too, since it has 27 members and the two switches over it are schema walkers that care about four. `default-signifies-exhaustive` stays false: most of these switches HAD a default, and inheriting its answer in silence is exactly how a kind goes half-wired.

## Bugs found

**`atago explain` silently dropped a pty teardown step.** A `pty:` step is legal in a scenario's teardown and the engine runs it, but `describeTeardownStep` had no pty branch, so `explain` printed a cleanup block that drove an interactive program with nothing to say so. The existing test's own comment listed the kinds teardown accepts and left pty out, which is how the gap survived.

**A `changes:` hint probed outside the scenario workdir.** `untrackedKindNote` built its path with a bare `filepath.Join`, so an entry naming `../secret` reported the kind of a file outside the workdir — a hint answering "does this exist, and what is it" about a path the spec has no business reaching. It resolves through `security.ResolveWorkdirPath` now, like every other path-taking assertion.

**A latent aliasing hazard in the pty stream sanitizer.** `buf = append(s.carry, chunk...)` can leave `buf` aliasing the carry buffer through its spare capacity, so a later append could rewrite bytes already handed to the emulator. It builds a fresh slice now.

Both first two arrived with a failing test written before the fix.

## Smaller improvements that came out of it

`engine.Status` gained `cleanIteration` as the single definition of "this `--repeat` iteration was not a failure" — the fold and `PassedIterations` each carried their own copy, and a past bug had them disagreeing about the flake rate. A scenario step carrying a suite-only kind now says `service steps are only allowed in suite.setup` instead of claiming atago recognizes no action there, which was wrong twice over. A discarded `json.Marshal` error became `jsStringLiteral`, one place where "encoding a string cannot fail" is written down rather than implied by a blank identifier.

## The atago-specific rules

General linters know Go; these four know atago, and all four report nothing today so that the next change cannot quietly take one away.

- **`fmt.Print*` is forbidden.** atago's stdout is a machine-readable contract under `--format json/junit/gha`, so a stray print corrupts the document a CI job parses. Every writer is injected already.
- **`os.Chdir` / `os.Setenv` / `os.Unsetenv` / `os.Clearenv` are forbidden.** Process-global state is incompatible with `--parallel`. The two deliberate exceptions in `internal/cli` run once at startup and now say so.
- **`math/rand` is forbidden.** A runner whose output has to be reproducible has no use for it.
- **Workdir joins must go through the resolver.** `forbidigo` matches the function name and never the arguments, so it cannot express "`filepath.Join` whose first argument is a confinement root" — the shape behind the ancestor-symlink hole fixed centrally in #429. `TestWorkdirJoinsGoThroughTheResolver` walks the AST instead, and every bypass has to be listed with the reason it is not author-written. A companion test deletes stale entries so the escape list keeps describing the code rather than excusing whatever later lands on the same function name. It found the `changes:` bug above on its first run, plus a `specDir` join grep had missed.

## What was deliberately left out

`noinlineerr` (833 findings, purely stylistic) and `unparam` are not included. Rules that did not survive measurement are left out rather than added for symmetry: forcing diag codes by banning `fmt.Errorf` would fire on 78 sites and duplicate the three AST guards and the E2E gate that already cover code coverage, and banning `os.Getenv` in the engine would flag two calls that ARE the feature, since `only: {env: X}` exists to read the host environment.

Some findings are annotated rather than changed, because the linter's advice is wrong for this code. All three `contextcheck` hits are deliberate: teardown must not derive from a context that is already done, or cleanup cancels instantly. All six `nilnil` hits are the documented optional-value idiom — no manifest found, no suite runtime needed, no stdin authored, no failing check — where a sentinel error would make absence look like failure; `nilnil`'s contribution here is prospective. `recvcheck` skips the yaml codec pair, since `UnmarshalYAML` must take a pointer and `MarshalYAML` a value.

## Verification

`go test ./...`, `golangci-lint run`, `make e2e` (691 scenarios, 687 passed / 4 skipped), `make docs` and `make site` all clean with no drift.
