### PR TITLE
fix(e2e): pin the bats formatter choice on the rule bats applies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Bug Fixes
 
+- The bats suite's pretty-formatter scenario states the condition bats actually applies. It read the formatter choice as "a terminal is attached", which is half the rule — bats stays on TAP when `CI` is set, however real the terminal is — so the scenario passed on a laptop and failed on the runner it was meant to protect. Both halves are now scenarios of their own, each setting `CI` explicitly, so the pair means the same thing wherever it runs.
 - A generated behavior doc renders a value that contains a backtick as the span it is. `atago doc` wrapped every asserted value in a single backtick, so an assertion on output that quotes a command — `` `false' failed ``, the shape most shells and test runners report a failure in — ended its code span at the value's own backtick and spilled the rest of the line into the page as prose the spec never wrote. The delimiter now grows past the longest backtick run inside the value, as CommonMark prescribes, and four committed docs regain the spans they had lost.
 
 ## [0.21.0] - 2026-08-18

--- a/doc/e2e/bats.md
+++ b/doc/e2e/bats.md
@@ -1,6 +1,6 @@
 # atago Behavior Specs
 ## Summary
-4 suites · 43 scenarios
+4 suites · 44 scenarios
 ## Contents
 - [bats (the verdict a test runner reports)](#bats-the-verdict-a-test-runner-reports) — 14 scenarios
   - [the version and the help text are answered on stdout](#scenario-the-version-and-the-help-text-are-answered-on-stdout)
@@ -28,7 +28,7 @@
   - [a test can read its own name, number, and file](#scenario-a-test-can-read-its-own-name-number-and-file)
   - [load pulls in a helper file next to the test](#scenario-load-pulls-in-a-helper-file-next-to-the-test)
   - [parallel jobs without the parallel binary fail as a raw shell error](#scenario-parallel-jobs-without-the-parallel-binary-fail-as-a-raw-shell-error)
-- [bats (formatters, reports, and gathered output)](#bats-formatters-reports-and-gathered-output) — 10 scenarios
+- [bats (formatters, reports, and gathered output)](#bats-formatters-reports-and-gathered-output) — 11 scenarios
   - [TAP version 13 carries the failure as a YAML block](#scenario-tap-version-13-carries-the-failure-as-a-yaml-block)
   - [the JUnit formatter reports counts and the failure element](#scenario-the-junit-formatter-reports-counts-and-the-failure-element)
   - [a report formatter writes a file and leaves stdout as TAP](#scenario-a-report-formatter-writes-a-file-and-leaves-stdout-as-tap)
@@ -38,7 +38,8 @@
   - [test output is hidden when it passes and shown when it fails](#scenario-test-output-is-hidden-when-it-passes-and-shown-when-it-fails)
   - [timing and tracing add to the report without changing the verdict](#scenario-timing-and-tracing-add-to-the-report-without-changing-the-verdict)
   - [the quoting and file reference in a failure are configurable](#scenario-the-quoting-and-file-reference-in-a-failure-are-configurable)
-  - [the pretty formatter exists only on a terminal](#scenario-the-pretty-formatter-exists-only-on-a-terminal)
+  - [the pretty formatter draws on a terminal](#scenario-the-pretty-formatter-draws-on-a-terminal)
+  - [a terminal under CI still reports TAP](#scenario-a-terminal-under-ci-still-reports-tap)
 - [bats (choosing which tests run)](#bats-choosing-which-tests-run) — 9 scenarios
   - [counting reports the number of tests and runs none of them](#scenario-counting-reports-the-number-of-tests-and-runs-none-of-them)
   - [the name filter is a regular expression, not a substring](#scenario-the-name-filter-is-a-regular-expression-not-a-substring)
@@ -997,7 +998,7 @@ bats --line-reference-format colon fail.bats
   - exit code is `1`
   - stdout contains `# (in test file fail.bats:2)`
 
-### Scenario: the pretty formatter exists only on a terminal
+### Scenario: the pretty formatter draws on a terminal
 _only when `bats --version` succeeds · skipped on Windows_
 #### Given
 - Fixture file `mixed.bats` is created.
@@ -1016,6 +1017,25 @@ _Fixture `mixed.bats`:_
 #### Then
 - rendered screen contains `mixed.bats`, `✓ passes`, `✗ fails`, `2 tests, 1 failure`
 - rendered screen does not contain `1..2`
+
+### Scenario: a terminal under CI still reports TAP
+_only when `bats --version` succeeds · skipped on Windows_
+#### Given
+- Fixture file `mixed.bats` is created.
+- The command runs with an isolated home under `${workdir}/.atago-home` (HOME/XDG or APPDATA redirected).
+
+#### Inputs
+_Fixture `mixed.bats`:_
+```text
+@test "passes" { true; }
+@test "fails" { false; }
+```
+#### When
+```shell
+# interactive (pty): bats mixed.bats
+```
+#### Then
+- rendered screen contains `1..2`, `ok 1 passes`, does not contain `✓ passes`
 
 ## bats (choosing which tests run)
 Everything [Bats](https://github.com/bats-core/bats-core) offers for running

--- a/test/e2e/thirdparty/bats/reporting.atago.yaml
+++ b/test/e2e/thirdparty/bats/reporting.atago.yaml
@@ -275,7 +275,7 @@ scenarios:
           stdout:
             contains: "# (in test file fail.bats:2)"
 
-  - name: the pretty formatter exists only on a terminal
+  - name: the pretty formatter draws on a terminal
     steps:
       - fixture:
           file: mixed.bats
@@ -290,11 +290,12 @@ scenarios:
           sandbox_home: true
           env:
             LC_ALL: C
-          session:
-            - expect: "2 tests, 1 failure"
+            # bats picks the pretty formatter only when a terminal is attached
+            # and CI is unset. The variable is cleared here so the choice is the
+            # terminal's, whether this suite runs on a laptop or on a runner.
+            CI: ""
       - assert:
-          # With a terminal attached the default formatter changes from tap to
-          # pretty: the file is a heading, results are check and cross marks, and
+          # The file becomes a heading, results become check and cross marks, and
           # the run ends with a counted summary that plain TAP never prints.
           screen:
             contains:
@@ -305,3 +306,31 @@ scenarios:
       - assert:
           screen:
             not_contains: "1..2"
+
+  - name: a terminal under CI still reports TAP
+    steps:
+      - fixture:
+          file: mixed.bats
+          content: |
+            @test "passes" { true; }
+            @test "fails" { false; }
+      - pty:
+          command: bats mixed.bats
+          cols: 80
+          rows: 24
+          timeout: 30s
+          sandbox_home: true
+          env:
+            LC_ALL: C
+            CI: "true"
+          session:
+            - expect: "not ok 2 fails"
+      - assert:
+          # The terminal is real, so this is bats deciding rather than detecting:
+          # a log that scrolls past in a CI job is worth more as TAP than as
+          # progress redrawn in place.
+          screen:
+            contains:
+              - "1..2"
+              - "ok 1 passes"
+            not_contains: "✓ passes"


### PR DESCRIPTION
## Summary

The scheduled ThirdParty run for the bats suite went red on its first CI execution (#601), and the suite was wrong rather than bats: the pretty-formatter scenario assumed bats picks pretty whenever a terminal is attached. The actual rule is `[[ -z "${CI:-}" && -t 0 && -t 1 ]] && command -v tput` — a terminal *and* no `CI` in the environment — so the scenario drew check marks on a laptop and got TAP on the runner.

It is now two scenarios that each set `CI` explicitly in the pty environment:

- the pretty formatter draws on a terminal (`CI: ""`) — the file heading, the check and cross marks, the counted summary, and no TAP plan line.
- a terminal under CI still reports TAP (`CI: "true"`) — the plan and ok lines on a real terminal, with no check mark.

Both halves are now independent of where the suite runs, which is what the scenario should have been in the first place.

## Verification

- `atago run ./test/e2e/thirdparty/bats` — 44 scenarios green, run both with `CI=true` in the environment and without it.
- `make docs`, `make site`, `go test -run 'TestDocs|TestThirdParty|TestSite' .`